### PR TITLE
Git testing framework and fix for some git-file-fetching issues

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -6,7 +6,8 @@ object Mima {
     // See https://github.com/typesafehub/migration-manager/wiki/sbt-plugin#basic-usage
     Seq(
       ProblemFilters.exclude[Problem]("org.scalafmt.config.*"),
-      ProblemFilters.exclude[Problem]("org.scalafmt.internal.*")
+      ProblemFilters.exclude[Problem]("org.scalafmt.internal.*"),
+      ProblemFilters.exclude[Problem]("org.scalafmt.util.GitOpsImpl.*")
     )
   }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -16,42 +16,41 @@ object GitOps {
   def apply(): GitOps = new GitOpsImpl(AbsoluteFile.userDir)
 }
 
-class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
+class GitOpsImpl(private[util] val workingDirectory: AbsoluteFile)
+    extends GitOps {
 
-  def exec(cmd: Seq[String]): String = {
-    val lastError = new StringBuilder
-    val swallowStderr = ProcessLogger(_ => Unit, err => lastError.append(err))
-    try {
-      sys.process
-        .Process(cmd, workingDirectory.jfile)
-        .!!(swallowStderr)
-        .trim
-    } catch {
-      case NonFatal(e) =>
-        throw new IllegalStateException(
-          s"Failed to run command ${cmd.mkString(" ")}. " +
-            s"Error: ${lastError.toString()}",
-          e)
+  private[util] def exec(cmd: Seq[String]): Try[Seq[String]] = {
+    val gitRes: Try[String] = Try {
+      val lastError = new StringBuilder
+      val swallowStderr = ProcessLogger(_ => Unit, err => lastError.append(err))
+      try {
+        sys.process
+          .Process(cmd, workingDirectory.jfile)
+          .!!(swallowStderr)
+          .trim
+      } catch {
+        case NonFatal(e) =>
+          throw new IllegalStateException(
+            s"Failed to run command ${cmd.mkString(" ")}. " +
+              s"Error: ${lastError.toString()}",
+            e)
+      }
     }
+
+    gitRes.map(_.lines.toSeq)
   }
 
   override def lsTree(dir: AbsoluteFile): Seq[AbsoluteFile] =
     rootDir.fold(Seq.empty[AbsoluteFile]) { rtDir =>
-      Try {
-        exec(
-          Seq(
-            "git",
-            "ls-tree",
-            "-r",
-            "HEAD",
-            "--name-only",
-            "--full-name",
-            dir.path
-          )
-          // DESNOTE(2017-06-02, pjrt): Since the git command above only returns
-          // files, no need to check if they are files
-        ).split(OsSpecific.lineSeparator).toSeq.map(f => rtDir / f)
-      }.getOrElse(Nil)
+      exec(
+        Seq(
+          "git",
+          "ls-files",
+          dir.path
+        )
+        // DESNOTE(2017-06-02, pjrt): Since the git command above only returns
+        // files, no need to check if they are files
+      ).toOption.toSeq.flatten.map(f => rtDir / f)
     }
 
   override def rootDir: Option[AbsoluteFile] = {
@@ -61,7 +60,7 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
       "--show-toplevel"
     )
     for {
-      rootPath <- Try(exec(cmd)).toOption
+      Seq(rootPath) <- exec(cmd).toOption
       file <- AbsoluteFile.fromPath(rootPath)
       if file.jfile.isDirectory
     } yield file
@@ -79,7 +78,7 @@ class GitOpsImpl(workingDirectory: AbsoluteFile) extends GitOps {
     // files, no need to check if they are files
     for {
       root <- rootDir.toSeq
-      path <- Try(exec(cmd)).toOption.toSeq.flatMap(_.lines)
+      path <- exec(cmd).toOption.toSeq.flatten
     } yield AbsoluteFile.fromFile(new File(path), root)
   }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -48,8 +48,6 @@ class GitOpsImpl(private[util] val workingDirectory: AbsoluteFile)
           "ls-files",
           dir.path
         )
-        // DESNOTE(2017-06-02, pjrt): Since the git command above only returns
-        // files, no need to check if they are files
       ).toOption.toSeq.flatten.map(f => rtDir / f)
     }
 
@@ -74,8 +72,6 @@ class GitOpsImpl(private[util] val workingDirectory: AbsoluteFile)
       "--diff-filter=d",
       branch
     )
