### PR TITLE
Enable builds under GraalVM

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -63,7 +63,7 @@ object Cli {
   }
 
   def main(args: Array[String]): Unit = {
-    val exit = mainWithOptions(args, CliOptions.default)
+    val exit = mainWithOptions(args, CliOptions())
     sys.exit(exit.code)
   }
 

--- a/scalafmt-core/js/src/main/scala/org/scalafmt/internal/package.scala
+++ b/scalafmt-core/js/src/main/scala/org/scalafmt/internal/package.scala
@@ -1,0 +1,5 @@
+package org.scalafmt
+
+package object internal {
+  type PriorityQueue[T] = scala.collection.mutable.PriorityQueue[T]
+}

--- a/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/PriorityQueue.scala
+++ b/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/PriorityQueue.scala
@@ -1,5 +1,7 @@
 package org.scalafmt.internal
 
+import java.util.Comparator
+
 /**
   * Minimal implementation of the PriorityQueue's functions needed.
   *
@@ -9,8 +11,11 @@ package org.scalafmt.internal
   *
   * @tparam T the values inside the queue
   */
-class PriorityQueue[T] {
-  private[this] val q = new java.util.PriorityQueue[T]
+class PriorityQueue[T <: Ordered[T]] {
+  private[this] val q =
+    new java.util.PriorityQueue[T](11, new Comparator[T] {
+      override def compare(t: T, t1: T): Int = t1.compare(t)
+    })
 
   def dequeueAll: Unit = q.clear()
 
@@ -20,9 +25,12 @@ class PriorityQueue[T] {
 
   def enqueue(x: T): Unit = q.add(x)
 
-  def +=(x: T): Unit = q.add(x)
+  def +=(x: T): PriorityQueue[T] = {
+    q.add(x)
+    this
+  }
 
-  def nonEmpty: Boolean = !q.isEmpty
+  def nonEmpty: Boolean = !isEmpty
 
   def isEmpty: Boolean = q.isEmpty
 

--- a/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/PriorityQueue.scala
+++ b/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/PriorityQueue.scala
@@ -1,7 +1,5 @@
 package org.scalafmt.internal
 
-import java.util.Comparator
-
 /**
   * Minimal implementation of the PriorityQueue's functions needed.
   *
@@ -11,11 +9,8 @@ import java.util.Comparator
   *
   * @tparam T the values inside the queue
   */
-class PriorityQueue[T <: Ordered[T]] {
-  private[this] val q =
-    new java.util.PriorityQueue[T](11, new Comparator[T] {
-      override def compare(t: T, t1: T): Int = t1.compare(t)
-    })
+class PriorityQueue[T](implicit ord: Ordering[T]) {
+  private[this] val q = new java.util.PriorityQueue[T](11, ord.reversed())
 
   def dequeueAll: Unit = q.clear()
 

--- a/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/PriorityQueue.scala
+++ b/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/PriorityQueue.scala
@@ -1,0 +1,29 @@
+package org.scalafmt.internal
+
+/**
+  * Minimal implementation of the PriorityQueue's functions needed.
+  *
+  * We use [[java.util.PriorityQueue]] to enable usage under GraalVM. The
+  * native-image compiler is unable to work with
+  * [[scala.collection.mutable.PriorityQueue]] currently.
+  *
+  * @tparam T the values inside the queue
+  */
+class PriorityQueue[T] {
+  private[this] val q = new java.util.PriorityQueue[T]
+
+  def dequeueAll: Unit = q.clear()
+
+  def dequeue(): T = q.poll()
+
+  def size: Int = q.size()
+
+  def enqueue(x: T): Unit = q.add(x)
+
+  def +=(x: T): Unit = q.add(x)
+
+  def nonEmpty: Boolean = !q.isEmpty
+
+  def isEmpty: Boolean = q.isEmpty
+
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -151,7 +151,7 @@ class BestFirstSearch(
       stop: Token,
       depth: Int = 0,
       maxCost: Int = Integer.MAX_VALUE): State = {
-    val Q = new mutable.PriorityQueue[State]()
+    val Q = new PriorityQueue[State]()
     var result = start
     var lastDequeue = start
     Q += start


### PR DESCRIPTION
This change enables Scalafmt to be built as a `native-image` with GraalVM from the scalafmt-cli jar.

This achieves one of the goals of #1172, namely, avoiding the JVM warm-up time.

For the scalafmt repo, I got a speed-up of **2.5x** in my computer. Also, since this method creates a binary just like the current recommended way using coursier and nailgun-ng in the console, it allows for much easier integration with editors such as emacs or vim and other script-based tooling (such as pre-commit hooks).

For building the test native-image I used [GraalVM CE 1..00-RC5](https://github.com/oracle/graal/releases/tag/vm-1.0.0-rc5) under Fedora 28, and I just used `native-image -jar scalafmt.jar`.

This is the test I performed:
```bash
[ssaavedra@proton] scalafmt % $(which time) ~/tmp/scalafmt.jar
Reformatting...
  100.0% [##########] 142 source files formatted
47.24user 0.88system 0:07.99elapsed 602%CPU (0avgtext+0avgdata 1054292maxresident)k
0inputs+960outputs (0major+265046minor)pagefaults 0swaps
[ssaavedra@proton] scalafmt % git checkout -- .
[ssaavedra@proton] scalafmt % $(which time) ~/tmp/scalafmt
Reformatting...
  100.0% [##########] 142 source files formatted
8.35user 0.27system 0:03.20elapsed 269%CPU (0avgtext+0avgdata 408940maxresident)k
0inputs+1512outputs (0major+116463minor)pagefaults 0swaps
```

It is important to instantiate `CliOptions()` in the main() method instead of using CliOptions.default because the Graal compiler runs `AbsoluteFile.userDir` at compile-time in order to put the actual value at compilation-time as a constant in the CliOptions.default object. Therefore, in order to have relative paths working again, the CliOptions must be ensured that is instantiated at runtime, and that such constants are not precompiled.

The PriorityQueue reimplementation was needed because currently the Scala version of PriorityQueue won't compile into GraalVM due to some calls not being straightforward enough for the static analyzer and some code gets marked as unreachable and is not included in the binary image.