### PR TITLE
Fix #880, filter diff files with canFormat

### DIFF
--- a/cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -101,7 +101,10 @@ object Cli {
 
   private def getFilesFromDiff(options: CliOptions): Seq[AbsoluteFile] = {
     val branch = options.diff.get
-    options.gitOps.diff(branch).filter(options.config.project.matcher.matches)
+    options.gitOps
+      .diff(branch)
+      .filter(options.config.project.matcher.matches)
+      .filter(canFormat)
   }
 
   /** Returns file paths defined via options.project */


### PR DESCRIPTION
scalafmt already filters files to format with canFormat for standard invocation.
This brings the '--diff' option into line with this behaviour