-    // DESNOTE(2017-06-02, pjrt): Since the git command above only returns
-    // files, no need to check if they are files
     for {
       root <- rootDir.toSeq
       path <- exec(cmd).toOption.toSeq.flatten

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -1,12 +1,209 @@
 package org.scalafmt.util
 
 import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
 
-import org.scalatest.FunSuite
+import scala.util._
 
-class GitOpsTest extends FunSuite {
-  test("lsTree") {
-    val files = GitOps().lsTree(AbsoluteFile.userDir)
-    assert(files.exists(x => x.path.endsWith(s".gitignore")))
+import org.scalatest._
+import org.scalactic.source.Position
+
+class GitOpsTest extends fixture.FunSuite {
+
+  import Matchers._
+  import GitOpsTest._
+
+  val root = AbsoluteFile.userDir
+  val dirName = "gitTestDir"
+
+  override type FixtureParam = GitOpsImpl
+
+  // DESNOTE(2017-08-16, pjrt): Create a temporary git directory for each
+  // test.
+  override def withFixture(test: OneArgTest) = {
+    val f = Files.createTempDirectory(dirName)
+    val absFile = AbsoluteFile.fromPath(f.toString).get
+    val ops = new GitOpsImpl(absFile)
+    init(ops)
+    // initial commit is needed
+    val initF = touch("initialfile")(ops)
+    add(initF)(ops)
+    commit(ops)
+    val t = try test.toNoArgTest(ops)
+    finally f.toFile.delete
+    withFixture(t)
   }
+
+  def touch(name: String = Random.alphanumeric.take(10).mkString)(
+      implicit ops: GitOpsImpl): AbsoluteFile = {
+    val f = File.createTempFile(name, ".ext", ops.workingDirectory.jfile)
+    AbsoluteFile.fromPath(f.toString).get
+  }
+
+  def modify(f: AbsoluteFile): Unit = {
+
+    val text = Random.alphanumeric.take(10).mkString
+    Files.write(Paths.get(f.path), text.getBytes(StandardCharsets.UTF_8))
+  }
+
+  def ls(implicit ops: GitOpsImpl) =
+    // DESNOTE(2017-08-17, pjrt): Filter out the initial file since it will
+    // just annoy us in the tests below
+    ops
+      .lsTree(ops.workingDirectory)
+      .filterNot(_.jfile.getName().contains("initialfile"))
+
+  test("lsTree should not return files not added to the index") {
+    implicit ops =>
+      touch()
+      ls shouldBe empty
+  }
+
+  test("#1010: lsTree should return staged files") { implicit ops =>
+    val f = touch()
+    add(f)
+    ls should contain only (f)
+  }
+
+  test("lsTree should return committed files") { implicit ops =>
+    val f = touch()
+    add(f)
+    commit
+    ls should contain only (f)
+  }
+
+  test("lsTree should not return commited files that have been deleted") {
+    implicit ops =>
+      val f = touch()
+      add(f)
+      commit
+      rm(f)
+      ls shouldBe empty
+  }
+
+  test("lsTree should return commited files that have been modified") {
+    implicit ops =>
+      val f = touch()
+      add(f)
+      commit
+      modify(f)
+      ls should contain only (f)
+  }
+
+  def diff(br: String = "HEAD")(implicit ops: GitOpsImpl): Seq[AbsoluteFile] =
+    ops.diff(br)
+
+  // diff
+  test("diff should return modified commited files") { implicit o =>
+    val f = touch()
+    add(f)
+    commit
+    modify(f)
+    diff() should contain only (f)
+  }
+
+  test("#1000: diff should not return git deleted files") { implicit o =>
+    val f = touch()
+    add(f)
+    commit
+    rm(f)
+    diff() shouldBe empty
+  }
+
+  test("#1000: diff should not return fs deleted files") { implicit o =>
+    val f = touch()
+    add(f)
+    commit
+    rmfs(f)
+    diff() shouldBe empty
+  }
+
+  test("diff should return added files against HEAD") { implicit o =>
+    val f1 = touch()
+    val f2 = touch()
+    add(f1)
+    add(f2)
+    diff() should contain only (f1, f2)
+  }
+
+  test("diff should return added files against a different branch") {
+    implicit o =>
+      val f = touch()
+      add(f)
+      commit
+      checkoutBr("other")
+      val f1 = touch()
+      val f2 = touch()
+      add(f1)
+      add(f2)
+      commit
+      diff("master") should contain only (f1, f2)
+  }
+
+  test(
+    "diff should return added files that are then modified against a different branch") {
+    implicit o =>
+      val f = touch()
+      add(f)
+      commit
+      checkoutBr("other")
+      val f1 = touch()
+      val f2 = touch()
+      add(f1)
+      add(f2)
+      modify(f1)
+      diff("master") should contain only (f1, f2)
+  }
+
+  test("diff should not return removed files against a different branch") {
+    implicit o =>
+      val f = touch()
+      add(f)
+      commit
+      checkoutBr("other")
+      val f1 = touch()
+      val f2 = touch()
+      add(f1)
+      add(f2)
+      commit
+      rm(f1)
+      diff("master") should contain only (f2)
+  }
+
+}
+
+private object GitOpsTest {
+
+  import OptionValues._
+  import Matchers._
+
+  // Filesystem commands
+  def rmfs(file: AbsoluteFile): Unit =
+    file.jfile.delete
+
+  // Git commands
+  def git(str: String)(implicit ops: GitOpsImpl, pos: Position): Seq[String] =
+    ops.exec("git" +: str.split(' ').toSeq) match {
+      case Failure(f) => fail(s"Failed git command. Got: $f")
+      case Success(s) => s
+    }
+
+  def init(implicit ops: GitOpsImpl): Unit =
+    git("init")
+
+  def add(file: AbsoluteFile)(implicit ops: GitOpsImpl): Unit =
+    git(s"add $file")
+
+  def rm(file: AbsoluteFile)(implicit ops: GitOpsImpl): Unit =
+    git(s"rm $file")
+
+  def commit(implicit ops: GitOpsImpl): Unit =
+    git(s"commit -m 'some-message'")
+
+  def checkout(br: String)(implicit ops: GitOpsImpl): Unit =
+    git(s"checkout $br")
+
+  def checkoutBr(newBr: String)(implicit ops: GitOpsImpl): Unit =
+    git(s"checkout -b $newBr")
 }


### PR DESCRIPTION
This PR fixes:

#962 by introducing a small testing framework for git and expand GitOpsTest
#1000 and #1010 by changing from `git ls-tree` to `git ls-files`

I remember reading somewhere that ls-tree is better, but I can't recall where or why. All I know is that the tests pass with `ls-files` but not `ls-trees`. 

Please point out any tests that I may have missed. 