### PR TITLE
Fix #883.

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/Align.scala
+++ b/core/src/main/scala/org/scalafmt/config/Align.scala
@@ -44,15 +44,43 @@ import metaconfig._
   * @param ifWhileOpenParen
   *   If true, aligns by ( in if/while/for. If false,
   *   indents by continuation indent at call site.
+  * @param tokenCategory
+  *   Customize which token kinds can align together. By default, only tokens with
+  *   the same `Token.productPrefix` align. To for example align = and <-,
+  *   set the values to:
+  *     Map("Equals" -> "Assign", "LeftArrow" -> "Assign")
+  *   Note. Requires mixedTokens to be true.
+  * @param treeCategory
+  *   Customize which tree kinds can align together. By default, only trees with
+  *   the same `Tree.productPrefix` align. To for example align Defn.Val and
+  *   Defn.Var, set the values to:
+  *     Map("Defn.Var" -> "Assign", "Defn.Val" -> "Assign")
+  *   Note. Requires mixedOwners to be true.
   */
 @DeriveConfDecoder
 case class Align(
     openParenCallSite: Boolean = true,
     openParenDefnSite: Boolean = true,
+    // TODO(olafur) deprecate these in favor of tokenCategory/treeCategory
     mixedOwners: Boolean = false,
+    mixedTokens: Boolean = false,
     tokens: Set[AlignToken] = Set.empty[AlignToken],
     arrowEnumeratorGenerator: Boolean = false,
-    ifWhileOpenParen: Boolean = true
+    ifWhileOpenParen: Boolean = true,
+    tokenCategory: Map[String, String] = Map(
+      "Equals" -> "Assign",
+      "LeftArrow" -> "Assign"
+    ),
+    treeCategory: Map[String, String] = Map(
+      "Defn.Val" -> "val/var/def",
+      "Defn.Var" -> "val/var/def",
+      "Defn.Def" -> "val/var/def",
+      "Defn.Class" -> "class/object/trait",
+      "Defn.Object" -> "class/object/trait",
+      "Defn.Trait" -> "class/object/trait",
+      "Enumerator.Generator" -> "for",
+      "Enumerator.Val" -> "for"
+    )
 ) {
   implicit val alignReader: ConfDecoder[Set[AlignToken]] =
     ScalafmtConfig.alignReader(tokens)

--- a/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -185,12 +185,18 @@ class FormatWriter(formatOps: FormatOps) {
 
   def key(token: Token): Int = {
     val ownerKey = {
-      val className = owners(token).getClass.getName
+      val treeKind = owners(token).productPrefix
       if (initStyle.align.mixedOwners)
-        FormatWriter.ownerCategory.getOrElse(className, className)
-      else className
+        initStyle.align.treeCategory.getOrElse(treeKind, treeKind)
+      else treeKind
     }
-    (token.getClass.getName, ownerKey).hashCode()
+    val tokenKey = {
+      val syntax = token.productPrefix
+      if (initStyle.align.mixedTokens)
+        initStyle.align.tokenCategory.getOrElse(syntax, syntax)
+      else syntax
+    }
+    (tokenKey, ownerKey).hashCode()
   }
 
   private def getAlignOwner(formatToken: FormatToken): Tree =
@@ -309,15 +315,6 @@ class FormatWriter(formatOps: FormatOps) {
 }
 
 object FormatWriter {
-
-  val ownerCategory: Map[String, String] = Map(
-    "scala.meta.Defn$Val$DefnValImpl" -> "val/var/def",
-    "scala.meta.Defn$Var$DefnVarImpl" -> "val/var/def",
-    "scala.meta.Defn$Def$DefnDefImpl" -> "val/var/def",
-    "scala.meta.Defn$Class$DefnClassImpl" -> "class/object/trait",
-    "scala.meta.Defn$Object$DefnObjectImpl" -> "class/object/trait",
-    "scala.meta.Defn$Trait$DefnTraitImpl" -> "class/object/trait"
-  )
 
   case class FormatLocation(formatToken: FormatToken,
                             split: Split,

--- a/core/src/test/resources/align/MixedTokens.stat
+++ b/core/src/test/resources/align/MixedTokens.stat
@@ -1,0 +1,12 @@
+style = defaultWithAlign
+align.mixedTokens = true
+<<< #883
+for {
+  a <- b
+  cc = d
+} yield cc
+>>>
+for {
+  a  <- b
+  cc = d
+} yield cc

--- a/core/src/test/resources/align/TrollAlignment.stat
+++ b/core/src/test/resources/align/TrollAlignment.stat
@@ -1,0 +1,20 @@
+style = defaultWithAlign
+align.mixedTokens = true
+align.treeCategory {
+  Case: Assign
+  "Enumerator.Generator": Assign
+}
+align.tokenCategory {
+  LeftArrow = Assign
+  RightArrow = Assign
+}
+<<< troll
+{
+  x match { case 1 => 2 }
+  for { a <- b } yield b
+}
+>>>
+{
+  x match { case 1 => 2 }
+  for { a          <- b } yield b
+}


### PR DESCRIPTION
This commit exposes new configuration options to control which
tree nodes and token kinds align together using `.productPrefix`
as keys.