### PR TITLE
Use the VCS root as a potential config path in the IntelliJ plugin

### DIFF
--- a/scalafmt-intellij/readme.md
+++ b/scalafmt-intellij/readme.md
@@ -13,7 +13,8 @@
 1. Select `Import module`;
 1. Be sure the `unmanaged-jars` dependency in the `intellij` module is set to `provided`
    inside `Project structure`/`Project settings`/`Modules`/`Dependencies` (btw, setting `provided` inside sbt file gives error);
-   Without this setting, the generated zip file will be >100mb instead of ~20mb.
+   Without this setting you'll get a classpath collision at runtime (and the generated zip file
+   will be >100mb instead of ~20mb).
 1. Right click on top of `intellij-scalafmt` plugin module and select `Prepare Plugin Module 'intellij-scalafmt' for deployment`;
 
 If everything went smoothly, you should have a `intellij-scalafmt/intellij-scalafmt.zip` file

--- a/scalafmt-intellij/src/main/scala/org/scalafmt/intellij/FileDocument.scala
+++ b/scalafmt-intellij/src/main/scala/org/scalafmt/intellij/FileDocument.scala
@@ -53,7 +53,8 @@ case class FileDocument(project: Option[Project], document: Document) {
 
 object FileDocument {
   def apply(document: Document): FileDocument = {
-    val project = projectForFile(FileDocumentManager.getInstance().getFile(document))
+    val project = projectForFile(
+      FileDocumentManager.getInstance().getFile(document))
     FileDocument(project, document)
   }
 }

--- a/scalafmt-intellij/src/main/scala/org/scalafmt/intellij/FileDocument.scala
+++ b/scalafmt-intellij/src/main/scala/org/scalafmt/intellij/FileDocument.scala
@@ -12,16 +12,15 @@ import org.scalafmt.{Formatted, Scalafmt}
 import IdeaUtils._
 import com.intellij.openapi.project.Project
 
-case class FileDocument(document: Document) {
-  private val virtualFile = FileDocumentManager.getInstance().getFile(document)
+case class FileDocument(project: Option[Project], document: Document) {
+  val virtualFile = FileDocumentManager.getInstance().getFile(document)
   def path = virtualFile.getPath
   def isSbt: Boolean = virtualFile.getFileType.getName == "SBT"
   def isScala: Boolean = virtualFile.getFileType.getName == "Scala"
   def canFormat: Boolean = isScala || isSbt
-  def project: Option[Project] = projectForFile(virtualFile.getPath)
 
   def format(): Unit = if (canFormat) {
-    val style = getStyle(project)
+    val style = getStyle(project, virtualFile)
     val runner =
       if (isSbt)
         style.runner.copy(dialect = scala.meta.dialects.Sbt0137)
@@ -49,5 +48,12 @@ case class FileDocument(document: Document) {
           })
         }
     }
+  }
+}
+
+object FileDocument {
+  def apply(document: Document): FileDocument = {
+    val project = projectForFile(FileDocumentManager.getInstance().getFile(document))
+    FileDocument(project, document)
   }
 }

--- a/scalafmt-intellij/src/main/scala/org/scalafmt/intellij/OnFileSaveComponent.scala
+++ b/scalafmt-intellij/src/main/scala/org/scalafmt/intellij/OnFileSaveComponent.scala
@@ -11,7 +11,11 @@ class OnFileSaveComponent extends ApplicationComponent {
   def getComponentName = IdeaUtils.PluginName
 
   def isIncludedInSettings(doc: FileDocument): Boolean =
-    IdeaUtils.getStyle(doc.project, doc.virtualFile).project.matcher.matches(doc.path)
+    IdeaUtils
+      .getStyle(doc.project, doc.virtualFile)
+      .project
+      .matcher
+      .matches(doc.path)
 
   def initComponent() {
     val bus = ApplicationManager.getApplication.getMessageBus

--- a/scalafmt-intellij/src/main/scala/org/scalafmt/intellij/OnFileSaveComponent.scala
+++ b/scalafmt-intellij/src/main/scala/org/scalafmt/intellij/OnFileSaveComponent.scala
@@ -11,7 +11,7 @@ class OnFileSaveComponent extends ApplicationComponent {
   def getComponentName = IdeaUtils.PluginName
 
   def isIncludedInSettings(doc: FileDocument): Boolean =
-    IdeaUtils.getStyle(doc.project).project.matcher.matches(doc.path)
+    IdeaUtils.getStyle(doc.project, doc.virtualFile).project.matcher.matches(doc.path)
 
   def initComponent() {
     val bus = ApplicationManager.getApplication.getMessageBus


### PR DESCRIPTION
Currently if the IntelliJ "project directory" is not located under the root of the repository for a project, two issues occur:

1. Because the plugin was determining the project for a file by comparing `project.getBasePath` to the file path, no project would be detected, and so there was nowhere to look for a scalafmt.conf other than the HOME directory.
1. Because the Project was not located under the root of the repository, even after successfully finding a project, we would not find a relevant config in the project directory.

This change fixes the first issue by using the ProjectFileIndex (as recommended [here](http://www.jetbrains.org/intellij/sdk/docs/reference_guide/project_model/project.html#checking-if-a-file-belongs-to-a-project)), and the second issue by using the Project to locate a configured VCS and look for a config there as well.