### PR TITLE
Add optIn.blankLineBeforeDocstring setting

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
@@ -46,6 +46,28 @@ import metaconfig._
   * @param selfAnnotationNewline See https://github.com/scalameta/scalafmt/issues/938
   *                              If true, will force a line break before a self annotation
   *                              if there was a line break there before.
+  * @param blankLineBeforeDocstring
+  *  If true, always insert a blank line before docstrings,
+  *  If false, preserves blank line only if one exists before.
+  *  Example:
+  *  {{{
+  *    // before
+  *    object Foo {
+  *      /** Docstring */
+  *      def foo = 2
+  *    }
+  *    // after, if blankLineBeforeDocstring=true
+  *    object Foo {
+  *      /** Docstring */
+  *      def foo = 2
+  *    }
+  *    // after, if blankLineBeforeDocstring=false
+  *    object Foo {
+  *
+  *      /** Docstring */
+  *      def foo = 2
+  *    }
+  *  }}}
   */
 @DeriveConfDecoder
 case class OptIn(
@@ -53,5 +75,7 @@ case class OptIn(
     breaksInsideChains: Boolean = false,
     breakChainOnFirstMethodDot: Boolean = true,
     selfAnnotationNewline: Boolean = true,
-    annotationNewlines: Boolean = true
+    annotationNewlines: Boolean = true,
+    // Candidate to become default true at some point.
+    blankLineBeforeDocstring: Boolean = false
 )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
@@ -47,8 +47,8 @@ import metaconfig._
   *                              If true, will force a line break before a self annotation
   *                              if there was a line break there before.
   * @param blankLineBeforeDocstring
-  *  If true, always insert a blank line before docstrings,
-  *  If false, preserves blank line only if one exists before.
+  *  If false, always insert a blank line before docstrings,
+  *  If true, preserves blank line only if one exists before.
   *  Example:
   *  {{{
   *    // before

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -55,14 +55,16 @@ object TokenOps {
       tok: FormatToken,
       style: ScalafmtConfig,
       owners: Token => Tree): Boolean = {
-    !isDocstring(tok.left) && {
+    !forceDocstringBlankLine(tok.left, style) && {
       val newlines = newlinesBetween(tok.between)
-      newlines > 1 || (isDocstring(tok.right) && !tok.left.is[Comment])
+      newlines > 1 ||
+      (forceDocstringBlankLine(tok.right, style) && !tok.left.is[Comment])
     }
   }
 
-  def isDocstring(token: Token): Boolean = {
-    token.is[Comment] && token.syntax.startsWith("/**")
+  def forceDocstringBlankLine(token: Token, style: ScalafmtConfig): Boolean = {
+    if (style.optIn.blankLineBeforeDocstring) false
+    else token.is[Comment] && token.syntax.startsWith("/**")
   }
 
   def lastToken(tree: Tree): Token = {

--- a/scalafmt-tests/src/test/resources/optIn/blankLineBeforeDocstring.stat
+++ b/scalafmt-tests/src/test/resources/optIn/blankLineBeforeDocstring.stat
@@ -1,0 +1,12 @@
+style = default
+optIn.blankLineBeforeDocstring = true
+<<< docstring does not force line break
+object Stuff {
+  /** Some function */
+  def hello = ()
+}
+>>>
+object Stuff {
+  /** Some function */
+  def hello = ()
+}


### PR DESCRIPTION
Previously, scalafmt always forced a blank line before docstrings. There
was no good reason for this, it was just a random decision I made before
v0.1 that no one has questioned until now. This behavior has in fact bugged
myself.

I think this setting is a good candidate to become default at some
point, but I'd like to receive a bit more feedback before making the
switch.

Review @alexandru