### PR TITLE
Document that RedundantBraces may cause non-idempotent formatting.

### DIFF
--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -622,6 +622,7 @@
 
 
     @sect(Rewrite.rewrite2name(RedundantBraces))
+      @b{Warning}. This rewrite can cause @sect.ref{Non-idempotent} formatting, see @issue(1055).
       @demoStyle(rewriteBraces)
         object RedundantBraces {
           def foo = {


### PR DESCRIPTION
Review @djspiewak 