### PR TITLE
Cleanup empty parentheses check

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -411,9 +411,9 @@ class FormatWriter(formatOps: FormatOps) {
       //
       // Insert a comma after b
       case TrailingCommas.always
-          if !left.is[Comma] && !left.is[Comment] &&
-            !(left.is[LeftParen] &&
-              right.is[RightParen]) && // isn't empty parentheses
+          if !left.is[Comma] &&
+            !left.is[Comment] &&
+            !left.is[LeftParen] && // skip empty parentheses
             !formatToken.right.is[Comment] &&
             right.is[CloseDelim] && isNewline =>
         sb.append(",")
@@ -428,8 +428,8 @@ class FormatWriter(formatOps: FormatOps) {
       case TrailingCommas.always
           if left.is[Comment] && !prevFormatToken.left.is[Comma] &&
             !prevFormatToken.left.is[Comment] &&
-            !(prevNonComment(formatToken).left.is[LeftParen] &&
-              right.is[RightParen]) && // isn't empty parentheses
+            !prevNonComment(formatToken).left
+              .is[LeftParen] && // skip empty parentheses
             right.is[CloseDelim] && isNewline =>
         sb.insert(
           sb.length - left.syntax.length - prevFormatToken.between.length,


### PR DESCRIPTION
While playing around with the trailing commas logic, I've noticed that the fix introduced in #1239 includes a redundant check.

Essentially this PR simplifies `!(A & B) & B` to `!A & B`,
since `!(A & B) && B === (!A || !B) && B`, so `!B` doesn't contribute
anything to the check.

Existing tests still pass.