### PR TITLE
Fail fast on invalid .scalafmt.conf when running with no args.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,8 @@ version: '{build}'
 os: Windows Server 2012
 install:
   - ps: iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
-  - ps: scoop install sbt
+  - ps: scoop bucket add versions
+  - ps: scoop install sbt0.13
 environment:
   CI_SCALA_VERSION: 2.12.2
 build_script:

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -2,7 +2,8 @@ package org.scalafmt.cli
 
 import java.io.InputStream
 import java.io.PrintStream
-
+import metaconfig.Configured.NotOk
+import metaconfig.Configured.Ok
 import org.scalafmt.config.Config
 import org.scalafmt.config.FilterMatcher
 import org.scalafmt.config.ProjectFiles
@@ -47,14 +48,12 @@ object CliOptions {
     for {
       configFile <- Option(getConfigJFile(dir))
       if configFile.jfile.isFile
-      parsedConfig <- {
-        Config
-          .fromHoconString(FileOps.readFile(configFile))
-          .toEither
-          .right
-          .toOption
+    } yield
+      Config.fromHoconString(FileOps.readFile(configFile)) match {
+        case Ok(value) => value
+        // Fail fast on invalid configuration.
+        case NotOk(error) => throw new IllegalArgumentException(error.msg)
       }
-    } yield parsedConfig
   }
 
   private def tryGit(options: CliOptions): Option[ScalafmtConfig] = {


### PR DESCRIPTION
`./scalafmt` would fall back to the default style if .scalafmt.conf
had a typo. Now it fails fast.