### PR TITLE
Fix the full-width example styling

### DIFF
--- a/readme/resources/custom.css
+++ b/readme/resources/custom.css
@@ -100,9 +100,43 @@ ul.menu-item-list {
   justify-content: space-around;
 }
 
+.scalafmt-rows {
+  background: #f9f9f9;
+  border-left: 10px solid #ccc;
+  display: flex;
+  justify-content: space-around;
+  flex-direction: column;
+}
+
+.scalafmt-rows .before:before,
+.scalafmt-rows .after:before {
+  color: #808080;
+  font-family: monospace;
+  content: "// Before";
+  font-size: 1em;
+  line-height: 1em;
+  vertical-align: -0.4em;
+  font-weight: bold;
+  font-style: italic;
+  padding-left: 20px;
+}
+
+.scalafmt-rows .after:before {
+  content: "// After";
+}
+
+.scalafmt-rows pre {
+  margin: 0;
+}
+
+.scalafmt-rows pre code {
+  padding: 0.5em 20px;
+}
+
 /** Ovrride pre code styling in case of pair split as it's taken caore of by
- * .scalafmt-pair*/
-.scalatex-site-Styles-content .scalafmt-pair pre code {
+ * .scalafmt-pair and .scalafmt-rows*/
+.scalatex-site-Styles-content .scalafmt-pair pre code,
+.scalatex-site-Styles-content .scalafmt-rows pre code {
   background: transparent;
   border-left: none;
 }

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -100,10 +100,11 @@ object Readme {
 
   def fullWidthDemo(style: ScalafmtConfig)(code: String) = {
     val formatted = Scalafmt.format(code, style).get
-    rows(List(
-      div(hl.scala(code), `class` := "before"),
-      div(hl.scala(formatted), `class` := "after")
-    ))
+    rows(
+      List(
+        div(hl.scala(code), `class` := "before"),
+        div(hl.scala(formatted), `class` := "after")
+      ))
   }
 
   def demoStyle(style: ScalafmtConfig)(code: String) = {

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -88,6 +88,8 @@ object Readme {
 
   def pairs(frags: Frag*) = div(frags, `class` := "scalafmt-pair")
 
+  def rows(frags: Frag*) = div(frags, `class` := "scalafmt-rows")
+
   def sideBySide(left: String, right: String) =
     pairs(List(left, right).map(x => half(hl.scala(x))): _*)
 
@@ -98,7 +100,10 @@ object Readme {
 
   def fullWidthDemo(style: ScalafmtConfig)(code: String) = {
     val formatted = Scalafmt.format(code, style).get
-    pairs(List(code, formatted).map(x => hl.scala(x)): _*)
+    rows(List(
+      div(hl.scala(code), `class` := "before"),
+      div(hl.scala(formatted), `class` := "after")
+    ))
   }
 
   def demoStyle(style: ScalafmtConfig)(code: String) = {


### PR DESCRIPTION
Before:

<img width="1792" alt="screen shot 2018-04-25 at 22 08 05" src="https://user-images.githubusercontent.com/83561/39270119-52ec5b44-48d5-11e8-80d9-483e10e611b9.png">

After:

<img width="1792" alt="screen shot 2018-04-25 at 22 07 42" src="https://user-images.githubusercontent.com/83561/39270114-4c31abec-48d5-11e8-8295-20e4a0b1b3f8.png">
