### PR TITLE
Micro optimalizations

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -33,9 +33,9 @@ class BestFirstSearch(
   /**
     * Precomputed table of splits for each token.
     */
-  val routes: Array[Seq[Split]] = {
+  val routes: Array[Array[Split]] = {
     val router = new Router(formatOps)
-    val result = Array.newBuilder[Seq[Split]]
+    val result = Array.newBuilder[Array[Split]]
     tokens.foreach { t =>
       result += router.getSplitsMemo(t)
     }
@@ -215,10 +215,10 @@ class BestFirstSearch(
             tokens(deepestYet.splits.length).left)
         } else {
 
-          val splits: Seq[Split] =
-            if (curr.formatOff) List(provided(splitToken))
+          val splits: Array[Split] =
+            if (curr.formatOff) Array(provided(splitToken))
             else if (splitToken.inside(range)) routes(curr.splits.length)
-            else List(provided(splitToken))
+            else Array(provided(splitToken))
 
           val actualSplit = {
             curr.policy
@@ -277,15 +277,15 @@ class BestFirstSearch(
       val tok = tokens(deepestYet.splits.length)
       val splitsAfterPolicy =
         deepestYet.policy.execute(Decision(tok, nextSplits))
-      val msg = s"""UNABLE TO FORMAT,
-                   |tok=$tok
-                   |state.length=${state.splits.length}
-                   |toks.length=${tokens.length}
-                   |deepestYet.length=${deepestYet.splits.length}
-                   |policies=${deepestYet.policy.policies}
-                   |nextSplits=$nextSplits
-                   |splitsAfterPolicy=$splitsAfterPolicy""".stripMargin
       if (runner.debug) {
+        val msg = s"""UNABLE TO FORMAT,
+                     |tok=$tok
+                     |state.length=${state.splits.length}
+                     |toks.length=${tokens.length}
+                     |deepestYet.length=${deepestYet.splits.length}
+                     |policies=${deepestYet.policy.policies}
+                     |nextSplits=$nextSplits
+                     |splitsAfterPolicy=$splitsAfterPolicy""".stripMargin
         logger.debug(s"""Failed to format
                         |$msg""".stripMargin)
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -5,7 +5,7 @@ package org.scalafmt.internal
   *
   * Used by [[Policy]] to enforce non-local formatting.
   */
-case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
+case class Decision(formatToken: FormatToken, splits: Array[Split]) {
   import org.scalafmt.util.TokenOps._
 
   def noNewlines: Decision =
@@ -14,7 +14,7 @@ case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
   def onlyNewlines(implicit line: sourcecode.Line): Decision = {
     val filtered = splits.filter(_.modification.isNewline)
     if (filtered.nonEmpty) Decision(formatToken, filtered)
-    else Decision(formatToken, Seq(Split(Newline, 0)))
+    else Decision(formatToken, Constants.NewlineSeq)
   }
 
   def forceNewline(implicit line: sourcecode.Line): Decision = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -157,7 +157,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     result.result()
   }
 
-  lazy val tok2idx: Map[FormatToken, Int] = HashMap[FormatToken,Int](tokens.zipWithIndex:_*)
+  lazy val tok2idx: Map[FormatToken, Int] =
+    HashMap[FormatToken, Int](tokens.zipWithIndex: _*)
 
   def prev(tok: Token): Token = prev(leftTok2tok(tok)).right
   def prev(tok: FormatToken): FormatToken = {
@@ -876,8 +877,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         Decision(
           t,
           Array(
-            Split.withIndent(mod, 0,
-              indent = Indent(indentParam, close2, Right))
+            Split
+              .withIndent(mod, 0, indent = Indent(indentParam, close2, Right))
           ))
       case Decision(t @ FormatToken(KwImplicit(), _, _), _)
           if style.verticalMultiline.newlineAfterImplicitKW || style.newlines.afterImplicitKWInVerticalMultiline =>
@@ -908,12 +909,17 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     val aboveArityThreshold = (maxArity >= style.verticalMultiline.arityThreshold) || (maxArity >= style.verticalMultilineAtDefinitionSiteArityThreshold)
 
     Array(
-      Split(NoSplit, 0, ignoreIf = !isBracket && aboveArityThreshold, policy = SingleLineBlock(singleLineExpire)),
-      Split.withIndent(Newline,
+      Split(
+        NoSplit,
+        0,
+        ignoreIf = !isBracket && aboveArityThreshold,
+        policy = SingleLineBlock(singleLineExpire)),
+      Split.withIndent(
+        Newline,
         1,
-        indent = Indent(firstIndent, close, Right) ,
-        policy = policy)// Otherwise split vertically
-      )
+        indent = Indent(firstIndent, close, Right),
+        policy = policy) // Otherwise split vertically
+    )
 
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -688,8 +688,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   def binPackParentConstructorSplits(
       owners: Set[Tree],
       lastToken: Token,
-      indent: Int)(implicit line: sourcecode.Line): Seq[Split] = {
-    Seq(
+      indent: Int)(implicit line: sourcecode.Line): Array[Split] = {
+    Array(
       Split(Space, 0)
         .withPolicy(SingleLineBlock(lastToken))
         .withIndent(Num(indent), lastToken, Left),
@@ -747,7 +747,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     * Implementation for `verticalMultiline`
     */
   def verticalMultiline(owner: Tree, ft: FormatToken)(
-      implicit style: ScalafmtConfig): Seq[Split] = {
+      implicit style: ScalafmtConfig): Array[Split] = {
 
     val FormatToken(open, r, _) = ft
     val close = matching(open)
@@ -904,7 +904,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
     val aboveArityThreshold = (maxArity >= style.verticalMultiline.arityThreshold) || (maxArity >= style.verticalMultilineAtDefinitionSiteArityThreshold)
 
-    Seq(
+    Array(
       Split(NoSplit, 0, ignoreIf = !isBracket && aboveArityThreshold)
         .withPolicy(SingleLineBlock(singleLineExpire)),
       Split(Newline, 1) // Otherwise split vertically

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -202,8 +202,8 @@ class FormatWriter(formatOps: FormatOps) {
     }
   }
 
-  lazy val topLevelTokens: List[TokenHash] = {
-    val buffer = List.newBuilder[TokenHash]
+  lazy val topLevelTokens: Array[TokenHash] = {
+    val buffer = Array.newBuilder[TokenHash]
     val trav = new Traverser {
       override def apply(tree: Tree): Unit = tree match {
         case Term.Block(_) =>
@@ -220,6 +220,7 @@ class FormatWriter(formatOps: FormatOps) {
     }
 
     trav(tree)
+
     buffer.result()
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -81,7 +81,7 @@ class Router(formatOps: FormatOps) {
     val newlines = newlinesBetween(formatToken.between)
 
     formatToken match {
-      case FormatToken(_: BOF, _, _) =>DontSplitSeq
+      case FormatToken(_: BOF, _, _) => DontSplitSeq
       case FormatToken(_, _: EOF, _) => NewlineSeq
       case FormatToken(start @ Interpolation.Start(), _, _) =>
         val isStripMargin = isMarginizedString(start)
@@ -104,16 +104,19 @@ class Router(formatOps: FormatOps) {
           Interpolation.Id(_) | Interpolation.Part(_) | Interpolation.Start() |
           Interpolation.SpliceStart(),
           _,
-          _) =>DontSplitSeq
+          _) =>
+        DontSplitSeq
       case FormatToken(
           _,
           Interpolation.Part(_) | Interpolation.End() |
           Interpolation.SpliceEnd(),
-          _) =>DontSplitSeq
-      case FormatToken(LeftBrace(), RightBrace(), _) =>DontSplitSeq
+          _) =>
+        DontSplitSeq
+      case FormatToken(LeftBrace(), RightBrace(), _) => DontSplitSeq
       // Import
       case FormatToken(Dot(), open @ LeftBrace(), _)
-          if parents(rightOwner).exists(_.is[Import]) =>DontSplitSeq
+          if parents(rightOwner).exists(_.is[Import]) =>
+        DontSplitSeq
       // Import left brace
       case FormatToken(open @ LeftBrace(), _, _)
           if parents(leftOwner).exists(_.is[Import]) =>
@@ -149,7 +152,8 @@ class Router(formatOps: FormatOps) {
         )
       // Interpolated string left brace
       case FormatToken(open @ LeftBrace(), _, _)
-          if leftOwner.is[SomeInterpolate] =>DontSplitSeq
+          if leftOwner.is[SomeInterpolate] =>
+        DontSplitSeq
       case FormatToken(_, close @ RightBrace(), _)
           if parents(rightOwner).exists(_.is[Import]) ||
             rightOwner.is[SomeInterpolate] =>
@@ -161,7 +165,8 @@ class Router(formatOps: FormatOps) {
             0)
         )
       case FormatToken(Dot(), underscore @ Underscore(), _)
-          if parents(rightOwner).exists(_.is[Import]) =>DontSplitSeq
+          if parents(rightOwner).exists(_.is[Import]) =>
+        DontSplitSeq
 
       // { ... } Blocks
       case tok @ FormatToken(open @ LeftBrace(), right, between) =>
@@ -309,7 +314,8 @@ class Router(formatOps: FormatOps) {
           if startsStatement(tok) && newlines == 0 =>
         val expire = statementStarts(hash(right)).tokens.last
         Array(
-          Split.withToken(Space,
+          Split.withToken(
+            Space,
             0,
             policy = SingleLineBlock(expire),
             token = expire),
@@ -398,11 +404,13 @@ class Router(formatOps: FormatOps) {
             Decision(t, s.filter(_.modification.isNewline))
         }, expire.end)
         Array(
-          Split.withToken(Space, 0,
+          Split.withToken(
+            Space,
+            0,
             token = expire,
             killOnFail = true,
             policy = SingleLineBlock(expire)),
-          Split(Space, 1,policy = forceNewlineBeforeExtends)
+          Split(Space, 1, policy = forceNewlineBeforeExtends)
         )
       // DefDef
       case tok @ FormatToken(KwDef(), name @ Ident(_), _) =>
@@ -493,9 +501,11 @@ class Router(formatOps: FormatOps) {
         val indent = Num(style.continuationIndent.defnSite)
         if (isTuple(leftOwner)) {
           Array(
-            Split(NoSplit, 0,
-              policy = SingleLineBlock(close, disallowSingleLineComments = false)
-            )
+            Split(
+              NoSplit,
+              0,
+              policy =
+                SingleLineBlock(close, disallowSingleLineComments = false))
           )
         } else {
           def penalizeBrackets(penalty: Int): Policy =
@@ -523,7 +533,8 @@ class Router(formatOps: FormatOps) {
             else NoSplit
 
           Array(
-            Split.withIndent(noSplitModification,
+            Split.withIndent(
+              noSplitModification,
               0 + (nestingPenalty * bracketMultiplier),
               policy = noSplitPolicy,
               indent = Indent(indent, close, Left)),
@@ -567,8 +578,9 @@ class Router(formatOps: FormatOps) {
             0,
             token = optimal,
             policy = noSplitPolicy,
-            indent= Indent(indent, close, Left)),
-          Split.withIndent(Newline,
+            indent = Indent(indent, close, Left)),
+          Split.withIndent(
+            Newline,
             2,
             policy = unindentPolicy,
             indent = Indent(4, close, Left))
@@ -760,10 +772,12 @@ class Router(formatOps: FormatOps) {
           )
         )
 
-      case FormatToken(LeftParen(), LeftBrace(), between) =>DontSplitSeq
+      case FormatToken(LeftParen(), LeftBrace(), between) => DontSplitSeq
 
-      case FormatToken(_, LeftBrace(), _) if isXmlBrace(rightOwner) =>DontSplitSeq
-      case FormatToken(RightBrace(), _, _) if isXmlBrace(leftOwner) =>DontSplitSeq
+      case FormatToken(_, LeftBrace(), _) if isXmlBrace(rightOwner) =>
+        DontSplitSeq
+      case FormatToken(RightBrace(), _, _) if isXmlBrace(leftOwner) =>
+        DontSplitSeq
       // non-statement starting curly brace
       case FormatToken(left, open @ LeftBrace(), _) =>
         val close = matchingParentheses(hash(open))
@@ -786,7 +800,7 @@ class Router(formatOps: FormatOps) {
         )
 
       // Delim
-      case FormatToken(_, Comma(), _) =>DontSplitSeq
+      case FormatToken(_, Comma(), _) => DontSplitSeq
       // These are mostly filtered out/modified by policies.
       case tok @ FormatToken(Comma(), right, _) =>
         // TODO(olafur) DRY, see OneArgOneLine.
@@ -850,9 +864,9 @@ class Router(formatOps: FormatOps) {
               )
             )
         }
-      case FormatToken(_, Semicolon(), _) =>DontSplitSeq
+      case FormatToken(_, Semicolon(), _) => DontSplitSeq
       case FormatToken(KwReturn(), _, _) =>
-       leftOwner match {
+        leftOwner match {
           case Term.Return(unit @ Lit.Unit()) if unit.tokens.isEmpty =>
             // Always force blank line for Unit "return".
             NewlineSeq
@@ -869,9 +883,10 @@ class Router(formatOps: FormatOps) {
 
           case _ =>
             left match {
-              case ident: Ident => Array(
-                Split(identModification(ident), 0)
-              )
+              case ident: Ident =>
+                Array(
+                  Split(identModification(ident), 0)
+                )
               case _ => DontSplitSeq
             }
         }
@@ -1011,7 +1026,8 @@ class Router(formatOps: FormatOps) {
           )
       // ApplyUnary
       case tok @ FormatToken(Ident(_), Literal(), _)
-          if leftOwner == rightOwner =>DontSplitSeq
+          if leftOwner == rightOwner =>
+        DontSplitSeq
       case FormatToken(op @ Ident(_), right, _) if leftOwner.parent.exists {
             case unary: Term.ApplyUnary =>
               unary.op.tokens.head == op
@@ -1196,10 +1212,12 @@ class Router(formatOps: FormatOps) {
 
       // Type variance
       case tok @ FormatToken(Ident(_), Ident(_), _)
-          if isTypeVariant(leftOwner) =>DontSplitSeq
+          if isTypeVariant(leftOwner) =>
+        DontSplitSeq
 
       // Var args
-      case FormatToken(_, Ident("*"), _) if rightOwner.is[Type.Repeated] =>DontSplitSeq
+      case FormatToken(_, Ident("*"), _) if rightOwner.is[Type.Repeated] =>
+        DontSplitSeq
 
       case FormatToken(open @ LeftParen(), right, _) =>
         val owner = owners(open)
@@ -1264,9 +1282,11 @@ class Router(formatOps: FormatOps) {
 
       // Protected []
       case tok @ FormatToken(_, LeftBracket(), _)
-          if isModPrivateProtected(leftOwner) =>DontSplitSeq
+          if isModPrivateProtected(leftOwner) =>
+        DontSplitSeq
       case tok @ FormatToken(LeftBracket(), _, _)
-          if isModPrivateProtected(leftOwner) =>DontSplitSeq
+          if isModPrivateProtected(leftOwner) =>
+        DontSplitSeq
 
       // Case
       case tok @ FormatToken(cs @ KwCase(), _, _) if leftOwner.is[Case] =>
@@ -1353,32 +1373,35 @@ class Router(formatOps: FormatOps) {
       // Interpolation
       case FormatToken(_, Interpolation.Id(_) | Xml.Start(), _) =>
         SpaceSplitSeq
-      case FormatToken(Interpolation.Id(_) | Xml.Start(), _, _) =>DontSplitSeq
+      case FormatToken(Interpolation.Id(_) | Xml.Start(), _, _) => DontSplitSeq
       // Throw exception
       case FormatToken(KwThrow(), _, _) =>
         SpaceSplitSeq
 
       // Singleton types
-      case FormatToken(_, KwType(), _) if rightOwner.is[Type.Singleton] =>DontSplitSeq
+      case FormatToken(_, KwType(), _) if rightOwner.is[Type.Singleton] =>
+        DontSplitSeq
       // seq to var args foo(seq:_*)
       case FormatToken(Colon(), Underscore(), _)
           if next(formatToken).right.syntax == "*" =>
         SpaceSplitSeq
       case FormatToken(Underscore(), asterisk @ Ident("*"), _)
-          if prev(formatToken).left.is[Colon] =>DontSplitSeq
+          if prev(formatToken).left.is[Colon] =>
+        DontSplitSeq
       // Xml
-      case FormatToken(Xml.Part(_), _, _) =>DontSplitSeq
-      case FormatToken(_, Xml.Part(_), _) =>DontSplitSeq
+      case FormatToken(Xml.Part(_), _, _) => DontSplitSeq
+      case FormatToken(_, Xml.Part(_), _) => DontSplitSeq
       // Fallback
-      case FormatToken(_, Dot(), _) =>DontSplitSeq
+      case FormatToken(_, Dot(), _) => DontSplitSeq
       case FormatToken(left, Hash(), _) =>
         Array(
           Split(if (endsWithSymbolIdent(left)) Space else NoSplit, 0)
         )
       case FormatToken(Hash(), ident: Ident, _) =>
         if (TokenOps.isSymbolicIdent(ident)) SpaceSplitSeq else DontSplitSeq
-      case FormatToken(Dot(), Ident(_) | KwThis() | KwSuper(), _) =>DontSplitSeq
-      case FormatToken(_, RightBracket(), _) =>DontSplitSeq
+      case FormatToken(Dot(), Ident(_) | KwThis() | KwSuper(), _) =>
+        DontSplitSeq
+      case FormatToken(_, RightBracket(), _) => DontSplitSeq
       case FormatToken(_, RightParen(), _) =>
         val mod =
           if (style.spaces.inParentheses &&
@@ -1396,10 +1419,10 @@ class Router(formatOps: FormatOps) {
         }
       case FormatToken(Keyword() | Modifier(), _, _) =>
         SpaceSplitSeq
-      case FormatToken(LeftBracket(), _, _) =>DontSplitSeq
+      case FormatToken(LeftBracket(), _, _) => DontSplitSeq
       case FormatToken(_, Delim(), _) =>
         SpaceSplitSeq
-      case FormatToken(Underscore(), Ident("*"), _) =>DontSplitSeq
+      case FormatToken(Underscore(), Ident("*"), _) => DontSplitSeq
       case FormatToken(RightArrow(), _, _) if leftOwner.is[Type.ByName] =>
         val mod = if (!style.spaces.inByNameTypes) NoSplit else Space
         Array(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -9,6 +9,7 @@ import org.scalafmt.util.TokenOps.rhsIsCommentedOut
 import scala.meta.tokens.Token.Ident
 
 case class OptimalToken(token: Token, killOnFail: Boolean = false)
+
 /**
   * A Split is the whitespace between two non-whitespace tokens.
   *
@@ -31,7 +32,7 @@ case class Split(
     indents: Seq[Indent[Length]] = Array.empty[Indent[Length]],
     policy: Policy = NoPolicy,
     optimalAt: Option[OptimalToken] = None)(
-  implicit val line: sourcecode.Line) {
+    implicit val line: sourcecode.Line) {
   import TokenOps._
   //def penalty: Boolean = policy != NoPolicy || optimalAt.isDefined ||addedPenalty
 
@@ -41,12 +42,13 @@ case class Split(
     case _ => this
   }
 
-  def indentation = indents
-    .map(_.length match {
-      case Num(x) => x.toString
-      case x => x.toString
-    })
-    .mkString("[", ", ", "]")
+  def indentation =
+    indents
+      .map(_.length match {
+        case Num(x) => x.toString
+        case x => x.toString
+      })
+      .mkString("[", ", ", "]")
 
   def length: Int = modification match {
     case m if m.isNewline => 0
@@ -79,8 +81,7 @@ case class Split(
       if (policy == NoPolicy) newPolicy
       else
         throw new UnsupportedOperationException("Can't have two policies yet.")
-    new Split(modification, cost, ignoreIf, indents, update, optimalAt)(
-      line)
+    new Split(modification, cost, ignoreIf, indents, update, optimalAt)(line)
   }
 
   def withPenalty(penalty: Int): Split =
@@ -117,34 +118,29 @@ case class Split(
 object Split {
 
   final def withIndent(
-             modification: Modification,
-             cost: Int,
-             ignoreIf: Boolean = false,
-             indent: Indent[Length],
-             policy: Policy = NoPolicy
-  )(implicit line: sourcecode.Line) ={
+      modification: Modification,
+      cost: Int,
+      ignoreIf: Boolean = false,
+      indent: Indent[Length],
+      policy: Policy = NoPolicy
+  )(implicit line: sourcecode.Line) = {
     val indents = indent.length match {
       case Num(0) => emptyIndent
       case _ => Array(indent)
     }
-    new Split(
-      modification,
-      cost,
-      ignoreIf,
-      indents,
-      policy)(line)
+    new Split(modification, cost, ignoreIf, indents, policy)(line)
   }
 
   val emptyIndent = Array[Indent[Length]]()
 
   final def withIdentAndOptionToken(
-             modification: Modification,
-             cost: Int,
-             indent: Indent[Length],
-             token: Option[Token],
-             policy: Policy = NoPolicy,
-             ignoreIf: Boolean = false
-           )(implicit line: sourcecode.Line) = {
+      modification: Modification,
+      cost: Int,
+      indent: Indent[Length],
+      token: Option[Token],
+      policy: Policy = NoPolicy,
+      ignoreIf: Boolean = false
+  )(implicit line: sourcecode.Line) = {
     val indents = indent.length match {
       case Num(0) => emptyIndent
       case _ => Array(indent)
@@ -152,48 +148,44 @@ object Split {
 
     val optimaltoken = token.map(OptimalToken(_))
 
+    new Split(modification, cost, ignoreIf, indents, policy, optimaltoken)(line)
+  }
+
+  @inline
+  final def withToken(
+      modification: Modification,
+      cost: Int,
+      token: Token,
+      ignoreIf: Boolean = false,
+      indents: Seq[Indent[Length]] = emptyIndent,
+      policy: Policy = NoPolicy,
+      killOnFail: Boolean = false
+  )(implicit line: sourcecode.Line) =
     new Split(
       modification,
       cost,
       ignoreIf,
       indents,
       policy,
-      optimaltoken)(line)
-  }
-
-  @inline
-  final def withToken(
-             modification: Modification,
-             cost: Int,
-             token: Token,
-             ignoreIf: Boolean = false,
-             indents: Seq[Indent[Length]] = emptyIndent,
-             policy: Policy = NoPolicy,
-             killOnFail: Boolean = false
-           )(implicit line: sourcecode.Line) = new Split(
-    modification,
-    cost,
-    ignoreIf,
-    indents,
-    policy,
-    Some(OptimalToken(token, killOnFail))
-  )(line)
+      Some(OptimalToken(token, killOnFail))
+    )(line)
 
   @inline
   final def withIdentAndToken(
-             modification: Modification,
-             cost: Int,
-             indent: Indent[Length],
-             token: Token,
-             ignoreIf: Boolean = false,
-             policy: Policy = NoPolicy,
-             killOnFail: Boolean = false
-           )(implicit line: sourcecode.Line) = new Split(
-    modification,
-    cost,
-    ignoreIf,
-    Array(indent),
-    policy,
-    Some(OptimalToken(token, killOnFail))
-  )(line)
+      modification: Modification,
+      cost: Int,
+      indent: Indent[Length],
+      token: Token,
+      ignoreIf: Boolean = false,
+      policy: Policy = NoPolicy,
+      killOnFail: Boolean = false
+  )(implicit line: sourcecode.Line) =
+    new Split(
+      modification,
+      cost,
+      ignoreIf,
+      Array(indent),
+      policy,
+      Some(OptimalToken(token, killOnFail))
+    )(line)
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -23,11 +23,15 @@ case class OptimalToken(token: Token, killOnFail: Boolean = false)
   *             this split originates.
   *
   */
+
+object Split{
+  final val emptyArray = Array[Indent[Length]]()
+}
 case class Split(
     modification: Modification,
     cost: Int,
     ignoreIf: Boolean = false,
-    indents: Vector[Indent[Length]] = Vector.empty[Indent[Length]],
+    indents: Seq[Indent[Length]] = Split.emptyArray,
     policy: Policy = NoPolicy,
     penalty: Boolean = false,
     optimalAt: Option[OptimalToken] = None)(
@@ -40,7 +44,7 @@ case class Split(
     case _ => this
   }
 
-  val indentation = indents
+  def indentation = indents
     .map(_.length match {
       case Num(x) => x.toString
       case x => x.toString

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -27,6 +27,7 @@ case class OptimalToken(token: Token, killOnFail: Boolean = false)
 object Split{
   final val emptyArray = Array[Indent[Length]]()
 }
+
 case class Split(
     modification: Modification,
     cost: Int,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -22,7 +22,7 @@ import scala.meta.Init
 class StyleMap(
     tokens: Array[FormatToken],
     init: ScalafmtConfig,
-    owners: Map[TokenHash, Tree],
+    owners: TokenHash => Tree,
     matching: Map[TokenHash, Token]) {
   import TokenOps.hash
   val literalR: FilterMatcher = init.binPack.literalsRegex

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -153,7 +153,7 @@ object TokenOps {
               exclude.forall(!_.contains(tok.left.start)) &&
               (disallowSingleLineComments || !isSingleLineComment(tok.left)) =>
           if (penaliseNewlinesInsideTokens && tok.leftHasNewline) {
-            Decision(tok, Seq.empty[Split])
+            Decision(tok, Array.empty[Split])
           } else {
             Decision(tok, splits.filterNot(_.modification.isNewline))
           }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -18,6 +18,9 @@ import org.scalafmt.internal.Policy
 import org.scalafmt.internal.Space
 import org.scalafmt.internal.Split
 
+import scala.util.MurmurHash
+import scala.util.hashing.MurmurHash3
+
 /**
   * Stateless helper functions on [[scala.meta.Token]].
   */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -193,8 +193,8 @@ object TreeOps {
   /**
     * Creates lookup table from token offset to its closest scala.meta tree.
     */
-  def getOwners(tree: Tree): Map[TokenHash, Tree] = {
-    val result = mutable.Map.newBuilder[TokenHash, Tree]
+  def getOwners(tree: Tree): TokenHash => Tree = {
+    val result = new mutable.LongMap[Tree](1024)
     def loop(x: Tree): Unit = {
       x.tokens.foreach { tok =>
         result += hash(tok) -> x
@@ -202,7 +202,7 @@ object TreeOps {
       x.children.foreach(loop)
     }
     loop(tree)
-    result.result().toMap
+    result.result()
   }
 
   @tailrec

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -23,6 +23,8 @@ import scala.reflect.classTag
 import org.scalafmt.Error
 import org.scalafmt.Error.UnexpectedTree
 import org.scalafmt.internal.FormatToken
+
+import scala.collection.mutable
 import scala.meta.Init
 
 /**
@@ -95,7 +97,7 @@ object TreeOps {
   }
 
   def getStatementStarts(tree: Tree): Map[TokenHash, Tree] = {
-    val ret = Map.newBuilder[TokenHash, Tree]
+    val ret = mutable.Map.newBuilder[TokenHash, Tree]
     ret.sizeHint(tree.tokens.length)
 
     def addAll(trees: Seq[Tree]): Unit = {
@@ -149,7 +151,7 @@ object TreeOps {
       x.children.foreach(loop)
     }
     loop(tree)
-    ret.result()
+    ret.result().toMap
   }
 
   /**
@@ -192,7 +194,7 @@ object TreeOps {
     * Creates lookup table from token offset to its closest scala.meta tree.
     */
   def getOwners(tree: Tree): Map[TokenHash, Tree] = {
-    val result = Map.newBuilder[TokenHash, Tree]
+    val result = mutable.Map.newBuilder[TokenHash, Tree]
     def loop(x: Tree): Unit = {
       x.tokens.foreach { tok =>
         result += hash(tok) -> x
@@ -200,7 +202,7 @@ object TreeOps {
       x.children.foreach(loop)
     }
     loop(tree)
-    result.result()
+    result.result().toMap
   }
 
   @tailrec


### PR DESCRIPTION
I made this pull request, Because i wanted to learn some optimalization in scala and was reading the  scalaftm documentation that you would like to have some microoptimalizations.

My test method was using the ScalafmtProps program for performance testing and using visualVM.

In summery i changed some Map implementation to either a mutable implementation or a better specialized version of Map.

I changed many sequences to Array since most of these where acesed in order. 
Added specialized constructors to Split to avoid copies  with the 'withXXX' 
Added more constants in the split operations to avoid initialization in the router.

If i could i would change the List in the Tree in scala.meta to an array as well.

after these optimalizations the ScalafmtProps ran in 
66746ms
before it was:
491728ms
My computer specs.
core I5 8250u 4 core and 16GB ram.
