### PR TITLE
Add a CLI option to fetch scalafmt config from URL.

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -176,8 +176,8 @@ object CliArgParser {
     s"""build commit: ${Versions.commit}
        |build time: ${new Date(Versions.timestamp.toLong)}""".stripMargin
 
-  private implicit val urlOptRead: Read[URL] = Read.reads {
-    Try(new URL(_)).fold(
+  private implicit val urlOptRead: Read[URL] = Read.reads { s =>
+    Try(new URL(s)).fold(
       _ => throw new IllegalArgumentException("Expected a URL"),
       identity
     )

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -10,8 +10,6 @@ import org.scalafmt.util.AbsoluteFile
 import org.scalafmt.util.FileOps
 import scopt.{OptionParser, Read}
 
-import scala.util.Try
-
 object CliArgParser {
 
   val usageExamples: String =
@@ -53,9 +51,7 @@ object CliArgParser {
         )
       }
 
-      private def readConfigFromURL(
-          url: URL,
-          c: CliOptions): CliOptions = {
+      private def readConfigFromURL(url: URL, c: CliOptions): CliOptions = {
         readConfig(FileOps.readURL(url), c)
       }
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -176,11 +176,6 @@ object CliArgParser {
     s"""build commit: ${Versions.commit}
        |build time: ${new Date(Versions.timestamp.toLong)}""".stripMargin
 
-  private implicit val urlOptRead: Read[URL] = Read.reads { s =>
-    Try(new URL(s)).fold(
-      _ => throw new IllegalArgumentException("Expected a URL"),
-      identity
-    )
-  }
+  private implicit val urlOptRead: Read[URL] = Read.reads(new URL(_))
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -2,6 +2,7 @@ package org.scalafmt.util
 
 import scala.io.Codec
 import java.io._
+import java.net.URL
 
 object FileOps {
 
@@ -40,10 +41,14 @@ object FileOps {
     */
   def readFile(filename: String)(implicit codec: Codec): String = {
     if (filename matches "https?://.*") {
-      scala.io.Source.fromURL(filename)("UTF-8").getLines().mkString("\n")
+      readURL(new URL(filename))
     } else {
       readFile(new File(filename))
     }
+  }
+
+  def readURL(url: URL): String = {
+    scala.io.Source.fromURL(url)("UTF-8").getLines().mkString("\n")
   }
 
   def readFile(file: AbsoluteFile)(implicit codec: Codec): String = {


### PR DESCRIPTION
Usage:
`scalafmt --config-url ${URL}`