### PR TITLE
Generalize with-chain wrapping for defs and type definitions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -24,7 +24,6 @@ import org.scalafmt.internal.ExpiresOn.Right
 import org.scalafmt.internal.Length.Num
 import org.scalafmt.internal.Length.StateColumn
 import org.scalafmt.internal.Policy.NoPolicy
-import org.scalafmt.util.`:parent:`
 import org.scalafmt.util.Delim
 import org.scalafmt.util.CtorModifier
 import org.scalafmt.util.InfixApplication

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -33,7 +33,7 @@ import org.scalafmt.util.Literal
 import org.scalafmt.util.LoggerOps
 import org.scalafmt.util.Modifier
 import org.scalafmt.util.RightParenOrBracket
-import org.scalafmt.util.SelfAnnotation
+import org.scalafmt.util.WithChain
 import org.scalafmt.util.SomeInterpolate
 import org.scalafmt.util.TokenOps
 import org.scalafmt.util.TreeOps
@@ -1021,7 +1021,7 @@ class Router(formatOps: FormatOps) {
               Split(Space, 0),
               Split(Newline, 1).withPolicy(policy)
             )
-          case t @ SelfAnnotation(top) =>
+          case t @ WithChain(top) =>
             val isFirstWith = !t.lhs.is[Type.With]
             if (isFirstWith) {
               val chain = withChain(top)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.util
 
 import scala.collection.immutable.Seq
+import scala.meta.Defn
 import scala.meta.Name
 import scala.meta.Pat
 import scala.meta.Template
@@ -41,6 +42,8 @@ object SelfAnnotation {
   def unapply(t: Type.With): Option[Type.With] =
     TreeOps.topTypeWith(t) match {
       case (top: Type.With) `:parent:` (_: Term.Param) `:parent:` (_: Template) =>
+        Some(top)
+      case (top: Type.With) `:parent:` (_: Defn.Type) =>
         Some(top)
       case _ => None
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.util
 
 import scala.collection.immutable.Seq
+import scala.meta.Decl
 import scala.meta.Defn
 import scala.meta.Name
 import scala.meta.Pat
@@ -38,12 +39,17 @@ object `:parent:` {
   }
 }
 
-object SelfAnnotation {
+object WithChain {
   def unapply(t: Type.With): Option[Type.With] =
     TreeOps.topTypeWith(t) match {
+      // self types
       case (top: Type.With) `:parent:` (_: Term.Param) `:parent:` (_: Template) =>
         Some(top)
+      // type definitions
       case (top: Type.With) `:parent:` (_: Defn.Type) =>
+        Some(top)
+      // function return types
+      case (top: Type.With) `:parent:` (_: Decl.Def) =>
         Some(top)
       case _ => None
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -45,11 +45,8 @@ object WithChain {
       // self types
       case (top: Type.With) `:parent:` (_: Term.Param) `:parent:` (_: Template) =>
         Some(top)
-      // type definitions
-      case (top: Type.With) `:parent:` (_: Defn.Type) =>
-        Some(top)
-      // function return types
-      case (top: Type.With) `:parent:` (_: Decl.Def) =>
+      // val/def/var/type definitions or declarations
+      case (top: Type.With) `:parent:` (_: Defn | _: Decl) =>
         Some(top)
       case _ => None
     }

--- a/scalafmt-tests/src/test/resources/default/TypeWith.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeWith.stat
@@ -9,3 +9,13 @@
       annotationOwnerLookUp: ScLiteral => Option[
           PsiAnnotationOwner with PsiElement]): Option[PsiAnnotationOwner] = 1
 }
+<<< #1133
+implicit val catsStdInstancesForOption
+   : Traverse[Option] with MonadError[Option, Unit] with Alternative[Option]
+       with CommutativeMonad[Option] with CoflatMap[Option] = ???
+>>>
+implicit val catsStdInstancesForOption: Traverse[Option]
+  with MonadError[Option, Unit]
+  with Alternative[Option]
+  with CommutativeMonad[Option]
+  with CoflatMap[Option] = ???

--- a/scalafmt-tests/src/test/resources/default/TypeWith.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeWith.stat
@@ -19,3 +19,29 @@ implicit val catsStdInstancesForOption: Traverse[Option]
   with Alternative[Option]
   with CommutativeMonad[Option]
   with CoflatMap[Option] = ???
+<<< with-chain types #1125
+type RequiredServices = Bag with
+  SomeOtherService.RequiredServices
+    with HasDynamicConfig with HasThrottles
+    with HasThrowableNotifier
+>>>
+type RequiredServices = Bag
+  with SomeOtherService.RequiredServices
+  with HasDynamicConfig
+  with HasThrottles
+  with HasThrowableNotifier
+<<< abstract def #1125
+trait NeedsServices {
+  def services:  Bag with
+    SomeOtherService.RequiredServices
+      with HasDynamicConfig with HasThrottles
+      with HasThrowableNotifier
+}
+>>>
+trait NeedsServices {
+  def services: Bag
+    with SomeOtherService.RequiredServices
+    with HasDynamicConfig
+    with HasThrottles
+    with HasThrowableNotifier
+}

--- a/scalafmt-tests/src/test/resources/unit/Type.stat
+++ b/scalafmt-tests/src/test/resources/unit/Type.stat
@@ -85,3 +85,19 @@ type Row =
 type a = b_! # D
 >>>
 type a = b_! #D
+<<< ONLY #1125
+type RequiredServices = Bag
+  with HasClockService
+  with HasDynamicConfig
+  with HasFSLogger
+  with HasFutureService
+  with HasThrottles
+  with HasThrowableNotifier
+>>>
+type RequiredServices = Bag
+  with HasClockService
+  with HasDynamicConfig
+  with HasFSLogger
+  with HasFutureService
+  with HasThrottles
+  with HasThrowableNotifier

--- a/scalafmt-tests/src/test/resources/unit/Type.stat
+++ b/scalafmt-tests/src/test/resources/unit/Type.stat
@@ -85,29 +85,3 @@ type Row =
 type a = b_! # D
 >>>
 type a = b_! #D
-<<< with-chain types #1125
-type RequiredServices = Bag with
-  SomeOtherService.RequiredServices
-    with HasDynamicConfig with HasThrottles
-    with HasThrowableNotifier
->>>
-type RequiredServices = Bag
-  with SomeOtherService.RequiredServices
-  with HasDynamicConfig
-  with HasThrottles
-  with HasThrowableNotifier
-<<< abstract def #1125
-trait NeedsServices {
-  def services:  Bag with
-    SomeOtherService.RequiredServices
-      with HasDynamicConfig with HasThrottles
-      with HasThrowableNotifier
-}
->>>
-trait NeedsServices {
-  def services: Bag
-    with SomeOtherService.RequiredServices
-    with HasDynamicConfig
-    with HasThrottles
-    with HasThrowableNotifier
-}

--- a/scalafmt-tests/src/test/resources/unit/Type.stat
+++ b/scalafmt-tests/src/test/resources/unit/Type.stat
@@ -85,21 +85,29 @@ type Row =
 type a = b_! # D
 >>>
 type a = b_! #D
-<<< #1125
-type RequiredServices = Bag with SomeOtherService.RequiredServices with HasClockService
-  with HasDynamicConfig with HasFSLogger with HasFutureService
-  with HasThrottles
-  with HasThrowableNotifier
+<<< with-chain types #1125
+type RequiredServices = Bag with
+  SomeOtherService.RequiredServices
+    with HasDynamicConfig with HasThrottles
+    with HasThrowableNotifier
 >>>
 type RequiredServices = Bag
   with SomeOtherService.RequiredServices
-  with HasClockService
   with HasDynamicConfig
-  with HasFSLogger
-  with HasFutureService
   with HasThrottles
   with HasThrowableNotifier
-<<< short line #1125
-type RequiredServices = Bag with SomeOtherService.RequiredServices with HasClockService
+<<< abstract def #1125
+trait NeedsServices {
+  def services:  Bag with
+    SomeOtherService.RequiredServices
+      with HasDynamicConfig with HasThrottles
+      with HasThrowableNotifier
+}
 >>>
-type RequiredServices = Bag with SomeOtherService.RequiredServices with HasClockService
+trait NeedsServices {
+  def services: Bag
+    with SomeOtherService.RequiredServices
+    with HasDynamicConfig
+    with HasThrottles
+    with HasThrowableNotifier
+}

--- a/scalafmt-tests/src/test/resources/unit/Type.stat
+++ b/scalafmt-tests/src/test/resources/unit/Type.stat
@@ -85,19 +85,21 @@ type Row =
 type a = b_! # D
 >>>
 type a = b_! #D
-<<< ONLY #1125
-type RequiredServices = Bag
-  with HasClockService
-  with HasDynamicConfig
-  with HasFSLogger
-  with HasFutureService
+<<< #1125
+type RequiredServices = Bag with SomeOtherService.RequiredServices with HasClockService
+  with HasDynamicConfig with HasFSLogger with HasFutureService
   with HasThrottles
   with HasThrowableNotifier
 >>>
 type RequiredServices = Bag
+  with SomeOtherService.RequiredServices
   with HasClockService
   with HasDynamicConfig
   with HasFSLogger
   with HasFutureService
   with HasThrottles
   with HasThrowableNotifier
+<<< short line #1125
+type RequiredServices = Bag with SomeOtherService.RequiredServices with HasClockService
+>>>
+type RequiredServices = Bag with SomeOtherService.RequiredServices with HasClockService


### PR DESCRIPTION
This fixes #1125 to handle wrapping of "with-chains".

For example, a long chain of

```scala
Foo with Bar with Baz
```

can be wrapped as

```scala
Foo
  with Bar
  with Baz
```

This was already implemented for self-types (`trait Xyz { self: Foo with Bar with Baz => `). This PR expands the behavior to handle type definitions (`type MyType = Foo with Bar with Baz`) and function return types (`def xyz: Foo with Bar with Baz`).