### PR TITLE
Fix trailing commas always/never not to put/delete trailing comma on incorrect location

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -438,9 +438,9 @@ class FormatWriter(formatOps: FormatOps) {
             !prevNonComment(formatToken).left
               .is[LeftParen] && // skip empty parentheses
             right.is[CloseDelim] && isNewline =>
-        sb.insert(
-          sb.length - left.syntax.length - prevFormatToken.between.length,
-          ",")
+        val indexOfComment = sb.lastIndexOf(left.syntax)
+        val index = sb.lastIndexOf(prevFormatToken.left.syntax, indexOfComment)
+        sb.insert(index + prevFormatToken.left.syntax.length, ",")
         sb.append(whitespace)
 
       // foo(
@@ -464,8 +464,9 @@ class FormatWriter(formatOps: FormatOps) {
       case TrailingCommas.never
           if left.is[Comment] && prevFormatToken.left.is[Comma] &&
             right.is[CloseDelim] && isNewline =>
-        sb.deleteCharAt(
-          sb.length - left.syntax.length - prevFormatToken.between.length - 1)
+        val indexOfComment = sb.lastIndexOf(left.syntax)
+        val indexOfComma = sb.lastIndexOf(prevFormatToken.left.syntax, indexOfComment)
+        sb.deleteCharAt(indexOfComma)
         sb.append(whitespace)
 
       // foo(a, b,)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -32,7 +32,7 @@ class FormatWriter(formatOps: FormatOps) {
     val sb = new StringBuilder()
     var lastState = State.start // used to calculate start of formatToken.right.
     reconstructPath(tokens, splits, debug = false) {
-      case (state, formatToken, whitespace) =>
+      case (state, formatToken, whitespace, tokenAligns) =>
         formatToken.left match {
           case c: Comment =>
             sb.append(formatComment(c, state.indentation))
@@ -52,7 +52,12 @@ class FormatWriter(formatOps: FormatOps) {
             sb.append(rewrittenToken)
         }
 
-        handleTrailingCommasAndWhitespace(formatToken, state, sb, whitespace)
+        handleTrailingCommasAndWhitespace(
+          formatToken,
+          state,
+          sb,
+          whitespace,
+          tokenAligns)
 
         formatToken.right match {
           // state.column matches the end of formatToken.right
@@ -149,10 +154,12 @@ class FormatWriter(formatOps: FormatOps) {
   def reconstructPath(
       toks: Array[FormatToken],
       splits: Vector[Split],
-      debug: Boolean)(callback: (State, FormatToken, String) => Unit): Unit = {
+      debug: Boolean)(
+      callback: (State, FormatToken, String, Map[FormatToken, Int]) => Unit)
+    : Unit = {
     require(toks.length >= splits.length, "splits !=")
     val locations = getFormatLocations(toks, splits, debug)
-    val tokenAligns = alignmentTokens(locations).withDefaultValue(0)
+    val tokenAligns = alignmentTokens(locations)
     var lastModification = locations.head.split.modification
     locations.zipWithIndex.foreach {
       case (FormatLocation(tok, split, state), i) =>
@@ -160,9 +167,10 @@ class FormatWriter(formatOps: FormatOps) {
         val whitespace = split.modification match {
           case Space =>
             val previousAlign =
-              if (lastModification == NoSplit) tokenAligns(prev(tok))
+              if (lastModification == NoSplit)
+                tokenAligns.getOrElse(prev(tok), 0)
               else 0
-            " " + (" " * (tokenAligns(tok) + previousAlign))
+            " " + (" " * (tokenAligns.getOrElse(tok, 0) + previousAlign))
           case nl: NewlineT
               if nl.acceptNoSplit && !tok.left.isInstanceOf[Comment] &&
                 state.indentation >= previous.state.column =>
@@ -184,7 +192,7 @@ class FormatWriter(formatOps: FormatOps) {
           case NoSplit => ""
         }
         lastModification = split.modification
-        callback.apply(state, tok, whitespace)
+        callback.apply(state, tok, whitespace, tokenAligns)
     }
     if (debug) {
 
@@ -394,7 +402,9 @@ class FormatWriter(formatOps: FormatOps) {
       formatToken: FormatToken,
       state: State,
       sb: StringBuilder,
-      whitespace: String): Unit = {
+      whitespace: String,
+      tokenAligns: Map[FormatToken, Int]
+  ): Unit = {
 
     import org.scalafmt.config.TrailingCommas
 
@@ -440,7 +450,14 @@ class FormatWriter(formatOps: FormatOps) {
             right.is[CloseDelim] && isNewline =>
         val indexOfComment = sb.lastIndexOf(left.syntax)
         val index = sb.lastIndexOf(prevFormatToken.left.syntax, indexOfComment)
-        sb.insert(index + prevFormatToken.left.syntax.length, ",")
+
+        // If the leading comment is vertically aligned, preserve the location of
+        // the comment to avoid breaking the alignment.
+        if (tokenAligns.get(prevFormatToken).isDefined) {
+          sb.setCharAt(index + prevFormatToken.left.syntax.length, ',')
+        } else {
+          sb.insert(index + prevFormatToken.left.syntax.length, ",")
+        }
         sb.append(whitespace)
 
       // foo(
@@ -465,8 +482,16 @@ class FormatWriter(formatOps: FormatOps) {
           if left.is[Comment] && prevFormatToken.left.is[Comma] &&
             right.is[CloseDelim] && isNewline =>
         val indexOfComment = sb.lastIndexOf(left.syntax)
-        val indexOfComma = sb.lastIndexOf(prevFormatToken.left.syntax, indexOfComment)
-        sb.deleteCharAt(indexOfComma)
+        val indexOfComma =
+          sb.lastIndexOf(prevFormatToken.left.syntax, indexOfComment)
+
+        // If the leading comment is vertically aligned, preserve the location of
+        // the comment to avoid breaking the alignment.
+        if (tokenAligns.get(prevFormatToken).isDefined) {
+          sb.setCharAt(indexOfComma, ' ')
+        } else {
+          sb.deleteCharAt(indexOfComma)
+        }
         sb.append(whitespace)
 
       // foo(a, b,)

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -420,3 +420,67 @@ Seq(
   "org.scalatest"      % "scalatest_2.11"               % "3.0.0" % Test,
   "org.scalamock"      %% "scalamock-scalatest-support" % "3.2.2" % Test
 )
+<<< align comments in method chain
+foo
+  .x() // comment1
+  .xx() // comment2
+  .xxx() // comment3
+>>>
+foo
+  .x()   // comment1
+  .xx()  // comment2
+  .xxx() // comment3
+<<< should align comments on separate statements
+object test {
+  val ys = xs
+    .filter(_ > 2) // comment1
+    .filter(x => x + 1) // comment2
+  ys.map(y => y + 1) // comment3
+}
+>>>
+object test {
+  val ys = xs
+    .filter(_ > 2)      // comment1
+    .filter(x => x + 1) // comment2
+  ys.map(y => y + 1)    // comment3
+}
+<<< align comments on type infix
+foo
+  .x[T]() // comment1
+  .xx[T]() // comment2
+>>>
+foo
+  .x[T]()  // comment1
+  .xx[T]() // comment2
+<<< align comments on params
+a.b(
+  1, // comment1
+  123  // comment2
+)
+>>>
+a.b(
+  1,  // comment1
+  123 // comment2
+)
+<<< should align comments on params of methods
+def method(
+    abc: String, // abc comment
+    d: String // d comment
+) = ???
+>>>
+def method(
+    abc: String, // abc comment
+    d: String    // d comment
+) = ???
+<<< shouldn't align comments on the line which only has a comment
+object x {
+  println("foo bar") // comment
+  // comment
+  println("foo") // comment
+}
+>>>
+object x {
+  println("foo bar") // comment
+  // comment
+  println("foo") // comment
+}

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysAlignMore.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysAlignMore.stat
@@ -1,0 +1,24 @@
+maxColumn = 30
+trailingCommas = always
+align = more
+<<< should consider comments with extra whitespace when adding trailing commas align more
+def method(
+    abc: String, // abc comment
+    d: String // d comment
+) = ???
+>>>
+def method(
+    abc: String, // abc comment
+    d: String,   // d comment
+) = ???
+<<< should consider comments when adding trailing comments align more
+def method(
+    a: String,  // a comment
+    b: String // b comment
+) = ???
+>>>
+def method(
+    a: String, // a comment
+    b: String, // b comment
+) = ???
+

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysComments.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysComments.stat
@@ -4,12 +4,24 @@ trailingCommas = always
 <<< should consider comments when adding trailing commas
 def method(
     a: String,
-    b: String // a comment
+    b: String // b comment
 ) = ???
 >>>
 def method(
     a: String,
-    b: String, // a comment
+    b: String, // b comment
+) = ???
+
+
+<<< should consider comments with extra whitespace when adding trailing commas
+def method(
+    abc: String, // abc comment
+    d: String    // d comment
+) = ???
+>>>
+def method(
+    abc: String, // abc comment
+    d: String, // d comment
 ) = ???
 
 <<< should consider indented comments on the next line when adding trailing commas

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
@@ -11,3 +11,25 @@ def method(
     a: String,
     b: String
 )
+
+<<< should consider comments when removing trailing commas
+def method(
+    a: String,
+    b: String, // b comment
+) = ???
+>>>
+def method(
+    a: String,
+    b: String // b comment
+) = ???
+
+<<< should consider comments with extra whitespace when removing trailing commas
+def method(
+    abc: String, // abc comment
+    d: String,   // d comment
+) = ???
+>>>
+def method(
+    abc: String, // abc comment
+    d: String // d comment
+) = ???

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNeverCommentsAlignMore.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNeverCommentsAlignMore.stat
@@ -1,0 +1,14 @@
+maxColumn = 30
+trailingCommas = never
+align = more
+
+<<< should consider comments when removing trailing commas while align comment
+def method(
+    abc: String, // abc comment
+    d: String,  // d comment
+)
+>>>
+def method(
+    abc: String, // abc comment
+    d: String    // d comment
+)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -195,7 +195,7 @@ trait HasTests extends FunSuiteLike with FormatAssertions {
     val builder = mutable.ArrayBuilder.make[FormatOutput]()
     new FormatWriter(Debug.formatOps)
       .reconstructPath(Debug.tokens, Debug.state.splits, debug = onlyOne) {
-        case (_, token, whitespace) =>
+        case (_, token, whitespace, _) =>
           builder += FormatOutput(
             token.left.syntax,
             whitespace,


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalafmt/issues/1254

This PR is based on https://github.com/scalameta/scalafmt/pull/1260 because the commit https://github.com/tanishiking/scalafmt/commit/61eec1d301acc35948be011a1ac7d86fba6ad447 which fixes #1254 will break the alignment of leading comments which is done by  https://github.com/scalameta/scalafmt/pull/1260. And this PR contains the commit (https://github.com/tanishiking/scalafmt/commit/47356126eca00704631937ce163320fdde442a8e) that fixes the breakage.

---

For instance, without https://github.com/tanishiking/scalafmt/commit/47356126eca00704631937ce163320fdde442a8e

Given setting
```
trailingCommas = always
align = more
```

Given code like this:
```scala
def method (
  x: String, // comment
  yyy: String // comment
)
```

Scalafmt formats code like this:
```scala
def method (
  x: String,  // comment
  yyy: String, // comment
)
```

Expected,
```scala
def method (
  x: String,   // comment
  yyy: String, // comment
)
```
