### PR TITLE
Add test for preserving location of comment when removing trailing comma

### DIFF
--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNeverComments.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNeverComments.stat
@@ -37,3 +37,27 @@ def method(
     b: String
 // a comment
 )
+<<< preserve the position of comment see #1231
+object Test {
+  def apply() = {
+    div(
+      div(
+        (5 to 5).map { res => 5 },
+        //
+      )
+    )
+  }
+}
+>>>
+object Test {
+  def apply() = {
+    div(
+      div(
+        (5 to 5).map { res =>
+          5
+        }
+        //
+      )
+    )
+  }
+}


### PR DESCRIPTION
see https://github.com/scalameta/scalafmt/issues/1231

This idempotency violation has been fixed as of https://github.com/scalameta/scalafmt/pull/1262
