### PR TITLE
Make it configurable when to exclude dangling parens for vertical

### DIFF
--- a/readme/Changelog05.scalatex
+++ b/readme/Changelog05.scalatex
@@ -31,11 +31,11 @@
       See @sect.ref(Rewrite.rewrite2name(RedundantBraces)).
       Thank you @user{ysusuk} for contributing this feature!
     @li
-      Bugfix for flag @cliFlags{verticalMultilineAtDefinitionSite = true} (disabled by default).
+      Bugfix for flag verticalMultilineAtDefinitionSite = true (disabled by default).
 @sect{0.5.4}
   @ul
     @li
-      New flag @cliFlags{verticalMultilineAtDefinitionSite = false}.
+      New flag verticalMultilineAtDefinitionSite = false.
       @hl.scala
         // if false (default)
         def format_![T <: Tree](

--- a/readme/Changelog07.scalatex
+++ b/readme/Changelog07.scalatex
@@ -61,9 +61,9 @@
 
     @li
       @b{NEW} Two settings
-      @config{newlines.beforeImplicitKWInVerticalMultiline=false}
+      newlines.beforeImplicitKWInVerticalMultiline=false
       and
-      @config{newlines.afterImplicitKWInVerticalMultiline=false}.
+      newlines.afterImplicitKWInVerticalMultiline=false
 
       @hl.scala
         // newlines.afterImplicitKWInVerticalMultiline = true

--- a/readme/Changelog10.scalatex
+++ b/readme/Changelog10.scalatex
@@ -67,7 +67,7 @@
       format are re-formatted.
     @li
       @pr(1143) by @user{mads-hartmann}.
-      Add @sect.ref{verticalMultilineAtDefinitionSiteArityThreshold} setting.
+      Add @sect.ref{verticalMultiline.arityThreshold} setting.
     @li
       @pr(1140) by @user{lorandszakacs}.
       Add @sect.ref{SortModifiers} rewrite rule.

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -311,7 +311,7 @@
     @p The @code{newlines.*} options are used to configure when and where @code{scalafmt} should
     insert newlines.
 
-    @warning
+    @sidenote
       You might be interested in the @sect.ref{Vertical Multiline} section.
 
     @sect{newlines.alwaysBeforeTopLevelStatements}
@@ -560,7 +560,7 @@
     @p
       If enabled this formats methods such that parameters are on
       their own line indented by
-      @sect.ref{continuationIndent.defnSite} separation between
+      @sect.ref{continuationIndent.defnSite}. Separation between
       parameter groups are indented by two spaces less than
       @sect.ref{continuationIndent.defnSite}. The return type is on
       its own line at then end.
@@ -577,8 +577,7 @@
         }
 
     @warning
-      This setting ignores continuation.defnSite,
-      binPack.unsafeDefnSite, and @sect.ref{align.openParenDefnSite}.
+      This setting ignores binPack.unsafeDefnSite, and @sect.ref{align.openParenDefnSite}.
 
     @p
       The default configuration options are
@@ -611,8 +610,8 @@
       Default: @b(default.verticalMultiline.newlineAfterOpenParen)
 
       @p
-        If true, add a newline aften the opening paren of a parameter
-        list. This can be used to control for formatting of methods that
+        If true, add a newline after the opening paren of a parameter
+        list. This can be used to control the formatting of methods that
         have multiple parameter lists.
 
       @fullWidthDemo(multilineNewlineAfterParen)

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -584,7 +584,7 @@
 
     @hl.scala(VerticalMultilineDefultConfigStr)
 
-    @sect{verticalMultiline.atDefinitionSite}
+    @sect{verticalMultiline.atDefnSite}
       Default: @b{false}
 
       @p

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -902,35 +902,6 @@
       There is a Scala.js style that is super experimental and does not
       work for complicated code.
 
-    @p
-      To enable a rewrite rule, add it to the config like this @config{verticalMultiline.arityThreshold = 2}.
-
-    @fullWidthDemo(arityThreshold)
-      case class Foo(x: String)
-      case class Bar(x: String, y: String)
-      case class VeryLongNames(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: String)
-      object A {
-        def foo(x: String, y: String)
-        def hello(how: String)(are: String)(you: String) = how + are + you
-      }
-
-  @sect{project}
-    @p
-      Configure which source files should be formatted in this project.
-    @cliFlags
-      # Only format files tracked by git.
-      project.git = true
-      # manually exclude files to format.
-      project.excludeFilters = [
-         regex1
-         regex2
-      ]
-      # manually include files to format.
-      project.includeFilters = [
-        regex1
-        regex2
-      ]
-
   @sect{Other}
 
     Scalafmt has a ton of internal configuration options which may be removed

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -312,10 +312,7 @@
     insert newlines.
 
     @warning
