### PR TITLE
Add Continuation Indentation for Type Annotation Site

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,21 @@ argument1: Type1 // indented by 4
 ): ReturnType
 ```
 
+### `continuationIndent.typeAnnSite`
+
+```scala mdoc:defaults
+continuationIndent.typeAnnSite
+```
+
+Same as `continuationIndent.callSite` except for type annotation and return type site. Example:
+
+```scala mdoc:scalafmt
+continuationIndent.defnSite = 4
+---
+def function(argument1: Type1)
+    : ReturnType // indented by 4
+```
+
 ## Alignment
 
 Default: **some**

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ContinuationIndent.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ContinuationIndent.scala
@@ -6,11 +6,13 @@ import metaconfig._
   * @param defnSite indentation around class/def
   * @param callSite indentation around function calls, etc.
   * @param extendSite indentation before `extends`
+  * @param typeAnnSite indentation before return type and type annotations
   */
 case class ContinuationIndent(
     callSite: Int = 2,
     defnSite: Int = 4,
-    extendSite: Int = 4
+    extendSite: Int = 4,
+    typeAnnSite: Int = 2
 ) {
   implicit val reader: ConfDecoder[ContinuationIndent] =
     generic.deriveDecoder(this).noTypos

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -726,7 +726,7 @@ class Router(formatOps: FormatOps) {
           // Spark style guide allows this:
           // https://github.com/databricks/scala-style-guide#indent
           Split(Newline, Constants.SparkColonNewline)
-            .withIndent(2, expire, Left)
+            .withIndent(style.continuationIndent.typeAnnSite, expire, Left)
             .withPolicy(penalizeNewlines)
         )
       case FormatToken(Colon(), _, _)

--- a/scalafmt-tests/src/test/resources/test/ContinuationIndentNoDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/test/ContinuationIndentNoDanglingParens.stat
@@ -1,0 +1,13 @@
+continuationIndent.callSite   = 2
+continuationIndent.defnSite   = 4
+continuationIndent.extendSite = 4
+continuationIndent.typeAnnSite = 6
+danglingParentheses = false
+maxColumn = 50
+<<< Type Annotation Site
+def doAThingFunction(extremelyLongNamedParameterNumberOne: Int, extremelyLongNamedParameterNumberTwo: Int): ExtremelyLongNameForAReturnValueType
+>>>
+def doAThingFunction(
+    extremelyLongNamedParameterNumberOne: Int,
+    extremelyLongNamedParameterNumberTwo: Int)
+      : ExtremelyLongNameForAReturnValueType


### PR DESCRIPTION
This particular change modifies formatting for definition sites when `danglingParentheses` config is set to false. 


As exercised in the tests, 
```scala
def doAThingFunction(extremelyLongNamedParameterNumberOne: Int, extremelyLongNamedParameterNumberTwo: Int): ExtremelyLongNameForAReturnValueType
```
becomes: 
```scala
def doAThingFunction(
    extremelyLongNamedParameterNumberOne: Int,
    extremelyLongNamedParameterNumberTwo: Int)
    : ExtremelyLongNameForAReturnValueType 
```
Whereas before, it would have always been indented to 2 spaces: 
```scala
def doAThingFunction(
    extremelyLongNamedParameterNumberOne: Int,
    extremelyLongNamedParameterNumberTwo: Int)
  : ExtremelyLongNameForAReturnValueType 
```


The default value for this new parameter is set such to match the existing formatting. 