### PR TITLE
Fix jvm options

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,7 +1,7 @@
 -Dfile.encoding=UTF8
 -Xms1G
--Xmx6G
--XX:MaxPermSize=512M
+-Xmx3G
+-XX:MaxMetaspaceSize=512M
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit

--- a/build.sbt
+++ b/build.sbt
@@ -182,8 +182,6 @@ lazy val benchmarks = project
       "-XX:+CMSClassUnloadingEnabled",
       "-XX:ReservedCodeCacheSize=128m",
       "-XX:MaxMetaspaceSize=1024m",
-      "-Xss8M",
-      "-Xms512M",
       "-XX:SurvivorRatio=128",
       "-XX:MaxTenuringThreshold=0",
       "-Xss8M",

--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val benchmarks = project
       "-XX:+CMSParallelRemarkEnabled",
       "-XX:+CMSClassUnloadingEnabled",
       "-XX:ReservedCodeCacheSize=128m",
-      "-XX:MaxPermSize=1024m",
+      "-XX:MaxMetaspaceSize=1024m",
       "-Xss8M",
       "-Xms512M",
       "-XX:SurvivorRatio=128",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val scalametaV = "4.0.0-M1"
   val scalatestV = "3.2.0-SNAP10"
   val scalacheckV = "1.13.5"
-  val coursier = "1.0.0-RC12"
+  val coursier = "1.0.3"
 
   val scalapb = Def.setting {
     ExclusionRule(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.0
+sbt.version=1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin(
   "io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version)
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
 addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.11")


### PR DESCRIPTION
`MaxPermSize` was replaced by `MaxMetaspaceSize`. The limitation of memory size is 4G, when `.travis.yml` is with default configuration.