### PR TITLE
Support `align.tokens={none,some,more,most}`

### DIFF
--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -140,6 +140,8 @@
 
         Pro tip: Enable this setting to minimize git diffs/conflicts from renamings and other refactorings.
 
+        @configurationBlock(alignNone, true)
+
       @sect{align=more}
         @format(alignMore)
           val x = 2 // true for assignment
@@ -176,6 +178,8 @@
             "com.lihaoyi" %% "sourcecode" % "0.1.1"
           )
 
+        @configurationBlock(alignMore, true)
+
       @sect{align=most}
         @format(alignMost)
           for {
@@ -191,6 +195,9 @@
           // feel free to open PR enabling more crazy vertical alignment here.
           // Expect changes.
 
+        @configurationBlock(alignMost, true)
+
+
     @sect{align.tokens}
       Default: @b{[caseArrow]}
 
@@ -199,6 +206,10 @@
         of an operator of token, and @code{owner}, which is the kind of
         the closest tree node that owns that token.
         If no @code{owner} is provided, then all tree kinds will be matched.
+
+      @p
+        @note. It is valid to set @code{align.tokens = more} to re-use settings
+        from @sect.ref{align=more}. Same applies for @code{none/some/most}.
 
 
       @format(alignCaseArrow)

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -100,7 +100,7 @@ object Readme {
 
   def rows(frags: Frag*) = div(frags, `class` := "scalafmt-rows")
 
-  def sideBySide(left: String, right: String) =
+  def sideBySide(left: String, right: String): TypedTag[String] =
     pairs(List(left, right).map(x => half(hl.scala(x))): _*)
 
   def demo(code: String) = {
@@ -119,17 +119,24 @@ object Readme {
   def allOptions =
     hl.scala.apply(Conf.printHocon(ScalafmtConfig.default))
 
-  def configurationBlock(style: ScalafmtConfig) = {
+  def configurationBlock(
+      style: ScalafmtConfig,
+      collapsed: Boolean = false): TypedTag[String] = {
     div(
       span(
         "Show/hide configuration used for this example",
         `class` := "scalafmt-configuration-toggle"),
       pre(changedConfig(style)),
-      `class` := "scalafmt-configuration"
+      `class` := {
+        "scalafmt-configuration" + (
+          if (collapsed) " collapsed"
+          else ""
+        )
+      }
     )
   }
 
-  def fullWidthDemo(style: ScalafmtConfig)(code: String) = {
+  def fullWidthDemo(style: ScalafmtConfig)(code: String): TypedTag[String] = {
     val formatted = Scalafmt.format(code, style).get
     div(
       rows(
@@ -140,7 +147,7 @@ object Readme {
       configurationBlock(style))
   }
 
-  def demoStyle(style: ScalafmtConfig)(code: String) = {
+  def demoStyle(style: ScalafmtConfig)(code: String): TypedTag[String] = {
     val formatted =
       Scalafmt.format(code, style.copy(runner = ScalafmtRunner.sbt)).get
     div(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -115,4 +115,13 @@ object Align {
     )
   )
   val allValues = List(default, none, some, most)
+
+  object Builtin {
+    def unapply(conf: Conf): Option[Align] = Option(conf).collect {
+      case Conf.Str("none") | Conf.Bool(false) => Align.none
+      case Conf.Str("some" | "default") => Align.some
+      case Conf.Str("more") | Conf.Bool(true) => Align.more
+      case Conf.Str("most") => Align.most
+    }
+  }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -335,18 +335,16 @@ object ScalafmtConfig {
   }
   def alignReader(base: ConfDecoder[Align]): ConfDecoder[Align] =
     ConfDecoder.instance[Align] {
-      case Conf.Str("none") | Conf.Bool(false) => Ok(Align.none)
-      case Conf.Str("some" | "default") => Ok(Align.some)
-      case Conf.Str("more") | Conf.Bool(true) => Ok(Align.more)
-      case Conf.Str("most") => Ok(Align.most)
+      case Align.Builtin(a) => Ok(a)
       case els => base.read(els)
     }
   def alignTokenReader(
       initTokens: Set[AlignToken]): ConfDecoder[Set[AlignToken]] = {
-    val baseReader = implicitly[ConfDecoder[Set[AlignToken]]]
+    val baseReader = ConfDecoder[Set[AlignToken]]
     ConfDecoder.instance[Set[AlignToken]] {
       case Conf.Obj(("add", conf) :: Nil) =>
         baseReader.read(conf).map(initTokens ++ _)
+      case Align.Builtin(a) => Ok(a.tokens)
       case els => baseReader.read(els)
     }
   }

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -1,4 +1,4 @@
-align = true
+align = more
 <<< => with comment
 x match {
   case 1 => 2 // this is a comment

--- a/scalafmt-tests/src/test/resources/align/duplicateAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/duplicateAlign.stat
@@ -1,0 +1,17 @@
+maxColumn = 20
+align.tokens = most
+<<< #1202
+{
+  foo(aaaaaaaa, bbbbb)
+  val x = 2
+  val xx = 2
+}
+>>>
+{
+  foo(
+    aaaaaaaa,
+    bbbbb
+  )
+  val x  = 2
+  val xx = 2
+}


### PR DESCRIPTION
Instead of making rules more complicated to support
```
align = more
align.openParenCallSite = true
```
We make it easier to override `align.tokens` by supporting
```
align.tokens = more
align.openParenCallSite = true
```

Fixes #1202