### PR TITLE
Fix issue #816: Makes verticalMultilineDefnSite respect continuationIndent.defnSite

### DIFF
--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -417,8 +417,8 @@ class Router(formatOps: FormatOps) {
       case FormatToken(open @ LeftParen(), r, between)
           if style.verticalMultilineAtDefinitionSite && isDefDef(leftOwner) =>
         val close = matchingParentheses(hash(open))
-        val indentParam = Num(4)
-        val indentSep = Num(2)
+        val indentParam = Num(style.continuationIndent.defnSite)
+        val indentSep = Num((indentParam.n - 2).max(0))
 
         @tailrec
         def loop(token: Token): Option[Token] =

--- a/core/src/test/resources/test/VerticalMultilineDefnSite.stat
+++ b/core/src/test/resources/test/VerticalMultilineDefnSite.stat
@@ -1,0 +1,14 @@
+maxColumn = 80
+verticalMultilineAtDefinitionSite = true
+continuationIndent.defnSite = 2
+<<< Work with continuationIndent.defnSite = 2
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
+>>>
+def format_![T <: Tree](
+  code: String,
+  foo: Int
+)(f: A => B,
+  k: D
+)(implicit ev: Parse[T],
+  ev2: EC
+): String


### PR DESCRIPTION
Makes `verticalMultilineDefnSite` respect `continuationIndent.defnSite`.

Parameters are now indented by `continuationIndent.defnSite`, while
parameter separators are indented by `continuationIndent.defnSite - 2`,
with `0` being the minimum.

`continuationIndent.defnSite` is defaulted to `4`, so this won't affect
how `verticalMultilineDefnSite` currently works.