### PR TITLE
Added a rule for space after an operator method

### DIFF
--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -771,6 +771,20 @@
         while(a) foo()
         for(a <- as) foo()
 
+    @sect{spaces.afterSymbolicDefs}
+      Default: @b(default.spaces.afterSymbolicDefs)
+
+      @hl.scala
+        // spaces.afterSymbolicDefs = true
+        trait Test[A] {
+          def <=> [B](that: Test[B]): Int
+        }
+
+        // spaces.afterSymbolicDefs = false
+        trait Test[A] {
+          def <=>[B](that: Test[B]): Int
+        }
+
     @sect{includeCurlyBraceInSelectChains}
       Default: @b(default.includeCurlyBraceInSelectChains)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
@@ -21,6 +21,9 @@ import org.scalafmt.config.SpaceBeforeContextBound.Never
   * @param inByNameTypes
   *   If false, removes space in by-name parameter.
   *   `def foo(a: =>A)`
+  * @param afterSymbolicDefs If true, adds a single space after an operator method
+  *   For example:
+  *   def <=> [T](that: T): Boolean
   */
 case class Spaces(
     beforeContextBoundColon: SpaceBeforeContextBound = Never,
@@ -29,7 +32,8 @@ case class Spaces(
     inParentheses: Boolean = false,
     neverAroundInfixTypes: Seq[String] = Nil,
     afterKeywordBeforeParen: Boolean = true,
-    inByNameTypes: Boolean = true
+    inByNameTypes: Boolean = true,
+    afterSymbolicDefs: Boolean = true
 ) {
   implicit val reader: ConfDecoder[Spaces] = generic.deriveDecoder(this).noTypos
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
@@ -33,7 +33,7 @@ case class Spaces(
     neverAroundInfixTypes: Seq[String] = Nil,
     afterKeywordBeforeParen: Boolean = true,
     inByNameTypes: Boolean = true,
-    afterSymbolicDefs: Boolean = true
+    afterSymbolicDefs: Boolean = false
 ) {
   implicit val reader: ConfDecoder[Spaces] = generic.deriveDecoder(this).noTypos
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -374,7 +374,7 @@ class Router(formatOps: FormatOps) {
                 t.tokens.map(_.syntax) == Seq("===") =>
             Space
           case name: Term.Name
-              if isSymbolicName(name.value) && name.parent.exists(isDefDef) =>
+              if style.spaces.afterSymbolicDefs && isSymbolicName(name.value) && name.parent.exists(isDefDef) =>
             Space
           case _ => NoSplit
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -36,6 +36,8 @@ import org.scalafmt.util.SomeInterpolate
 import org.scalafmt.util.TokenOps
 import org.scalafmt.util.TreeOps
 import org.scalafmt.util.Trivia
+
+import scala.meta.Decl.Def
 import scala.meta.Lit
 
 // Too many to import individually.
@@ -73,6 +75,8 @@ class Router(formatOps: FormatOps) {
     val leftOwner = owners(formatToken.left)
     val rightOwner = owners(formatToken.right)
     val newlines = newlinesBetween(formatToken.between)
+    val isDef = rightOwner.tokens.headOption.exists(_.is[KwDef])
+
     formatToken match {
       case FormatToken(_: BOF, _, _) =>
         Seq(
@@ -370,6 +374,8 @@ class Router(formatOps: FormatOps) {
           case t: Term.Name
               if style.spaces.afterTripleEquals &&
                 t.tokens.map(_.syntax) == Seq("===") =>
+            Space
+          case name: Term.Name if isDef && isSymbolicName(name.value) =>
             Space
           case _ => NoSplit
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -357,10 +357,10 @@ class Router(formatOps: FormatOps) {
       // Opening [ with no leading space.
       // Opening ( with no leading space.
       case FormatToken(
-            KwSuper() | KwThis() | Ident(_) | RightBracket() | RightBrace() |
-            RightParen() | Underscore(),
-            LeftParen() | LeftBracket(),
-            _) if noSpaceBeforeOpeningParen(rightOwner) && {
+          KwSuper() | KwThis() | Ident(_) | RightBracket() | RightBrace() |
+          RightParen() | Underscore(),
+          LeftParen() | LeftBracket(),
+          _) if noSpaceBeforeOpeningParen(rightOwner) && {
             leftOwner.parent.forall {
               // infix applications have no space.
               case _: Type.ApplyInfix | _: Term.ApplyInfix => false

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -374,7 +374,8 @@ class Router(formatOps: FormatOps) {
                 t.tokens.map(_.syntax) == Seq("===") =>
             Space
           case name: Term.Name
-              if style.spaces.afterSymbolicDefs && isSymbolicName(name.value) && name.parent.exists(isDefDef) =>
+              if style.spaces.afterSymbolicDefs && isSymbolicName(name.value) && name.parent
+                .exists(isDefDef) =>
             Space
           case _ => NoSplit
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -37,7 +37,6 @@ import org.scalafmt.util.TokenOps
 import org.scalafmt.util.TreeOps
 import org.scalafmt.util.Trivia
 
-import scala.meta.Decl.Def
 import scala.meta.Lit
 
 // Too many to import individually.
@@ -75,7 +74,6 @@ class Router(formatOps: FormatOps) {
     val leftOwner = owners(formatToken.left)
     val rightOwner = owners(formatToken.right)
     val newlines = newlinesBetween(formatToken.between)
-    val isDef = rightOwner.tokens.headOption.exists(_.is[KwDef])
 
     formatToken match {
       case FormatToken(_: BOF, _, _) =>
@@ -359,10 +357,10 @@ class Router(formatOps: FormatOps) {
       // Opening [ with no leading space.
       // Opening ( with no leading space.
       case FormatToken(
-          KwSuper() | KwThis() | Ident(_) | RightBracket() | RightBrace() |
-          RightParen() | Underscore(),
-          LeftParen() | LeftBracket(),
-          _) if noSpaceBeforeOpeningParen(rightOwner) && {
+            KwSuper() | KwThis() | Ident(_) | RightBracket() | RightBrace() |
+            RightParen() | Underscore(),
+            LeftParen() | LeftBracket(),
+            _) if noSpaceBeforeOpeningParen(rightOwner) && {
             leftOwner.parent.forall {
               // infix applications have no space.
               case _: Type.ApplyInfix | _: Term.ApplyInfix => false
@@ -375,7 +373,8 @@ class Router(formatOps: FormatOps) {
               if style.spaces.afterTripleEquals &&
                 t.tokens.map(_.syntax) == Seq("===") =>
             Space
-          case name: Term.Name if isDef && isSymbolicName(name.value) =>
+          case name: Term.Name
+              if isSymbolicName(name.value) && name.parent.exists(isDefDef) =>
             Space
           case _ => NoSplit
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -234,12 +234,15 @@ object TokenOps {
   }
 
   def isSymbolicIdent(tok: Token): Boolean = tok match {
-    case Ident(name) =>
-      val head = name.head
-      // DESNOTE(2017-02-03, pjrt) Variable names can start with a letter or
-      // an `_`, operators cannot. This check should suffice.
-      !head.isLetter && head != '_'
+    case Ident(name) => isSymbolicName(name)
     case _ => false
+  }
+
+  def isSymbolicName(name: String): Boolean = {
+    val head = name.head
+    // DESNOTE(2017-02-03, pjrt) Variable names can start with a letter or
+    // an `_`, operators cannot. This check should suffice.
+    !head.isLetter && head != '_'
   }
 
   // According to spec:

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -303,3 +303,19 @@ def foo =
     val bar = fetchBar()
     bar.map(_ + 10)
   })
+<<< #915 Space on both sides of operator method definition (positive)
+trait Test[A] {
+  def <=>[B](that: Test[B]): Int
+}
+>>>
+trait Test[A] {
+  def <=> [B](that: Test[B]): Int
+}
+<<< #915 Space on both sides of operator method definition (negative)
+trait Test[A] {
+  def A_~>[B](that: Test[B]): Int
+}
+>>>
+trait Test[A] {
+  def A_~>[B](that: Test[B]): Int
+}

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -303,19 +303,11 @@ def foo =
     val bar = fetchBar()
     bar.map(_ + 10)
   })
-<<< #915 Space on both sides of operator method definition (positive)
+<<< #915 No space on both sides of operator method definition by default
 trait Test[A] {
   def <=>[B](that: Test[B]): Int
 }
 >>>
 trait Test[A] {
-  def <=> [B](that: Test[B]): Int
-}
-<<< #915 Space on both sides of operator method definition (negative)
-trait Test[A] {
-  def A_~>[B](that: Test[B]): Int
-}
->>>
-trait Test[A] {
-  def A_~>[B](that: Test[B]): Int
+  def <=>[B](that: Test[B]): Int
 }

--- a/scalafmt-tests/src/test/resources/spaces/AfterSymbolicDefs.stat
+++ b/scalafmt-tests/src/test/resources/spaces/AfterSymbolicDefs.stat
@@ -1,0 +1,17 @@
+spaces.afterSymbolicDefs = true
+<<< #915 Space on both sides of operator method definition (positive)
+trait Test[A] {
+  def <=>[B](that: Test[B]): Int
+}
+>>>
+trait Test[A] {
+  def <=> [B](that: Test[B]): Int
+}
+<<< #915 Space on both sides of operator method definition (negative)
+trait Test[A] {
+  def A_~>[B](that: Test[B]): Int
+}
+>>>
+trait Test[A] {
+  def A_~>[B](that: Test[B]): Int
+}

--- a/scalafmt-tests/src/test/resources/unit/UnaryApply.stat
+++ b/scalafmt-tests/src/test/resources/unit/UnaryApply.stat
@@ -27,8 +27,7 @@
 <<< #697 you shall not change AST!!
   def =!=(that: S): Boolean = ! ===(that)
 >>>
-def =!= (that: S): Boolean =
-  ! ===(that)
+def =!=(that: S): Boolean = ! ===(that)
 <<< #710 you shall not add unneeded space!!
   if (!_member) Some(x) else None
 >>>

--- a/scalafmt-tests/src/test/resources/unit/UnaryApply.stat
+++ b/scalafmt-tests/src/test/resources/unit/UnaryApply.stat
@@ -27,7 +27,8 @@
 <<< #697 you shall not change AST!!
   def =!=(that: S): Boolean = ! ===(that)
 >>>
-def =!=(that: S): Boolean = ! ===(that)
+def =!= (that: S): Boolean =
+  ! ===(that)
 <<< #710 you shall not add unneeded space!!
   if (!_member) Some(x) else None
 >>>


### PR DESCRIPTION
A possible fix for https://github.com/scalameta/scalafmt/issues/915

It reuses existing `isSymbolicName` to decide if method name is an operator or not.