-      There are three options that are covered in the @sect.ref{Vertical Multiline} section
-      as they are only relevant if that feature is enabled. The options are are
-      @sect.ref{newlines.alwaysBeforeMultilineDef}, @sect.ref{newlines.afterImplicitKWInVerticalMultiline}
-      and @sect.ref{newlines.alwaysBeforeMultilineDef}.
+      You might be interested in the @sect.ref{Vertical Multiline} section.
 
     @sect{newlines.alwaysBeforeTopLevelStatements}
       Default: @b(default.newlines.alwaysBeforeTopLevelStatements)
@@ -560,47 +557,72 @@
 
   @sect{Vertical Multiline}
 
-    @sect{verticalMultilineAtDefinitionSite}
-      Default: @b{false}
+    @p
+      If enabled this formats methods such that parameters are on
+      their own line indented by
+      @sect.ref{continuationIndent.defnSite} separation between
+      parameter groups are indented by two spaces less than
+      @sect.ref{continuationIndent.defnSite}. The return type is on
+      its own line at then end.
 
-      @p
-        If true, reformat multi-line function definitions in the following way
-      @fullWidthDemo(verticalAlign)
+    @sidenote
+      This formatting is only triggered if the method definition
+      exceeds the @sect.ref{maxColumn} value in width or if the number
+      of arguments to the method exceeds the
+      @sect.ref{verticalMultiline.arityThreshold}.
+
+    @fullWidthDemo(verticalAlign)
         object a {
           def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
         }
-      @p
-        All parameters are on their own line indented by four (4), separation between
-        parameter groups are indented by two (2). ReturnType is on its own line at
-        then end. This will only trigger if the function would go over
-        maxColumn. If a multi-line function can fit in a single line, it will
-        make it so. Note that this setting ignores continuation.defnSite,
-        binPack.unsafeDefnSite, and align.openParenDefnSite.
+
+    @warning
+      This setting ignores continuation.defnSite,
+      binPack.unsafeDefnSite, and @sect.ref{align.openParenDefnSite}.
+
+    @p
+      The default configuration options are
+
+    @hl.scala(VerticalMultilineDefultConfigStr)
+
+    @sect{verticalMultiline.atDefinitionSite}
+      Default: @b{false}
 
       @p
-        To enable this add it to the config like this @config{verticalMultilineAtDefinitionSite = true}.
+        If true, enable vertical multiline formatting as described above.
 
-    @sect{verticalMultilineAtDefinitionSiteArityThreshold}
+    @sect{verticalMultiline.arityThreshold}
       Default: @b{100}
 
       @p
-        If set, this will trigger a vertical multi-line formatting as described above even though the
-        definition falls below the maxColumn width.
-
-      @p
-        To enable a rewrite rule, add it to the config like this @config{verticalMultilineAtDefinitionSiteArityThreshold = 2}.
+        If set, this will trigger a vertical multi-line formatting
+        even though the definition falls below the
+        @sect.ref{maxColumn} width.
 
       @fullWidthDemo(arityThreshold)
         case class Foo(x: String)
         case class Bar(x: String, y: String)
-        case class VeryLongNames(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: String)
         object A {
           def foo(x: String, y: String)
           def hello(how: String)(are: String)(you: String) = how + are + you
         }
 
-    @sect{newlines.beforeImplicitKWInVerticalMultiline}
-      Default: @b(default.newlines.beforeImplicitKWInVerticalMultiline)
+    @sect{verticalMultiline.newlineAfterOpenParen}
+      Default: @b(default.verticalMultiline.newlineAfterOpenParen)
+
+      @p
+        If true, add a newline aften the opening paren of a parameter
+        list. This can be used to control for formatting of methods that
+        have multiple parameter lists.
+
+      @fullWidthDemo(multilineNewlineAfterParen)
+        object a {
+          def other(a: String, b: String)(c: String) = a + b + c
+        }
+
+    @sect{verticalMultiline.newlineBeforeImplicitKW}
+      Default: @b(default.verticalMultiline.newlineBeforeImplicitKW)
+
       @p If true, add a newline before an implicit keyword in function and class definitions.
 
       @fullWidthDemo(verticalAlignImplicitBefore)
@@ -608,8 +630,9 @@
           def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
         }
 
-    @sect{newlines.afterImplicitKWInVerticalMultiline}
-      Default: @b(default.newlines.afterImplicitKWInVerticalMultiline)
+    @sect{verticalMultiline.newlineAfterImplicitKW}
+      Default: @b(default.verticalMultiline.newlineAfterImplicitKW)
+
       @p If true, add a newline after an implicit keyword in function and class definitions.
 
       @fullWidthDemo(verticalAlignImplicitAfter)
@@ -617,9 +640,22 @@
           def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
         }
 
+    @sect{verticalMultiline.excludeDanglingParens}
+      Default: @b(default.verticalMultiline.excludeDanglingParens.mkString(","))
+
+      @p
+        This setting defines which cases should be allowed to have
+        dangling parens.
+
+      @fullWidthDemo(multilineDanglingParens)
+        case class Bar(x: String, y: String)
+
     @sect{newlines.alwaysBeforeMultilineDef}
       Default: @b(default.newlines.alwaysBeforeMultilineDef)
