### PR TITLE
Vertical align adjacent single lines of comment

### DIFF
--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -420,3 +420,67 @@ Seq(
   "org.scalatest"      % "scalatest_2.11"               % "3.0.0" % Test,
   "org.scalamock"      %% "scalamock-scalatest-support" % "3.2.2" % Test
 )
+<<< align comments in method chain
+foo
+  .x() // comment1
+  .xx() // comment2
+  .xxx() // comment3
+>>>
+foo
+  .x()   // comment1
+  .xx()  // comment2
+  .xxx() // comment3
+<<< should align comments on separate statements
+object test {
+  val ys = xs
+    .filter(_ > 2) // comment1
+    .filter(x => x + 1) // comment2
+  ys.map(y => y + 1) // comment3
+}
+>>>
+object test {
+  val ys = xs
+    .filter(_ > 2)      // comment1
+    .filter(x => x + 1) // comment2
+  ys.map(y => y + 1)    // comment3
+}
+<<< align comments on type infix
+foo
+  .x[T]() // comment1
+  .xx[T]() // comment2
+>>>
+foo
+  .x[T]()  // comment1
+  .xx[T]() // comment2
+<<< align comments on params
+a.b(
+  1, // comment1
+  123  // comment2
+)
+>>>
+a.b(
+  1,  // comment1
+  123 // comment2
+)
+<<< should align comments on params of methods
+def method(
+    abc: String, // abc comment
+    d: String // d comment
+) = ???
+>>>
+def method(
+    abc: String, // abc comment
+    d: String    // d comment
+) = ???
+<<< shouldn't align comments on the line which only has a comment
+object x {
+  println("foo bar") // comment
+  // comment
+  println("foo") // comment
+}
+>>>
+object x {
+  println("foo bar") // comment
+  // comment
+  println("foo") // comment
+}


### PR DESCRIPTION
Addresses https://github.com/scalameta/scalafmt/issues/1242

The reason why scalafmt doesn't align the adjacent single line of comments which appears in method chains or parameters with `align=more` is that [columnsMatch](https://github.com/scalameta/scalafmt/blob/bcfe2b296144e6bf6fac1c253b8c12fc7031ca12/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala#L277-L294) in `FormatWriter.scala` doesn't matches the two adjacent `//`s.

There are mainly two factors that makes `columnsMatch` doesn't match two `//`s.

---

The first one is that [vAlignDepth(row1Owner) == vAlignDepth(row2Owner)](https://github.com/scalameta/scalafmt/blob/bcfe2b296144e6bf6fac1c253b8c12fc7031ca12/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala#L285-L286
) become usually `false` when we are trying to match the two `//`s which appears in method chains or parameters like below.

```scala
x
  .foo // comment1
  .bar  // comment2

def method(
  a: String, // comment3
  b: Int // comment4
)
```

I tried to adjust the depth of them in https://github.com/scalameta/scalafmt/pull/1243 by stop incrementing the depth on `Term.Apply`, `Term.Select` and so on.
However, as @olafurpg advised in https://github.com/scalameta/scalafmt/pull/1243#pullrequestreview-142073794, it is more natural and safe to just ignore the vAlignDepth of the rowOwners when we try to align single-line comments.

---

The another one is that the `key` of `row1.formatToken.right` and `row2.formatToken.right` sometimes differs when we try to align single-line comments which appear in method chains, because some of them are `Term.Apply` and some are `Term.Select`.

https://github.com/scalameta/scalafmt/blob/bcfe2b296144e6bf6fac1c253b8c12fc7031ca12/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala#L287

I tried to adjust it in https://github.com/scalameta/scalafmt/pull/1243 by grouping the keys of `Term.Apply` and `Term.Select`.
However, as advised in https://github.com/scalameta/scalafmt/pull/1243#pullrequestreview-142073794, its better to just ignore the tree owners.

---

Therefore, in this PR, we just ignore the `vAlignDepth` and tree owners in `columnsMatch` when we try to align single-line comments.
