### PR TITLE
Fix the mysterious case of missing newline at end of file.

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -2,6 +2,9 @@ package org.scalafmt.util
 
 import scala.io.Codec
 import java.io._
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 object FileOps {
 
@@ -51,23 +54,7 @@ object FileOps {
   }
 
   def readFile(file: File)(implicit codec: Codec): String = {
-    // Prefer this to inefficient Source.fromFile.
-    val sb = new StringBuilder
-    val br = new BufferedReader(
-      new InputStreamReader(new FileInputStream(file), codec.charSet))
-    try {
-      var line = ""
-      while ({
-        line = br.readLine()
-        line != null
-      }) {
-        sb.append(line)
-        sb.append("\n")
-      }
-    } finally {
-      br.close()
-    }
-    sb.toString()
+    new String(Files.readAllBytes(file.toPath), codec.charSet)
   }
 
   def getFile(path: String*): File = {
@@ -75,22 +62,23 @@ object FileOps {
   }
 
   def writeFile(file: AbsoluteFile, content: String)(
-      implicit codec: Codec): Unit =
+      implicit codec: Codec
+  ): Unit = {
     writeFile(file.jfile, content)
+  }
 
   def writeFile(file: File, content: String)(implicit codec: Codec): Unit = {
-    // For java 6 compatibility we don't use java.nio.
-    val bw = new BufferedWriter(
-      new OutputStreamWriter(new FileOutputStream(file), codec.charSet))
-    try {
-      bw.write(content)
-    } finally {
-      bw.close()
-    }
-
+    writeFile(file.toPath, content)
   }
+
+  def writeFile(path: Path, content: String)(implicit codec: Codec): Unit = {
+    val bytes = content.getBytes(codec.charSet)
+    Files.write(path, bytes)
+  }
+
   def writeFile(filename: String, content: String)(
-      implicit codec: Codec): Unit = {
-    writeFile(new File(filename), content)
+      implicit codec: Codec
+  ): Unit = {
+    writeFile(Paths.get(filename), content)
   }
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -17,6 +17,7 @@ import org.scalafmt.util.OsSpecific._
 import org.scalafmt.util.FileOps
 import org.scalatest.FunSuite
 import FileTestOps._
+import java.io.IOException
 import scala.meta.internal.io.FileIO
 
 abstract class AbstractCliTest extends FunSuite with DiffAssertions {
@@ -196,7 +197,7 @@ class CliTest extends AbstractCliTest {
     val exit = Cli.run(formatInPlace)
     assert(exit.is(ExitCode.TestError))
     val str = FileOps.readFile(tmpFile.toString)
-    assertNoDiff(str, unformatted + '\n')
+    assertNoDiff(str, unformatted)
   }
 
   test("scalafmt foo.randomsuffix is formatted") {
@@ -282,7 +283,7 @@ class CliTest extends AbstractCliTest {
   test("scalafmt doesnotexist.scala throws error") {
     def check(filename: String): Unit = {
       val args = Array(s"$filename.scala".asFilename)
-      intercept[FileNotFoundException] {
+      intercept[IOException] {
         Cli.exceptionThrowingMain(args)
       }
     }
@@ -313,6 +314,7 @@ class CliTest extends AbstractCliTest {
          |}
          |/target/foo.scala
          |object A   { }
+         |
          |/.scalafmt.conf
          |maxColumn = 2
          |project.excludeFilters = [target]
@@ -409,8 +411,8 @@ class CliTest extends AbstractCliTest {
     val conf = Cli.getConfig(args, opts)
     Cli.run(conf.get)
 
-    assertNoDiff(root / "scalatex.scalatex", unformatted + '\n')
-    assertNoDiff(root / "sbt.sbtfile", sbtOriginal + '\n')
+    assertNoDiff(root / "scalatex.scalatex", unformatted)
+    assertNoDiff(root / "sbt.sbtfile", sbtOriginal)
 
     assertNoDiff(root / "scalafile.scala", formatted)
     val sbtFormatted =
@@ -440,7 +442,7 @@ class CliTest extends AbstractCliTest {
     runWith(root, s"$inner1 $inner2 $full")
 
     assertNoDiff(inner1 / "file1.scala", formatted)
-    assertNoDiff(inner2 / "file2.scalahala", unformatted + '\n')
+    assertNoDiff(inner2 / "file2.scalahala", unformatted)
     assertNoDiff(full, formatted)
   }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -7,7 +7,6 @@ import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
-
 import org.scalafmt.Error.MisformattedFile
 import org.scalafmt.Error.NoMatchingFiles
 import org.scalafmt.config.Config
@@ -17,8 +16,8 @@ import org.scalafmt.util.DiffAssertions
 import org.scalafmt.util.OsSpecific._
 import org.scalafmt.util.FileOps
 import org.scalatest.FunSuite
-
 import FileTestOps._
+import scala.meta.internal.io.FileIO
 
 abstract class AbstractCliTest extends FunSuite with DiffAssertions {
 
@@ -617,5 +616,14 @@ class CliTest extends AbstractCliTest {
     intercept[IllegalArgumentException] {
       noArgTest(root, "", Seq(Array.empty))
     }
+  }
+
+  test("eof") {
+    val in = Files.createTempFile("scalafmt", "Foo.scala")
+    Files.write(in, "object A".getBytes(StandardCharsets.UTF_8))
+    val exit = Cli.mainWithOptions(Array(in.toString), CliOptions.default)
+    assert(exit.isOk)
+    val obtained = new String(Files.readAllBytes(in), StandardCharsets.UTF_8)
+    assert(obtained == "object A\n")
   }
 }


### PR DESCRIPTION
Turns out that the old crappy file read/write code was buggy so that
Scalafmt sometimes didn't insert a newline at the end of files. Now,
Scalafmt uses nio.Files and it correctly writes a newline at
the end of the file if it's missing.

Fixes #1317