### PR TITLE
Enable sbt-idea-plugin in intellij project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,7 @@ lazy val intellij = project
     cleanFiles += ideaDownloadDirectory.value
   )
   .dependsOn(coreJVM, cli)
+  .enablePlugins(SbtIdeaPlugin)
 
 lazy val tests = project
   .in(file("scalafmt-tests"))


### PR DESCRIPTION
This makes the `downloadIdea` command work again.