### PR TITLE
Add  -r bintray:scalameta/maven to Coursier install commands

### DIFF
--- a/readme/Installation.scalatex
+++ b/readme/Installation.scalatex
@@ -17,6 +17,7 @@
         Create a standalone executable in @code{/usr/local/bin/scalafmt} with (sudo if necessary):
         @hl.xml
           coursier bootstrap com.geirsson:scalafmt-cli_2.12:@V.stable \
+            -r bintray:scalameta/maven \
             -o /usr/local/bin/scalafmt --standalone --main org.scalafmt.cli.Cli
           scalafmt --version # should be @org.scalafmt.Versions.stable
 
@@ -24,6 +25,7 @@
         Alternatively you can create a slim 15 KiB bootstrap script with:
         @hl.xml
           coursier bootstrap com.geirsson:scalafmt-cli_2.12:@V.stable \
+            -r bintray:scalameta/maven \
             -o scalafmt --main org.scalafmt.cli.Cli
           ./scalafmt --version # should be @org.scalafmt.Versions.stable
 
@@ -47,6 +49,7 @@
           Create a standalone executable in @code{/usr/local/bin/scalafmt_ng} with (sudo if necessary)
           @hl.xml
             coursier bootstrap --standalone com.geirsson:scalafmt-cli_2.12:@V.stable \
+              -r bintray:scalameta/maven \
               -o /usr/local/bin/scalafmt_ng -f --main com.martiansoftware.nailgun.NGServer
             scalafmt_ng & // start nailgun in background
             ng ng-alias scalafmt org.scalafmt.cli.Cli


### PR DESCRIPTION
Add  -r bintray:scalameta/maven to Coursier install commands because
the version resolves to the latest commit hash on master, which is
auto-published to bintray, but *not* to Maven Central.