### PR TITLE
Fix version number in website and document pre-release.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -300,7 +300,7 @@ lazy val noPublish = Seq(
   publishLocal := {}
 )
 
-lazy val stableVersion = Def.setting(version.value.replaceAll("\\+.*", ""))
+lazy val stableVersion = Def.setting(version.value.replaceAll("\\-.*", ""))
 lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
   buildInfoKeys := Seq[BuildInfoKey](
     name,

--- a/readme/Installation.scalatex
+++ b/readme/Installation.scalatex
@@ -38,6 +38,21 @@
         @hl.xml
           coursier bootstrap --help | grep -A 1 "\-\-java-opt"
 
+    @sect{Pre-release}
+      Our CI publishes a pre-release version of scalafmt to Bintray on every merge into master.
+      To use a pre-release, replace @V.stable with the version here:
+
+      @raw
+        <a href='https://bintray.com/scalameta/maven/scalafmt-cli/_latestVersion'><img src='https://api.bintray.com/packages/scalameta/maven/scalafmt-cli/images/download.svg'></a>
+
+      @p
+        If you use coursier to install a pre-release, be sure to include the flag @code{-r bintray:scalameta/maven}
+        so that the artifact can be resolved.
+      @p
+        If you use sbt to install a pre-release, be sure to add the following setting
+        @hl.scala
+          resolvers += Resolver.bintray("scalameta", "maven")
+
     @sect{Nailgun}
 
       Nailgun is recommended if you want to integrate @code{scalafmt} with a


### PR DESCRIPTION
After replacing + with - in #1082 then the website started showing the
pre-release version instead of the stable release. This commit
adds a new section under the installation docs explaining how to consume
pre-releases.

<img width="848" alt="screen shot 2017-12-02 at 12 11 29" src="https://user-images.githubusercontent.com/1408093/33514763-f6148d2a-d759-11e7-9a58-1f276ac9632b.png">

FYI @lloydmeta 