### PR TITLE
Return non-zero exit code in ./scalafmt if no files match filter

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -9,6 +9,7 @@ import java.io.PrintStream
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.martiansoftware.nailgun.NGContext
+import org.scalafmt.Error.NoMatchingFiles
 import org.scalafmt.Error.UnableToParseCliOptions
 import org.scalafmt.Formatted
 import org.scalafmt.Scalafmt
@@ -153,6 +154,7 @@ object Cli {
 
   def run(options: CliOptions): Unit = {
     val inputMethods = getInputMethods(options)
+    if (inputMethods.isEmpty) throw NoMatchingFiles
     val counter = new AtomicInteger()
     val termDisplayMessage =
       if (options.testing) "Looking for unformatted files..."
@@ -171,7 +173,6 @@ object Cli {
     val sbtOptions = options.copy(
       config = options.config.copy(runner = options.config.runner.forSbt))
     val termDisplay = newTermDisplay(options, inputMethods, termDisplayMessage)
-    val N = inputMethods.length
     inputMethods.par.foreach { inputMethod =>
       val inputConfig = if (inputMethod.isSbt) sbtOptions else options
       handleFile(inputMethod, inputConfig)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
@@ -78,6 +78,12 @@ object Error {
   case class InvalidScalafmtConfiguration(throwable: Throwable)
       extends Error(s"Failed to read configuration: $throwable")
 
+  case object NoMatchingFiles
+      extends Error(
+        "No files formatted/tested. " +
+          "Verify your configured include/exclude filters and " +
+          "supplied command line arguments.")
+
   case class InvalidOption(option: String)
       extends Error(s"Invalid option $option")
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -10,6 +10,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import org.scalafmt.Error.MisformattedFile
+import org.scalafmt.Error.NoMatchingFiles
 import org.scalafmt.config.Config
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.util.AbsoluteFile
@@ -49,7 +50,7 @@ abstract class AbstractCliTest extends FunSuite with DiffAssertions {
 
   val baseCliOptions: CliOptions = getMockOptions(
     AbsoluteFile
-      .fromPath(File.createTempFile("base", "dir").getAbsolutePath)
+      .fromPath(Files.createTempDirectory("base-dir").toString)
       .get)
 
   def getConfig(args: Array[String]): CliOptions = {
@@ -271,6 +272,12 @@ class CliTest extends AbstractCliTest {
     }
     check("notfound")
     check("target/notfound")
+  }
+
+  test("scalafmt (no matching files) throws error") {
+    intercept[NoMatchingFiles.type] {
+      Cli.run(baseCliOptions)
+    }
   }
 
   test("scalafmt (no arg) read config from git repo") {

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FileTestOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FileTestOps.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.cli
 
 import java.io.File
+import java.nio.file.Files
 
 import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.FileOps
@@ -12,9 +13,7 @@ object FileTestOps {
     * necessary files/directories with respective file contents.
     */
   def string2dir(layout: String): AbsoluteFile = {
-    val root = File.createTempFile("root", "root")
-    root.delete()
-    root.mkdir()
+    val root = Files.createTempDirectory("root").toFile
     layout.split("(?=\n/)").foreach { row =>
       val path :: contents :: Nil =
         row.stripPrefix("\n").split("\n", 2).toList


### PR DESCRIPTION
Intends to fix #876 