### PR TITLE
Expand on the align=none protip

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,7 +141,9 @@ x match { // false for case arrows
 ```
 
 > **Pro tip**: Enable this setting to minimize git diffs/conflicts from
-> renamings and other refactorings.
+> renamings and other refactorings, without having to ignore whitespace
+> changes in diffs or use `--ignore-all-space` to avoid conflicts when
+> git merging or rebasing.
 
 #### `align=some`
 

--- a/readme/Configuration.scalatex
+++ b/readme/Configuration.scalatex
@@ -138,7 +138,10 @@
           foo(a: Int, // false for call site
               b: String): Int
 
-        Pro tip: Enable this setting to minimize git diffs/conflicts from renamings and other refactorings.
+        Pro tip: Enable this setting to minimize git diffs/conflicts from
+        renamings and other refactorings, without having to ignore whitespace
+        changes in diffs or use `--ignore-all-space` to avoid conflicts when
+        git merging or rebasing.
 
         @configurationBlock(alignNone, true)
 


### PR DESCRIPTION
Mention vertical alignment mitigation strategies, so that users can
better decide whether they want to align and use the strategies, or not
align and therefore not need them.