### PR TITLE
Fix file not found errors when running from a subdirectory w/ project.git = true

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -46,6 +46,7 @@ class GitOpsImpl(private[util] val workingDirectory: AbsoluteFile)
         Seq(
           "git",
           "ls-files",
+          "--full-name",
           dir.path
         )
       ).toOption.toSeq.flatten.map(f => rtDir / f)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -93,14 +93,16 @@ class GitOpsTest extends fixture.FunSuite {
   test(
     "lsTree should return files properly when the working directory is under the git root directory") {
     implicit ops =>
+      val f1 = touch()
+      add(f1)
+
       val newDir = mkDir()
-      println(s"new dir $newDir")
-      val f = touch(dir = Some(newDir))
-      add(f)
+      val f2 = touch(dir = Some(newDir))
+      add(f2)
 
       {
         val innerGitOps = new GitOpsImpl(newDir)
-        ls(innerGitOps) should contain(f)
+        ls(innerGitOps) should contain only f2
       }
   }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -100,9 +100,9 @@ class GitOpsTest extends fixture.FunSuite {
 
       {
         val innerGitOps = new GitOpsImpl(newDir)
-        ls(innerGitOps) should contain (f)
+        ls(innerGitOps) should contain(f)
       }
-    }
+  }
 
   test("lsTree should return commited files that have been modified") {
     implicit ops =>

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -96,14 +96,12 @@ class GitOpsTest extends fixture.FunSuite {
       val f1 = touch()
       add(f1)
 
-      val newDir = mkDir()
-      val f2 = touch(dir = Some(newDir))
+      val innerDir = mkDir()
+      val f2 = touch(dir = Some(innerDir))
       add(f2)
 
-      {
-        val innerGitOps = new GitOpsImpl(newDir)
-        ls(innerGitOps) should contain only f2
-      }
+      val innerGitOps = new GitOpsImpl(innerDir)
+      ls(innerGitOps) should contain only f2
   }
 
   test("lsTree should return commited files that have been modified") {


### PR DESCRIPTION
Closes #1086 

* Add back --full-name when invoking Git 
* Add a test