### PR TITLE
Add support to force upper/lower case literal suffixes

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Case.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Case.scala
@@ -1,0 +1,20 @@
+package org.scalafmt.config
+
+import metaconfig.ConfCodec
+
+sealed abstract class Case {
+  import Case._
+  def process(str: String): String = this match {
+    case Unchanged => str
+    case Lower => str.toLowerCase()
+    case Upper => str.toUpperCase()
+  }
+}
+
+object Case {
+  implicit val codec: ConfCodec[Case] =
+    ReaderUtil.oneOf[Case](Upper, Lower, Unchanged)
+  case object Upper extends Case
+  case object Lower extends Case
+  case object Unchanged extends Case
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Literals.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Literals.scala
@@ -1,0 +1,17 @@
+package org.scalafmt.config
+
+import metaconfig._
+
+case class Literals(
+    long: Case = Case.Upper,
+    float: Case = Case.Lower,
+    double: Case = Case.Lower
+) {
+  implicit val reader: ConfDecoder[Literals] =
+    generic.deriveDecoder(this).noTypos
+}
+
+object Literals {
+  implicit val surface: generic.Surface[Literals] = generic.deriveSurface
+  implicit lazy val encoder: ConfEncoder[Literals] = generic.deriveEncoder
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -109,6 +109,7 @@ case class ScalafmtConfig(
     continuationIndent: ContinuationIndent = ContinuationIndent(),
     align: Align = Align(),
     spaces: Spaces = Spaces(),
+    literals: Literals = Literals(),
     lineEndings: LineEndings = LineEndings.unix,
     rewriteTokens: Map[String, String] = Map.empty[String, String],
     rewrite: RewriteSettings = RewriteSettings(),
@@ -137,6 +138,7 @@ case class ScalafmtConfig(
   private implicit val projectReader = project.reader
   private implicit val rewriteReader = rewrite.reader
   private implicit val spacesReader = spaces.reader
+  private implicit val literalsReader = literals.reader
   private implicit val continuationIndentReader = continuationIndent.reader
   private implicit val binpackReader = binPack.reader
   private implicit val newlinesReader = newlines.reader

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -36,7 +36,13 @@ class FormatWriter(formatOps: FormatOps) {
             sb.append(formatComment(c, state.indentation))
           case token @ Interpolation.Part(_) =>
             sb.append(formatMarginizedString(token, state.indentation))
-          case literal @ Constant.String(_) => // Ignore, see below.
+          case Constant.String(_) => // Ignore, see below.
+          case c: Constant.Long =>
+            sb.append(initStyle.literals.long.process(c.syntax))
+          case c: Constant.Float =>
+            sb.append(initStyle.literals.float.process(c.syntax))
+          case c: Constant.Double =>
+            sb.append(initStyle.literals.double.process(c.syntax))
           case token =>
             val rewrittenToken =
               formatOps.initStyle.rewriteTokens

--- a/scalafmt-tests/src/test/resources/test/LitUnchanged.stat
+++ b/scalafmt-tests/src/test/resources/test/LitUnchanged.stat
@@ -1,0 +1,27 @@
+literals.long = unchanged
+literals.float = unchanged
+literals.double = unchanged
+<<< long
+1l
+>>>
+1l
+<<< long ok
+ 1L
+>>>
+1L
+<<< float
+1F
+>>>
+1F
+<<< float ok
+ 1f
+>>>
+1f
+<<< double
+1D
+>>>
+1D
+<<< double ok
+ 1d
+>>>
+1d

--- a/scalafmt-tests/src/test/resources/unit/Lit.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lit.stat
@@ -1,0 +1,25 @@
+40 columns                              |
+<<< long
+1l
+>>>
+1L
+<<< long ok
+ 1L
+>>>
+1L
+<<< float
+1F
+>>>
+1f
+<<< float ok
+ 1f
+>>>
+1f
+<<< double
+1D
+>>>
+1d
+<<< double ok
+ 1d
+>>>
+1d


### PR DESCRIPTION
```
1l => 1L
1F => 1f
1D => 1d
```

Fixes #293