### PR TITLE
Introduce "default", "akka" and "akka-http" as IndentOperator config

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -46,7 +46,11 @@ object IndentOperator {
     ScalafmtConfig.indentOperatorsExcludeAkka)
   implicit val IndentOperatorDecoder: ConfDecoder[IndentOperator] =
     ConfDecoder.instance[IndentOperator] {
-      case Conf.Str("spray") => Ok(IndentOperator.akka)
-      case els => default.reader.read(els)
+      case Conf.Str("spray" | "akka" | "akka-http") =>
+        Ok(IndentOperator.akka)
+      case Conf.Str("default") =>
+        Ok(IndentOperator.default)
+      case els =>
+        default.reader.read(els)
     }
 }


### PR DESCRIPTION
This will allow users to override the current config via a comment and then set
it back to what it was. Something like:

```
// scalafmt: { indentOperator = spray }
get {
  path("hey) {
    complete("yeah!")
  } ~
  path("oh") {
    complete("oh oh")
  }
}
// scalafmt: { indentOperator = default }
```


I've reused an existing test but instead of `indentOperator = spray`, I used the new one: `indentOperator = default` to make sure it works. I'm not entirely sure the test is valuable, let me know otherwise.

Also, if I follow the contributing guidelines, I should be adding stuff to the documentation. IndentOperator are only found, AFAIK, in the `Other` section of the configuration. This section seems to be generated from `default.fields` and I can't figure out where this variable comes from.

There is also a mention of the IndentOperator in the fourth changelog. Should I add a changelog file?