### PR TITLE
Welcome Rikito Taniguchi to the team!

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ The current maintainers (people who can merge pull requests) are:
 * Pedro J Rodriguez Tavarez - [`@pjrt`](https://github.com/pjrt)
 * Iurii Susuk - [`@ysusuk`](https://github.com/ysusuk)
 * Paul Draper - [`@pauldraper`](https://github.com/pauldraper)
+* Rikito Taniguchi [`@tanishiking`](https://github.com/tanishiking)
 
 An up-to-date list of contributors is available here: https://github.com/scalameta/scalafmt/graphs/contributors
 


### PR DESCRIPTION
Rikito has been actively helping out in both Scalafmt and Scalafix. He is the maintainer of [scalaunfmt](https://github.com/tanishiking/scalaunfmt), a tool to automatically generate .scalafmt.conf that most closely matches an existing codebase's formatting conventions.  I am happy to welcome him as a Scalafmt collaborator so he can merge PRs and cut new releases.