### PR TITLE
Add braces around multi-line lambda body

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RedundantBracesSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RedundantBracesSettings.scala
@@ -2,6 +2,19 @@ package org.scalafmt.config
 
 import metaconfig._
 
+/**
+  * @param methodBodies if true, removes redundant braces around method bodies
+  * @param includeUnitMethods if true, also removes redundant braces around method bodies
+  *                           with unit return types
+  * @param maxLines the maximum block size to process (anything larger will be ignored)
+  * @param stringInterpolation if true, removes redundant braces around values interpolated
+  *                            in strings, as in s"Hello, ${name}" => s"Hello $name"
+  * @param generalExpressions if true, removes redundant braces around basically any
+  *                           expression (danger, possibly superfluous)
+  * @param alwaysAroundMultilineLambda if true, will *add* redundant braces around
+  *                                    any muliti-line lambda body, regardless of
+  *                                    whether it is a single statement
+  */
 case class RedundantBracesSettings(
     methodBodies: Boolean = true,
     includeUnitMethods: Boolean = true,
@@ -9,7 +22,8 @@ case class RedundantBracesSettings(
     stringInterpolation: Boolean = false,
     // Re-enable generalExpressions once
     // https://github.com/scalameta/scalafmt/issues/1147 is fixed
-    generalExpressions: Boolean = false
+    generalExpressions: Boolean = false,
+    alwaysAroundMultilineLambda: Boolean = false
 ) {
   val reader: ConfDecoder[RedundantBracesSettings] =
     generic.deriveDecoder(this).noTypos

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -69,10 +69,11 @@ case object RedundantBraces extends Rewrite {
 
   private def processLambdaBody(
       body: Term)(implicit ctx: RewriteCtx, builder: PatchBuilder) = {
-    val isMultilineBody = body.tokens.head.pos.startLine < body.tokens.last.pos.endLine
+    val isSingleStatement = body.isNot[Term.Block]
+    def isMultilineBody = body.tokens.head.pos.startLine < body.tokens.last.pos.endLine
     def rightToken: Option[Token] =
       ctx.tokenTraverser.find(body.tokens.last)(_.isNot[Whitespace])
-    if (isMultilineBody && rightToken.exists(!_.is[RightBrace])) {
+    if (isSingleStatement && isMultilineBody && rightToken.exists(!_.is[RightBrace])) {
       builder += TokenPatch.AddLeft(body.tokens.head, "{\n", keepTok = true)
       builder += TokenPatch.AddRight(body.tokens.last, "\n}", keepTok = true)
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -10,7 +10,7 @@ import scala.meta.tokens.Token.LF
 import scala.meta.tokens.Token.LeftBrace
 import scala.meta.tokens.Token.RightBrace
 import org.scalafmt.util.TreeOps._
-import org.scalafmt.util.Whitespace
+import org.scalafmt.util.Trivia
 
 /**
   * Removes/adds curly braces where desired.
@@ -72,7 +72,7 @@ case object RedundantBraces extends Rewrite {
     val isSingleStatement = body.isNot[Term.Block]
     def isMultilineBody = body.tokens.head.pos.startLine < body.tokens.last.pos.endLine
     def rightToken: Option[Token] =
-      ctx.tokenTraverser.find(body.tokens.last)(_.isNot[Whitespace])
+      ctx.tokenTraverser.find(body.tokens.last)(_.isNot[Trivia])
     if (isSingleStatement && isMultilineBody && rightToken.exists(!_.is[RightBrace])) {
       builder += TokenPatch.AddLeft(body.tokens.head, "{\n", keepTok = true)
       builder += TokenPatch.AddRight(body.tokens.last, "\n}", keepTok = true)

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-insert.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-insert.stat
@@ -66,3 +66,13 @@ xs.map(
     .filter(_.hasBar)
     .toList
 )
+<<< #1222 multiple lines with existing braces (negative)
+xs.map(foo => {
+  val fwb = foo.withBar(bar)
+  fwb.toList
+  })
+>>>
+xs.map(foo => {
+  val fwb = foo.withBar(bar)
+  fwb.toList
+})

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-insert.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-insert.stat
@@ -1,0 +1,68 @@
+maxColumn = 40 #                       |
+rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.alwaysAroundMultilineLambda = true
+<<< #1222 add curly braces around body
+xs.map(foo =>
+  foo
+    .withBar(bar)
+    .toList)
+>>>
+xs.map(foo => {
+  foo
+    .withBar(bar)
+    .toList
+})
+<<< BAD? #1222 add curly braces around body with two args
+twoArgs(
+  foo => foo
+    .withBar(bar)
+    .toList,
+  15
+)
+>>>
+twoArgs(
+  foo => {
+    foo
+      .withBar(bar)
+      .toList
+  },
+  15
+)
+<<< #1222 braces already exist (negative)
+xs.map(foo => {
+  foo
+  .withBar(bar)
+    .toList})
+>>>
+xs.map(foo => {
+  foo
+    .withBar(bar)
+    .toList
+})
+<<< #1222 braces-only format (negative)
+xs.map { foo =>
+  foo
+  .withBar(bar)
+    .toList}
+>>>
+xs.map { foo =>
+  foo
+    .withBar(bar)
+    .toList
+}
+<<< #1222 single line param (negative)
+xs.map(foo => foo.withBar(bar)).filter(_.isBar)
+>>>
+xs.map(foo => foo.withBar(bar))
+  .filter(_.isBar)
+<<< #1222 ignore if anonymous param (negative)
+xs.map(_
+    .withBar(bar)
+    .filter(_.hasBar)
+    .toList)
+>>>
+xs.map(
+  _.withBar(bar)
+    .filter(_.hasBar)
+    .toList
+)

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-insert.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-insert.stat
@@ -76,3 +76,17 @@ xs.map(foo => {
   val fwb = foo.withBar(bar)
   fwb.toList
 })
+<<< #1222 with a comment between the closing paren (negative)
+xs.map(foo => {
+  foo
+    .withBar(bar)
+    .toList
+  // Add the bar and make it a list
+})
+>>>
+xs.map(foo => {
+  foo
+    .withBar(bar)
+    .toList
+  // Add the bar and make it a list
+})


### PR DESCRIPTION
Implements rewrite for #1222

If there is a lambda with multiple line body, it will require braces to wrap the body (even though it is a single statement).

Before
```scala
xs.map(foo =>
  foo
    .withBar(bar)
    .toList)
```
After
```scala
xs.map(foo => {
  foo
    .withBar(bar)
    .toList
})
```

Part of the motivation for this is that the current behavior inserts another line before the lambda argument:
```scala
xs.map(
  foo => 
    foo
      .withBar(bar)
      .toList)
```
This is still an open issue, tracked in #667, but this PR sort of adds an alternate solution.