-      @p If true, add a newline before the body of a multiline def without curly braces.
+
+      @p
+        If true, add a newline before the body of a multiline def
+        without curly braces.
 
       @fullWidthDemo(verticalAlign)
         object a {
@@ -866,6 +902,34 @@
       There is a Scala.js style that is super experimental and does not
       work for complicated code.
 
+    @p
+      To enable a rewrite rule, add it to the config like this @config{verticalMultiline.arityThreshold = 2}.
+
+    @fullWidthDemo(arityThreshold)
+      case class Foo(x: String)
+      case class Bar(x: String, y: String)
+      case class VeryLongNames(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: String)
+      object A {
+        def foo(x: String, y: String)
+        def hello(how: String)(are: String)(you: String) = how + are + you
+      }
+
+  @sect{project}
+    @p
+      Configure which source files should be formatted in this project.
+    @cliFlags
+      # Only format files tracked by git.
+      project.git = true
+      # manually exclude files to format.
+      project.excludeFilters = [
+         regex1
+         regex2
+      ]
+      # manually include files to format.
+      project.includeFilters = [
+        regex1
+        regex2
+      ]
 
   @sect{Other}
 

--- a/readme/resources/custom.css
+++ b/readme/resources/custom.css
@@ -106,6 +106,7 @@ ul.menu-item-list {
   display: flex;
   justify-content: space-around;
   flex-direction: column;
+  margin: 15px 0;
 }
 
 .scalafmt-rows .before:before,
@@ -167,10 +168,22 @@ blockquote small {
   background-color: #fff3cd;
   border-left: 10px solid #ffd97a;
   padding: .75rem 1.25rem;
-
 }
 
 .scalatex-site-Styles-content .warning a:link,
 .scalatex-site-Styles-content .warning a:visited {
   color: #bd8805;
+}
+
+.sidenote {
+  margin: 1em 0;
+  color: #0c5460;
+  background-color: #d1ecf1;
+  border-left: 10px solid #bee5eb;
+  padding: .75rem 1.25rem;
+}
+
+.scalatex-site-Styles-content .sidenote a:link,
+.scalatex-site-Styles-content .sidenote a:visited {
+  color: #37a;
 }

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -207,7 +207,7 @@ object Readme {
 
   val verticalAlign = ScalafmtConfig.default.copy(
     maxColumn = 60,
-    verticalMultiline = VerticalMultiline(atDefinitionSite = true)
+    verticalMultiline = VerticalMultiline(atDefnSite = true)
   )
 
   val VerticalMultilineDefultConfigStr = "verticalmultiline = {\n" + Config
@@ -218,7 +218,7 @@ object Readme {
   val verticalAlignImplicitBefore = ScalafmtConfig.default.copy(
     maxColumn = 60,
     verticalMultiline = VerticalMultiline(
-      atDefinitionSite = true,
+      atDefnSite = true,
       newlineBeforeImplicitKW = true
     )
   )
@@ -226,7 +226,7 @@ object Readme {
   val verticalAlignImplicitAfter = ScalafmtConfig.default.copy(
     maxColumn = 60,
     verticalMultiline = VerticalMultiline(
-      atDefinitionSite = true,
+      atDefnSite = true,
       newlineAfterImplicitKW = true
     )
   )
@@ -235,7 +235,7 @@ object Readme {
     continuationIndent =
       ScalafmtConfig.default.continuationIndent.copy(defnSite = 2),
     verticalMultiline = VerticalMultiline(
-      atDefinitionSite = true,
+      atDefnSite = true,
       arityThreshold = 2,
       newlineAfterOpenParen = true
     )
@@ -245,7 +245,7 @@ object Readme {
     continuationIndent =
       ScalafmtConfig.default.continuationIndent.copy(defnSite = 2),
     verticalMultiline = VerticalMultiline(
-      atDefinitionSite = true,
+      atDefnSite = true,
       arityThreshold = 2,
       excludeDanglingParens = Nil
     )
@@ -254,7 +254,7 @@ object Readme {
   val arityThreshold =
     ScalafmtConfig.default.copy(
       verticalMultiline =
-        VerticalMultiline(atDefinitionSite = true, arityThreshold = 2)
+        VerticalMultiline(atDefnSite = true, arityThreshold = 2)
     )
 
   def fmt(style: ScalafmtConfig)(code: String): TypedTag[String] =

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -10,6 +10,7 @@ import org.scalafmt.cli.Cli
 import org.scalafmt.cli.CliArgParser
 import org.scalafmt.config._
 import org.scalafmt.rewrite._
+import org.scalafmt.config.Config
 
 object hl extends scalatex.site.Highlighter
 
@@ -70,6 +71,8 @@ object Readme {
   def note = b("NOTE")
 
   def warning(frags: Frag*) = div(frags, `class` := "warning")
+
+  def sidenote(frags: Frag*) = div(frags, `class` := "sidenote")
 
   def github: String = "https://github.com"
   def repo: String = "https://github.com/scalameta/scalafmt"
@@ -204,29 +207,54 @@ object Readme {
 
   val verticalAlign = ScalafmtConfig.default.copy(
     maxColumn = 60,
-    verticalMultilineAtDefinitionSite = true
+    verticalMultiline = VerticalMultiline(atDefinitionSite = true)
   )
+
+  val VerticalMultilineDefultConfigStr = "verticalmultiline = {\n" + Config
+    .toHocon(ScalafmtConfig.default.verticalMultiline)
+    .map("  " + _)
+    .mkString("\n") + "\n}"
 
   val verticalAlignImplicitBefore = ScalafmtConfig.default.copy(
     maxColumn = 60,
-    verticalMultilineAtDefinitionSite = true,
-    newlines = ScalafmtConfig.default.newlines.copy(
-      beforeImplicitKWInVerticalMultiline = true
+    verticalMultiline = VerticalMultiline(
+      atDefinitionSite = true,
+      newlineBeforeImplicitKW = true
     )
   )
 
   val verticalAlignImplicitAfter = ScalafmtConfig.default.copy(
     maxColumn = 60,
-    verticalMultilineAtDefinitionSite = true,
-    newlines = ScalafmtConfig.default.newlines.copy(
-      afterImplicitKWInVerticalMultiline = true
+    verticalMultiline = VerticalMultiline(
+      atDefinitionSite = true,
+      newlineAfterImplicitKW = true
+    )
+  )
+
+  val multilineNewlineAfterParen = ScalafmtConfig.default.copy(
+    continuationIndent =
+      ScalafmtConfig.default.continuationIndent.copy(defnSite = 2),
+    verticalMultiline = VerticalMultiline(
+      atDefinitionSite = true,
+      arityThreshold = 2,
+      newlineAfterOpenParen = true
+    )
+  )
+
+  val multilineDanglingParens = ScalafmtConfig.default.copy(
+    continuationIndent =
+      ScalafmtConfig.default.continuationIndent.copy(defnSite = 2),
+    verticalMultiline = VerticalMultiline(
+      atDefinitionSite = true,
+      arityThreshold = 2,
+      excludeDanglingParens = Nil
     )
   )
 
   val arityThreshold =
     ScalafmtConfig.default.copy(
-      verticalMultilineAtDefinitionSite = true,
-      verticalMultilineAtDefinitionSiteArityThreshold = 2
+      verticalMultiline =
+        VerticalMultiline(atDefinitionSite = true, arityThreshold = 2)
     )
 
   def fmt(style: ScalafmtConfig)(code: String): TypedTag[String] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -86,6 +86,10 @@ case class Newlines(
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
+    @deprecated("Use VerticalMultiline.newlineAfterImplicitKW instead")
+    afterImplicitKWInVerticalMultiline: Boolean = false,
+    @deprecated("Use VerticalMultiline.newlineBeforeImplicitKW instead")
+    beforeImplicitKWInVerticalMultiline: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true
 )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -54,48 +54,6 @@ import metaconfig._
   *   If `always`, it will always add one empty line (opposite of `never`).
   *   If `preserve`, and there isn't an empty line, it will keep it as it is.
   *   If there is one or more empty lines, it will place a single empty line.
-  * @param afterImplicitKWInVerticalMultiline  If true, add a newline after an implicit keyword in function and
-  *                                   class definitions (only for verticalMultiline style)
-  * {{{
-  *   // newlines.afterImplicitKWInVerticalMultiline = true
-  *   def format(
-  *     code: String,
-  *     age: Int
-  *   )(implicit
-  *     ev: Parser,
-  *     c: Context
-  *   ): String
-  *   // newlines.afterImplicitKWInVerticalMultiline = false
-  *   def format(
-  *     code: String,
-  *     age: Int
-  *   )(implicit ev: Parser,
-  *     c: Context
-  *   ): String
-  * }}}
-  * @param beforeImplicitKWInVerticalMultiline If true, add a newline before an implicit keyword in function and
-  *                                   class definitions (only for verticalMultiline style)
-  * {{{
-  *   // newlines.afterImplicitKWInVerticalMultiline = true
-  *   // newlines.beforeImplicitKWInVerticalMultiline = true
-  *   def format(
-  *     code: String,
-  *     age: Int
-  *   )(
-  *     implicit
-  *     ev: Parser,
-  *     c: Context
-  *   ): String
-  *   // newlines.afterImplicitKWInVerticalMultiline = true
-  *   // newlines.beforeImplicitKWInVerticalMultiline = false
-  *   def format(
-  *     code: String,
-  *     age: Int
-  *   )(implicit
-  *     ev: Parser,
-  *     c: Context
-  *   ): String
-  * }}}
   * @param alwaysBeforeElseAfterCurlyIf if true, add a new line between the end of a curly if and the following else.
   *   For example
   *   if(someCond) {
@@ -128,8 +86,6 @@ case class Newlines(
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
-    afterImplicitKWInVerticalMultiline: Boolean = false,
-    beforeImplicitKWInVerticalMultiline: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true
 )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -97,27 +97,6 @@ import org.scalafmt.util.ValidationOps
   *        x + 2
   *    }.filter(_ > 2)
   *  }}}
-  * @param verticalMultilineAtDefinitionSite If true, reformat multi-line function definitions in
-  *                                          the following way
-  *                                          {{{
-  *                                             def format(
-  *                                                 code: String,
-  *                                                 age: Int
-  *                                               )(implicit ev: Parser,
-  *                                                 c: Context
-  *                                               ): String
-  *                                           )
-  *                                          }}}
-  *
-  *                                          All parameters are on their own line indented by four (4), separation between
-  *                                          parameter groups are indented by two (2). ReturnType is on its own line at
-  *                                          the end. This will only be triggered if the function would go over
-  *                                          [[maxColumn]]. If a multi-line function can fit in a single line, it will
-  *                                          make it so. Note that this setting ignores continuation.defnSite,
-  *                                          [[binPack.unsafeDefnSite]], and [[align.openParenDefnSite]].
-  * @param verticalMultilineAtDefinitionSiteArityThreshold If set, this will trigger a vertical multi-line formatting as
-  *                                                        described above even though the definition falls below the
-  *                                                        [[maxColumn]] width.
   */
 @DeriveConfDecoder
 case class ScalafmtConfig(
@@ -144,8 +123,7 @@ case class ScalafmtConfig(
     assumeStandardLibraryStripMargin: Boolean = false,
     danglingParentheses: Boolean = false,
     poorMansTrailingCommasInConfigStyle: Boolean = false,
-    verticalMultilineAtDefinitionSite: Boolean = false,
-    verticalMultilineAtDefinitionSiteArityThreshold: Int = 100,
+    @Recurse verticalMultiline: VerticalMultiline = VerticalMultiline(),
     onTestFailure: String = "",
     encoding: Codec = "UTF-8",
     @Recurse project: ProjectFiles = ProjectFiles()

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -123,7 +123,7 @@ case class ScalafmtConfig(
     assumeStandardLibraryStripMargin: Boolean = false,
     danglingParentheses: Boolean = false,
     poorMansTrailingCommasInConfigStyle: Boolean = false,
-    @deprecated("Use VerticalMultiline.atDefinitionSite instead")
+    @deprecated("Use VerticalMultiline.atDefnSite instead")
     verticalMultilineAtDefinitionSite: Boolean = false,
     @deprecated("Use VerticalMultiline.arityThreshold instead")
     verticalMultilineAtDefinitionSiteArityThreshold: Int = 100,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -123,6 +123,10 @@ case class ScalafmtConfig(
     assumeStandardLibraryStripMargin: Boolean = false,
     danglingParentheses: Boolean = false,
     poorMansTrailingCommasInConfigStyle: Boolean = false,
+    @deprecated("Use VerticalMultiline.atDefinitionSite instead")
+    verticalMultilineAtDefinitionSite: Boolean = false,
+    @deprecated("Use VerticalMultiline.arityThreshold instead")
+    verticalMultilineAtDefinitionSiteArityThreshold: Int = 100,
     @Recurse verticalMultiline: VerticalMultiline = VerticalMultiline(),
     onTestFailure: String = "",
     encoding: Codec = "UTF-8",

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -3,7 +3,7 @@ package org.scalafmt.config
 import metaconfig._
 
 /**
-  * Configuration related ot multi-line formatting.
+  * Configuration related to multi-line formatting.
   */
 @DeriveConfDecoder
 case class VerticalMultiline(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -1,0 +1,29 @@
+package org.scalafmt.config
+
+import metaconfig._
+
+/**
+  * Configuration related ot multi-line formatting.
+  */
+@DeriveConfDecoder
+case class VerticalMultiline(
+    atDefinitionSite: Boolean = false,
+    arityThreshold: Int = 100,
+    newlineBeforeImplicitKW: Boolean = false,
+    newlineAfterImplicitKW: Boolean = false,
+    newlineAfterOpenParen: Boolean = false,
+    excludeDanglingParens: List[DanglingExclude] = List(
+      DanglingExclude.`class`,
+      DanglingExclude.`trait`
+    )
+)
+
+sealed abstract class DanglingExclude
+
+object DanglingExclude {
+  case object `class` extends DanglingExclude
+  case object `trait` extends DanglingExclude
+
+  implicit val danglingExcludeReader: ConfDecoder[DanglingExclude] =
+    ReaderUtil.oneOf[DanglingExclude](`class`, `trait`)
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -7,7 +7,7 @@ import metaconfig._
   */
 @DeriveConfDecoder
 case class VerticalMultiline(
-    atDefinitionSite: Boolean = false,
+    atDefnSite: Boolean = false,
     arityThreshold: Int = 100,
     newlineBeforeImplicitKW: Boolean = false,
     newlineAfterImplicitKW: Boolean = false,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -807,9 +807,12 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         val mixedParamsWithCtorModifier =
           mixedParams && owners(prevT).is[CtorModifier]
 
+        // We don't want to create newlines for default values.
+        val isDefinition = ownerCheck(close2)
+
         val shouldAddNewline =
           (isImplicitArgList && newlineBeforeImplicitEnabled) ||
-          (style.verticalMultiline.newlineAfterOpenParen && !isImplicitArgList) ||
+          (style.verticalMultiline.newlineAfterOpenParen && !isImplicitArgList && isDefinition) ||
           mixedParamsWithCtorModifier
 
         val mod =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -794,7 +794,6 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       // - newlineAfterOpenParen is enabled
       // - Mixed-params case with constructor modifier `] private (`
       case Decision(t @ FormatToken(open2 @ LeftParen(), right, _), _) =>
-
         val close2 = matchingParentheses(hash(open2))
         val prevT = prev(t).left
 
@@ -802,7 +801,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
         val newlineBeforeImplicitEnabled =
           style.verticalMultiline.newlineBeforeImplicitKW ||
-          style.newlines.beforeImplicitKWInVerticalMultiline
+            style.newlines.beforeImplicitKWInVerticalMultiline
 
         val mixedParamsWithCtorModifier =
           mixedParams && owners(prevT).is[CtorModifier]
@@ -812,8 +811,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
         val shouldAddNewline =
           (isImplicitArgList && newlineBeforeImplicitEnabled) ||
-          (style.verticalMultiline.newlineAfterOpenParen && !isImplicitArgList && isDefinition) ||
-          mixedParamsWithCtorModifier
+            (style.verticalMultiline.newlineAfterOpenParen && !isImplicitArgList && isDefinition) ||
+            mixedParamsWithCtorModifier
 
         val mod =
           if (shouldAddNewline) Newline

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -796,7 +796,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case Decision(t @ FormatToken(open2 @ LeftParen(), right, _), _) =>
         val newlinewBeforeImplicit =
           right.is[KwImplicit] &&
-            style.verticalMultiline.newlineBeforeImplicitKW
+            (style.verticalMultiline.newlineBeforeImplicitKW || style.newlines.beforeImplicitKWInVerticalMultiline)
         val close2 = matchingParentheses(hash(open2))
         val prevT = prev(t).left
         val mixedParamsWithCtorModifier = mixedParams && owners(prevT)
@@ -812,7 +812,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
               .withIndent(indentParam, close2, Right)
           ))
       case Decision(t @ FormatToken(KwImplicit(), _, _), _)
-          if style.verticalMultiline.newlineAfterImplicitKW =>
+          if (style.verticalMultiline.newlineAfterImplicitKW || style.newlines.afterImplicitKWInVerticalMultiline) =>
         val split = Split(Newline, 0)
         Decision(t, Seq(split))
     }
@@ -838,7 +838,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case _ => 0
     }
 
-    val aboveArityThreshold = maxArity >= style.verticalMultiline.arityThreshold
+    val aboveArityThreshold = (maxArity >= style.verticalMultiline.arityThreshold) || (maxArity >= style.verticalMultilineAtDefinitionSiteArityThreshold)
 
     Seq(
       Split(NoSplit, 0, ignoreIf = !isBracket && aboveArityThreshold)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -431,7 +431,7 @@ class Router(formatOps: FormatOps) {
       // Parameter opening for one parameter group. This format works
       // on the WHOLE defnSite (via policies)
       case ft @ FormatToken((LeftParen() | LeftBracket()), _, _)
-          if style.verticalMultiline.atDefinitionSite &&
+          if (style.verticalMultiline.atDefinitionSite || style.verticalMultilineAtDefinitionSite) &&
             isDefnSiteWithParams(leftOwner) =>
         verticalMultiline(leftOwner, ft)(style)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -431,7 +431,7 @@ class Router(formatOps: FormatOps) {
       // Parameter opening for one parameter group. This format works
       // on the WHOLE defnSite (via policies)
       case ft @ FormatToken((LeftParen() | LeftBracket()), _, _)
-          if (style.verticalMultiline.atDefinitionSite || style.verticalMultilineAtDefinitionSite) &&
+          if (style.verticalMultiline.atDefnSite || style.verticalMultilineAtDefinitionSite) &&
             isDefnSiteWithParams(leftOwner) =>
         verticalMultiline(leftOwner, ft)(style)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -431,7 +431,7 @@ class Router(formatOps: FormatOps) {
       // Parameter opening for one parameter group. This format works
       // on the WHOLE defnSite (via policies)
       case ft @ FormatToken((LeftParen() | LeftBracket()), _, _)
-          if style.verticalMultilineAtDefinitionSite &&
+          if style.verticalMultiline.atDefinitionSite &&
             isDefnSiteWithParams(leftOwner) =>
         verticalMultiline(leftOwner, ft)(style)
 

--- a/scalafmt-tests/src/test/resources/test/arityThreshold.source
+++ b/scalafmt-tests/src/test/resources/test/arityThreshold.source
@@ -1,6 +1,6 @@
 maxColumn = 80
 verticalMultiline = {
-    atDefinitionSite = true
+    atDefnSite = true
     arityThreshold = 2
 }
 continuationIndent.defnSite = 2

--- a/scalafmt-tests/src/test/resources/test/arityThreshold.source
+++ b/scalafmt-tests/src/test/resources/test/arityThreshold.source
@@ -1,9 +1,10 @@
 maxColumn = 80
-verticalMultilineAtDefinitionSite = true
-verticalMultilineAtDefinitionSiteArityThreshold = 2
-danglingParentheses = true
+verticalMultiline = {
+    atDefinitionSite = true
+    arityThreshold = 2
+}
 continuationIndent.defnSite = 2
-<<< Verify that verticalMultilineAtDefinitionSiteArityThreshold works as expected
+<<< Verify that verticalMultiline.arityThreshold works as expected
 case class Foo(x: String)
 case class Bar(x: String, y: String)
 case class VeryLongNames(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: String)

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -1,6 +1,6 @@
 maxColumn = 80
 verticalMultiline = {
-    atDefinitionSite = true
+    atDefnSite = true
 }
 continuationIndent.defnSite = 2
 <<< Work with continuationIndent.defnSite = 2

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -1,5 +1,7 @@
 maxColumn = 80
-verticalMultilineAtDefinitionSite = true
+verticalMultiline = {
+    atDefinitionSite = true
+}
 continuationIndent.defnSite = 2
 <<< Work with continuationIndent.defnSite = 2
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -1,6 +1,6 @@
 maxColumn = 80
 verticalMultiline = {
-    atDefinitionSite = true
+    atDefnSite = true
     newlineAfterImplicitKW = true
 }
 continuationIndent.defnSite = 2

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -1,9 +1,10 @@
 maxColumn = 80
-verticalMultilineAtDefinitionSite = true
+verticalMultiline = {
+    atDefinitionSite = true
+    newlineAfterImplicitKW = true
+}
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 0
-newlines.afterImplicitKWInVerticalMultiline = true
-newlines.beforeImplicitKWInVerticalMultiline = true
 
 <<< should add a newline after implicit keyword in function definitions
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
@@ -13,8 +14,7 @@ def format_![T <: Tree](
   foo: Int
 )(f: A => B,
   k: D
-)(
-  implicit
+)(implicit
   ev: Parse[T],
   ev2: EC
 ): String
@@ -30,22 +30,20 @@ final class UserProfile(
   address: Address,
   profession: Profesion,
   school: School
-)(
-  implicit
+)(implicit
   ctx: Context,
   ec: Executor)
 extends Profile
 with UserSettings
 with SomethingElse
-  
+
 <<< should work with an empty first param group
 override def load()(implicit taskCtx: Context,
       ec: ExecutionContext
     ): Future[Seq[A] Or B]
 >>>
 override def load(
-)(
-  implicit
+)(implicit
   taskCtx: Context,
   ec: ExecutionContext
 ): Future[Seq[A] Or B]
@@ -58,14 +56,14 @@ override def load(code: String)()(implicit taskCtx: Context,
 override def load(
   code: String
 )(
-)(
-  implicit
+)(implicit
   taskCtx: Context,
   ec: ExecutionContext
 ): Future[Seq[A] Or B]
 
 <<< should work without explicit parameter groups
-implicit def pairEncoder[A, B](implicit aEncoder: CsvEncoder[A],
+implicit def pairEncoder[A, B](
+    implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]
 >>>

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -1,6 +1,6 @@
 maxColumn = 80
 verticalMultiline = {
-    atDefinitionSite = true
+    atDefnSite = true
     newlineAfterImplicitKW = true
     newlineBeforeImplicitKW = true
 }

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -1,8 +1,11 @@
 maxColumn = 80
-verticalMultilineAtDefinitionSite = true
+verticalMultiline = {
+    atDefinitionSite = true
+    newlineAfterImplicitKW = true
+    newlineBeforeImplicitKW = true
+}
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 0
-newlines.afterImplicitKWInVerticalMultiline = true
 
 <<< should add a newline after implicit keyword in function definitions
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
@@ -12,7 +15,8 @@ def format_![T <: Tree](
   foo: Int
 )(f: A => B,
   k: D
-)(implicit
+)(
+  implicit
   ev: Parse[T],
   ev2: EC
 ): String
@@ -28,20 +32,22 @@ final class UserProfile(
   address: Address,
   profession: Profesion,
   school: School
-)(implicit
+)(
+  implicit
   ctx: Context,
   ec: Executor)
 extends Profile
 with UserSettings
 with SomethingElse
-
+  
 <<< should work with an empty first param group
 override def load()(implicit taskCtx: Context,
       ec: ExecutionContext
     ): Future[Seq[A] Or B]
 >>>
 override def load(
-)(implicit
+)(
+  implicit
   taskCtx: Context,
   ec: ExecutionContext
 ): Future[Seq[A] Or B]
@@ -54,14 +60,14 @@ override def load(code: String)()(implicit taskCtx: Context,
 override def load(
   code: String
 )(
-)(implicit
+)(
+  implicit
   taskCtx: Context,
   ec: ExecutionContext
 ): Future[Seq[A] Or B]
 
 <<< should work without explicit parameter groups
-implicit def pairEncoder[A, B](
-    implicit aEncoder: CsvEncoder[A],
+implicit def pairEncoder[A, B](implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]
 >>>

--- a/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
@@ -1,7 +1,7 @@
 maxColumn = 80
 continuationIndent.defnSite = 2
 verticalMultiline = {
-    atDefinitionSite = true
+    atDefnSite = true
     arityThreshold = 2 // Used here to force reformatting.
     excludeDanglingParens = []
     newlineAfterOpenParen = true

--- a/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
@@ -5,6 +5,8 @@ verticalMultiline = {
     arityThreshold = 2 // Used here to force reformatting.
     excludeDanglingParens = []
     newlineAfterOpenParen = true
+    newlineBeforeImplicitKW = false // make sure this is respected
+    newlineAfterImplicitKW = true
 }
 <<< It should force a newline after open paren.
 def other(a: String, b: String)(c: String) = a + b + c
@@ -14,4 +16,14 @@ def other(
   b: String
 )(
   c: String
+) = a + b + c
+
+<<< It should still respect newlineBeforeImplicitKW
+def other[T](a: String, b: String)(implicit c: Parse[T]) = a + b + c
+>>>
+def other[T](
+  a: String,
+  b: String
+)(implicit
+  c: Parse[T]
 ) = a + b + c

--- a/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
@@ -1,0 +1,17 @@
+maxColumn = 80
+continuationIndent.defnSite = 2
+verticalMultiline = {
+    atDefinitionSite = true
+    arityThreshold = 2 // Used here to force reformatting.
+    excludeDanglingParens = []
+    newlineAfterOpenParen = true
+}
+<<< It should force a newline after open paren.
+def other(a: String, b: String)(c: String) = a + b + c
+>>>
+def other(
+  a: String,
+  b: String
+)(
+  c: String
+) = a + b + c

--- a/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
@@ -27,3 +27,19 @@ def other[T](
 )(implicit
   c: Parse[T]
 ) = a + b + c
+
+<<< newlineAfterOpenParen should only act on definitions (not on invocations in the definitions)
+def executeQuery(query: Document, vars: Json = Json.obj()): Json
+>>>
+def executeQuery(
+  query: Document,
+  vars: Json = Json.obj()
+): Json
+
+<<< Another case of the one above
+def executeQuery(query: Document, vars: Thing = Thing(a,b,c)): Json
+>>>
+def executeQuery(
+  query: Document,
+  vars: Thing = Thing(a, b, c)
+): Json

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -1,4 +1,6 @@
-verticalMultilineAtDefinitionSite = true
+verticalMultiline = {
+    atDefinitionSite = true
+}
 maxColumn = 80
 continuationIndent.extendSite = 2
 <<< curried function over maxColumn

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -1,5 +1,5 @@
 verticalMultiline = {
-    atDefinitionSite = true
+    atDefnSite = true
 }
 maxColumn = 80
 continuationIndent.extendSite = 2

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDangling.source
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDangling.source
@@ -1,7 +1,7 @@
 maxColumn = 80
 continuationIndent.defnSite = 2
 verticalMultiline = {
-    atDefinitionSite = true
+    atDefnSite = true
     arityThreshold = 2
     excludeDanglingParens = []
 }

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDangling.source
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDangling.source
@@ -1,0 +1,29 @@
+maxColumn = 80
+continuationIndent.defnSite = 2
+verticalMultiline = {
+    atDefinitionSite = true
+    arityThreshold = 2
+    excludeDanglingParens = []
+}
+<<< Verify that it respects dangling parens options
+sealed trait Foobar
+case class Foo(x: String) extends Foobar
+case class Bar(x: String, y: String) extends Foobar
+case class VeryLongNames(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: String)
+case class X1()
+case class X2(x: Int, y: Int) { def hello: String = "Hello" }
+>>>
+sealed trait Foobar
+case class Foo(x: String) extends Foobar
+case class Bar(
+  x: String,
+  y: String
+) extends Foobar
+case class VeryLongNames(
+  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: String
+)
+case class X1()
+case class X2(
+  x: Int,
+  y: Int
+) { def hello: String = "Hello" }


### PR DESCRIPTION
The configuration defaults to the previous behavior.