### PR TITLE
Fix configuration example for continuationIndent.callSite in document

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ continuationIndent.callSite
 Example:
 
 ```scala mdoc:scalafmt
-continuationIndent.defnSite = 2
+continuationIndent.callSite = 2
 ---
 function(
 argument1, // indented by 2


### PR DESCRIPTION
We may want the config example for `continuationIndent.callSite` to explicitly set
`continuationIndent.callSite` instead of `continutionIndent.defnSite` (although this example is correct because `continuationIndent.callSite` is `2` by default).

## before
![screenshot from 2018-11-06 23-10-55](https://user-images.githubusercontent.com/9353584/48069831-c9a69f00-e219-11e8-9e5f-2c91ab6b086f.png)

## after
![screenshot from 2018-11-06 23-10-43](https://user-images.githubusercontent.com/9353584/48069830-c9a69f00-e219-11e8-8ac8-e432e52a9f55.png)
