### PR TITLE
 Add includeNoParensInSelectChains

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -728,6 +728,30 @@ List(1)
   .filter(_ > 2)
 ```
 
+### `includeNoParensInSelectChains`
+
+```scala mdoc:defaults
+includeNoParensInSelectChains
+```
+
+```scala mdoc:scalafmt
+includeNoParensInSelectChains = true
+---
+List(1)
+  .toIterator
+  .buffered
+  .map(_ + 2)
+  .filter(_ > 2)
+```
+
+```scala mdoc:scalafmt
+includeNoParensInSelectChains = false
+---
+List(1).toIterator.buffered
+  .map(_ + 2)
+  .filter(_ > 2)
+```
+
 ### `optIn.breakChainOnFirstMethodDot`
 
 ```scala mdoc:defaults

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -109,6 +109,20 @@ import org.scalafmt.util.ValidationOps
   *        x + 2
   *    }.filter(_ > 2)
   *  }}}
+  * @param includeNoParensInSelectChains
+  *  If true, includes applications without parens in select chains/pipelines.
+  *  {{{
+  *    // If true
+  *    List(1)
+  *      .toIterator
+  *      .buffered
+  *      .map(_ + 2)
+  *      .filter(_ > 2)
+  *    // If false
+  *    List(1).toIterator.buffered
+  *      .map(_ + 2)
+  *      .filter(_ > 2)
+  *  }}}
   */
 case class ScalafmtConfig(
     version: String = org.scalafmt.Versions.stable,
@@ -132,6 +146,7 @@ case class ScalafmtConfig(
     importSelectors: ImportSelectors = ImportSelectors.noBinPack,
     unindentTopLevelOperators: Boolean = false,
     includeCurlyBraceInSelectChains: Boolean = true,
+    includeNoParensInSelectChains: Boolean = false,
     assumeStandardLibraryStripMargin: Boolean = false,
     danglingParentheses: Boolean = true,
     poorMansTrailingCommasInConfigStyle: Boolean = false,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -122,8 +122,9 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       val openApply = next(leftTok2tok(tok)).right
       def startsOpenApply =
         isOpenApply(
-          openApply,
-          includeCurly = initStyle.includeCurlyBraceInSelectChains)
+          token = openApply,
+          includeCurly = initStyle.includeCurlyBraceInSelectChains,
+          includeNoParens = initStyle.includeNoParensInSelectChains)
       def isChildOfImport =
         parents(rightOwner).exists(_.is[Import])
       def isShortCurlyChain(chain: Vector[Term.Select]): Boolean =
@@ -465,7 +466,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     */
   def getSelectsLastToken(dot: Dot): Token = {
     var curr = next(leftTok2tok(dot))
-    while (isOpenApply(curr.right, includeCurly = true) &&
+    while (isOpenApply(token = curr.right, includeCurly = true, includeNoParens = true) &&
       !statementStarts.contains(hash(curr.right))) {
       curr = leftTok2tok(matchingParentheses(hash(curr.right)))
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -122,7 +122,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       val openApply = next(leftTok2tok(tok)).right
       def startsOpenApply =
         isOpenApply(
-          token = openApply,
+          openApply,
           includeCurly = initStyle.includeCurlyBraceInSelectChains,
           includeNoParens = initStyle.includeNoParensInSelectChains)
       def isChildOfImport =
@@ -466,7 +466,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     */
   def getSelectsLastToken(dot: Dot): Token = {
     var curr = next(leftTok2tok(dot))
-    while (isOpenApply(token = curr.right, includeCurly = true, includeNoParens = true) &&
+    while (isOpenApply(curr.right, includeCurly = true, includeNoParens = true) &&
       !statementStarts.contains(hash(curr.right))) {
       curr = leftTok2tok(matchingParentheses(hash(curr.right)))
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -123,10 +123,11 @@ object TokenOps {
     else Space
   }
 
-  def isOpenApply(token: Token, includeCurly: Boolean = false): Boolean =
+  def isOpenApply(token: Token, includeCurly: Boolean, includeNoParens: Boolean): Boolean =
     token match {
       case LeftParen() | LeftBracket() => true
       case LeftBrace() if includeCurly => true
+      case Dot() if includeNoParens => true
       case _ => false
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -123,7 +123,10 @@ object TokenOps {
     else Space
   }
 
-  def isOpenApply(token: Token, includeCurly: Boolean, includeNoParens: Boolean): Boolean =
+  def isOpenApply(
+      token: Token,
+      includeCurly: Boolean = false,
+      includeNoParens: Boolean = false): Boolean =
     token match {
       case LeftParen() | LeftBracket() => true
       case LeftBrace() if includeCurly => true

--- a/scalafmt-tests/src/test/resources/test/includeNoParensInSelectChains.stat
+++ b/scalafmt-tests/src/test/resources/test/includeNoParensInSelectChains.stat
@@ -1,0 +1,11 @@
+includeNoParensInSelectChains = true
+<<< include applications without parens in select chains
+List(1).toIterator.buffered
+  .map(_ + 2)
+  .filter(_ > 2)
+>>>
+List(1)
+  .toIterator
+  .buffered
+  .map(_ + 2)
+  .filter(_ > 2)


### PR DESCRIPTION
This introduces an option `includeNoParensInSelectChains` (any better naming ideas? was going for consistency with `includeCurlyBraceInSelectChains`) which, in conjunction with `optIn.breakChainOnFirstMethodDot`, treats applications without parens the same as those with parens.

For example, this:

```
List(1).toIterator.buffered
  .map(_ + 2)
  .filter(_ > 2)
```

is reformatted as:

```
List(1)
  .toIterator
  .buffered
  .map(_ + 2)
  .filter(_ > 2)
```

This partially addresses #1042.