### PR TITLE
Add two more trailingCommas tests for when comments have additional whitespace alignment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -31,6 +31,7 @@ class FormatWriter(formatOps: FormatOps) {
   def mkString(splits: Vector[Split]): String = {
     val sb = new StringBuilder()
     var lastState = State.start // used to calculate start of formatToken.right.
+    var previousLeftWhitespace = ""
     reconstructPath(tokens, splits, debug = false) {
       case (state, formatToken, whitespace) =>
         formatToken.left match {
@@ -52,7 +53,16 @@ class FormatWriter(formatOps: FormatOps) {
             sb.append(rewrittenToken)
         }
 
-        handleTrailingCommasAndWhitespace(formatToken, state, sb, whitespace)
+        handleTrailingCommasAndWhitespace(
+          formatToken,
+          state,
+          sb,
+          whitespace,
+          previousLeftWhitespace)
+
+        // Need to keep track of the actual previous left token whitespace,
+        // Since prevFormatToken.between.length is the original length
+        previousLeftWhitespace = whitespace
 
         formatToken.right match {
           // state.column matches the end of formatToken.right
@@ -387,7 +397,8 @@ class FormatWriter(formatOps: FormatOps) {
       formatToken: FormatToken,
       state: State,
       sb: StringBuilder,
-      whitespace: String): Unit = {
+      whitespace: String,
+      previousLeftWhitespace: String): Unit = {
 
     import org.scalafmt.config.TrailingCommas
 
@@ -432,7 +443,7 @@ class FormatWriter(formatOps: FormatOps) {
               right.is[RightParen]) && // isn't empty parentheses
             right.is[CloseDelim] && isNewline =>
         sb.insert(
-          sb.length - left.syntax.length - prevFormatToken.between.length,
+          sb.length - left.syntax.length - previousLeftWhitespace.size,
           ",")
         sb.append(whitespace)
 
@@ -458,7 +469,7 @@ class FormatWriter(formatOps: FormatOps) {
           if left.is[Comment] && prevFormatToken.left.is[Comma] &&
             right.is[CloseDelim] && isNewline =>
         sb.deleteCharAt(
-          sb.length - left.syntax.length - prevFormatToken.between.length - 1)
+          sb.length - left.syntax.length - previousLeftWhitespace.size - 1)
         sb.append(whitespace)
 
       // foo(a, b,)

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysComments.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysComments.stat
@@ -4,12 +4,24 @@ trailingCommas = always
 <<< should consider comments when adding trailing commas
 def method(
     a: String,
-    b: String // a comment
+    b: String // b comment
 ) = ???
 >>>
 def method(
     a: String,
-    b: String, // a comment
+    b: String, // b comment
+) = ???
+
+
+<<< should consider comments with extra whitespace when adding trailing commas
+def method(
+    abc: String, // abc comment
+    d: String    // d comment
+) = ???
+>>>
+def method(
+    abc: String, // abc comment
+    d: String, // d comment
 ) = ???
 
 <<< should consider indented comments on the next line when adding trailing commas

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
@@ -11,3 +11,25 @@ def method(
     a: String,
     b: String
 )
+
+<<< should consider comments when removing trailing commas
+def method(
+    a: String,
+    b: String, // b comment
+) = ???
+>>>
+def method(
+    a: String,
+    b: String // b comment
+) = ???
+
+<<< should consider comments with extra whitespace when removing trailing commas
+def method(
+    abc: String, // abc comment
+    d: String,   // d comment
+) = ???
+>>>
+def method(
+    abc: String, // abc comment
+    d: String // d comment
+) = ???


### PR DESCRIPTION
Related issue: https://github.com/scalameta/scalafmt/issues/1254

Related code: https://github.com/scalameta/scalafmt/blob/fd0df2a8d6ce94815fef87ff8257eb5f5e8d63e6/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala#L412-L462

It probably wouldn't hurt to think about some more complicated tests that include alignment formatting too?  I'm just not super familiar enough with scalafmt to create them yet.  This is just an example of scratching my own itch as we are exploring adding scalafmt to our codebase, and this causes the resulting code to not compile if `trailingCommas: always` is set.

Passes the existing formatTests