### PR TITLE
SortModifiers rewrite fixes + doc prettyfying

### DIFF
--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -689,30 +689,47 @@
         Modifiers are sorted based on the given order. Affects modifiers of the following
         definitions: trait, class, object, type, and val+var, both as fields and class parameters.
 
-      Demo run. On the left you have the code before sorting, on the right after.
-      @demoStyle(rewriteSortModifiers)
-        sealed trait ADT
-        final private object ADTs {
+      @hl.scala
+        //before
+        final lazy private implicit val x = 42
+        lazy final implicit private val y = 42
 
-          private final type T1 = Int
-          final private[ADTs] type T2 = String
+        //after
+        private final implicit lazy val x = 42
+        private final implicit lazy val y = 42
 
-          final private implicit object ADT1 extends ADT
-          implicit private final object ADT2 extends ADT
-          final implicit private object ADT3 extends ADT
+      @hl.scala
+        //before
+        class Test(
+          implicit
+          final private val i1: Int,
+          private final val i2: String
+        )
 
-          abstract sealed class ADTA(val name: T1) extends ADT {
-            def test: T1
-          }
+        //after
+        class Test(
+            implicit
+            private final val i1: Int,
+            private final val i2: String
+        )
 
-          final class ADT4(private[ADTs] final implicit var impl: T2) extends ADT {
-            lazy private[ADT4] implicit override val test: T1 = 42
-          }
+      @hl.scala
+        //before
+        object X {
+          sealed protected[X] trait ADT
+          final private case object A1 extends ADT
+          private final case class A2(x: Int) extends ADT
+        }
+
+        //after
+        object X {
+          protected[X] sealed trait ADT
+          private final case object A1 extends ADT
+          private final case class A2(x: Int) extends ADT
         }
 
       If you choose the non-default sort order then you have to specify all eight modifiers in the order you wish to see
       them. Hint: since some modifiers are mutually exclusive, you might want to order them next to each other.
-
 
       @p
         Example config:

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -35,15 +35,14 @@ object SortModifiers extends Rewrite {
       case t: Defn.Trait => sortMods(t.mods)
       case p: Term.Param =>
         sortMods(
-          p.mods.filterNot(m => m.is[Mod.ValParam] || m.is[Mod.VarParam]),
-          code = code)
+          p.mods.filterNot(m => m.is[Mod.ValParam] || m.is[Mod.VarParam])
+        )
     }
     patchesOfPatches.flatten
   }
 
   private def sortMods(
-      oldMods: Seq[Mod],
-      code: Tree = null
+      oldMods: Seq[Mod]
   )(implicit order: Vector[ModKey]): Seq[Patch] = {
     if (oldMods.isEmpty) Nil
     else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -69,7 +69,7 @@ object SortModifiers extends Rewrite {
     * )
     * }}}
     *
