### PR TITLE
Make ScalafmtReflect format any files if respectProjectFilters=false

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -179,7 +179,7 @@ case class ScalafmtReflect(
   }
 
   private def isIgnoredFile(filename: String, config: Object): Boolean = {
-    if (!respectProjectFilters) true
+    if (!respectProjectFilters) false
     else {
       val matcher = invoke(invoke(config, "project"), "matcher")
       val matches = matcher.getClass.getMethod("matches", classOf[String])

--- a/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
@@ -228,6 +228,27 @@ class DynamicSuite extends FunSuite with DiffAssertions {
     f.ignoreExcludeFilters()
   }
 
+  check("ignore-exclude-filters") { f =>
+    f.setConfig(
+      """
+        |project.includeFilters = [
+        |  ".*Spec\\.scala$"
+        |]
+        |project.excludeFilters = [
+        |  "UserSpec\\.scala$"
+        |]
+        |""".stripMargin
+    )
+    def check(): Unit = {
+      f.assertNotIgnored("path/App.pm")
+      f.assertNotIgnored("path/App.scala")
+      f.assertNotIgnored("path/UserSpec.scala")
+    }
+    f.setVersion(latest)
+    f.ignoreExcludeFilters()
+    check()
+  }
+
   check("config-error") { f =>
     f.setConfig(
       s"""max=70


### PR DESCRIPTION
Close https://github.com/scalameta/scalafmt/issues/1360

For the details, please see the issue above.
This change is required to install scalafmt-dynamic to scalafmt-cli, because `scalafmt-cli <filename>` format the specified file no matter what the filename is, and it is necessary to ignore the project filter (format any inputs) to preserve the behavior.