### PR TITLE
Add new setting `includeFixesFrom.v1_2_0 = false`.

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IncludeFixesFrom.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IncludeFixesFrom.scala
@@ -1,0 +1,12 @@
+package org.scalafmt.config
+
+import metaconfig._
+
+@DeriveConfDecoder
+case class IncludeFixesFrom(
+    v1_2_0: Boolean = true
+)
+
+object IncludeFixesFrom {
+  val default = IncludeFixesFrom()
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -144,6 +144,7 @@ case class ScalafmtConfig(
     verticalMultilineAtDefinitionSite: Boolean = false,
     onTestFailure: String = "",
     encoding: Codec = "UTF-8",
+    @Recurse includeFixesFrom: IncludeFixesFrom = IncludeFixesFrom.default,
     @Recurse project: ProjectFiles = ProjectFiles()
 ) {
   implicit val alignDecoder: ConfDecoder[Align] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -297,9 +297,10 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
           if procedure.decltpe.isDefined &&
             procedure.decltpe.get.tokens.isEmpty =>
         procedure.body.tokens.find(_.is[LeftBrace])
-      case Defn.Def(_, _, _, _, _, b @ Term.Block(_)) =>
+      case Defn.Def(_, _, _, _, _, b @ Term.Block(_))
+          if initStyle.includeFixesFrom.v1_2_0 =>
         b.tokens.headOption
-      case _: Ctor.Primary =>
+      case _: Ctor.Primary if initStyle.includeFixesFrom.v1_2_0 =>
         leftTok2tok(matchingParentheses(hash(open))) match {
           // This is a terrible terrible hack. Please consider removing this.
           // The RightParen() LeftBrace() pair is presumably a ") {" combination

--- a/scalafmt-tests/src/test/resources/newdefault/includeFixesFrom.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/includeFixesFrom.stat
@@ -1,0 +1,14 @@
+style = default
+includeFixesFrom.v1_2_0 = false
+<<< native 82
+class Motion(val callsign: CallSign, val posOne: Vector3D, val posTwo: Vector3D) {
+  def renderScene(scene: Scene, canvasContext: CanvasRenderingContext2D): Unit = {
+    blah
+  }
+}
+>>>
+class Motion(val callsign: CallSign, val posOne: Vector3D, val posTwo: Vector3D) {
+  def renderScene(scene: Scene, canvasContext: CanvasRenderingContext2D): Unit = {
+    blah
+  }
+}


### PR DESCRIPTION
This setting allows users to upgrade integrations such as the IntelliJ
plugin without having their codebase formatted against the latest
scalafmt fixes. Large codebases may prefer to wait upgrading scalafmt to
bundle multiple version upgrades in a single PR.

Any thoughts @stuhood @xeno-by ?