### PR TITLE
avoid generating invalid scala code

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -830,7 +830,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     val paramGroupSplitter: PartialFunction[Decision, Decision] = {
       // If this is a class, then don't dangle the last paren unless the line ends with a comment
       case Decision(t @ FormatToken(previous, rp @ RightParenOrBracket(), _), _)
-          if shouldNotDangle && rp == lastParen && !isSingleLineComment(previous) =>
+          if shouldNotDangle && rp == lastParen && !isSingleLineComment(
+            previous) =>
         val split = Split(NoSplit, 0)
         Decision(t, Seq(split))
       // Indent seperators `)(` and `](` by `indentSep`

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -828,9 +828,9 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     }
 
     val paramGroupSplitter: PartialFunction[Decision, Decision] = {
-      // If this is a class, then don't dangle the last paren
-      case Decision(t @ FormatToken(_, rp @ RightParenOrBracket(), _), _)
-          if shouldNotDangle && rp == lastParen =>
+      // If this is a class, then don't dangle the last paren unless the line ends with a comment
+      case Decision(t @ FormatToken(previous, rp @ RightParenOrBracket(), _), _)
+          if shouldNotDangle && rp == lastParen && !isSingleLineComment(previous) =>
         val split = Split(NoSplit, 0)
         Decision(t, Seq(split))
       // Indent seperators `)(` and `](` by `indentSep`

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDefnSiteNoDangling.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDefnSiteNoDangling.stat
@@ -1,0 +1,17 @@
+maxColumn = 40
+danglingParentheses = false
+verticalMultiline.atDefnSite = true
+<<< ONLY handles comment correctly
+case class Example(
+    a: Example,
+    b: Example,
+    c: Example,
+    d: Example // Comment
+)
+>>>
+case class Example(
+    a: Example,
+    b: Example,
+    c: Example,
+    d: Example // Comment
+  )

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDefnSiteNoDangling.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDefnSiteNoDangling.stat
@@ -1,7 +1,7 @@
 maxColumn = 40
 danglingParentheses = false
 verticalMultiline.atDefnSite = true
-<<< ONLY handles comment correctly
+<<< handles comment correctly
 case class Example(
     a: Example,
     b: Example,
@@ -15,3 +15,15 @@ case class Example(
     c: Example,
     d: Example // Comment
   )
+<<< leaves things alone if you move the )
+case class Example(
+    a: Example,
+    b: Example,
+    c: Example,
+    d: Example) // Comment
+>>>
+case class Example(
+    a: Example,
+    b: Example,
+    c: Example,
+    d: Example) // Comment


### PR DESCRIPTION
#966 

The suggested fix in the ticket is a rewrite rule. While I think that would be reasonable, it's more complex. This patch is the absolute minimal version that fixes the invalid code generation. If you want the code formatted as suggested in the linked issue, scalafmt will preserve that style as long as you do the edit (move the parenthesis) yourself.