### PR TITLE
Fix combination of trailingCommas=always and verticalMultilineAtDefnSite=true

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -181,6 +181,20 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   }
 
   @tailrec
+  final def prevNonCommentWithCount(
+      curr: FormatToken,
+      accum: Int = 0): (Int, FormatToken) = {
+    if (!curr.left.is[Comment]) accum -> curr
+    else {
+      val tok = prev(curr)
+      if (tok == curr) accum -> curr
+      else prevNonCommentWithCount(tok, accum + 1)
+    }
+  }
+  def prevNonComment(curr: FormatToken): FormatToken =
+    prevNonCommentWithCount(curr)._2
+
+  @tailrec
   final def nextNonCommentWithCount(
       curr: FormatToken,
       accum: Int = 0): (Int, FormatToken) = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -412,6 +412,8 @@ class FormatWriter(formatOps: FormatOps) {
       // Insert a comma after b
       case TrailingCommas.always
           if !left.is[Comma] && !left.is[Comment] &&
+            !(left.is[LeftParen] &&
+              right.is[RightParen]) && // isn't empty parentheses
             !formatToken.right.is[Comment] &&
             right.is[CloseDelim] && isNewline =>
         sb.append(",")
@@ -426,6 +428,8 @@ class FormatWriter(formatOps: FormatOps) {
       case TrailingCommas.always
           if left.is[Comment] && !prevFormatToken.left.is[Comma] &&
             !prevFormatToken.left.is[Comment] &&
+            !(prevNonComment(formatToken).left.is[LeftParen] &&
+              right.is[RightParen]) && // isn't empty parentheses
             right.is[CloseDelim] && isNewline =>
         sb.insert(
           sb.length - left.syntax.length - prevFormatToken.between.length,

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysVerticalMultilineAtDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysVerticalMultilineAtDefnSite.stat
@@ -1,0 +1,26 @@
+maxColumn = 30
+trailingCommas = always
+verticalMultilineAtDefinitionSite = true
+
+<<< shouldn't put comma in empty parentheses
+case class Test()(a1: Int, a2: Int, a3: Int, a4: Int, a5: Int)
+>>>
+case class Test(
+  )(a1: Int,
+    a2: Int,
+    a3: Int,
+    a4: Int,
+    a5: Int)
+
+<<< shouldn't put comma in parentheses that contains only comment
+case class Test(
+// comment
+)(a1: Int, a2: Int, a3: Int, a4: Int, a5: Int)
+>>>
+case class Test(
+// comment
+  )(a1: Int,
+    a2: Int,
+    a3: Int,
+    a4: Int,
+    a5: Int)


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalafmt/issues/1224

In the original issue, the expected formatted code is something like the below one. (doesn't put newline in the first empty parentheses). However, whether putting a newline in the empty parentheses is an issue of the verticalMultiline.
This PR fixes trailingCommas=always not to break compilation by checking the target formatToken is surrounded by empty parentheses

```scala
case class Test()(a1: Int,
    a2: Int,
    a3: Int,
    a4: Int,
    a5: Int,
    a6: Int,
    a7: Int,
    a8: Int,
    a9: Int)
```