### PR TITLE
Fix #735. newlines before and after implicit keyword

### DIFF
--- a/core/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/core/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -54,6 +54,48 @@ import metaconfig._
   *   If `always`, it will always add one empty line (opposite of `never`).
   *   If `preserve`, and there isn't an empty line, it will keep it as it is.
   *   If there is one or more empty lines, it will place a single empty line.
+  * @param afterImplicitKWInVerticalMultiline  If true, add a newline after an implicit keyword in function and
+  *                                   class definitions (only for verticalMultiline style)
+  * {{{
+  *   // newlines.afterImplicitKWInVerticalMultiline = true
+  *   def format(
+  *     code: String,
+  *     age: Int
+  *   )(implicit
+  *     ev: Parser,
+  *     c: Context
+  *   ): String
+  *   // newlines.afterImplicitKWInVerticalMultiline = false
+  *   def format(
+  *     code: String,
+  *     age: Int
+  *   )(implicit ev: Parser,
+  *     c: Context
+  *   ): String
+  * }}}
+  * @param beforeImplicitKWInVerticalMultiline If true, add a newline before an implicit keyword in function and
+  *                                   class definitions (only for verticalMultiline style)
+  * {{{
+  *   // newlines.afterImplicitKWInVerticalMultiline = true
+  *   // newlines.beforeImplicitKWInVerticalMultiline = true
+  *   def format(
+  *     code: String,
+  *     age: Int
+  *   )(
+  *     implicit
+  *     ev: Parser,
+  *     c: Context
+  *   ): String
+  *   // newlines.afterImplicitAtDefnSite = true
+  *   // newlines.beforeImplicitKWInVerticalMultiline = false
+  *   def format(
+  *     code: String,
+  *     age: Int
+  *   )(implicit
+  *     ev: Parser,
+  *     c: Context
+  *   ): String
+  * }}}
   */
 @DeriveConfDecoder
 case class Newlines(
@@ -63,7 +105,9 @@ case class Newlines(
     penalizeSingleSelectMultiArgList: Boolean = true,
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
     alwaysBeforeTopLevelStatements: Boolean = false,
-    afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never
+    afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
+    afterImplicitKWInVerticalMultiline: Boolean = false,
+    beforeImplicitKWInVerticalMultiline: Boolean = false
 )
 
 sealed abstract class NewlineCurlyLambda

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -766,17 +766,23 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       // Do NOT Newline the first param after the split, unless we have a
       // mixed-params case with a Ctor modifier.
       // `] private (`
-      case Decision(t @ FormatToken(open2 @ LeftParen(), _, _), _) =>
+      case Decision(t @ FormatToken(open2 @ LeftParen(), right, _), _) =>
+        val newlinewBeforeImplicit = right
+          .is[KwImplicit] && style.newlines.beforeImplicitKWInVerticalMultiline
         val close2 = matchingParentheses(hash(open2))
         val prevT = prev(t).left
         val mod =
-          if (mixedParams && owners(prevT).is[CtorModifier]) Newline
+          if ((mixedParams && owners(prevT).is[CtorModifier]) || newlinewBeforeImplicit) Newline
           else NoSplit
         Decision(t,
                  Seq(
                    Split(mod, 0)
                      .withIndent(indentParam, close2, Right)
                  ))
+      case Decision(t @ FormatToken(KwImplicit(), _, _), _)
+          if style.newlines.afterImplicitKWInVerticalMultiline =>
+        val split = Split(Newline, 0)
+        Decision(t, Seq(split))
     }
 
     // Our policy is a combination of OneArgLineSplit and a custom splitter

--- a/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/core/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -772,7 +772,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         val close2 = matchingParentheses(hash(open2))
         val prevT = prev(t).left
         val mod =
