### PR TITLE
Allow with-chain wrapping for all params #1125

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -42,11 +42,8 @@ object `:parent:` {
 object WithChain {
   def unapply(t: Type.With): Option[Type.With] =
     TreeOps.topTypeWith(t) match {
-      // self types
-      case (top: Type.With) `:parent:` (_: Term.Param) `:parent:` (_: Template) =>
-        Some(top)
-      // val/def/var/type definitions or declarations
-      case (top: Type.With) `:parent:` (_: Defn | _: Decl) =>
+      // self types, params, val/def/var/type definitions or declarations
+      case (top: Type.With) `:parent:` (_: Defn | _: Decl | _: Term.Param) =>
         Some(top)
       case _ => None
     }

--- a/scalafmt-tests/src/test/resources/default/TypeWith.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeWith.stat
@@ -45,3 +45,34 @@ trait NeedsServices {
     with HasThrottles
     with HasThrowableNotifier
 }
+<<< class param #1125
+class NeedsServices(
+   services:  Bag with
+    SomeOtherService.RequiredServices
+      with HasDynamicConfig with HasThrottles
+      with HasThrowableNotifier
+)
+>>>
+class NeedsServices(
+    services: Bag
+      with SomeOtherService.RequiredServices
+      with HasDynamicConfig
+      with HasThrottles
+      with HasThrowableNotifier
+)
+<<< def param #1125
+def sendRequest(services:  Bag with
+    SomeOtherService.RequiredServices
+      with HasDynamicConfig with HasHttpService, request: Request
+): Future[Response] = ???
+>>>
+def sendRequest(services: Bag
+                  with SomeOtherService.RequiredServices
+                  with HasDynamicConfig
+                  with HasHttpService,
+                request: Request): Future[Response] = ???
+<<< def param negative #1125
+def sendRequest(services:  Bag with Foo with Bar, request: Request): Future[Response] = ???
+>>>
+def sendRequest(services: Bag with Foo with Bar,
+                request: Request): Future[Response] = ???


### PR DESCRIPTION
Back to #1125, this covers parameter types for with-chains.

Currently,

```scala
class NeedsServices(
    services: Bag
      with SomeOtherService.RequiredServices
      with HasDynamicConfig
      with HasThrottles
      with HasThrowableNotifier
)
```

ends up as 
```scala
class NeedsServices(
    services: Bag with SomeOtherService.RequiredServices with HasDynamicConfig with HasThrottles with HasThrowableNotifier
)
```

With this change it will wrap it as expected with one `with` per line.