-    * `val i1`, and `var i2` have an ``Mod.Implicit`` with empty tokens.
+    * `val i1`, and `var i2` have a ``Mod.Implicit`` with empty tokens.
     * Therefore we want to completely ignore this "mod" whenever we sort,
     * and apply patches
     */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -35,29 +35,46 @@ object SortModifiers extends Rewrite {
       case t: Defn.Trait => sortMods(t.mods)
       case p: Term.Param =>
         sortMods(
-          p.mods.filterNot(m => m.is[Mod.ValParam] || m.is[Mod.VarParam]))
+          p.mods.filterNot(m => m.is[Mod.ValParam] || m.is[Mod.VarParam]),
+          code = code)
     }
     patchesOfPatches.flatten
   }
 
   private def sortMods(
-      oldMods: Seq[Mod]
+      oldMods: Seq[Mod],
+      code: Tree = null
   )(implicit order: Vector[ModKey]): Seq[Patch] = {
     if (oldMods.isEmpty) Nil
     else {
-      val sortedMods: Seq[Mod] = oldMods.sortWith(orderModsBy(order))
-      sortedMods.zip(oldMods).flatMap {
+      val sanitized = oldMods.filterNot(isHiddenImplicit)
+      val sortedMods: Seq[Mod] = sanitized.sortWith(orderModsBy(order))
+
+      sortedMods.zip(sanitized).flatMap {
         case (next, old) =>
-          if (old.tokens.isEmpty) {
-            //required for cases like: def foo(implicit x: Int)
-            Nil
-          } else {
-            val removeOld = old.tokens.map(t => TokenPatch.Remove(t))
-            val addNext = TokenPatch.AddRight(old.tokens.head, next.syntax)
-            removeOld :+ addNext
-          }
+          val removeOld = old.tokens.map(t => TokenPatch.Remove(t))
+          val addNext = TokenPatch.AddRight(old.tokens.head, next.syntax)
+          removeOld :+ addNext
       }
     }
+  }
+
+  /**
+    * In cases like:
+    * {{{
+    *   class X(
+    *     implicit
+    *     private[this] val i1: Int,
+    *     private[this] var i2: String
+    * )
+    * }}}
+    *
+    * `val i1`, and `var i2` have an ``Mod.Implicit`` with empty tokens.
+    * Therefore we want to completely ignore this "mod" whenever we sort,
+    * and apply patches
+    */
+  private def isHiddenImplicit(m: Mod): Boolean = {
+    m.tokens.isEmpty && m.is[Mod.Implicit]
   }
 
   /**

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
@@ -6,7 +6,10 @@ rewrite {
   }
 }
 
-
+<<< 1148 — only implicit param
+def foo(implicit x: Int)
+>>>
+def foo(implicit x: Int)
 <<< 1148 — implicit class param negative test
 class X(private final val x: Int)(
     implicit

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
@@ -1,0 +1,63 @@
+maxColumn = 200 #to not disturb the output too much
+rewrite {
+  rules = [SortModifiers]
+  sortModifiers {
+    order = ["private", "protected" , "abstract", "final", "sealed", "implicit", "override", "lazy"]
+  }
+}
+
+
+<<< 1148 — implicit class param negative test
+class X(private final val x: Int)(
+    implicit
+    val i1: Int
+)
+>>>
+class X(private final val x: Int)(
+    implicit
+    val i1: Int
+)
+<<< 1148 — implicit val with only private
+class X(private final val x: Int)(
+    implicit
+    private[this] val i1: Int,
+    private[this] var i2: String
+)
+>>>
+class X(private final val x: Int)(
+    implicit
+    private[this] val i1: Int,
+    private[this] var i2: String
+)
+<<< 1148 — implicit val with private and final
+class X(private final val x: Int)(
+    implicit
+    final private[this] val i1: Int,
+    private[this] final var i2: String
+)
+>>>
+class X(private final val x: Int)(
+    implicit
+    private[this] final val i1: Int,
+    private[this] final var i2: String
+)
+<<< 1148 — implicit val with duplicate implicit mod
+class X(private final val x: Int)(
+    implicit val i1: Int,
+    implicit val i2: Int
+)
+>>>
+class X(private final val x: Int)(
+    implicit val i1: Int,
+    implicit var i2: Int
+)
+<<< 1148 — implicit val with duplicate implicit, final, private mod
+class X(private final val x: Int)(
+    implicit final private val i1: Int,
+    implicit final private var i2: Int
+)
+>>>
+class X(private final val x: Int)(
+    private final implicit val i1: Int,
+    private final implicit val i2: Int
+)

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
@@ -44,20 +44,20 @@ class X(private final val x: Int)(
 <<< 1148 — implicit val with duplicate implicit mod
 class X(private final val x: Int)(
     implicit val i1: Int,
-    implicit val i2: Int
+    implicit var i2: Int
 )
 >>>
 class X(private final val x: Int)(
     implicit val i1: Int,
     implicit var i2: Int
 )
-<<< 1148 — implicit val with duplicate implicit, final, private mod
+<<< 1148 — implicit val with duplicate implicit, final, private mod — slight inconsistency
 class X(private final val x: Int)(
     implicit final private val i1: Int,
     implicit final private var i2: Int
 )
 >>>
 class X(private final val x: Int)(
-    private final implicit val i1: Int,
-    private final implicit val i2: Int
+    implicit private final val i1: Int,
+    private final implicit var i2: Int
 )

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148_implicit_first_in_order.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148_implicit_first_in_order.stat
@@ -6,7 +6,10 @@ rewrite {
   }
 }
 
-
+<<< 1148 — only implicit param
+def foo(implicit x: Int)
+>>>
+def foo(implicit x: Int)
 <<< 1148 — implicit class param negative test
 class X(final private val x: Int)(
     implicit

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148_implicit_first_in_order.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148_implicit_first_in_order.stat
@@ -1,0 +1,63 @@
+maxColumn = 200 #to not disturb the output too much
+rewrite {
+  rules = [SortModifiers]
+  sortModifiers {
+    order = ["implicit", "final", "sealed", "abstract", "override", "private", "protected", "lazy"]
+  }
+}
+
+
+<<< 1148 — implicit class param negative test
+class X(final private val x: Int)(
+    implicit
+    val i1: Int
+)
+>>>
+class X(final private val x: Int)(
+    implicit
+    val i1: Int
+)
+<<< 1148 — implicit val with only private
+class X(private final val x: Int)(
+    implicit
+    private[this] val i1: Int,
+    private[this] var i2: String
+)
+>>>
+class X(final private val x: Int)(
+    implicit
+    private[this] val i1: Int,
+    private[this] var i2: String
+)
+<<< 1148 — implicit val with private and final
+class X(private final val x: Int)(
+    implicit
+    final private[this] val i1: Int,
+    private[this] final var i2: String
+)
+>>>
+class X(final private val x: Int)(
+    implicit
+    final private[this] val i1: Int,
+    final private[this] var i2: String
+)
+<<< 1148 — implicit val with duplicate implicit mod
+class X(private final val x: Int)(
+    implicit val i1: Int,
+    implicit var i2: Int
+)
+>>>
+class X(final private val x: Int)(
+    implicit val i1: Int,
+    implicit var i2: Int
+)
+<<< 1148 — implicit val with duplicate implicit, final, private mod — slight inconsistency
+class X(private final val x: Int)(
+    implicit final private val i1: Int,
+    implicit final private var i2: Int
+)
+>>>
+class X(final private val x: Int)(
+    implicit final private val i1: Int,
+    implicit final private var i2: Int
+)


### PR DESCRIPTION
Closes #1148 (bug), #1149 (docs)

There is one super weird corner case that is not handled properly by the fix. There's also a test for it:
If you have a sort order where `implicit` has lower order than the rest, then the following code gets formatted weirdly.

Config:
```
rewrite {
  rules = [SortModifiers]
  sortModifiers {
    order = ["private", "protected" , "abstract", "final", "sealed", "implicit", "override", "lazy"]
  }
}
```
Original code:
```
class X(private final val x: Int)(
    implicit final private val i1: Int,
    implicit final private var i2: Int
)
```
Formatted code:
```
class X(private final val x: Int)(
    implicit private final val i1: Int,
    private final implicit var i2: Int
)
```

But this is a super weird corner case where the `implicit` keyword is duplicated, and honestly until I wrote this format I had no idea that was even possible 😅. 

You will also notice that this implementation is actually cleaner than the buggy one, which is a pleasant surprise 😃 
/cc @olafurpg 