### PR TITLE
PoC remove starting new line on ScalaDocs multiline commens

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -73,9 +73,18 @@ class FormatWriter(formatOps: FormatOps) {
         val spaces: String =
           if (isDocstring && initStyle.scalaDocs) " " * (indent + 2)
           else " " * (indent + 1)
-        leadingAsteriskSpace
+        val str = leadingAsteriskSpace
           .matcher(comment.syntax)
           .replaceAll(s"\n$spaces\\*")
+
+        if (isDocstring && initStyle.scalaDocs) {
+          str
+            .replaceFirst("/\\*\\*\\s+", "/** ") // move second line up if first line just contains /** and spaces
+            .replaceFirst("\\*\\*\\s\\*", "\\*\\*") // replace result /** * to /**
+        } else {
+          str
+        }
+
       } else {
         comment.syntax
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -78,6 +78,7 @@ class FormatWriter(formatOps: FormatOps) {
           .replaceAll(s"\n$spaces\\*")
 
         if (isDocstring && initStyle.scalaDocs) {
+          // TODO: use proper Pattern and improve regex
           str
             .replaceFirst("/\\*\\*\\s+", "/** ") // move second line up if first line just contains /** and spaces
             .replaceFirst("\\*\\*\\s\\*", "\\*\\*") // replace result /** * to /**

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -10,8 +10,7 @@ object a {
 >>>
 object a {
 
-  /**
-    * Returns True is this state will always return better formatting than other.
+  /** Returns True is this state will always return better formatting than other.
     */
   def alwaysBetter(other: State): Boolean =
     this.cost <= other.cost &&
@@ -109,8 +108,7 @@ final def getSelectChain(
       TypedPipe.from[U](pipe, fields)(flowDef, mode, conv)
     })
 >>>
-/**
-  * If any errors happen below this line, but before a groupBy, write to a TypedSink
+/** If any errors happen below this line, but before a groupBy, write to a TypedSink
   */
 def addTrap[U >: T](trapSink: Source with TypedSink[T])(
     implicit conv: TupleConverter[U]): TypedPipe[U] =

--- a/scalafmt-tests/src/test/resources/unit/Basic.source
+++ b/scalafmt-tests/src/test/resources/unit/Basic.source
@@ -25,13 +25,11 @@ object a {
 >>>
 object a {
 
-  /**
-    * One
+  /** One
     */
   def one = 1
 
-  /**
-    * Two
+  /** Two
     */
   def two = 2
 }

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -20,8 +20,7 @@ object a
 import foo.bar
 import kaz.bar
 
-/**
-  * Docstring
+/** Docstring
   */
 object a
 <<< Rename

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -8,8 +8,7 @@ object a
 >>>
 package foo
 
-/**
-  * comment
+/** comment
   */
 object a
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
@@ -8,7 +8,9 @@ import org.scalatest.FunSuite
 class CommentTest extends FunSuite with DiffAssertions {
   val javadocStyle: ScalafmtConfig =
     ScalafmtConfig.default.copy(docstrings = Docstrings.JavaDoc)
-  test("remove trailing space in comments") {
+  val scaladocStyle: ScalafmtConfig =
+    ScalafmtConfig.default.copy(docstrings = Docstrings.ScalaDoc)
+  test("remove trailing space in comments with JavaDoc style") {
     val trailingSpace = "   "
     val original = s"""object a {
                       |  // inline comment$trailingSpace
@@ -43,6 +45,52 @@ class CommentTest extends FunSuite with DiffAssertions {
                      |}
                      |""".stripMargin
     val obtained = Scalafmt.format(original, javadocStyle).get
+    assertNoDiff(obtained, expected)
+  }
+
+  test("remove trailing space in comments with ScalaDoc style") {
+    val trailingSpace = "   "
+    val original = s"""object a {
+                      |  // inline comment$trailingSpace
+                      |/**$trailingSpace
+                      |  * Y is cool$trailingSpace
+                      |  */
+                      |/*$trailingSpace
+                      |  * X is cool$trailingSpace
+                      |  */
+                      |/*
+                      |    I have blank lines with JavaStyle, do nothing
+                      |
+                      |    Please preserve them.
+                      |  */
+                      |/**
+                      |    I have blank lines with ScalaStyle, move line up
+                      |
+                      |    Please preserve them.
+                      | */
+                      |val y = 2
+                      |}
+                   """.stripMargin
+    val expected = """object a {
+                     |  // inline comment
+                     |  /** Y is cool
+                     |    */
+                     |  /*
+                     |   * X is cool
+                     |   */
+                     |  /*
+                     |    I have blank lines with JavaStyle, do nothing
+                     |
+                     |    Please preserve them.
+                     |   */
+                     |  /** I have blank lines with ScalaStyle, move line up
+                     |
+                     |    Please preserve them.
+                     |    */
+                     |  val y = 2
+                     |}
+                     |""".stripMargin
+    val obtained = Scalafmt.format(original, scaladocStyle).get
     assertNoDiff(obtained, expected)
   }
 }


### PR DESCRIPTION
Given that we officially don't have one scala style for multiline comments but 3! https://contributors.scala-lang.org/t/creation-of-a-standard-scala-style-guide/933

I'd like to add a new feature to scalafmt, so at least under a new non default flag, all multiline comments will look the same, using the old  ScalaDoc comments style.

This style is for poor souls like me @eddsteel and @olafurpg that followed the old style, as @olafurpg mentioned it here https://github.com/scala/docs.scala-lang/pull/801#pullrequestreview-44702920

@eddsteel started a discussion on https://contributors.scala-lang.org/t/quiet-changes-to-the-style-guide/923 but I'm not sure how that would end 🤷‍♂️ 

This PoC will match the old published version of the Scala doc style, 
```scala
The general format for a ScalaDoc comment should be as follows:

/** This is a brief description of what's being documented.
  *
  * This is further documentation of what we're documenting.  It should
  * provide more details as to how this works and what it does. 
  */
def myMethod = {}
```

Currently scalafmt doesn't modify these comments:
```scala
/** test
  */
```
or
```scala
/**
  * test
  */
```
I'd like at least to make them consisten to one style.

My current implementation is just a PoC, it doesn't have the flag, it has some corner case where an empty multicomment 
```scala
  /**
    */
```
gets modified to:
```scala
  /**/ // <- bug
```

I just wanted to receive some feedback and check that maintainers are ok with this idea