### PR TITLE
Clean up handling of exit codes in the cli

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/TermDisplay.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/TermDisplay.scala
@@ -248,7 +248,6 @@ object TermDisplay {
         downloads -= url
 
         val info = infos.remove(url)
-        assert(info != null)
 
         if (success)
           doneQueue += (url -> update0(info))

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -544,9 +544,63 @@ class CliTest extends AbstractCliTest {
                |@@ -1,1 +1,1 @@
                |-object    A { }
                |+object A {}
-               |
                |error: --test failed
                |To fix this ...""".stripMargin
+          )
+        )
+      }
+    )
+  }
+
+  test("--test succeeds even with parse error") {
+    val input =
+      """|/foo.scala
+         |object A {
+         |""".stripMargin
+    noArgTest(
+      string2dir(input),
+      input,
+      Seq(Array("--test")),
+      assertExit = { exit =>
+        assert(exit.isOk)
+      },
+      assertOut = out => {
+        println(out)
+        assert(
+          out.contains(
+            """|foo.scala:2: error: } expected but end of file found
+               |
+               |^
+               |error: ParseError=2""".stripMargin
+          )
+        )
+      }
+    )
+  }
+
+  test("--test fails with parse error if fatalWarnings=true") {
+    val input =
+      """|/.scalafmt.conf
+         |runner.fatalWarnings = true
+         |
+         |/foo.scala
+         |object A {
+         |""".stripMargin
+    noArgTest(
+      string2dir(input),
+      input,
+      Seq(Array("--test")),
+      assertExit = { exit =>
+        assert(exit == ExitCode.ParseError)
+      },
+      assertOut = out => {
+        println(out)
+        assert(
+          out.contains(
+            """|foo.scala:2: error: } expected but end of file found
+               |
+               |^
+               |error: ParseError=2""".stripMargin
           )
         )
       }


### PR DESCRIPTION
This commit reverts the change that a non-zero exit code is reported for
parse errors. Instead, users must enable runner.fatalWarnings to get a
failing exit code for parse errors or other unexpected errors.

Fixes #815 
Fixes #349