### PR TITLE
Fix for #1223 regression in unindentTopLevelOperators/continuationIndent

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -506,7 +506,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       formatToken.left.is[Token.Equals] &&
         owners(formatToken.left).is[Defn]
     val indent: Int = {
-      if (style.unindentTopLevelOperators && isAssignment) {
+      if (style.unindentTopLevelOperators && isAssignment &&
+        newlinesBetween(next(next(formatToken)).between) > 0) {
         // see https://github.com/scalameta/scalafmt/issues/848
         2
       } else if ((style.unindentTopLevelOperators ||

--- a/scalafmt-tests/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/src/test/resources/test/IndentOperator.stat
@@ -112,3 +112,25 @@ val x =
 val x = 1 +
   2 +
   3
+<<< #1223 infix with call
+val x = y :: List(
+a,
+b,
+c
+)
+>>>
+val x = y :: List(
+  a,
+  b,
+  c
+)
+<<< #1223 infix operator two
+  val x = y andThen List(
+  a,
+  b
+  )
+>>>
+val x = y andThen List(
+  a,
+  b
+)


### PR DESCRIPTION
All previous tests pass, and added the new tests based upon the PR.  Fixes regression #1223 