### PR TITLE
Implement SortModifiers rewrite rule

### DIFF
--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -684,6 +684,53 @@
       @demoStyle(rewriteAsciiImports)
         import foo.{~>, `symbol`, bar, Random}
 
+    @sect(Rewrite.rewrite2name(SortModifiers))
+      @p
+        Modifiers are sorted based on the given order. Affects modifiers of the following
+        definitions: trait, class, object, type, and val+var, both as fields and class parameters.
+
+      Demo run. On the left you have the code before sorting, on the right after.
+      @demoStyle(rewriteSortModifiers)
+        sealed trait ADT
+        final private object ADTs {
+
+          private final type T1 = Int
+          final private[ADTs] type T2 = String
+
+          final private implicit object ADT1 extends ADT
+          implicit private final object ADT2 extends ADT
+          final implicit private object ADT3 extends ADT
+
+          abstract sealed class ADTA(val name: T1) extends ADT {
+            def test: T1
+          }
+
+          final class ADT4(private[ADTs] final implicit var impl: T2) extends ADT {
+            lazy private[ADT4] implicit override val test: T1 = 42
+          }
+        }
+
+      If you choose the non-default sort order then you have to specify all eight modifiers in the order you wish to see
+      them. Hint: since some modifiers are mutually exclusive, you might want to order them next to each other.
+
+
+      @p
+        Example config:
+        @cliFlags
+          rewrite {
+            rules = [SortModifiers]
+            #optional, see default values below
+            sortModifiers {
+              order = ["implicit", "final", "sealed", "abstract",
+                       "override", "private", "protected", "lazy"]
+            }
+          }
+
+      Default values:
+      @ul
+        @li
+          @code{rewrite.sortModifiers.order} = @rewriteSortModifiersDefaultString
+
     @sect(Rewrite.rewrite2name(PreferCurlyFors))
       @p
         Replaces parentheses into curly braces in for comprehensions that

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -180,7 +180,7 @@ object Readme {
     */
   val rewriteSortModifiersDefaultString =
     SortSettings.defaultOrder
-      .map(_.getClass.getSimpleName.replace("`", "").stripSuffix("$"))
+      .map(_.productPrefix)
       .mkString("[\"", "\", \"", "\"]")
 
   val rewritePreferCurlyFors =

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -159,6 +159,30 @@ object Readme {
         rules = Seq(AsciiSortImports)
       ))
 
