### PR TITLE
Add setting newlines.beforeCaseClassParameterDefn

### DIFF
--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -381,6 +381,26 @@
       implicit def validatedInstances[E](implicit E: Semigroup[E]): Traverse[
           Validated[E, ?]] with ApplicativeError[Validated[E, ?], E] = 2
 
+  @sect{newlines.beforeCaseClassParameterDefn}
+    Together with @b{verticalMultilineAtDefinitionSite}, this will
+    align parameter definitions vertically, with a line for each, and
+    not attempt to fit the case class definition on a single line.
+
+    Default @b(default.newlines.beforeCaseClassParameterDefn)
+
+    Requires @b{verticalMultilineAtDefinitionSite} set to @b(true).
+
+    @hl.scala
+      // verticalMultilineAtDefinitionSite = true
+      // newlines.beforeCaseClassParameterDefn = false
+      case class A(b: Int, c: Int)
+
+      // verticalMultilineAtDefinitionSite = true
+      // newlines.beforeCaseClassParameterDefn = true
+      case class A(
+          b: Int,
+          c: Int)
+
   @sect{spaces.afterKeywordBeforeParen}
     Default: @b(default.spaces.afterKeywordBeforeParen)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -114,6 +114,7 @@ case class Newlines(
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
     afterImplicitKWInVerticalMultiline: Boolean = false,
     beforeImplicitKWInVerticalMultiline: Boolean = false,
+    beforeCaseClassParameterDefn: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false
 )
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -24,6 +24,7 @@ import org.scalafmt.internal.ExpiresOn.Left
 import org.scalafmt.internal.ExpiresOn.Right
 import org.scalafmt.internal.Length.Num
 import org.scalafmt.internal.Policy.NoPolicy
+import org.scalafmt.util.CaseClass
 import org.scalafmt.util.CtorModifier
 import org.scalafmt.util.StyleMap
 import org.scalafmt.util.TokenOps
@@ -823,13 +824,30 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       if (isBracket) close // If we can fit the type params, make it so
       else lastParen // If we can fit all in one block, make it so
 
-    Seq(
+    // Determine if we should just allocate a line for each parameter
+    // definition for case classes, and not attempt to fit everything
+    // on a single line.
+    val newlineBefore =
+      !isBracket && style.newlines.beforeCaseClassParameterDefn && owners(
+        ft.left).is[CaseClass]
+
+    val fitInSingleLine =
       Split(NoSplit, 0)
-        .withPolicy(SingleLineBlock(singleLineExpire)),
-      Split(Newline, 1) // Otherwise split vertically
+        .withPolicy(SingleLineBlock(singleLineExpire))
+
+    val splitVertically =
+      Split(Newline, 1)
         .withIndent(firstIndent, close, Right)
         .withPolicy(policy)
-    )
+
+    if (newlineBefore) {
+      Seq(splitVertically)
+    } else {
+      Seq(
+        fitInSingleLine,
+        splitVertically // Otherwise split vertically
+      )
+    }
 
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeClasses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeClasses.scala
@@ -1,6 +1,5 @@
 package org.scalafmt.util
 
-import scala.collection.immutable.Seq
 import scala.meta._
 import scala.meta.internal.classifiers.classifier
 
@@ -16,4 +15,15 @@ trait CtorModifier
 object CtorModifier {
   def unapply(tree: Tree): Boolean =
     tree.is[Mod.Private] || tree.is[Mod.Protected]
+}
+@classifier
+trait CaseClass
+object CaseClass {
+  def unapply(tree: Tree): Boolean =
+    tree match {
+      case defn: Defn =>
+        defn.is[Defn.Class] && tree.children.exists(_.is[Mod.Case])
+      case _ =>
+        tree.parent.exists(_.is[CaseClass])
+    }
 }

--- a/scalafmt-tests/src/test/resources/newlines/beforeCaseClassParameterDefn.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeCaseClassParameterDefn.stat
@@ -1,0 +1,44 @@
+verticalMultilineAtDefinitionSite = true
+newlines.beforeCaseClassParameterDefn = true
+
+<<< Force newline before parameter list
+case class A(a: Int)
+>>>
+case class A(
+    a: Int)
+
+<<< Force newline before multi-argument parameter list
+case class A(a: Int, b: Double)
+>>>
+case class A(
+    a: Int,
+    b: Double)
+
+<<< Force newline before parameter list with ctor modifier
+case class A private (a: Int)
+>>>
+case class A private (
+    a: Int)
+
+<<< Preserve regular class parameter definitions
+class A(a: Int)
+>>>
+class A(a: Int)
+
+<<< Preserve method parameters in case class definitions
+case class A {
+  def fn(a: Int): Int = 0
+}
+>>>
+case class A {
+  def fn(a: Int): Int = 0
+}
+
+<<< Preserve method parameters in class definitions
+class A {
+  def fn(a: Int): Int = 0
+}
+>>>
+class A {
+  def fn(a: Int): Int = 0
+}

--- a/scalafmt-tests/src/test/resources/newlines/beforeCaseClassParameterDefnFalse.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeCaseClassParameterDefnFalse.stat
@@ -1,0 +1,8 @@
+verticalMultilineAtDefinitionSite = true
+newlines.beforeCaseClassParameterDefn = false
+
+<<< Fit to single line (when false)
+case class A(
+  a: Int)
+>>>
+case class A(a: Int)


### PR DESCRIPTION
When verticalMultilineAtDefinitionSite is specified,
this allows for forcing each parameter definition of
case classes on it's own line, and not attempting to
fit it on a single line.

This mimics the IntelliJ code style for method dec-
laration parameters "New line after '('".