### PR TITLE
Render the used config values as part of formatting examples

### DIFF
--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -20,3 +20,6 @@
 
 @raw
   <a href="https://github.com/scalameta/scalafmt"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+
+@raw
+  <script src="custom.js"></script>

--- a/readme/resources/custom.css
+++ b/readme/resources/custom.css
@@ -133,6 +133,25 @@ ul.menu-item-list {
   padding: 0.5em 20px;
 }
 
+.scalafmt-configuration {
+  background: #ececec;
+  border-left: 10px solid #ccc;
+  padding: 1em 20px;
+  margin-bottom: 20px;
+}
+
+.scalafmt-configuration span {
+    font-style: italic;
+}
+
+.scalafmt-configuration-toggle:hover {
+  cursor: pointer;
+}
+
+.scalafmt-configuration.collapsed pre {
+  display: none;
+}
+
 /** Ovrride pre code styling in case of pair split as it's taken caore of by
  * .scalafmt-pair and .scalafmt-rows*/
 .scalatex-site-Styles-content .scalafmt-pair pre code,

--- a/readme/resources/custom.js
+++ b/readme/resources/custom.js
@@ -1,0 +1,7 @@
+Array
+  .from(document.getElementsByClassName('scalafmt-configuration-toggle'))
+  .forEach(function(elem) {
+    elem.onclick = function() {
+      elem.parentElement.classList.toggle('collapsed');
+    }
+  });

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -123,7 +123,7 @@ object Readme {
         "Show/hide configuration used for this example",
         `class` := "scalafmt-configuration-toggle"),
       pre(changedConfig(style)),
-      `class` := "scalafmt-configuration collapsed"
+      `class` := "scalafmt-configuration"
     )
   }
 

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -10,6 +10,7 @@ import org.scalafmt.cli.Cli
 import org.scalafmt.cli.CliArgParser
 import org.scalafmt.config._
 import org.scalafmt.rewrite._
+import org.scalafmt.config.Config
 
 object hl extends scalatex.site.Highlighter
 
@@ -100,19 +101,50 @@ object Readme {
     sideBySide(code, formatted)
   }
 
+  def changedConfig(style: ScalafmtConfig): String = {
+    // Quite a hacky implementation for now.
+    // This only works as we're flattening the HOCON configuration so
+    //   a = [
+    //    b = 1
+    //    c = 2
+    //   ]
+    // turns into
+    //   a.b = 1
+    //   a.c = 2
+    // which means a simple line-by-line string diffing is sufficient for now.
+    val defaultStrs = Config.toHocon(ScalafmtConfig.default).toSet
+    val configStrs = Config.toHocon(style).toSet
+    configStrs.diff(defaultStrs).mkString("\n")
+  }
+
+  def configurationBlock(style: ScalafmtConfig) = {
+    div(
+      span(
+        "Show/hide configuration used for this example",
+        `class` := "scalafmt-configuration-toggle"),
+      pre(changedConfig(style)),
+      `class` := "scalafmt-configuration collapsed"
+    )
+  }
+
   def fullWidthDemo(style: ScalafmtConfig)(code: String) = {
     val formatted = Scalafmt.format(code, style).get
-    rows(
-      List(
-        div(hl.scala(code), `class` := "before"),
-        div(hl.scala(formatted), `class` := "after")
-      ))
+    div(
+      rows(
+        List(
+          div(hl.scala(code), `class` := "before"),
+          div(hl.scala(formatted), `class` := "after")
+        )),
+      configurationBlock(style))
   }
 
   def demoStyle(style: ScalafmtConfig)(code: String) = {
     val formatted =
       Scalafmt.format(code, style.copy(runner = ScalafmtRunner.sbt)).get
-    sideBySide(code, formatted)
+    div(
+      sideBySide(code, formatted),
+      configurationBlock(style)
+    )
   }
 
   def example(code: String): TypedTag[String] = {
@@ -221,6 +253,11 @@ object Readme {
     newlines = ScalafmtConfig.default.newlines.copy(
       afterImplicitKWInVerticalMultiline = true
     )
+  )
+
+  val newlineAlwaysBeforeTopLevelStatements = ScalafmtConfig.default.copy(
+    newlines = ScalafmtConfig.default.newlines
+      .copy(alwaysBeforeTopLevelStatements = true)
   )
 
   val arityThreshold =


### PR DESCRIPTION
This is a fix for #1130