+  val rewriteSortModifiers =
+    ScalafmtConfig.default120.copy(
+      rewrite = ScalafmtConfig.default.rewrite.copy(
+        rules = Seq(SortModifiers)
+      ))
+
+  /**
+    * This looks way too hacky. But can't seem to find a typeclass
+    * that "encodes" the ``ModKey`` enum.
+    *
+    * Adittionally, a Vector of Strings is simply concatenated, hence
+    * the artificial .mkString.
+    * {{{
+    *    [error]  found   : Vector[org.scalafmt.config.SortSettings.ModKey]
+    *    [error]  required: scalatags.Text.Modifier
+    *    [error]     (which expands to)  scalatags.generic.Modifier[scalatags.text.Builder]
+    *    [error]           @code{rewrite.sortModifiers.order} = @rewriteSortModifiers.rewrite.sortModifiers.order
+    * }}}
+    */
+  val rewriteSortModifiersDefaultString =
+    SortSettings.defaultOrder
+      .map(_.getClass.getSimpleName.replace("`", "").stripSuffix("$"))
+      .mkString("[\"", "\", \"", "\"]")
+
   val rewritePreferCurlyFors =
     ScalafmtConfig.default.copy(
       rewrite = ScalafmtConfig.default.rewrite.copy(

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -167,10 +167,10 @@ object Readme {
 
   /**
     * This looks way too hacky. But can't seem to find a typeclass
-    * that "encodes" the ``ModKey`` enum.
+    * that ought to "encode" the ``ModKey`` enum.
     *
-    * Adittionally, a Vector of Strings is simply concatenated, hence
-    * the artificial .mkString.
+    * Additionally, a Vector of Strings is simply concatenated, hence
+    * the extra .mkString.
     * {{{
     *    [error]  found   : Vector[org.scalafmt.config.SortSettings.ModKey]
     *    [error]  required: scalatags.Text.Modifier

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ReaderUtil.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ReaderUtil.scala
@@ -14,8 +14,8 @@ object ReaderUtil {
       options: sourcecode.Text[T]*): ConfDecoder[T] =
     oneOfImpl(lowerCaseNoBackticks, options)
 
-  private val lowerCase: String => String = s => s.toLowerCase
-  private val lowerCaseNoBackticks: String => String = s =>
+  private def lowerCase(s: String): String = s.toLowerCase
+  private def lowerCaseNoBackticks(s: String): String =
     s.toLowerCase().replace("`", "")
 
   private def oneOfImpl[T: ClassTag](

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
@@ -9,7 +9,8 @@ case class RewriteSettings(
     rules: Seq[Rewrite] = Nil,
     @Recurse redundantBraces: RedundantBracesSettings =
       RedundantBracesSettings(),
-    @Recurse neverInfix: Pattern = Pattern.neverInfix
+    @Recurse neverInfix: Pattern = Pattern.neverInfix,
+    @Recurse sortModifiers: SortSettings = SortSettings.default
 ) {
   Rewrite.validateRewrites(rules) match {
     case Nil => // OK
@@ -20,5 +21,13 @@ case class RewriteSettings(
         )
       )
   }
+
+  if (sortModifiers.order.distinct.length != 8)
+    throw InvalidScalafmtConfiguration(
+      new IllegalArgumentException(
+        "'sortModifiers.order', if specified, it has to contain all of the following values in the order you wish them sorted:" +
+          """["private", "protected" , "abstract", "final", "sealed", "implicit", "override", "lazy"]"""
+      )
+    )
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
@@ -18,7 +18,7 @@ object SortSettings {
       `override`,
       `private`,
       `protected`,
-      `lazy`,
+      `lazy`
     )
 
   val defaultOrder: Vector[ModKey] =
@@ -34,7 +34,7 @@ object SortSettings {
       `private`,
       `protected`,
       //
-      `lazy`,
+      `lazy`
     )
 
   def default: SortSettings =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
@@ -1,0 +1,53 @@
+package org.scalafmt.config
+
+import metaconfig._
+
+@DeriveConfDecoder
+case class SortSettings(
+    order: Vector[SortSettings.ModKey]
+)
+
+object SortSettings {
+
+  implicit val SortSettingsModKeyReader: ConfDecoder[ModKey] =
+    ReaderUtil.oneOfIgnoreBackticks[ModKey](
+      `implicit`,
+      `final`,
+      `sealed`,
+      `abstract`,
+      `override`,
+      `private`,
+      `protected`,
+      `lazy`,
+    )
+
+  val defaultOrder: Vector[ModKey] =
+    Vector(
+      `implicit`,
+      //
+      `final`,
+      `sealed`,
+      `abstract`,
+      //
+      `override`,
+      //
+      `private`,
+      `protected`,
+      //
+      `lazy`,
+    )
+
+  def default: SortSettings =
+    SortSettings(defaultOrder)
+
+  sealed trait ModKey
+
+  case object `private` extends ModKey
+  case object `protected` extends ModKey
+  case object `final` extends ModKey
+  case object `sealed` extends ModKey
+  case object `abstract` extends ModKey
+  case object `implicit` extends ModKey
+  case object `override` extends ModKey
+  case object `lazy` extends ModKey
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
@@ -40,7 +40,7 @@ object SortSettings {
   def default: SortSettings =
     SortSettings(defaultOrder)
 
-  sealed trait ModKey
+  sealed trait ModKey extends Product
 
   case object `private` extends ModKey
   case object `protected` extends ModKey

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -31,7 +31,8 @@ object Rewrite {
       AsciiSortImports,
       PreferCurlyFors,
       ExpandImportSelectors,
-      AvoidInfix
+      AvoidInfix,
+      SortModifiers
     )
 
   private def nameMap[T](t: sourcecode.Text[T]*): Map[String, T] = {
@@ -45,7 +46,8 @@ object Rewrite {
     AsciiSortImports,
     PreferCurlyFors,
     ExpandImportSelectors,
-    AvoidInfix
+    AvoidInfix,
+    SortModifiers
   )
   val rewrite2name: Map[Rewrite, String] = name2rewrite.map(_.swap)
   val available = Rewrite.name2rewrite.keys.mkString(", ")

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -22,6 +22,10 @@ object SortModifiers extends Rewrite {
      * are considered Mods, instead of being similar to `Defn.Val`, or `Defn.Var`.
      */
     val patchesOfPatches = code.collect {
+      case d: Decl.Def => sortMods(d.mods)
+      case v: Decl.Val => sortMods(v.mods)
+      case v: Decl.Var => sortMods(v.mods)
+      case t: Decl.Type => sortMods(t.mods)
       case d: Defn.Def => sortMods(d.mods)
       case v: Defn.Val => sortMods(v.mods)
       case v: Defn.Var => sortMods(v.mods)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -1,0 +1,100 @@
+package org.scalafmt.rewrite
+
+import org.scalafmt.config.SortSettings._
+
+import scala.meta.Tree
+import scala.meta._
+
+/**
+  * Sorts the modifiers on a field/def/param.
+  *
+  * WIP:
+  * should this include the rule to sort
+  * class, object, trait definitions? Or should
+  * that be a separate one?
+  */
+object SortModifiers extends Rewrite {
+
+  override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {
+    val order = ctx.style.rewrite.sortModifiers.order
+
+    val sortMods: Seq[Mod] => Seq[Mod] = { mods =>
+      mods.sortWith(orderModsBy(order))
+    }
+
+    /*
+     * in the case of Class, Object, and of class constructor parameters
+     * some Mods are immovable, e.g. "case class X".
+     *
+     * The case of parameters is a bit more curious, because there the
+     * "val" or "var" in, say:
+     * {{{
+     *   class Test(private final val x: Int)
+     * }}}
+     * are considered Mods, instead of being similar to `Defn.Val`, or `Defn.Var`.
+     */
+    val patchesOfPatches = code.collect {
+      case d: Defn.Def => patchMods(sortMods, d.mods)
+      case v: Defn.Val => patchMods(sortMods, v.mods)
+      case v: Defn.Var => patchMods(sortMods, v.mods)
+      case t: Defn.Type => patchMods(sortMods, t.mods)
+      case c: Defn.Class => patchMods(sortMods, c.mods.filterNot(isCase))
+      case o: Defn.Object => patchMods(sortMods, o.mods.filterNot(isCase))
+      case t: Defn.Trait => patchMods(sortMods, t.mods)
+      case p: Term.Param => patchMods(sortMods, p.mods.filterNot(isValOrVar))
+    }
+    patchesOfPatches.flatten
+  }
+
+  private val isValOrVar: Mod => Boolean = m =>
+    m.is[Mod.ValParam] || m.is[Mod.VarParam]
+
+  private val isCase: Mod => Boolean = m => m.is[Mod.Case]
+
+  private def patchMods(
+      sortMods: Seq[Mod] => Seq[Mod],
+      oldMods: Seq[Mod]): Seq[Patch] = {
+    if (oldMods.isEmpty) Nil
+    else {
+      val sortedMods: Seq[Mod] = sortMods(oldMods)
+      sortedMods.zip(oldMods).flatMap {
+        case (next, old) =>
+          if (old.tokens.isEmpty) {
+            //Not sure why this happens, how can you have a mod with no tokens?
+            //but see the `SortModifiers_Mod_With_No_Token.source` test for an example.
+            //The weirdest part is that it actually formats the file correctly...
+            //
+            //so it's better to not do anything than crash `scalafmt`
+            //P.S. can I emmit a warning?
+            Nil
+          } else {
+            val removeOld = old.tokens.map(t => TokenPatch.Remove(t))
+            val addNext = TokenPatch.AddRight(old.tokens.head, next.syntax)
+            removeOld :+ addNext
+          }
+      }
+    }
+  }
+
+  /**
+    * @return
+    *   m1 < m2; according to the order given by the Vector
+    */
+  private def orderModsBy(order: Vector[ModKey])(m1: Mod, m2: Mod): Boolean = {
+    val idx1 = order.indexWhere(modCorrespondsToSettingKey(m1))
+    val idx2 = order.indexWhere(modCorrespondsToSettingKey(m2))
+    idx1 < idx2
+  }
+
+  private def modCorrespondsToSettingKey(m: Mod)(p: ModKey): Boolean = {
+    p == `private` && m.is[Mod.Private] ||
+    p == `protected` && m.is[Mod.Protected] ||
+    p == `final` && m.is[Mod.Final] ||
+    p == `sealed` && m.is[Mod.Sealed] ||
+    p == `abstract` && m.is[Mod.Abstract] ||
+    p == `lazy` && m.is[Mod.Lazy] ||
+    p == `implicit` && m.is[Mod.Implicit] ||
+    p == `override` && m.is[Mod.Override]
+  }
+
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -5,14 +5,6 @@ import org.scalafmt.config.SortSettings._
 import scala.meta.Tree
 import scala.meta._
 
-/**
-  * Sorts the modifiers on a field/def/param.
-  *
-  * WIP:
-  * should this include the rule to sort
-  * class, object, trait definitions? Or should
-  * that be a separate one?
-  */
 object SortModifiers extends Rewrite {
 
   override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers.stat
@@ -190,3 +190,17 @@ private abstract sealed class Test(private[Test] final implicit override val x: 
 abstract sealed private case class Test(override implicit final private[Test] val x: Int)
 >>>
 private abstract sealed case class Test(private[Test] final implicit override val x: Int)
+<<< abstract declarations
+trait test {
+  override final private[test] type Foo
+  override implicit final private[test] val foo: Int
+  override implicit final private[test] var bad: Int
+  override implicit final private def bar: Int
+}
+>>>
+trait test {
+  private[test] final override type Foo
+  private[test] final implicit override val foo: Int
+  private[test] final implicit override var bad: Int
+  private final implicit override def bar: Int
+}

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers.stat
@@ -1,0 +1,192 @@
+maxColumn = 200 #to not disturb the output too much
+rewrite {
+  rules = [SortModifiers]
+  sortModifiers {
+    order = ["private", "protected" , "abstract", "final", "sealed", "implicit", "override", "lazy"]
+  }
+}
+<<< def — no mods
+object test {
+  def foo: Int = ???
+}
+>>>
+object test {
+  def foo: Int = ???
+}
+<<< def — private
+object test {
+  private def foo: Int = ???
+}
+>>>
+object test {
+  private def foo: Int = ???
+}
+<<< def — final private
+object test {
+  final private def foo: Int = ???
+}
+>>>
+object test {
+  private final def foo: Int = ???
+}
+<<< def — final private — scoped
+object test {
+  final private[test] def foo: Int = ???
+}
+>>>
+object test {
+  private[test] final def foo: Int = ???
+}
+<<< def — override implicit final private
+object test {
+  override implicit final private def foo: Int = ???
+}
+>>>
+object test {
+  private final implicit override def foo: Int = ???
+}
+<<< def — override implicit final private — scoped
+object test {
+  override implicit final private[test] def foo: Int = ???
+}
+>>>
+object test {
+  private[test] final implicit override def foo: Int = ???
+}
+<<< val — no mods
+object test {
+  val foo: Int = ???
+}
+>>>
+object test {
+  val foo: Int = ???
+}
+<<< val — private
+object test {
+  private val foo: Int = ???
+}
+>>>
+object test {
+  private val foo: Int = ???
+}
+<<< val — final private
+object test {
+  final private val foo: Int = ???
+}
+>>>
+object test {
+  private final val foo: Int = ???
+}
+<<< val — final private — scoped
+object test {
+  final private[test] val foo: Int = ???
+}
+>>>
+object test {
+  private[test] final val foo: Int = ???
+}
+<<< val — override implicit final private
+object test {
+  override implicit final private val foo: Int = ???
+}
+>>>
+object test {
+  private final implicit override val foo: Int = ???
+}
+<<< val — override implicit final private — scoped
+object test {
+  override implicit final private[test] val foo: Int = ???
+}
+>>>
+object test {
+  private[test] final implicit override val foo: Int = ???
+}
+<<< val — lazy override implicit final private[test] — scoped
+object test {
+  lazy override implicit final private[test] val foo: Int = ???
+}
+>>>
+object test {
+  private[test] final implicit override lazy val foo: Int = ???
+}
+<<< type — no mods
+object test {
+  type foo = Int
+}
+>>>
+object test {
+  type foo = Int
+}
+<<< type — private
+object test {
+  private type foo = Int
+}
+>>>
+object test {
+  private type foo = Int
+}
+<<< type — final private
+object test {
+  final private type foo = Int
+}
+>>>
+object test {
+  private final type foo = Int
+}
+<<< type — final private — scoped
+object test {
+  final private[test] type foo = Int
+}
+>>>
+object test {
+  private[test] final type foo = Int
+}
+<<< type — override final private
+object test {
+  override final private type foo = Int
+}
+>>>
+object test {
+  private final override type foo = Int
+}
+<<< type — override final private — scoped
+object test {
+  override final private[test] type foo = Int
+}
+>>>
+object test {
+  private[test] final override type foo = Int
+}
+
+<<< type — override final private higher kind — scoped
+object test {
+  override final private[test] type foo[+A] = List[A]
+}
+>>>
+object test {
+  private[test] final override type foo[+A] = List[A]
+}
+<<< class param mod — none
+class Test(x: Int)
+>>>
+class Test(x: Int)
+<<< class param mod — private
+class Test(private val x: Int)
+>>>
+class Test(private val x: Int)
+<<< class param val — final private
+class Test(final private val x: Int)
+>>>
+class Test(private final val x: Int)
+<<< class param val — override implicit final private[Test]
+class Test(override implicit final private[Test] val x: Int)
+>>>
+class Test(private[Test] final implicit override val x: Int)
+<<< class defn + param — abstract final private
+abstract sealed private class Test(override implicit final private[Test] val x: Int)
+>>>
+private abstract sealed class Test(private[Test] final implicit override val x: Int)
+<<< case class defn + param — abstract final private
+abstract sealed private case class Test(override implicit final private[Test] val x: Int)
+>>>
+private abstract sealed case class Test(private[Test] final implicit override val x: Int)

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers1.source
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers1.source
@@ -41,3 +41,37 @@ private[test] final object Tests {
 
   private[test] final class Test3(override val name: String = "42")(private[this] final implicit val foo: Int) extends Test
 }
+<<< convoluted sealed trait hierarchy — no changes
+package test
+
+private[test] sealed trait Test {
+  def name: String
+}
+
+private[test] final object Tests {
+
+  protected[Tests] final case object Test1 extends Test {
+    final implicit override lazy val name: String = "foo"
+  }
+
+  final case class Test2(implicit override val name: String) extends Test
+
+  private[test] final class Test3(override val name: String = "42")(private[this] final implicit val foo: Int) extends Test
+}
+>>>
+package test
+
+private[test] sealed trait Test {
+  def name: String
+}
+
+private[test] final object Tests {
+
+  protected[Tests] final case object Test1 extends Test {
+    final implicit override lazy val name: String = "foo"
+  }
+
+  final case class Test2(implicit override val name: String) extends Test
+
+  private[test] final class Test3(override val name: String = "42")(private[this] final implicit val foo: Int) extends Test
+}

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers1.source
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers1.source
@@ -1,0 +1,43 @@
+maxColumn = 200 #to not disturb the output too much
+rewrite {
+  rules = [SortModifiers]
+  sortModifiers {
+    order = ["private", "protected" , "abstract", "final", "sealed", "implicit", "override", "lazy"]
+  }
+}
+
+
+<<< convoluted sealed trait hierarchy
+package test
+
+sealed private[test] trait Test {
+  def name: String
+}
+
+final private[test] object Tests {
+
+  final protected[Tests] case object Test1 extends Test {
+    override final lazy implicit val name: String = "foo"
+  }
+
+  final case class Test2(override implicit val name: String) extends Test
+
+  private[test] final class Test3(override val name: String = "42")(final private[this] implicit val foo: Int) extends Test
+}
+>>>
+package test
+
+private[test] sealed trait Test {
+  def name: String
+}
+
+private[test] final object Tests {
+
+  protected[Tests] final case object Test1 extends Test {
+    final implicit override lazy val name: String = "foo"
+  }
+
+  final case class Test2(implicit override val name: String) extends Test
+
+  private[test] final class Test3(override val name: String = "42")(private[this] final implicit val foo: Int) extends Test
+}

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Default.source
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Default.source
@@ -1,0 +1,50 @@
+maxColumn = 200 #to not disturb the output too much
+rewrite {
+  rules = [SortModifiers]
+}
+
+
+<<< default formatting of ADT
+package test
+
+sealed private[test] trait Test {
+  protected def name: String
+}
+
+final private[test] object Tests {
+
+  private final type T1 = Int
+  final private type T2 = String
+
+  final private implicit case object Test1 extends Test { def name: String = "Test1" }
+  implicit private final case object Test2 extends Test { def name: String = "Test2" }
+  final implicit private case object Test3 extends Test { def name: String = "Test3" }
+
+  sealed abstract class TestSup(protected override val name: String) extends Test
+
+  final class Test4(implicit final private val impl: String) extends Test {
+    final protected implicit override lazy val name: String = impl
+  }
+}
+>>>
+package test
+
+sealed private[test] trait Test {
+  protected def name: String
+}
+
+final private[test] object Tests {
+
+  final private type T1 = Int
+  final private type T2 = String
+
+  implicit final private case object Test1 extends Test { def name: String = "Test1" }
+  implicit final private case object Test2 extends Test { def name: String = "Test2" }
+  implicit final private case object Test3 extends Test { def name: String = "Test3" }
+
+  sealed abstract class TestSup(override protected val name: String) extends Test
+
+  final class Test4(implicit final private val impl: String) extends Test {
+    implicit final override protected lazy val name: String = impl
+  }
+}

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Default.source
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Default.source
@@ -48,3 +48,47 @@ final private[test] object Tests {
     implicit final override protected lazy val name: String = impl
   }
 }
+<<< default formatting of ADT — no changes
+package test
+
+sealed private[test] trait Test {
+  protected def name: String
+}
+
+final private[test] object Tests {
+
+  final private type T1 = Int
+  final private type T2 = String
+
+  implicit final private case object Test1 extends Test { def name: String = "Test1" }
+  implicit final private case object Test2 extends Test { def name: String = "Test2" }
+  implicit final private case object Test3 extends Test { def name: String = "Test3" }
+
+  sealed abstract class TestSup(override protected val name: String) extends Test
+
+  final class Test4(implicit final private val impl: String) extends Test {
+    implicit final override protected lazy val name: String = impl
+  }
+}
+>>>
+package test
+
+sealed private[test] trait Test {
+  protected def name: String
+}
+
+final private[test] object Tests {
+
+  final private type T1 = Int
+  final private type T2 = String
+
+  implicit final private case object Test1 extends Test { def name: String = "Test1" }
+  implicit final private case object Test2 extends Test { def name: String = "Test2" }
+  implicit final private case object Test3 extends Test { def name: String = "Test3" }
+
+  sealed abstract class TestSup(override protected val name: String) extends Test
+
+  final class Test4(implicit final private val impl: String) extends Test {
+    implicit final override protected lazy val name: String = impl
+  }
+}

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Mod_With_No_Token.source
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Mod_With_No_Token.source
@@ -1,0 +1,43 @@
+maxColumn = 200 #to not disturb the output too much
+rewrite {
+  rules = [SortModifiers]
+  sortModifiers {
+    order = ["private", "protected" , "abstract", "final", "sealed", "implicit", "override", "lazy"]
+  }
+}
+
+
+<<< Almost bug in convoluted modifiers
+package test
+
+sealed private[test] trait Test {
+  def name: String
+}
+
+final private[test] object Tests {
+
+  final protected[Tests] case object Test1 extends Test {
+    override final lazy implicit val name: String = "foo"
+  }
+
+  final case class Test2(override implicit val name: String) extends Test
+
+  private[test] final class Test3(override val name: String = "42", final private[this] implicit val foo: Int) extends Test
+}
+>>>
+package test
+
+private[test] sealed trait Test {
+  def name: String
+}
+
+private[test] final object Tests {
+
+  protected[Tests] final case object Test1 extends Test {
+    final implicit override lazy val name: String = "foo"
+  }
+
+  final case class Test2(implicit override val name: String) extends Test
+
+  private[test] final class Test3(override val name: String = "42", private[this] final implicit val foo: Int) extends Test
+}


### PR DESCRIPTION
Closes #1138 
Later edit:
I decided to add docs even before feedback.

TODO:
- [x] If the implementation/behavior/defaults are deemed OK, then I will add the appropriate documentation as well

This rewrite rule will sort the modifiers applied to the following language constructs:
- Defn.Def
- Defn.Val
- Defn.Var
- Defn.Type
- Defn.Class
- Defn.Object
- Defn.Trait
- Term.Param

Example config:
```
rewrite {
  rules = [SortModifiers]
  sortModifiers {
    # also the default value, the user has to specify all 8. The message if they fail
    # to do so is very instructive, and the docs will be clear, so hopefully it's user friendly
    order = ["implicit", "final", "sealed", "abstract", "override", "private", "protected", "lazy"]
  }
}
```

Later edit — example with config:
```
maxColumn = 200
rewrite {
  rules = [SortModifiers]
}
```

Before:
```
package test

sealed private[test] trait Test {
  protected def name: String
}

final private[test] object Tests {

  private final type T1 = Int
  final private type T2 = String

  final private implicit case object Test1 extends Test { def name: String = "Test1" }
  implicit private final case object Test2 extends Test { def name: String = "Test2" }
  final implicit private case object Test3 extends Test { def name: String = "Test3" }

  sealed abstract class TestSup(protected override val name: String) extends Test

  final class Test4(implicit final private val impl: String) extends Test {
    final protected implicit override lazy val name: String = impl
  }
}
```

After:
```
package test

sealed private[test] trait Test {
  protected def name: String
}

final private[test] object Tests {

  final private type T1 = Int
  final private type T2 = String

  implicit final private case object Test1 extends Test { def name: String = "Test1" }
  implicit final private case object Test2 extends Test { def name: String = "Test2" }
  implicit final private case object Test3 extends Test { def name: String = "Test3" }

  sealed abstract class TestSup(override protected val name: String) extends Test

  final class Test4(implicit final private val impl: String) extends Test {
    implicit final override protected lazy val name: String = impl
  }
}
```
-----
N.B:
There is some weird behavior that shows up when formatting `SortModifiers_Mod_With_No_Token.source`. The tokens of a Mod are empty (which makes very little sense to me). This case is explicitly handled and no patches are applied to the code. And lo' and behold everything formats as expected anyway. Very, very weird.

Supporting changes:
 - added a method `org.scalafmt.config.ReaderUtil.oneOfIgnoreBackticks`
   to easily define a reader for the config that ignores backticks in
   case object names. So I factored out the implementation of `oneOf`