### PR TITLE
Print out unified diff on --test failure.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ lazy val cli = project
     allSettings,
     mainClass in assembly := Some("org.scalafmt.cli.Cli"),
     libraryDependencies ++= Seq(
+      "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "com.martiansoftware" % "nailgun-server" % "0.9.1",
       "com.github.scopt" %% "scopt" % "3.5.0"
     )
@@ -150,7 +151,6 @@ lazy val tests = project
     noPublish,
     libraryDependencies ++= Seq(
       // Test dependencies
-      "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "com.lihaoyi" %% "scalatags" % "0.6.3",
       "org.typelevel" %% "paiges-core" % "0.2.0",
       scalametaTestkit

--- a/scalafmt-cli-sbt/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
+++ b/scalafmt-cli-sbt/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala
@@ -1,5 +1,4 @@
 package org.scalafmt.sbt
-import scala.meta.internal.tokenizers.PlatformTokenizerCache
 import sbt._
 import Keys._
 
@@ -8,10 +7,11 @@ object ScalafmtPlugin extends AutoPlugin {
   object autoImport {
     val scalafmt: Command =
       Command.args("scalafmt", "run the scalafmt command line interface.") {
-        case (state, args) =>
-          org.scalafmt.cli.Cli.main("--non-interactive" +: args.toArray)
-          PlatformTokenizerCache.megaCache.clear()
-          state
+        case (s, args) =>
+          org.scalafmt.cli.Cli.exceptionThrowingMain(
+            "--non-interactive" +: args.toArray
+          )
+          s
       }
   }
   override def globalSettings: Seq[Def.Setting[_]] =

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -65,6 +65,7 @@ object CliOptions {
     tryDirectory(options)(options.common.workingDirectory)
   }
 }
+
 case class CommonOptions(
     workingDirectory: AbsoluteFile = AbsoluteFile.userDir,
     out: PrintStream = System.out,

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ExitCode.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ExitCode.scala
@@ -1,0 +1,56 @@
+package org.scalafmt.cli
+
+import scala.collection.mutable
+
+sealed abstract case class ExitCode(code: Int, name: String) {
+  def isOk: Boolean = this == ExitCode.Ok
+  def is(c: ExitCode): Boolean =
+    (code & c.code) != 0
+  override def toString: String = s"$name=$code"
+}
+
+object ExitCode {
+  // NOTE: ExitCode resembles an Enumeration very much, but has minor differences
+  // for example how the name is calculated for merged exit codes.
+  private var counter = 0
+  private val allInternal = mutable.ListBuffer.empty[ExitCode]
+  private val cache =
+    new java.util.concurrent.ConcurrentHashMap[Int, ExitCode]
+  private def generateExitStatus(implicit name: sourcecode.Name) = {
+    val code = counter
+    counter = if (counter == 0) 1 else counter << 1
+    val result = new ExitCode(code, name.value) {}
+    allInternal += result
+    result
+  }
+  // see https://github.com/scalameta/scalafmt/issues/941
+  // format: off
+  val Ok,
+      TestError,
+      ParseError,
+      CommandLineArgumentError,
+      UnexpectedError
+    : ExitCode = generateExitStatus
+  // format: on
+  lazy val all: List[ExitCode] = allInternal.toList
+  private def codeToName(code: Int): String = {
+    if (code == 0) Ok.name
+    else {
+      val names = all.collect {
+        case exit if (exit.code & code) != 0 => exit.name
+      }
+      names.mkString("+")
+    }
+  }
+  def apply(code: Int): ExitCode = {
+    if (cache.contains(code)) cache.get(code)
+    else {
+      val result = new ExitCode(code, codeToName(code)) {}
+      cache.put(code, result)
+      result
+    }
+  }
+
+  def merge(exit1: ExitCode, exit2: ExitCode): ExitCode =
+    apply(exit1.code | exit2.code)
+}


### PR DESCRIPTION
Previously, scalafmt --test failed on the first error.
Now it runs on all files and prints all violation errors and returns a
custom exit code for --test failure.

Fixes #912