### PR TITLE
updated maven settings

### DIFF
--- a/readme/Installation.scalatex
+++ b/readme/Installation.scalatex
@@ -209,7 +209,7 @@
     It is possible to use scalafmt in Maven with the following externally maintained plugin:
     @ul
       @li
-        @lnk("mvn_scalafmt", "https://github.com/pianista215/mvn_scalafmt")
+        @lnk("mvn_scalafmt", "https://github.com/SimonJPegg/mvn_scalafmt")
 
   @sect{Vim}
     @ul


### PR DESCRIPTION
replaced un-maintained maven plugin with the more current one
Alternatively we can keep both, but the `old` one is too old to keep if you ask me -  `Current version of the embedded Scalafmt is 0.2.11`