### PR TITLE
Unskip trailing commas tests, fixes #1174

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,8 @@ lazy val cli = project
     libraryDependencies ++= Seq(
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "com.martiansoftware" % "nailgun-server" % "0.9.1",
-      "com.github.scopt" %% "scopt" % "3.5.0"
+      "com.github.scopt" %% "scopt" % "3.5.0",
+      scalacheck % Test
     )
   )
   .dependsOn(coreJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,7 @@ lazy val tests = project
     noPublish,
     libraryDependencies ++= Seq(
       // Test dependencies
-      "org.scalacheck" %% "scalacheck" % "1.14.0",
+      scalacheck,
       "com.lihaoyi" %% "scalatags" % "0.6.3",
       "org.typelevel" %% "paiges-core" % "0.2.0",
       scalametaTestkit
@@ -170,6 +170,7 @@ lazy val benchmarks = project
     moduleName := "scalafmt-benchmarks",
     libraryDependencies ++= Seq(
       scalametaTestkit,
+      scalacheck % Test,
       scalatest.value % Test
     ),
     javaOptions in run ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -151,6 +151,7 @@ lazy val tests = project
     noPublish,
     libraryDependencies ++= Seq(
       // Test dependencies
+      "org.scalacheck" %% "scalacheck" % "1.14.0",
       "com.lihaoyi" %% "scalatags" % "0.6.3",
       "org.typelevel" %% "paiges-core" % "0.2.0",
       scalametaTestkit

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,10 @@
+inThisBuild(
+  List(
+    libraryDependencies ++= List(
+      scalacheck % Test
+    )
+  )
+)
 import Dependencies._
 import org.scalajs.sbtplugin.cross.CrossProject
 
@@ -60,8 +67,7 @@ lazy val cli = project
     libraryDependencies ++= Seq(
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "com.martiansoftware" % "nailgun-server" % "0.9.1",
-      "com.github.scopt" %% "scopt" % "3.5.0",
-      scalacheck % Test
+      "com.github.scopt" %% "scopt" % "3.5.0"
     )
   )
   .dependsOn(coreJVM)
@@ -152,7 +158,6 @@ lazy val tests = project
     noPublish,
     libraryDependencies ++= Seq(
       // Test dependencies
-      scalacheck,
       "com.lihaoyi" %% "scalatags" % "0.6.3",
       "org.typelevel" %% "paiges-core" % "0.2.0",
       scalametaTestkit
@@ -171,7 +176,6 @@ lazy val benchmarks = project
     moduleName := "scalafmt-benchmarks",
     libraryDependencies ++= Seq(
       scalametaTestkit,
-      scalacheck % Test,
       scalatest.value % Test
     ),
     javaOptions in run ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,8 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 object Dependencies {
   val metaconfigV = "0.7.2"
   val scalametaV = "4.0.0-M1"
-  val scalatestV = "3.0.4"
+  val scalatestV = "3.2.0-SNAP10"
+  val scalacheckV = "1.13.5"
   val coursier = "1.0.0-RC12"
 
   val scalapb = Def.setting {
@@ -19,6 +20,7 @@ object Dependencies {
   val scalametaTestkit = "org.scalameta" %% "testkit" % scalametaV
   val scalariform = "org.scalariform" %% "scalariform" % "0.1.8"
 
+  val scalacheck = "org.scalacheck" %% "scalacheck" % scalacheckV
   val scalatest = Def.setting("org.scalatest" %%% "scalatest" % scalatestV)
   val scalameta = Def.setting("org.scalameta" %%% "scalameta" % scalametaV excludeAll scalapb.value)
   val metaconfig = Def.setting("com.geirsson" %%% "metaconfig-core" % metaconfigV)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.7.2"
-  val scalametaV = "3.7.4"
+  val scalametaV = "4.0.0-M1"
   val scalatestV = "3.0.4"
   val coursier = "1.0.0-RC12"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysComments.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysComments.stat
@@ -1,7 +1,7 @@
 maxColumn = 30
 trailingCommas = always
 
-<<< SKIP should consider comments when adding trailing commas
+<<< should consider comments when adding trailing commas
 def method(
     a: String,
     b: String // a comment

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNeverComments.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNeverComments.stat
@@ -1,7 +1,7 @@
 maxColumn = 30
 trailingCommas = never
 
-<<< SKIP should consider comments when removing trailing commas
+<<< should consider comments when removing trailing commas
 def method(
     a: String,
     b: String, // a comment


### PR DESCRIPTION
Upgrading scalameta resulted in a "ClassNotFoundException" for a
scalacheck class that was fixed by adding a dependency on scalacheck in
the tests.

Fixes #1182