### PR TITLE
Fix #736: Make verticalMultiline apply to classes too

### DIFF
--- a/core/src/test/resources/test/VerticalMultiline.stat
+++ b/core/src/test/resources/test/VerticalMultiline.stat
@@ -1,5 +1,6 @@
 verticalMultilineAtDefinitionSite = true
 maxColumn = 80
+continuationIndent.extendSite = 2
 <<< curried function over maxColumn
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
 >>>
@@ -98,17 +99,22 @@ def format_![T <: Tree](
     ev2: EC
   ): String
 
-<<< should not affect classes
-final class UserProfile(name: String, age: Int, address: Address, profession: Profesion, school: School)
-  extends Profile with UserSettings
+<<< should affect classes
+final class UserProfile(name: String, age: Int, address: Address, profession: Profesion, school: School)(
+  implicit ctx: Context, ec: Executor)
+  extends Profile with UserSettings with SomethingElse
 >>>
-final class UserProfile(name: String,
-                        age: Int,
-                        address: Address,
-                        profession: Profesion,
-                        school: School)
-    extends Profile
-    with UserSettings
+final class UserProfile(
+    name: String,
+    age: Int,
+    address: Address,
+    profession: Profesion,
+    school: School
+  )(implicit ctx: Context,
+    ec: Executor)
+  extends Profile
+  with UserSettings
+  with SomethingElse
 
 <<< should work with an empty first param group
 override def load()(implicit taskCtx: Context,


### PR DESCRIPTION
Makes `verticalMultilineAtDefinitionSite` apply to classes too. Fixes issue #736 