### PR TITLE
Add an "original code" section the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,12 @@ maxColumn = 100
 
 ## Steps
 
-I ran scalafmt like this:
+Given code like this:
+```scala
+ORIGINAL CODE
+```
+
+When I run scalafmt like this:
 
 ```bash
 scalafmt


### PR DESCRIPTION
This way it's clear what the state of the code was before running scalafmt, so it's clear what scalafmt did, compared to what you expected it to do.

See https://github.com/scalameta/scalafmt/issues/913#issuecomment-351806982 for an example of how the previous template can be misleading.