### PR TITLE
a failing test for `verticalMultiline = { atDefnSite = true }`

### DIFF
--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline2.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline2.stat
@@ -1,0 +1,10 @@
+verticalMultiline = {
+    atDefnSite = true
+}
+<<< Don't break code when there are comments
+class TestClass(
+  field3: String // comment
+)
+>>>
+class TestClass(
+  field3: String) // comment


### PR DESCRIPTION
Adding a test for a currently failing case - the formatted code doesn't parse. Have no idea where to fix it, so I hope the test case is good enough :)

This test fails with current master and 1.6.0-RC4.

The option:
```
verticalMultiline = {
    atDefnSite = true
}
```

The code:
```
class TestClass(
  field3: String // comment
)
```

Formatted code:
```
class TestClass(
    field3: String // comment)
```

The closing `)` got commented.