### PR TITLE
Implement option for discarding whitespace between a keyword and left-paren

### DIFF
--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -379,6 +379,21 @@
       implicit def validatedInstances[E](implicit E: Semigroup[E]): Traverse[
           Validated[E, ?]] with ApplicativeError[Validated[E, ?], E] = 2
 
+  @sect{spaces.afterKeywordBeforeParen}
+    Default: @b(default.spaces.afterKeywordBeforeParen)
+
+    @hl.scala
+      // spaces.afterKeywordBeforeParen = true
+      if(a) foo()
+      while(a) foo()
+      for(a <- as) foo()
+
+      // spaces.afterKeywordBeforeParen = false
+      if (a) foo()
+      while (a) foo()
+      for (a <- as) foo()
+
+
   @sect{binPack.parentConstructors}
     Default: @b(default.binPack.parentConstructors)
 

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -384,14 +384,14 @@
 
     @hl.scala
       // spaces.afterKeywordBeforeParen = true
-      if(a) foo()
-      while(a) foo()
-      for(a <- as) foo()
-
-      // spaces.afterKeywordBeforeParen = false
       if (a) foo()
       while (a) foo()
       for (a <- as) foo()
+
+      // spaces.afterKeywordBeforeParen = false
+      if(a) foo()
+      while(a) foo()
+      for(a <- as) foo()
 
 
   @sect{binPack.parentConstructors}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
@@ -14,7 +14,7 @@ import org.scalafmt.config.SpaceBeforeContextBound.Never
   * @param neverAroundInfixTypes
   *   If ["##"] is specified as operator then
   *   formats `Generic[Foo] ## Repr` as `Generic[Foo]##Repr`.
-  * @param afterKeywordBeforeParen if true, adds a space betwen a keyword and a parenthesis.
+  * @param afterKeywordBeforeParen if false, does not add a space betwen a keyword and a parenthesis.
   *   For example:
   *   if(a) println("HELLO!")
   *   while(a) println("HELLO!")
@@ -26,5 +26,5 @@ case class Spaces(
     inImportCurlyBraces: Boolean = false,
     inParentheses: Boolean = false,
     neverAroundInfixTypes: Seq[String] = Nil,
-    afterKeywordBeforeParen: Boolean = false
+    afterKeywordBeforeParen: Boolean = true
 )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
@@ -14,6 +14,10 @@ import org.scalafmt.config.SpaceBeforeContextBound.Never
   * @param neverAroundInfixTypes
   *   If ["##"] is specified as operator then
   *   formats `Generic[Foo] ## Repr` as `Generic[Foo]##Repr`.
+  * @param afterKeywordBeforeParen if true, adds a space betwen a keyword and a parenthesis.
+  *   For example:
+  *   if(a) println("HELLO!")
+  *   while(a) println("HELLO!")
   */
 @DeriveConfDecoder
 case class Spaces(
@@ -21,5 +25,6 @@ case class Spaces(
     afterTripleEquals: Boolean = false,
     inImportCurlyBraces: Boolean = false,
     inParentheses: Boolean = false,
-    neverAroundInfixTypes: Seq[String] = Nil
+    neverAroundInfixTypes: Seq[String] = Nil,
+    afterKeywordBeforeParen: Boolean = false
 )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -550,7 +550,7 @@ class Router(formatOps: FormatOps) {
 
       // If configured to skip the trailing space after `if` and other keywords, do so.
       case FormatToken(KwIf() | KwFor() | KwWhile(), LeftParen(), _)
-          if style.spaces.afterKeywordBeforeParen =>
+          if !style.spaces.afterKeywordBeforeParen =>
         Seq(Split(NoSplit, 0))
 
       case tok @ FormatToken(LeftParen() | LeftBracket(), right, between)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -545,7 +545,14 @@ class Router(formatOps: FormatOps) {
             .withPolicy(unindentPolicy)
             .withIndent(4, close, Left)
         )
-      case FormatToken(LeftParen(), RightParen(), _) => Seq(Split(NoSplit, 0))
+      case FormatToken(LeftParen(), RightParen(), _) =>
+        Seq(Split(NoSplit, 0))
+
+      // If configured to skip the trailing space after `if` and other keywords, do so.
+      case FormatToken(KwIf() | KwFor() | KwWhile(), LeftParen(), _)
+          if style.spaces.afterKeywordBeforeParen =>
+        Seq(Split(NoSplit, 0))
+
       case tok @ FormatToken(LeftParen() | LeftBracket(), right, between)
           if !isSuperfluousParenthesis(formatToken.left, leftOwner) &&
             (!style.binPack.unsafeCallSite && isCallSite(leftOwner)) ||

--- a/scalafmt-tests/src/test/resources/spaces/AfterKeywordBeforeParen.stat
+++ b/scalafmt-tests/src/test/resources/spaces/AfterKeywordBeforeParen.stat
@@ -1,0 +1,13 @@
+spaces.afterKeywordBeforeParen = true
+<<< reformats if
+if (a) println("HELLO!")
+>>>
+if(a) println("HELLO!")
+<<< reformats while
+while (a) println("HELLO!")
+>>>
+while(a) println("HELLO!")
+<<< reformats for
+for (a <- as) println("HELLO!")
+>>>
+for(a <- as) println("HELLO!")

--- a/scalafmt-tests/src/test/resources/spaces/AfterKeywordBeforeParen.stat
+++ b/scalafmt-tests/src/test/resources/spaces/AfterKeywordBeforeParen.stat
@@ -1,4 +1,4 @@
-spaces.afterKeywordBeforeParen = true
+spaces.afterKeywordBeforeParen = false
 <<< reformats if
 if (a) println("HELLO!")
 >>>


### PR DESCRIPTION
## spaces.afterKeywordBeforeParen
Default: `true`

```scala
// spaces.afterKeywordBeforeParen = false
if(a) foo()
while(a) foo()
for(a <- as) foo()

// spaces.afterKeywordBeforeParen = true
if (a) foo()
while (a) foo()
for (a <- as) foo()
```