### PR TITLE
Add support for inserting a line break between a curly if and an else.

### DIFF
--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -476,6 +476,28 @@
       @lnk("this comment", "https://github.com/scalameta/scalafmt/pull/611#issue-196230948")
       for further motivation.
 
+
+  @sect{newlines.alwaysBeforeElseAfterCurlyIf}
+    Default: @b(default.newlines.alwaysBeforeElseAfterCurlyIf)
+
+    @hl.scala
+      // newlines.alwaysBeforeElseAfterCurlyIf = true
+      if(someCond) {
+        foo()
+      }
+      else {
+        bar()
+      }
+
+      // newlines.alwaysBeforeElseAfterCurlyIf = false
+      if(someCond) {
+        foo()
+      } else {
+        bar()
+      }
+
+
+
   @sect{binPack.literalArgumentLists}
     Default: @b(default.binPack.literalArgumentLists)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -96,6 +96,12 @@ import metaconfig._
   *     c: Context
   *   ): String
   * }}}
+  * @param alwaysBeforeElseAfterCurlyIf if true, add a new line between the end of a curly if and the following else.
+  *   For example
+  *   if(someCond) {
+  *     // ...
+  *   }
+  *   else //...
   */
 @DeriveConfDecoder
 case class Newlines(
@@ -107,7 +113,8 @@ case class Newlines(
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
     afterImplicitKWInVerticalMultiline: Boolean = false,
-    beforeImplicitKWInVerticalMultiline: Boolean = false
+    beforeImplicitKWInVerticalMultiline: Boolean = false,
+    alwaysBeforeElseAfterCurlyIf: Boolean = false
 )
 
 sealed abstract class NewlineCurlyLambda

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1067,7 +1067,10 @@ class Router(formatOps: FormatOps) {
             .withPolicy(SingleLineBlock(expire, exclude = exclude)),
           Split(newlineModification, 1).withIndent(2, expire, Left)
         )
-      case FormatToken(RightBrace(), KwElse() | KwYield(), _) =>
+      case FormatToken(RightBrace(), KwElse(), _) =>
+        if (style.newlines.alwaysBeforeElseAfterCurlyIf) Seq(Split(Newline, 0))
+        else Seq(Split(Space, 0))
+      case FormatToken(RightBrace(), KwYield(), _) =>
         Seq(
           Split(Space, 0)
         )

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeElseAfterCurlyIf.stat
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeElseAfterCurlyIf.stat
@@ -1,0 +1,12 @@
+style = default
+newlines.alwaysBeforeElseAfterCurlyIf = true
+
+<<< Insert line break between curly if and else
+if (someCond) {
+  something()
+} else somethingElse()
+>>>
+if (someCond) {
+  something()
+}
+else somethingElse()


### PR DESCRIPTION
```scala
// newlines.alwaysBeforeElseAfterCurlyIf = true
if(someCond) {
  foo()
}
else {
  bar()
}

// newlines.alwaysBeforeElseAfterCurlyIf = false
if(someCond) {
  foo()
} else {
  bar()
}
```