### PR TITLE
Align comments in the middle of method chain

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -69,6 +69,8 @@ case class Align(
       "Defn.Class" -> "class/object/trait",
       "Defn.Object" -> "class/object/trait",
       "Defn.Trait" -> "class/object/trait",
+      "Term.Apply" -> "term.apply/term.select",
+      "Term.Select" -> "term.apply/term.select",
       "Enumerator.Generator" -> "for",
       "Enumerator.Val" -> "for"
     )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -704,7 +704,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   private final def vAlignDepthUnCached(tree: Tree): Int = {
     val count: Int = tree match {
       // infix applications don't count towards the length, context #531
-      case _: Term.ApplyInfix => 0
+      case _ @(_: Term.Apply | _: Term.ApplyInfix | _: Term.Select) => 0
       case _ => 1
     }
     tree.parent match {

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -420,3 +420,13 @@ Seq(
   "org.scalatest"      % "scalatest_2.11"               % "3.0.0" % Test,
   "org.scalamock"      %% "scalamock-scalatest-support" % "3.2.2" % Test
 )
+<<< align coments in method chain
+foo
+  .x() // comment1
+  .xx() // comment2
+  .xxx() // comment3
+>>>
+foo
+  .x()   // comment1
+  .xx()  // comment2
+  .xxx() // comment3

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -420,7 +420,7 @@ Seq(
   "org.scalatest"      % "scalatest_2.11"               % "3.0.0" % Test,
   "org.scalamock"      %% "scalamock-scalatest-support" % "3.2.2" % Test
 )
-<<< align coments in method chain
+<<< align comments in method chain
 foo
   .x() // comment1
   .xx() // comment2
@@ -430,3 +430,47 @@ foo
   .x()   // comment1
   .xx()  // comment2
   .xxx() // comment3
+<<< should not align comments on separate statements
+object test {
+  val ys = xs
+    .filter(_ > 2) // comment1
+    .map(x => x + 1) // comment2
+  ys.map(y => y + 111) // comment3
+}
+>>>
+object test {
+  val ys = xs
+    .filter(_ > 2)   // comment1
+    .map(x => x + 1) // comment2
+  ys.map(y => y + 111) // comment3
+}
+<<< align type infix
+foo
+  .x[T]() // comment1
+  .xx[T]() // comment2
+>>>
+foo
+  .x[T]()  // comment1
+  .xx[T]() // comment2
+<<< align on params
+a.b(
+  1, // comment1
+  1  // comment2
+)
+>>>
+a.b(
+  1, // comment1
+  1  // comment2
+)
+<<< should not align arrow in separate maps
+object a {
+  Map(xx -> yy)
+  Map(x -> y)
+  Map(xxx -> yyy)
+}
+>>>
+object a {
+  Map(xx -> yy)
+  Map(x -> y)
+  Map(xxx -> yyy)
+}


### PR DESCRIPTION
This PR addresses https://github.com/scalameta/scalafmt/issues/1242