### PR TITLE
Change publish organization to org.scalameta from com.geirsson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ def scala212 = "2.12.8"
 
 inThisBuild(
   List(
-    organization := "com.geirsson", // not org.scalameta because that's a breaking change
+    organization := "org.scalameta",
     homepage := Some(url("https://github.com/scalameta/scalafmt")),
     licenses := List(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")

--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ lazy val interfaces = project
     moduleName := "scalafmt-interfaces",
     description := "Dependency-free, pure Java public interfaces to integrate with Scalafmt through a build tool or editor plugin.",
     crossVersion := CrossVersion.disabled,
+    autoScalaLibrary := false,
     resourceGenerators.in(Compile) += Def.task {
       val out =
         managedResourceDirectories

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,10 +83,10 @@ It is not possible to reset this setting for all existing projects.
 
 ```scala
 // In project/plugins.sbt. Note, does not support sbt 0.13, only sbt 1.0.
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "1.5.1")
 ```
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.geirsson/sbt-scalafmt/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.geirsson/sbt-scalafmt)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.scalameta/sbt-scalafmt/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.scalameta/sbt-scalafmt)
 
 ### Task keys
 
@@ -160,7 +160,7 @@ Create a standalone executable in `/usr/local/bin/scalafmt` with (sudo if
 necessary):
 
 ```sh
-coursier bootstrap com.geirsson:scalafmt-cli_2.12:@STABLE_VERSION@ \
+coursier bootstrap org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
   -r bintray:scalameta/maven \
   -o /usr/local/bin/scalafmt --standalone --main org.scalafmt.cli.Cli
 scalafmt --version # should be @STABLE_VERSION@
@@ -169,7 +169,7 @@ scalafmt --version # should be @STABLE_VERSION@
 Alternatively you can create a slim 15 KiB bootstrap script with:
 
 ```sh
-coursier bootstrap com.geirsson:scalafmt-cli_2.12:@STABLE_VERSION@ \
+coursier bootstrap org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
   -r bintray:scalameta/maven \
   -o scalafmt --main org.scalafmt.cli.Cli
 ./scalafmt --version # should be @STABLE_VERSION@
@@ -216,7 +216,7 @@ vim/Emacs/Atom/Sublime/VS Code.
   necessary)
 
 ```sh
-coursier bootstrap --standalone com.geirsson:scalafmt-cli_2.12:@STABLE_VERSION@ \
+coursier bootstrap --standalone org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
   -r bintray:scalameta/maven \
   -o /usr/local/bin/scalafmt_ng -f --main com.martiansoftware.nailgun.NGServer
 scalafmt_ng & // start nailgun in background
@@ -295,7 +295,7 @@ You pay the JVM startup penalty on every format unless you're using
 Use the `scalafmt-dynamic` module to integrate with Scalafmt.
 
 ```scala
-libraryDependencies += "com.geirsson" %% "scalafmt-dynamic" % "@STABLE_VERSION@"
+libraryDependencies += "org.scalameta" %% "scalafmt-dynamic" % "@STABLE_VERSION@"
 ```
 
 First, create an instance of `Scalafmt` and get paths for the file to format
@@ -416,7 +416,7 @@ with no external dependencies.
 
 ```xml
 <dependency>
-    <groupId>com.geirsson</groupId>
+    <groupId>org.scalameta</groupId>
     <artifactId>scalafmt-interfaces</artifactId>
     <version>@STABLE_VERSION@</version>
 </dependency>
@@ -432,7 +432,7 @@ import org.scalafmt.interfaces.*;
 // ClassLoader that shares only org.scalafmt.interfaces from this classloader.
 ClassLoader sharedParent = new ScalafmtClassLoader(this.getClass.getClassLoader)
 
-// Jars to com.geirsson:scalafmt-dynamic_2.12:@STABLE_VERSION@ classpath. Obtain
+// Jars to org.scalameta:scalafmt-dynamic_2.12:@STABLE_VERSION@ classpath. Obtain
 // these from your build tool or programmatically with ivy/coursier.
 URL[] jars = // ...
 ClassLoader scalafmtDynamic = new URLClassLoader(jars, sharedParent)

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
@@ -137,12 +137,18 @@ final case class ScalafmtDynamic(
       val scalaVersion =
         if (version.startsWith("0.")) BuildInfo.scala211
         else BuildInfo.scala
+      val organization =
+        if (version.startsWith("1") || version.startsWith("0") || version == "2.0.0-RC1") {
+          "com.geirsson"
+        } else {
+          "org.scalameta"
+        }
       val jars = CoursierSmall.fetch(
         new Settings()
           .withDependencies(
             List(
               new Dependency(
-                "com.geirsson",
+                organization,
                 s"scalafmt-cli_$scalaBinaryVersion",
                 version
               ),
@@ -156,7 +162,10 @@ final case class ScalafmtDynamic(
           .withTtl(Some(Duration.Inf))
           .withWriter(reporter.downloadWriter())
           .withRepositories(
-            new Settings().repositories ++ List(
+            List(
+              Repository.MavenCentral,
+              Repository.Ivy2Local,
+              Repository.SonatypeReleases,
               Repository.SonatypeSnapshots
             )
           )

--- a/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
@@ -43,7 +43,7 @@ class DynamicSuite extends FunSuite with DiffAssertions {
     var dynamic = Scalafmt
       .create(this.getClass.getClassLoader)
       .withReporter(reporter)
-      .withDefaultVersion("1.6.0-RC4")
+      .withDefaultVersion(latest)
     def ignoreVersion(): Unit = {
       dynamic = dynamic.withRespectVersion(false)
     }
@@ -125,6 +125,8 @@ class DynamicSuite extends FunSuite with DiffAssertions {
     }
   }
 
+  def latest = "2.0.0-RC1"
+
   def checkVersion(version: String): Unit = {
     check(s"v$version") { f =>
       f.setConfig(
@@ -135,11 +137,11 @@ class DynamicSuite extends FunSuite with DiffAssertions {
     }
   }
 
-  checkVersion("1.6.0-RC4")
+  checkVersion(latest)
   checkVersion("1.0.0")
 
   check("filename-ok") { f =>
-    f.setConfig("version=1.6.0-RC4")
+    f.setConfig(s"version=$latest")
     f.assertError(
       "object A {",
       """|error: filename-ok.scala: L1: error: } expected but end of file found
@@ -163,9 +165,9 @@ class DynamicSuite extends FunSuite with DiffAssertions {
   check("missing-version") { f =>
     f.assertError(
       "object A  { }",
-      """|
-         |error: path/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=1.6.0-RC4'.
-         |""".stripMargin
+      s"""|
+          |error: path/.scalafmt.conf: missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=$latest'.
+          |""".stripMargin
     )
   }
 
@@ -193,7 +195,7 @@ class DynamicSuite extends FunSuite with DiffAssertions {
       f.assertIgnored("path/App.scala")
       f.assertIgnored("path/UserSpec.scala")
     }
-    f.setVersion("1.6.0-RC4")
+    f.setVersion(latest)
     check()
     f.setVersion("1.0.0")
     check()
@@ -202,25 +204,25 @@ class DynamicSuite extends FunSuite with DiffAssertions {
 
   check("config-error") { f =>
     f.setConfig(
-      """max=70
-        |version=1.6.0-RC4
-        |""".stripMargin
+      s"""max=70
+         |version=$latest
+         |""".stripMargin
     )
     f.assertError(
-      """|error: path/.scalafmt.conf: Invalid field: max. Expected one of version, maxColumn, docstrings, optIn, binPack, continuationIndent, align, spaces, literals, lineEndings, rewriteTokens, rewrite, indentOperator, newlines, runner, indentYieldKeyword, importSelectors, unindentTopLevelOperators, includeCurlyBraceInSelectChains, assumeStandardLibraryStripMargin, danglingParentheses, poorMansTrailingCommasInConfigStyle, trailingCommas, verticalMultilineAtDefinitionSite, verticalMultilineAtDefinitionSiteArityThreshold, verticalMultiline, onTestFailure, encoding, project
+      """|error: path/.scalafmt.conf: Invalid field: max. Expected one of version, maxColumn, docstrings, optIn, binPack, continuationIndent, align, spaces, literals, lineEndings, rewriteTokens, rewrite, indentOperator, newlines, runner, indentYieldKeyword, importSelectors, unindentTopLevelOperators, includeCurlyBraceInSelectChains, includeNoParensInSelectChains, assumeStandardLibraryStripMargin, danglingParentheses, poorMansTrailingCommasInConfigStyle, trailingCommas, verticalMultilineAtDefinitionSite, verticalMultilineAtDefinitionSiteArityThreshold, verticalMultiline, onTestFailure, encoding, project
          |""".stripMargin
     )
   }
 
   check("config-cache") { f =>
-    f.setConfig("version=1.6.0-RC4")
+    f.setVersion(latest)
     f.assertFormat()
     f.assertFormat()
     assert(f.parsedCount == 1, f.parsed)
     f.setConfig(
-      """version=1.6.0-RC4
-        |maxColumn = 40
-        |""".stripMargin
+      s"""version=$latest
+         |maxColumn = 40
+         |""".stripMargin
     )
     f.assertFormat()
     assert(f.parsedCount == 2, f.parsed)
@@ -232,7 +234,7 @@ class DynamicSuite extends FunSuite with DiffAssertions {
         |""".stripMargin
     )
     f.assertFormat()
-    assert(f.parsed == Map("1.0.0" -> 1, "1.6.0-RC4" -> 3))
+    assert(f.parsed == Map("1.0.0" -> 1, latest -> 3))
   }
 
   check("wrong-version") { f =>
@@ -264,7 +266,7 @@ class DynamicSuite extends FunSuite with DiffAssertions {
       """|project.includeFilters = [ ".*" ]
          |""".stripMargin
     )
-    f.setVersion("1.6.0-RC4")
+    f.setVersion(latest)
     check()
     f.setVersion("1.2.0")
     check()

--- a/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/Scalafmt.java
+++ b/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/Scalafmt.java
@@ -22,7 +22,7 @@ import java.util.ServiceLoader;
  * - it uses the correct parser for `*.sbt` and `*.sc` files.
  * - it automatically caches parsing of configuration files avoiding redundant work when possible.
  * - it has two external library dependencies (com.geirsson:coursier-small and com.typesafe:config),
- *   which is a smaller dependency footprint compared to com.geirsson:scalafmt-core.
+ *   which is a smaller dependency footprint compared to scalafmt-core.
  */
 public interface Scalafmt {
 


### PR DESCRIPTION
Scalafmt has historically been published from com.geirsson to avoid
breaking changes. Now that we're releasing v2 and scalafmt-dynamic
can take care of adjusting the organization it's time to bite the bullet
and switch.