### PR TITLE
alwaysBeforeTopLevelStatements

### DIFF
--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -63,17 +63,16 @@ object TokenOps {
       newlines > 1 || (isDocstring(tok.right) && !tok.left.is[Comment])
     } || {
       // alwaysBeforeTopLevelStatements logic
+      style.newlines.alwaysBeforeTopLevelStatements &&
       !tok.left.is[Comment] &&
       !TreeOps.isAnnotation(leftOwner) &&
-      style.newlines.alwaysBeforeTopLevelStatements &&
-      (isTopLevelStatment(tok.right, rightOwner) || TreeOps
-        .isMultiline( // Either top level definition or multiline statement on the right
-          rightOwner)) &&
+      (isTopLevelStatment(tok.right, rightOwner) || TreeOps.isMultiline(
+        rightOwner)) &&
       // left side must be part of a multiline statement or right, if not then statements must start with a different keyword (e.g. block of case objects / case classes sticks together)
-      (leftOwner.parent.exists(TreeOps.isMultiline) || TreeOps.isMultiline(
-        rightOwner) || leftOwner.parent.exists(
-        _.tokens.head.syntax != tok.right.syntax)) &&
-      !leftOwner.tokens.contains(tok.right) // right token may not be child of left tokens parent
+      (leftOwner.parent.exists(TreeOps.isMultiline)
+      || TreeOps.isMultiline(rightOwner)
+      || leftOwner.parent.exists(_.tokens.head.syntax != tok.right.syntax)) && !leftOwner.tokens
+        .contains(tok.right) // right token may not be child of left tokens parent
     }
   }
 

--- a/core/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -54,16 +54,26 @@ object TokenOps {
   def shouldGet2xNewlines(tok: FormatToken,
                           style: ScalafmtConfig,
                           owners: Token => Tree): Boolean = {
+    val leftOwner = owners(tok.left)
+    val rightOwner = owners(tok.right)
+
+    // Docstring logic
     !isDocstring(tok.left) && {
       val newlines = newlinesBetween(tok.between)
       newlines > 1 || (isDocstring(tok.right) && !tok.left.is[Comment])
     } || {
+      // alwaysBeforeTopLevelStatements logic
       !tok.left.is[Comment] &&
-      !owners(tok.left).parent.exists(_.is[Mod.Annot]) &&
+      !TreeOps.isAnnotation(leftOwner) &&
       style.newlines.alwaysBeforeTopLevelStatements &&
-      tok.between.count(_.is[KwNew]) < 2 && isTopLevelStatment(
-        tok.right,
-        owners(tok.right))
+      (isTopLevelStatment(tok.right, rightOwner) || TreeOps
+        .isMultiline( // Either top level definition or multiline statement on the right
+          rightOwner)) &&
+      // left side must be part of a multiline statement or right, if not then statements must start with a different keyword (e.g. block of case objects / case classes sticks together)
+      (leftOwner.parent.exists(TreeOps.isMultiline) || TreeOps.isMultiline(
+        rightOwner) || leftOwner.parent.exists(
+        _.tokens.head.syntax != tok.right.syntax)) &&
+      !leftOwner.tokens.contains(tok.right) // right token may not be child of left tokens parent
     }
   }
 

--- a/core/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/core/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -486,4 +486,12 @@ object TreeOps {
   // procedure syntax has decltpe: Some("")
   def isProcedureSyntax(defn: Defn.Def): Boolean =
     defn.decltpe.exists(_.tokens.isEmpty)
+
+  def isMultiline(tree: Tree): Boolean = tree.tokens.exists(_.is[LF])
+
+  def isAnnotation(tree: Tree): Boolean = tree.parent match {
+    case None => false
+    case Some(e) if e.is[Mod.Annot] => true
+    case Some(e) => isAnnotation(e)
+  }
 }

--- a/core/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
+++ b/core/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
@@ -9,6 +9,9 @@ package a {
   object a {
       val v1 = 1
       val v2 = 2
+      val v3 = {
+        3
+      }
       case class C1
       sealed trait T1
       final class FC1
@@ -16,6 +19,9 @@ package a {
       def b = v2
       def c: Int
       def d: Int = 2
+      def e: Int = {
+        3
+      }
       def e = a match {
         case 1 => true
         case 2 => false
@@ -29,10 +35,13 @@ package a {
   import x2.b
 
   package b {
-
     object a {
       val v1 = 1
       val v2 = 2
+
+      val v3 = {
+        3
+      }
 
       case class C1
 
@@ -41,12 +50,13 @@ package a {
       final class FC1
 
       def a = v1
-
       def b = v2
-
       def c: Int
-
       def d: Int = 2
+
+      def e: Int = {
+        3
+      }
 
       def e = a match {
         case 1 => true
@@ -135,13 +145,77 @@ object A {
   class B
   @Singleton
   class B @Inject()(val x: Int)
+  @js.native
+  class C() {
+    def c = 5
+  }
 }
 >>>
 object A {
-
   @Annotation
   class B
 
   @Singleton
   class B @Inject()(val x: Int)
+
+  @js.native
+  class C() {
+    def c = 5
+  }
+}
+
+<<< Don't add NL before single-line defs
+object Main {
+  def x = 1
+  def y = 2
+  def z = 3
+
+  def foo = {
+    println("foo")
+  }
+
+  def bar = {
+    println("bar")
+  }
+}
+>>>
+object Main {
+  def x = 1
+  def y = 2
+  def z = 3
+
+  def foo = {
+    println("foo")
+  }
+
+  def bar = {
+    println("bar")
+  }
+}
+
+<<< Add NL before multi-line statements
+object Main {
+  def x = 1
+  def y = 2
+  def z = 3
+  def foo = {
+    println("foo")
+  }
+  def bar = {
+    println("bar")
+  }
+}
+>>>
+object Main {
+  def x = 1
+  def y = 2
+  def z = 3
+
+  def foo = {
+    println("foo")
+  }
+
+  def bar = {
+    println("bar")
+  }
 }


### PR DESCRIPTION
* keep blocks of singleline statements which start with the same keyword together (case [object|class] / vals / defs / etc)
* fix bug with annotations which are used with a prefix, like js.native
* add newlines to non-toplevel statements if they are multiline

#893 and #892

Even though this adds some details to alwaysBeforeTopLevelStatements, I think this shouldn't go into it's own setting