### PR TITLE
Remake the CLI interface

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -84,7 +84,7 @@ object Cli {
     options.fileFetchMode match {
       case m @ (GitFiles | RecursiveSearch) =>
         val fetchFiles: AbsoluteFile => Seq[AbsoluteFile] =
-          if (m == GitFiles) options.gitOps.lsFiles(_)
+          if (m == GitFiles) options.gitOps.lsTree(_)
           else FileOps.listFiles(_)
 
         options.files.flatMap {

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -35,8 +35,8 @@ object CliArgParser {
     new scopt.OptionParser[CliOptions]("scalafmt") {
       override def showUsageOnError = false
 
-      private def printAndExit(inludeUsage: Boolean)(ignore: Unit,
-                                             c: CliOptions): CliOptions = {
+      private def printAndExit(
+          inludeUsage: Boolean)(ignore: Unit, c: CliOptions): CliOptions = {
         if (inludeUsage) showUsage
         else showHeader
         sys.exit
@@ -81,9 +81,8 @@ object CliArgParser {
         .action((opt, c) => c.copy(writeMode = Stdout))
         .text("write formatted files to stdout")
 
-
       opt[Boolean]("git")
-        .action((opt, c) => c.copy(inputGit = opt))
+        .action((opt, c) => c.copy(git = Some(opt)))
         .text("if true, ignore files in .gitignore (default false)")
       opt[Seq[String]]("exclude")
         .action((excludes, c) => c.copy(customExcludes = excludes))

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -71,19 +71,20 @@ object CliArgParser {
         .optional()
         .unbounded()
         .action((file, c) => addFile(file, c))
-        .text("file or directory, in which case all *.scala files are formatted.")
-
-      opt[WriteMode]('w', "write-mode")
-        .action((opt, c) => c.copy(writeMode = opt))
-        .text("write mode. Can be stdout or override (default).")
+        .text(
+          "file or directory, in which case all *.scala files are formatted.")
 
       opt[Unit]('i', "in-place")
         .action((opt, c) => c.copy(writeMode = Override))
-        .text("alias for --write-mode=override")
+        .text("format files in-place (default)")
       opt[Unit]("stdout")
         .action((opt, c) => c.copy(writeMode = Stdout))
-        .text("alias for --write-mode=stdout")
+        .text("write formatted files to stdout")
 
+
+      opt[Boolean]("git")
+        .action((opt, c) => c.copy(inputGit = opt))
+        .text("if true, ignore files in .gitignore (default false)")
       opt[Seq[String]]("exclude")
         .action((excludes, c) => c.copy(customExcludes = excludes))
         .text(

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -25,9 +25,9 @@ object CliArgParser {
        |scalafmt --diff-branch 2.x # same as --diff, except against branch 2.x
        |scalafmt --stdin # read from stdin and print to stdout
        |scalafmt --stdin --assume-filename foo.sbt # required to format .sbt files
-       |scalafmt -f Code.scala             # print formatted contents to stdout.
-       |scalafmt -i -f Code1.scala,A.scala # write formatted contents to file.
-       |scalafmt -i -f . --exclude target  # format all files in directory excluding target
+       |scalafmt Code1.scala A.scala       # write formatted contents to file.
+       |scalafmt --stdout Code.scala       # print formatted contents to stdout.
+       |scalafmt --exclude target          # format all files in directory excluding target
        |scalafmt --config .scalafmt.conf   # read custom style from file
        |scalafmt --config-str "style=IntelliJ" # define custom style as a flag, must be quoted.""".stripMargin
 
@@ -74,9 +74,21 @@ object CliArgParser {
         .text(
           "file or directory, in which case all *.scala files are formatted.")
 
+      opt[Seq[File]]('f', "files")
+        .action { (files, c) =>
+          c.copy(customFiles =
+            AbsoluteFile.fromFiles(files, c.common.workingDirectory))
+        }
+        .hidden() // this option isn't needed anymore. Simply pass the files as
+        // arguments. Keeping for backwards compatability
+        .text("file or directory, in which case all *.scala files are formatted. Deprecated: pass files as arguments")
+
       opt[Unit]('i', "in-place")
         .action((opt, c) => c.copy(writeMode = Override))
+        .hidden() // this option isn't needed anymore. Simply don't pass
+        // --stdout. Keeping for backwards compatability
         .text("format files in-place (default)")
+
       opt[Unit]("stdout")
         .action((opt, c) => c.copy(writeMode = Stdout))
         .text("write formatted files to stdout")

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -34,15 +34,9 @@ object CliOptions {
     } else {
       tryCurrentDirectory(parsed).orElse(tryGit(parsed))
     }
-    val inplace =
-      args.isEmpty || {
-        !parsed.testing && (
-          parsed.inPlace ||
-          (parsed.customFiles.isEmpty && style.isDefined)
-        )
-      }
+    val newMode = if (parsed.testing) Stdout else parsed.writeMode
     parsed.copy(
-      inPlace = inplace,
+      writeMode = newMode,
       config = style.getOrElse(parsed.config)
     )
   }
@@ -86,7 +80,7 @@ case class CliOptions(
     range: Set[Range] = Set.empty[Range],
     customFiles: Seq[AbsoluteFile] = Nil,
     customExcludes: Seq[String] = Nil,
-    inPlace: Boolean = false,
+    writeMode: WriteMode = Override,
     testing: Boolean = false,
     stdIn: Boolean = false,
     quiet: Boolean = false,
@@ -98,7 +92,8 @@ case class CliOptions(
     common: CommonOptions = CommonOptions(),
     gitOpsConstructor: AbsoluteFile => GitOps = x => new GitOpsImpl(x)
 ) {
-  require(!(inPlace && testing), "inPlace and testing can't both be true")
+
+  val inPlace: Boolean = writeMode == Override
 
   val gitOps: GitOps = gitOpsConstructor(common.workingDirectory)
   def withProject(projectFiles: ProjectFiles): CliOptions = {

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -85,6 +85,7 @@ case class CliOptions(
     stdIn: Boolean = false,
     quiet: Boolean = false,
     debug: Boolean = false,
+    inputGit: Boolean = false,
     nonInteractive: Boolean = false,
     diff: Option[String] = None,
     assumeFilename: String = "stdin.scala", // used when read from stdin
@@ -94,6 +95,9 @@ case class CliOptions(
 ) {
 
   val inPlace: Boolean = writeMode == Override
+
+  val git: Boolean =
+    config.project.git || inputGit
 
   val gitOps: GitOps = gitOpsConstructor(common.workingDirectory)
   def withProject(projectFiles: ProjectFiles): CliOptions = {

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/FileFetchMode.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/FileFetchMode.scala
@@ -1,0 +1,23 @@
+package org.scalafmt.cli
+
+/**
+  * Determines how we fetch files for formatting
+  */
+sealed trait FileFetchMode
+
+/**
+  * A simple recursive strategy where each directory is expanded
+  */
+final case object RecursiveSearch extends FileFetchMode
+
+/**
+  * A call to `git ls-files --name-only <dir>`
+  */
+final case object GitFiles extends FileFetchMode
+
+/**
+  * A call to `git diff --name-only --diff-filter=d <branch>`
+  *
+  * When this is set, files passed via the cli are ignored.
+  */
+final case class DiffFiles(branch: String) extends FileFetchMode

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/WriteMode.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/WriteMode.scala
@@ -1,0 +1,19 @@
+package org.scalafmt.cli
+
+import scopt.Read
+
+sealed trait WriteMode
+
+object WriteMode {
+  implicit val readInst: Read[WriteMode] =
+    Read.reads { _.toLowerCase match {
+      case "override" => Override
+      case "stdout" => Stdout
+      case otherwise =>
+        throw new IllegalArgumentException(
+          s"`$otherwise` is not allowed. Expected `override` or `stdout`")
+    }}
+}
+
+case object Override extends WriteMode
+case object Stdout extends WriteMode

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/WriteMode.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/WriteMode.scala
@@ -2,18 +2,13 @@ package org.scalafmt.cli
 
 import scopt.Read
 
+/**
+ * Determines the mode in which Scalafmt will behave
+ *
+ * Override = Replace the file with its formatted form
+ * Stdout = Print the formatted file to Stdout (leaving the original file untouched)
+ */
 sealed trait WriteMode
-
-object WriteMode {
-  implicit val readInst: Read[WriteMode] =
-    Read.reads { _.toLowerCase match {
-      case "override" => Override
-      case "stdout" => Stdout
-      case otherwise =>
-        throw new IllegalArgumentException(
-          s"`$otherwise` is not allowed. Expected `override` or `stdout`")
-    }}
-}
 
 case object Override extends WriteMode
 case object Stdout extends WriteMode

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/WriteMode.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/WriteMode.scala
@@ -3,11 +3,11 @@ package org.scalafmt.cli
 import scopt.Read
 
 /**
- * Determines the mode in which Scalafmt will behave
- *
- * Override = Replace the file with its formatted form
- * Stdout = Print the formatted file to Stdout (leaving the original file untouched)
- */
+  * Determines the mode in which Scalafmt will behave
+  *
+  * Override = Replace the file with its formatted form
+  * Stdout = Print the formatted file to Stdout (leaving the original file untouched)
+  */
 sealed trait WriteMode
 
 case object Override extends WriteMode

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -7,7 +7,7 @@ import org.scalafmt.util.OsSpecific
 case class ProjectFiles(
     git: Boolean = false,
     files: Seq[String] = Nil,
-    includeFilters: Seq[String] = Seq(".*\\.scala", ".*\\.sbt"),
+    includeFilters: Seq[String] = Seq(".*\\.scala$", ".*\\.sbt$"),
     excludeFilters: Seq[String] = Nil
 ) {
   lazy val matcher: FilterMatcher =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/AbsoluteFile.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/AbsoluteFile.scala
@@ -6,6 +6,8 @@ import java.io.File
 sealed abstract case class AbsoluteFile(jfile: File) {
   def path: String = jfile.getAbsolutePath
   def /(other: String) = new AbsoluteFile(new File(jfile, other)) {}
+
+  override def toString(): String = path
 }
 
 object AbsoluteFile {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -8,7 +8,7 @@ import java.io.File
 
 trait GitOps {
   def diff(branch: String): Seq[AbsoluteFile]
-  def lsFiles(dir: AbsoluteFile): Seq[AbsoluteFile]
+  def lsTree(dir: AbsoluteFile): Seq[AbsoluteFile]
   def rootDir: Option[AbsoluteFile]
 }
 
@@ -35,18 +35,23 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
     }
   }
 
-  override def lsFiles(dir: AbsoluteFile): Seq[AbsoluteFile] =
-    Try {
-      exec(
-        Seq(
-          "git",
-          "ls-files",
-          dir.path
-        )
-      ).split(OsSpecific.lineSeparator).toSeq.collect {
-        case f if new File(f).isFile => workingDirectory / f
-      }
-    }.getOrElse(Nil)
+  override def lsTree(dir: AbsoluteFile): Seq[AbsoluteFile] =
+    rootDir.fold(Seq.empty[AbsoluteFile]) { rtDir => 
+      Try {
+        exec(
+          Seq(
+            "git",
+            "ls-tree",
+            "-r",
+            "HEAD",
+            "--name-only",
+            dir.path
+          )
+        ).split(OsSpecific.lineSeparator).toSeq.collect {
+          case f if new File(f).isFile => rtDir / f
+        }
+      }.getOrElse(Nil)
+    }
 
   override def rootDir: Option[AbsoluteFile] =
     Try {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -8,7 +8,7 @@ import java.io.File
 
 trait GitOps {
   def diff(branch: String): Seq[AbsoluteFile]
-  def lsTree: Seq[AbsoluteFile]
+  def lsFiles(dir: AbsoluteFile): Seq[AbsoluteFile]
   def rootDir: Option[AbsoluteFile]
 }
 
@@ -35,15 +35,13 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
     }
   }
 
-  override def lsTree: Seq[AbsoluteFile] =
+  override def lsFiles(dir: AbsoluteFile): Seq[AbsoluteFile] =
     Try {
       exec(
         Seq(
           "git",
-          "ls-tree",
-          "-r",
-          "HEAD",
-          "--name-only"
+          "ls-files",
+          dir.path
         )
       ).split(OsSpecific.lineSeparator).toSeq.collect {
         case f if new File(f).isFile => workingDirectory / f

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -36,7 +36,7 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
   }
 
   override def lsTree(dir: AbsoluteFile): Seq[AbsoluteFile] =
-    rootDir.fold(Seq.empty[AbsoluteFile]) { rtDir => 
+    rootDir.fold(Seq.empty[AbsoluteFile]) { rtDir =>
       Try {
         exec(
           Seq(

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -148,19 +148,7 @@ class CliTest extends FunSuite with DiffAssertions {
     assert(str == unformatted)
   }
 
-  test("scalafmt --write-mode=override foo.randomsuffix is formatted") {
-    val tmpFile = Files.createTempFile("prefix", "randomsuffix")
-    Files.write(tmpFile, unformatted.getBytes)
-    val args = Array(
-      "--write-mode=override",
-      tmpFile.toFile.getAbsolutePath
-    )
-    Cli.main(args)
-    val obtained = FileOps.readFile(tmpFile.toString)
-    assertNoDiff(obtained, formatted)
-  }
-
-  test("scalafmt -i is an alias for --write-mode=override") {
+  test("scalafmt -i foo.randomsuffix is formatted") {
     val tmpFile = Files.createTempFile("prefix", "randomsuffix")
     Files.write(tmpFile, unformatted.getBytes)
     val args = Array(

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -332,7 +332,7 @@ class CliTest extends FunSuite with DiffAssertions {
       val mock = getMockOptions(input, workingDir)
       mock.copy(common = mock.common.copy(workingDirectory = workingDir))
     }
-    val config = Cli.getConfig(Array("-i","foo.scala"), options).get
+    val config = Cli.getConfig(Array("-i", "foo.scala"), options).get
     Cli.run(config)
     val obtained = FileOps.readFile(workingDir / "foo.scala")
     assertNoDiff(obtained, expected)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
@@ -5,7 +5,8 @@ import org.scalafmt.util.FileOps
 import org.scalafmt.util.GitOps
 
 class FakeGitOps(root: AbsoluteFile) extends GitOps {
-  override def lsFiles(dir: AbsoluteFile): Vector[AbsoluteFile] = FileOps.listFiles(dir)
+  override def lsFiles(dir: AbsoluteFile): Vector[AbsoluteFile] =
+    FileOps.listFiles(dir)
   override def rootDir: Option[AbsoluteFile] = Some(root)
   override def diff(branch: String): Seq[AbsoluteFile] = lsFiles(root)
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
@@ -5,8 +5,8 @@ import org.scalafmt.util.FileOps
 import org.scalafmt.util.GitOps
 
 class FakeGitOps(root: AbsoluteFile) extends GitOps {
-  override def lsFiles(dir: AbsoluteFile): Vector[AbsoluteFile] =
+  override def lsTree(dir: AbsoluteFile): Vector[AbsoluteFile] =
     FileOps.listFiles(dir)
   override def rootDir: Option[AbsoluteFile] = Some(root)
-  override def diff(branch: String): Seq[AbsoluteFile] = lsFiles(root)
+  override def diff(branch: String): Seq[AbsoluteFile] = lsTree(root)
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
@@ -5,7 +5,7 @@ import org.scalafmt.util.FileOps
 import org.scalafmt.util.GitOps
 
 class FakeGitOps(root: AbsoluteFile) extends GitOps {
-  override def lsTree: Vector[AbsoluteFile] = FileOps.listFiles(root)
+  override def lsFiles(dir: AbsoluteFile): Vector[AbsoluteFile] = FileOps.listFiles(dir)
   override def rootDir: Option[AbsoluteFile] = Some(root)
-  override def diff(branch: String): Seq[AbsoluteFile] = lsTree
+  override def diff(branch: String): Seq[AbsoluteFile] = lsFiles(root)
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/DiffAssertions.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/DiffAssertions.scala
@@ -8,6 +8,7 @@ import java.util.TimeZone
 
 import org.scalactic.source.Position
 import org.scalatest.FunSuiteLike
+import org.scalatest.exceptions.StackDepthException
 import org.scalatest.exceptions.TestFailedException
 
 trait DiffAssertions extends FunSuiteLike {
@@ -18,7 +19,7 @@ trait DiffAssertions extends FunSuiteLike {
                          obtained: String,
                          diff: String)(implicit pos: Position)
       extends TestFailedException(
-        _ => Some(title + "\n" + error2message(obtained, expected)),
+        (_: StackDepthException) => Some(title + "\n" + error2message(obtained, expected)),
         None: Option[Throwable],
         pos)
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/DiffAssertions.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/DiffAssertions.scala
@@ -19,7 +19,8 @@ trait DiffAssertions extends FunSuiteLike {
                          obtained: String,
                          diff: String)(implicit pos: Position)
       extends TestFailedException(
-        (_: StackDepthException) => Some(title + "\n" + error2message(obtained, expected)),
+        (_: StackDepthException) =>
+          Some(title + "\n" + error2message(obtained, expected)),
         None: Option[Throwable],
         pos)
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSuite
 
 class GitOpsTest extends FunSuite {
   test("lsTree") {
-    val files = GitOps().lsFiles(AbsoluteFile.userDir)
+    val files = GitOps().lsTree(AbsoluteFile.userDir)
     assert(files.exists(x => x.path.endsWith(s".gitignore")))
   }
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSuite
 
 class GitOpsTest extends FunSuite {
   test("lsTree") {
-    val files = GitOps().lsTree
+    val files = GitOps().lsFiles(AbsoluteFile.userDir)
     assert(files.exists(x => x.path.endsWith(s".gitignore")))
   }
 }


### PR DESCRIPTION
Implement #875: Remake scalafmt's CLI

* Remove --files
  * Instead, files are take in as arguments (like a normal cli)
  * If no arguments are passed, `./` is assumed
* Remake how we handle write-modes
  * Write modes can either be `Override` (in-place) or `Stdout` (--stdout)
  * `-i/--in-place` is now the default all of the time
  * `--stdout` will print to stdout the formatted files
* Implement a `--git=[true|flase]` flag that will override `.scalafmt.conf`
* Fix an issue where the default `includeFilters` accepted more than just `scala` and `sbt`
* [Internal] Simplify how we fetch files (now it all goes through one function)
* [Internal] Simplify how we use CliOptions