### PR TITLE
Fix newlines around function blocks Fixes #1097

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
@@ -43,3 +43,26 @@ def f = {
     g(x)
   }
 }
+
+<<< Don't put newlines around functions blocks
+foo { c =>
+  {
+    println("Foo")
+  }
+}
+>>>
+foo { c => {
+    println("Foo")
+  }
+}
+
+<<< Preserve no newlines around function blocks
+foo { c => {
+    println("Foo")
+  }
+}
+>>>
+foo { c => {
+    println("Foo")
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
@@ -44,3 +44,14 @@ def f = {
     g(x)
   }
 }
+
+<<< Preserve no newlines around functions blocks
+foo { c =>  {
+    println("Foo")
+  }
+}
+>>>
+foo { c => {
+    println("Foo")
+  }
+}


### PR DESCRIPTION
Reworked `newlines.afterCurlyLambda` to not insert a newline at all if a function block follows. Was a bit unsure if I should have introduced a new parameter, or just work with the existing one. Decided to work with the existing one as if I didn't, the name wouldn't make as much sense anymore.