### PR TITLE
Resolve with lock retry

### DIFF
--- a/bootstrap/src/main/scala/org/scalafmt/bootstrap/Bootstrap.scala
+++ b/bootstrap/src/main/scala/org/scalafmt/bootstrap/Bootstrap.scala
@@ -68,8 +68,9 @@ object ScalafmtBootstrap {
 
     val cacheFile =
       sys.env.getOrElse("SCALAFMT_CACHE",
-                        new File(new File(sys.props("user.home"), ".cache"),
+                        new File(new File(sys.props("user.dir"), ".cache"),
                                  "sbt-scalafmt").getAbsolutePath)
+
     val fetch = Fetch.from(
       repositories,
       Cache.fetch(

--- a/bootstrap/src/main/scala/org/scalafmt/bootstrap/Bootstrap.scala
+++ b/bootstrap/src/main/scala/org/scalafmt/bootstrap/Bootstrap.scala
@@ -78,7 +78,7 @@ object ScalafmtBootstrap {
         logger = Some(logger)
       )
     )
-    val resolution = start.process.run(fetch).unsafePerformSync
+    val resolution = runResolutionWithLockRetry(start, fetch, 50)
     val errors: Seq[(Dependency, Seq[String])] = resolution.errors
     if (errors.nonEmpty) Left(new FetchError(errors))
     else {
@@ -99,6 +99,21 @@ object ScalafmtBootstrap {
         case Success(cli) => Right(new ScalafmtBootstrap(cli) {})
         case Failure(e) => Left(e)
       }
+    }
+  }
+
+  private def runResolutionWithLockRetry(
+      start: Resolution,
+      fetch: Fetch.Metadata[Task],
+      remainingAttempts: Int): Resolution = {
+    val resolution = start.process.run(fetch).unsafePerformSync
+    val errors = resolution.errors
+    val allErrorsAreLock = errors.forall(_._2.forall(_.startsWith("locked")))
+    if (errors.nonEmpty && remainingAttempts >= 0 && allErrorsAreLock) {
+      Thread.sleep(50)
+      runResolutionWithLockRetry(start, fetch, remainingAttempts - 1)
+    } else {
+      resolution
     }
   }
 


### PR DESCRIPTION
Bootstrap should resolve with lock retry, incase of concurrent dependency usage, as seen with concurrent scalafmt usage on travis-ci

As seen and discussed 
https://github.com/scalameta/scalafmt/issues/807
https://github.com/akka/alpakka/pull/216