### PR TITLE
Fix #808: newlines after curly lambda

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/core/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -1,6 +1,6 @@
 package org.scalafmt.config
 
-import metaconfig.ConfigReader
+import metaconfig.{ConfigReader, Reader}
 
 /**
   * @param penalizeSingleSelectMultiArgList
@@ -36,6 +36,24 @@ import metaconfig.ConfigReader
   *     n =>
   *       consume(n)
   *   }
+  * @param afterCurlyLambda
+  *   If `never` (default), it will remove any extra lines below curly lambdas
+  *   {{{
+  *   something.map { x =>
+  *
+  *     f(x)
+  *   }
+  *   }}}
+  *   will become
+  *   {{{
+  *   something.map { x =>
+  *     f(x)
+  *   }
+  *   }}}
+  *
+  *   If `always`, it will always add one empty line (opposite of `never`).
+  *   If `preserve`, and there isn't an empty line, it will keep it as it is.
+  *   If there is one or more empty lines, it will place a single empty line.
   */
 @ConfigReader
 case class Newlines(
@@ -44,5 +62,18 @@ case class Newlines(
     sometimesBeforeColonInMethodReturnType: Boolean = true,
     penalizeSingleSelectMultiArgList: Boolean = true,
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
-    alwaysBeforeTopLevelStatements: Boolean = false
+    alwaysBeforeTopLevelStatements: Boolean = false,
+    afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never
 )
+
+sealed abstract class NewlineCurlyLambda
+
+object NewlineCurlyLambda {
+
+  case object preserve extends NewlineCurlyLambda
+  case object always extends NewlineCurlyLambda
+  case object never extends NewlineCurlyLambda
+
+  implicit val newlineCurlyLambdaReader: Reader[NewlineCurlyLambda] =
+    ReaderUtil.oneOf[NewlineCurlyLambda](preserve, always, never)
+}

--- a/core/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/core/src/main/scala/org/scalafmt/internal/Router.scala
@@ -18,7 +18,7 @@ import scala.meta.Type
 import scala.meta.tokens.Token
 
 import org.scalafmt.Error.UnexpectedTree
-import org.scalafmt.config.ImportSelectors
+import org.scalafmt.config.{ImportSelectors, NewlineCurlyLambda}
 import org.scalafmt.internal.ExpiresOn.Left
 import org.scalafmt.internal.ExpiresOn.Right
 import org.scalafmt.internal.Length.Num
@@ -239,9 +239,16 @@ class Router(formatOps: FormatOps) {
           leftOwner.asInstanceOf[Term.Function].body)
         val canBeSpace =
           statementStarts(hash(right)).isInstanceOf[Term.Function]
+        val afterCurlyNewlines =
+          style.newlines.afterCurlyLambda match {
+            case NewlineCurlyLambda.never => Newline
+            case NewlineCurlyLambda.always => Newline2x
+            case NewlineCurlyLambda.preserve =>
+              if (newlines >= 2) Newline2x else Newline
+          }
         Seq(
           Split(Space, 0, ignoreIf = !canBeSpace),
-          Split(Newline, 1).withIndent(2, endOfFunction, Left)
+          Split(afterCurlyNewlines, 1).withIndent(2, endOfFunction, Left)
         )
       case FormatToken(arrow @ RightArrow(), right, _)
           if leftOwner.is[Term.Function] =>

--- a/core/src/test/resources/newlines/afterCurlyLambdaAlways.stat
+++ b/core/src/test/resources/newlines/afterCurlyLambdaAlways.stat
@@ -1,0 +1,46 @@
+style = default
+newlines.afterCurlyLambda = always
+
+<<< Preserve (when always) newline in lambda call
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}
+
+<<< Force newline in lambda call
+def f = {
+  something.call { x =>
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}
+<<< Remove extra newlines in lambda call
+def f = {
+  something.call { x =>
+
+
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}

--- a/core/src/test/resources/newlines/afterCurlyLambdaNever.stat
+++ b/core/src/test/resources/newlines/afterCurlyLambdaNever.stat
@@ -1,0 +1,45 @@
+style = default
+newlines.afterCurlyLambda = never
+
+<<< Remove newline in lambda call
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+    g(x)
+  }
+}
+
+<<< Preseve no-newline in lambda call
+def f = {
+  something.call { x =>
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+    g(x)
+  }
+}
+
+<<< Remove many newlines in lambda call
+def f = {
+  something.call { x =>
+
+
+
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+    g(x)
+  }
+}

--- a/core/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
+++ b/core/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
@@ -1,0 +1,46 @@
+style = default
+newlines.afterCurlyLambda = preserve
+
+<<< Preserve newline in lambda call
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}
+
+<<< Preserve no-newline in lambda call
+def f = {
+  something.call { x =>
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+    g(x)
+  }
+}
+
+<<< Replace multiple newlines with a single newline when preseving
+def f = {
+  something.call { x =>
+
+
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}


### PR DESCRIPTION
Fixes issue #808 by introducing a new setting: `newlines.afterCurlyLambda`

This option can have one of three settings: never (default), always and
preserve.

* `never`(default) removes all lines. Before this commit, this is what was happening
* `always` inserts one line if there is non and removes extra lines if
    there are more. This means there is always one (1) line
* `preserve` is a combination of `never` and `always`. If the user does
    not have an extra line, there it will not add an extra line (like
    `never`). If there user has one or more lines, it will replaces it
    with one line (like `always`).