-          if ((mixedParams && owners(prevT).is[CtorModifier]) || newlinewBeforeImplicit) Newline
+          if ((mixedParams && owners(prevT)
+                .is[CtorModifier]) || newlinewBeforeImplicit) Newline
           else NoSplit
         Decision(t,
                  Seq(

--- a/core/src/test/resources/newlines/afterImplicitKWInVerticalMultiline.stat
+++ b/core/src/test/resources/newlines/afterImplicitKWInVerticalMultiline.stat
@@ -1,0 +1,72 @@
+maxColumn = 80
+verticalMultilineAtDefinitionSite = true
+continuationIndent.defnSite = 2
+continuationIndent.extendSite = 0
+newlines.afterImplicitKWInVerticalMultiline = true
+
+<<< should add a newline after implicit keyword in function definitions
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
+>>>
+def format_![T <: Tree](
+  code: String,
+  foo: Int
+)(f: A => B,
+  k: D
+)(implicit
+  ev: Parse[T],
+  ev2: EC
+): String
+
+<<< should add a newline after implicit keyword in class definitions
+final class UserProfile(name: String, age: Int, address: Address, profession: Profesion, school: School)(
+  implicit ctx: Context, ec: Executor)
+  extends Profile with UserSettings with SomethingElse
+>>>
+final class UserProfile(
+  name: String,
+  age: Int,
+  address: Address,
+  profession: Profesion,
+  school: School
+)(implicit
+  ctx: Context,
+  ec: Executor)
+extends Profile
+with UserSettings
+with SomethingElse
+  
+<<< should work with an empty first param group
+override def load()(implicit taskCtx: Context,
+      ec: ExecutionContext
+    ): Future[Seq[A] Or B]
+>>>
+override def load(
+)(implicit
+  taskCtx: Context,
+  ec: ExecutionContext
+): Future[Seq[A] Or B]
+
+<<< should work with an empty non-first param group
+override def load(code: String)()(implicit taskCtx: Context,
+      ec: ExecutionContext
+    ): Future[Seq[A] Or B]
+>>>
+override def load(
+  code: String
+)(
+)(implicit
+  taskCtx: Context,
+  ec: ExecutionContext
+): Future[Seq[A] Or B]
+
+<<< should work without explicit parameter groups
+implicit def pairEncoder[A, B](
+    implicit aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]
+>>>
+implicit def pairEncoder[A, B](
+  implicit
+  aEncoder: CsvEncoder[A],
+  bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]

--- a/core/src/test/resources/newlines/beforeImplicitKWInVerticalMultiline.stat
+++ b/core/src/test/resources/newlines/beforeImplicitKWInVerticalMultiline.stat
@@ -1,0 +1,76 @@
+maxColumn = 80
+verticalMultilineAtDefinitionSite = true
+continuationIndent.defnSite = 2
+continuationIndent.extendSite = 0
+newlines.afterImplicitKWInVerticalMultiline = true
+newlines.beforeImplicitKWInVerticalMultiline = true
+
+<<< should add a newline after implicit keyword in function definitions
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
+>>>
+def format_![T <: Tree](
+  code: String,
+  foo: Int
+)(f: A => B,
+  k: D
+)(
+  implicit
+  ev: Parse[T],
+  ev2: EC
+): String
+
+<<< should add a newline after implicit keyword in class definitions
+final class UserProfile(name: String, age: Int, address: Address, profession: Profesion, school: School)(
+  implicit ctx: Context, ec: Executor)
+  extends Profile with UserSettings with SomethingElse
+>>>
+final class UserProfile(
+  name: String,
+  age: Int,
+  address: Address,
+  profession: Profesion,
+  school: School
+)(
+  implicit
+  ctx: Context,
+  ec: Executor)
+extends Profile
+with UserSettings
+with SomethingElse
+  
+<<< should work with an empty first param group
+override def load()(implicit taskCtx: Context,
+      ec: ExecutionContext
+    ): Future[Seq[A] Or B]
+>>>
+override def load(
+)(
+  implicit
+  taskCtx: Context,
+  ec: ExecutionContext
+): Future[Seq[A] Or B]
+
+<<< should work with an empty non-first param group
+override def load(code: String)()(implicit taskCtx: Context,
+      ec: ExecutionContext
+    ): Future[Seq[A] Or B]
+>>>
+override def load(
+  code: String
+)(
+)(
+  implicit
+  taskCtx: Context,
+  ec: ExecutionContext
+): Future[Seq[A] Or B]
+
+<<< should work without explicit parameter groups
+implicit def pairEncoder[A, B](implicit aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]
+>>>
+implicit def pairEncoder[A, B](
+  implicit
+  aEncoder: CsvEncoder[A],
+  bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]


### PR DESCRIPTION
This introduces 2 new settings: `newlines.beforeImplicitKWInVerticalMultiline` and `newlines.afterImplicitKWInVerticalMultiline`. Both are set to `false` by default.