### PR TITLE
Indent body of vals when unindentTopLevelOperators=true.

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -488,8 +488,14 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     val modification = newlines2Modification(
       formatToken.between,
       rightIsComment = formatToken.right.isInstanceOf[Comment])
-    val indent = {
-      if ((style.unindentTopLevelOperators ||
+    def isAssignment =
+      formatToken.left.is[Token.Equals] &&
+        owners(formatToken.left).is[Defn]
+    val indent: Int = {
+      if (style.unindentTopLevelOperators && isAssignment) {
+        // see https://github.com/scalameta/scalafmt/issues/848
+        2
+      } else if ((style.unindentTopLevelOperators ||
         isTopLevelInfixApplication(owner)) &&
         (style.indentOperator.includeRegexp
           .findFirstIn(op.tokens.head.syntax)
@@ -528,7 +534,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
     owner.parent match {
       case Some(_: Type.ApplyInfix)
-          if style.spaces.neverAroundInfixTypes.contains((op.value)) =>
+          if style.spaces.neverAroundInfixTypes.contains(op.value) =>
         Split(NoSplit, 0)
       case _ =>
         Split(modification, 0).withIndent(Num(indent), expire, ExpiresOn.Left)

--- a/scalafmt-tests/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/src/test/resources/test/IndentOperator.stat
@@ -94,3 +94,21 @@ object TestRoutes {
       ???
     }
 }
+<<< #848
+  val x =
+  1 +
+  2 +
+  3
+>>>
+val x =
+  1 +
+  2 +
+  3
+<<< #848 same line
+  val x = 1 +
+  2 +
+  3
+>>>
+val x = 1 +
+  2 +
+  3


### PR DESCRIPTION
Fixes #848.

Manually tested against https://github.com/hseeberger/akka-http-json and
it introduces no diff.