### PR TITLE
Add custom reporter endpoint for missing scalafmt version

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
@@ -103,11 +103,7 @@ final case class ScalafmtDynamic(
                   code
               }
             case None =>
-              reporter.error(
-                config,
-                s"missing setting 'version'. " +
-                  s"To fix this problem, add the following line to .scalafmt.conf: 'version=$defaultVersion'."
-              )
+              reporter.missingVersion(config, defaultVersion)
               code
           }
         }

--- a/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtReporter.java
+++ b/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtReporter.java
@@ -31,6 +31,20 @@ public interface ScalafmtReporter {
     void excluded(Path file);
 
     /**
+     * This .scalafmt.conf file is missing the 'version' setting.
+     *
+     * @param config the .scalafmt.conf file.
+     * @param defaultVersion the configured default Scalafmt version.
+     */
+    default void missingVersion(Path config, String defaultVersion) {
+        String message = String.format(
+            "missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=%s'.",
+            defaultVersion
+        );
+        error(config, message);
+    }
+
+    /**
      * The .scalafmt.conf file was parsed with the given Scalafmt version.
      */
     void parsedConfig(Path config, String scalafmtVersion);


### PR DESCRIPTION
Clients may want custom error handling in this case so it deserves a
custom endpoint.