### PR TITLE
Empty input with `--diff` and `--stdin` is okay

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -154,7 +154,8 @@ object Cli {
 
   def run(options: CliOptions): Unit = {
     val inputMethods = getInputMethods(options)
-    if (inputMethods.isEmpty) throw NoMatchingFiles
+    if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
+      throw NoMatchingFiles
     val counter = new AtomicInteger()
     val termDisplayMessage =
       if (options.testing) "Looking for unformatted files..."

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
@@ -3,7 +3,6 @@ package org.scalafmt
 import scala.meta.Case
 import scala.meta.Tree
 import scala.meta.tokens.Token
-import scala.meta.tokens.Token
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
@@ -81,8 +81,7 @@ object Error {
   case object NoMatchingFiles
       extends Error(
         "No files formatted/tested. " +
-          "Verify your configured include/exclude filters and " +
-          "supplied command line arguments.")
+          "Verify include/exclude filters and command line arguments.")
 
   case class InvalidOption(option: String)
       extends Error(s"Invalid option $option")

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -280,6 +280,15 @@ class CliTest extends AbstractCliTest {
     }
   }
 
+  test("scalafmt (no matching files) is okay with --diff and --stdin") {
+    val diff = getConfig(Array("--diff"))
+    val stdin = getConfig(Array("--stdin")).copy(
+      common = CommonOptions(in = new ByteArrayInputStream("".getBytes))
+    )
+    Cli.run(diff)
+    Cli.run(stdin)
+  }
+
   test("scalafmt (no arg) read config from git repo") {
     val input = string2dir(
       """|/foo.scala

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -2,7 +2,6 @@ package org.scalafmt.cli
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.io.File
 import java.io.FileNotFoundException
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
@@ -24,7 +23,7 @@ import FileTestOps._
 abstract class AbstractCliTest extends FunSuite with DiffAssertions {
 
   def mkArgs(str: String): Array[String] =
-    str.split(' ').toArray
+    str.split(' ')
 
   def runWith(root: AbsoluteFile, argStr: String): Unit = {
     val args = mkArgs(argStr)


### PR DESCRIPTION
An empty input (no matching input files) should not throw an error if `--diff` or `--stdin` is specified.
Previously discussed in #876.

Are there any additional exceptions?
