### PR TITLE
Harden AvoidInfix.

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
@@ -140,3 +140,12 @@ seq should have length 5 and true
 "org.scalamacros" % "paradise" % "2.1.0" intransitive()
 >>>
 ("org.scalamacros" % "paradise" % "2.1.0").intransitive()
+<<< double nest
+    def contains(ip: String) = apply map (_ blah strToIp(ip))
+>>>
+def contains(ip: String) = apply.map(_.blah(strToIp(ip)))
+<<< crazy
+ val makeVersion = nodots _ compose stripVersion _
+
+>>>
+val makeVersion = (nodots _).compose(stripVersion _)


### PR DESCRIPTION
I ran AvoidInfix on ornicar/lila and found a bunch of errors.

- Don't remove critical parens in nested infix.
- Handle eta expansion in lhs infix application.