### PR TITLE
Try / finally formatted on a single line

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -216,7 +216,10 @@ class Router(formatOps: FormatOps) {
         val skipSingleLineBlock =
           startsLambda ||
             newlines > 0 ||
-            leftOwner.parent.exists(_.is[Term.If])
+            leftOwner.parent.exists {
+              case _: Term.If | _: Term.Try | _: Term.TryWithHandler => true
+              case _ => false
+            }
 
         val spaceMod = xmlSpace(leftOwner)
 
@@ -864,8 +867,6 @@ class Router(formatOps: FormatOps) {
           }) =>
         val rhs: Tree = leftOwner match {
           case l: Term.Assign => l.rhs
-          case l: Term.Assign => l.rhs
-          case l: Term.Assign => l.lhs
           case l: Term.Param => l.default.get
           case l: Defn.Type => l.body
           case l: Defn.Val => l.rhs

--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -88,7 +88,9 @@ val createAsStat = if (semantics.asInstanceOfs == Unchecked) {
 def processOptions(): Unit = {
   if (option.startsWith("relSourceMap:")) {
     val uriStr = option.stripPrefix("relSourceMap:")
-    try { relSourceMap = Some(new URI(uriStr)) } catch {
+    try {
+      relSourceMap = Some(new URI(uriStr))
+    } catch {
       case e: URISyntaxException => error(s"$uriStr is not a valid URI")
     }
   } else {

--- a/scalafmt-tests/src/test/resources/default/Try.stat
+++ b/scalafmt-tests/src/test/resources/default/Try.stat
@@ -58,3 +58,9 @@ object Foo {
     bar()
   }
 }
+<<< try/catch with handler
+try { foo()  } catch handler
+>>>
+try {
+  foo()
+} catch handler

--- a/scalafmt-tests/src/test/resources/default/Try.stat
+++ b/scalafmt-tests/src/test/resources/default/Try.stat
@@ -45,3 +45,16 @@ object Foo {
   try proc.waitFor()
   catch { case e: Throwable => run() }
 }
+<<< try/finally curly no single line blocks
+object Foo {
+  try { foo()  }
+  finally {  bar()  }
+}
+>>>
+object Foo {
+  try {
+    foo()
+  } finally {
+    bar()
+  }
+}


### PR DESCRIPTION
A possible fix for https://github.com/scalameta/scalafmt/issues/1002

It extends the rule prohibiting single line blocks for `if` blocks to try-catch blocks as well