### PR TITLE
Revert fix for unindentTopLevelOperators, acknowledge limitation instead

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -502,14 +502,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     val modification = newlines2Modification(
       formatToken.between,
       rightIsComment = formatToken.right.isInstanceOf[Comment])
-    def isAssignment =
-      formatToken.left.is[Token.Equals] &&
-        owners(formatToken.left).is[Defn]
-    val indent: Int = {
-      if (style.unindentTopLevelOperators && isAssignment) {
-        // see https://github.com/scalameta/scalafmt/issues/848
-        2
-      } else if ((style.unindentTopLevelOperators ||
+    val indent = {
+      if ((style.unindentTopLevelOperators ||
         isTopLevelInfixApplication(owner)) &&
         (style.indentOperator.includeRegexp
           .findFirstIn(op.tokens.head.syntax)
@@ -548,7 +542,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
     owner.parent match {
       case Some(_: Type.ApplyInfix)
-          if style.spaces.neverAroundInfixTypes.contains(op.value) =>
+          if style.spaces.neverAroundInfixTypes.contains((op.value)) =>
         Split(NoSplit, 0)
       case _ =>
         Split(modification, 0).withIndent(Num(indent), expire, ExpiresOn.Left)

--- a/scalafmt-tests/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/src/test/resources/test/IndentOperator.stat
@@ -112,3 +112,29 @@ val x =
 val x = 1 +
 2 +
 3
+<<< #1223 assignment + regular application
+val x = a + B(
+    a,
+    2
+)
+>>>
+val x = a + B(
+  a,
+  2
+)
+<<< #1223 assignment + right-associative + regular application
+val x = a :: B(
+    a,
+    2
+)
+>>>
+val x = a :: B(
+  a,
+  2
+)
+<<< #1282 known limitation - counter-example why PR insufficient
+val x = 1 + 2 +
+  3
+>>>
+val x = 1 + 2 +
+3

--- a/scalafmt-tests/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/src/test/resources/test/IndentOperator.stat
@@ -94,3 +94,21 @@ object TestRoutes {
       ???
     }
 }
+<<< #848 known limitation - right-hand side of assignment is unindented
+  val x =
+  1 +
+  2 +
+  3
+>>>
+val x =
+1 +
+2 +
+3
+<<< #848 known limitation 2 - right-hand side of assignment is unindented
+  val x = 1 +
+  2 +
+  3
+>>>
+val x = 1 +
+2 +
+3

--- a/scalafmt-tests/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/src/test/resources/test/IndentOperator.stat
@@ -94,21 +94,3 @@ object TestRoutes {
       ???
     }
 }
-<<< #848
-  val x =
-  1 +
-  2 +
-  3
->>>
-val x =
-  1 +
-  2 +
-  3
-<<< #848 same line
-  val x = 1 +
-  2 +
-  3
->>>
-val x = 1 +
-  2 +
-  3


### PR DESCRIPTION
I can't come up with a reasonable definition for how `unindentTopLevelOperators=true` should behave for assignments. The option is not documented on the website so I prefer to revert the fix that introduced the regression and live instead with the original bug.

Fixes #1223 
Supersedes #1282