### PR TITLE
Fix #799 Allow ASCII sorting of imports

### DIFF
--- a/core/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -22,6 +22,7 @@ object Rewrite {
       RedundantBraces,
       RedundantParens,
       SortImports,
+      AsciiSortImports,
       PreferCurlyFors,
       ExpandImportSelectors,
       AvoidInfix
@@ -45,7 +46,8 @@ object Rewrite {
   val default: Seq[Rewrite] = name2rewrite.values.toSeq
 
   private def incompatibleRewrites: List[(Rewrite, Rewrite)] = List(
-    SortImports -> ExpandImportSelectors
+    SortImports -> ExpandImportSelectors,
+    SortImports -> AsciiSortImports
   )
 
   def validateRewrites(rewrites: Seq[Rewrite]): Seq[String] = {

--- a/core/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -36,6 +36,7 @@ object Rewrite {
     RedundantBraces,
     RedundantParens,
     SortImports,
+    AsciiSortImports,
     PreferCurlyFors,
     ExpandImportSelectors,
     AvoidInfix

--- a/core/src/main/scala/org/scalafmt/rewrite/SortImports.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/SortImports.scala
@@ -15,25 +15,12 @@ import scala.meta._
   *
   * import a.{b, c}
   */
-case object SortImports extends Rewrite {
-  // sort contributed by @djspiewak: https://gist.github.com/djspiewak/127776c2b6a9d6cd3c21a228afd4580f
-  private val LCase = """([a-z].*)""".r
-  private val UCase = """([A-Z].*)""".r
-  private val Other = """(.+)""".r
+sealed trait SortImports extends Rewrite {
 
-  private def sorted(strs: Seq[String]): Seq[String] = {
-    // we really want partition, but there is no ternary version of it
-    val (syms, lcs, ucs) = strs.foldLeft(
-      (Vector.empty[String], Vector.empty[String], Vector.empty[String])) {
-      case ((syms, lcs, ucs), str) =>
-        str match {
-          case LCase(s) => (syms, lcs :+ s, ucs)
-          case UCase(s) => (syms, lcs, ucs :+ s)
-          case Other(s) => (syms :+ s, lcs, ucs)
-        }
-    }
-    syms.sorted ++ lcs.sorted ++ ucs.sorted
-  }
+  /**
+   * The sorting scheme to use when sorting the imports
+   */
+  def sorted(str: Seq[String]): Seq[String]
 
   override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {
     code.collect {
@@ -59,4 +46,40 @@ case object SortImports extends Rewrite {
         }
     }.flatten
   }
+}
+
+/**
+ * Sort imports with symbols at the beginning, followed by lowercase and
+ * finally uppercase
+ */
+case object SortImports extends SortImports {
+
+  // sort contributed by @djspiewak: https://gist.github.com/djspiewak/127776c2b6a9d6cd3c21a228afd4580f
+  private val LCase = """([a-z].*)""".r
+  private val UCase = """([A-Z].*)""".r
+  private val Other = """(.+)""".r
+
+  override def sorted(strs: Seq[String]): Seq[String] = {
+    // we really want partition, but there is no ternary version of it
+    val (syms, lcs, ucs) = strs.foldLeft(
+      (Vector.empty[String], Vector.empty[String], Vector.empty[String])) {
+      case ((syms, lcs, ucs), str) =>
+        str match {
+          case LCase(s) => (syms, lcs :+ s, ucs)
+          case UCase(s) => (syms, lcs, ucs :+ s)
+          case Other(s) => (syms :+ s, lcs, ucs)
+        }
+    }
+    syms.sorted ++ lcs.sorted ++ ucs.sorted
+  }
+}
+
+/**
+ * Sort imports using the traditional ASCII sorting
+ *
+ * See: http://support.ecisolutions.com/doc-ddms/help/reportsmenu/ascii_sort_order_chart.htm
+ */
+case object AsciiSortImports extends SortImports {
+
+  override def sorted(strs: Seq[String]): Seq[String] = strs.sorted
 }

--- a/core/src/main/scala/org/scalafmt/rewrite/SortImports.scala
+++ b/core/src/main/scala/org/scalafmt/rewrite/SortImports.scala
@@ -18,8 +18,8 @@ import scala.meta._
 sealed trait SortImports extends Rewrite {
 
   /**
-   * The sorting scheme to use when sorting the imports
-   */
+    * The sorting scheme to use when sorting the imports
+    */
   def sorted(str: Seq[String]): Seq[String]
 
   override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {
@@ -49,9 +49,9 @@ sealed trait SortImports extends Rewrite {
 }
 
 /**
- * Sort imports with symbols at the beginning, followed by lowercase and
- * finally uppercase
- */
+  * Sort imports with symbols at the beginning, followed by lowercase and
+  * finally uppercase
+  */
 case object SortImports extends SortImports {
 
   // sort contributed by @djspiewak: https://gist.github.com/djspiewak/127776c2b6a9d6cd3c21a228afd4580f
@@ -75,10 +75,10 @@ case object SortImports extends SortImports {
 }
 
 /**
- * Sort imports using the traditional ASCII sorting
- *
- * See: http://support.ecisolutions.com/doc-ddms/help/reportsmenu/ascii_sort_order_chart.htm
- */
+  * Sort imports using the traditional ASCII sorting
+  *
+  * See: http://support.ecisolutions.com/doc-ddms/help/reportsmenu/ascii_sort_order_chart.htm
+  */
 case object AsciiSortImports extends SortImports {
 
   override def sorted(strs: Seq[String]): Seq[String] = strs.sorted

--- a/core/src/test/resources/rewrite/AsciiSortImports.stat
+++ b/core/src/test/resources/rewrite/AsciiSortImports.stat
@@ -1,0 +1,11 @@
+rewrite.rules = [AsciiSortImports]
+
+<<< ascii sorting
+import a.{
+  ~>,
+  lowercase,
+  Uppercase,
+  `symbol`
+}
+>>>
+import a.{Uppercase, `symbol`, lowercase, ~>}

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -531,6 +531,12 @@
       @demoStyle(rewriteImports)
         import foo.{Zilch, bar, Random, sand}
 
+    @sect(Rewrite.rewrite2name(AsciiSortImports))
+      @p
+        The imports are sorted by their Ascii codes
+      @demoStyle(rewriteAsciiImports)
+        import foo.{~>, `symbol`, bar, Random}
+
     @sect(Rewrite.rewrite2name(PreferCurlyFors))
       @p
         Replaces parentheses into curly braces in for comprehensions that

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -149,6 +149,12 @@ object Readme {
         rules = Seq(SortImports)
       ))
 
+  val rewriteAsciiImports =
+    ScalafmtConfig.default.copy(
+      rewrite = ScalafmtConfig.default.rewrite.copy(
+        rules = Seq(AsciiSortImports)
+      ))
+
   val rewritePreferCurlyFors =
     ScalafmtConfig.default.copy(
       rewrite = ScalafmtConfig.default.rewrite.copy(


### PR DESCRIPTION
Adds a new rewrite.rule: `AsciiSortImports`. This rules works exactly as
SortImports but sorts in the traditional ASCII form.

This is wanted since many editors (ie: IntelliJ) use the ASCII sorting
when sorting their imports. Having this option allows people to better
transition to Scalafmt from existing codebases and decreases tension
between Scalafmt and most editors (users can use a mix of Scalafmt and
their editors at will).

NOTE: This setting is incompatible with `SortImports`