### PR TITLE
Add size to AvoidInfix

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
@@ -31,7 +31,8 @@ object Pattern {
       "thrownBy",
       "synchronized",
       "have",
-      "when"
+      "when",
+      "size"
     )
   )
 }


### PR DESCRIPTION
The issue I'm trying to resolve is:
```
runningJobs should have size 0
```
reformated to:
```
(runningJobs should have).size(0)
```

This might be an issue with other similarly named functions like:
```
Seq() size
```
will not be reformated to:
```
Seq() size
```

Let me know what you think.