### PR TITLE
Make scalafmt-cli to use scalafmt-dynamic module instead of depending on specific version of scalafmt-core.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,10 +126,18 @@ lazy val cli = project
     libraryDependencies ++= Seq(
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "com.martiansoftware" % "nailgun-server" % "0.9.1",
-      "com.github.scopt" %% "scopt" % "3.5.0"
-    )
+      "com.github.scopt" %% "scopt" % "3.5.0",
+      // undeclared transitive dependency of coursier-small
+      "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
+    ),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 11)) => Seq("-target:jvm-1.8")
+        case _ => Seq.empty
+      }
+    }
   )
-  .dependsOn(coreJVM, interfaces)
+  .dependsOn(coreJVM, dynamic)
 
 lazy val intellij = project
   .in(file("scalafmt-intellij"))

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -1,22 +1,10 @@
 package org.scalafmt.cli
 
 import com.martiansoftware.nailgun.NGContext
-import java.io.{InputStream, OutputStreamWriter, PrintStream}
-import java.nio.file.Paths
-import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
-import java.util.function.UnaryOperator
+import java.io.{InputStream, PrintStream}
+import org.scalafmt.Versions
+import org.scalafmt.util.AbsoluteFile
 
-import metaconfig.Configured
-import org.scalafmt.Error.MisformattedFile
-import org.scalafmt.Error.NoMatchingFiles
-import org.scalafmt.config.{FilterMatcher, ScalafmtConfig}
-import org.scalafmt.{Formatted, Scalafmt, Versions}
-import org.scalafmt.interfaces.{Scalafmt => ScalafmtInterface}
-import org.scalafmt.util.{AbsoluteFile, FileOps, OsSpecific}
-
-import scala.meta.internal.tokenizers.PlatformTokenizerCache
-import scala.meta.parsers.ParseException
-import scala.meta.tokenizers.TokenizeException
 import scala.util.control.NoStackTrace
 
 object Cli {
@@ -84,65 +72,6 @@ object Cli {
     CliArgParser.scoptParser.parse(args, init).map(CliOptions.auto(args, init))
   }
 
-  /** Returns file paths defined via options.{customFiles,customExclude} */
-  private def getFilesFromCliOptions(
-      options: CliOptions,
-      filter: Option[FilterMatcher]): Seq[AbsoluteFile] = {
-    def canFormat(f: AbsoluteFile): Boolean =
-      filter.map(_.matches(f)).getOrElse(true)
-    val files = options.fileFetchMode match {
-      case m @ (GitFiles | RecursiveSearch) =>
-        val fetchFiles: AbsoluteFile => Seq[AbsoluteFile] =
-          if (m == GitFiles) options.gitOps.lsTree(_)
-          else FileOps.listFiles(_)
-
-        options.files.flatMap {
-          case d if d.jfile.isDirectory => fetchFiles(d).filter(canFormat)
-          // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
-          // formatted regardless of what it is or where it is.
-          case f => Seq(f)
-        }
-      case DiffFiles(branch) =>
-        options.gitOps.diff(branch).filter(canFormat)
-    }
-    val excludeRegexp = options.excludeFilterRegexp
-    files.filter { f =>
-      excludeRegexp.findFirstIn(f.path).isEmpty
-    }
-  }
-
-  private def getInputMethods(
-      options: CliOptions,
-      filter: Option[FilterMatcher]): Seq[InputMethod] = {
-    if (options.stdIn) {
-      Seq(InputMethod.StdinCode(options.assumeFilename, options.common.in))
-    } else {
-      val projectFiles: Seq[AbsoluteFile] =
-        getFilesFromCliOptions(options, filter)
-      projectFiles.map(InputMethod.FileContents.apply)
-    }
-  }
-
-  def newTermDisplay(
-      options: CliOptions,
-      inputMethods: Seq[InputMethod],
-      msg: String): TermDisplay = {
-    val termDisplay = new TermDisplay(
-      new OutputStreamWriter(options.info),
-      fallbackMode =
-        options.nonInteractive ||
-          TermDisplay.defaultFallbackMode
-    )
-    if (!options.quiet &&
-      (options.inPlace || options.testing) &&
-      inputMethods.length > 5) {
-      termDisplay.init()
-      termDisplay.startTask(msg, options.common.workingDirectory.jfile)
-      termDisplay.taskLength(msg, inputMethods.length, 0)
-    }
-    termDisplay
-  }
-
   private[cli] def run(options: CliOptions): ExitCode = {
     val termDisplayMessage =
       if (options.testing) "Looking for unformatted files..."
@@ -157,12 +86,13 @@ object Cli {
     // - `scalafmt-dynamic` if the specified `version` setting doesn't match build version.
     // - `scalafmt-core` if the specified `version` setting match with build version
     //   (or if the `version` is not specified).
-    val exit = options.version match {
-      case None => runScalafmt(options, termDisplayMessage)
+    val runner: ScalafmtRunner = options.version match {
+      case None => ScalafmtCoreRunner
       case Some(v) if v == Versions.version =>
-        runScalafmt(options, termDisplayMessage)
-      case _ => runDynamic(options, termDisplayMessage)
+        ScalafmtCoreRunner
+      case _ => ScalafmtDynamicRunner
     }
+    val exit = runner.run(options, termDisplayMessage)
 
     if (options.testing) {
       if (exit.isOk) {
@@ -183,171 +113,6 @@ object Cli {
       ExitCode.Ok
     } else {
       exit
-    }
-  }
-
-  private def runDynamic(
-      options: CliOptions,
-      termDisplayMessage: String
-  ): ExitCode = {
-    def handleFile(
-        inputMethod: InputMethod,
-        scalafmtInstance: ScalafmtInterface,
-        options: CliOptions
-    ): Unit = {
-      val input = inputMethod.readInput(options)
-
-      // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
-      // formatted regardless of what it is or where it is.
-      val shouldRespectFilters =
-        AbsoluteFile.fromPath(inputMethod.filename).forall { file =>
-          !options.customFiles.contains(file)
-        }
-      val formatResult = scalafmtInstance
-        .withRespectProjectFilters(shouldRespectFilters)
-        .format(
-          options.configPath,
-          Paths.get(inputMethod.filename),
-          input
-        )
-      inputMethod.write(formatResult, input, options)
-    }
-
-    val inputMethods = getInputMethods(options, None)
-    if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
-      throw NoMatchingFiles
-
-    val counter = new AtomicInteger()
-    val reporter = new ScalafmtCliReporter(options)
-    val scalafmtInstance = ScalafmtInterface
-      .create(this.getClass.getClassLoader)
-      .withReporter(reporter)
-
-    // Path names fully qualified by `customFiles`.
-    // If there exists fqpns, create another instance of `scalafmt-dynamic`
-    // that ignores `excludeFilters` because fully qualified files will (try to) be
-    // formatted regardless of what it is or where it is (and excludeFilter).
-    val fqpns = inputMethods.filter { input =>
-      AbsoluteFile.fromPath(input.filename).forall { file =>
-        options.customFiles.contains(file)
-      }
-    }
-    val scalafmtInstanceIgnoreFilters =
-      if (fqpns.isEmpty) scalafmtInstance
-      else
-        ScalafmtInterface
-          .create(this.getClass.getClassLoader)
-          .withReporter(reporter)
-          .withRespectProjectFilters(false)
-
-    val termDisplay = newTermDisplay(options, inputMethods, termDisplayMessage)
-
-    inputMethods.foreach { inputMethod =>
-      val instance =
-        // Use scalafmt-dynamic that ignores exclude filters for fully qualified paths
-        if (fqpns.contains(inputMethod)) scalafmtInstanceIgnoreFilters
-        else scalafmtInstance
-      try handleFile(inputMethod, instance, options)
-      catch {
-        case e: MisformattedFile => reporter.error(e.file.toPath, e)
-      }
-      PlatformTokenizerCache.megaCache.clear()
-      termDisplay.taskProgress(termDisplayMessage, counter.incrementAndGet())
-    }
-
-    val exit = reporter.getExitCode
-
-    termDisplay.completedTask(termDisplayMessage, exit.isOk)
-    termDisplay.stop()
-
-    exit
-  }
-
-  private def runScalafmt(
-      options: CliOptions,
-      termDisplayMessage: String
-  ): ExitCode = {
-    def handleFile(
-        inputMethod: InputMethod,
-        options: CliOptions,
-        config: ScalafmtConfig): ExitCode = {
-      try unsafeHandleFile(inputMethod, options, config)
-      catch {
-        case MisformattedFile(_, diff) =>
-          options.common.err.println(diff)
-          ExitCode.TestError
-      }
-    }
-    def unsafeHandleFile(
-        inputMethod: InputMethod,
-        options: CliOptions,
-        config: ScalafmtConfig
-    ): ExitCode = {
-      val input = inputMethod.readInput(options)
-      val scalafmtConfig =
-        if (inputMethod.isSbt || inputMethod.isSc) config.forSbt
-        else config
-      val formatResult = Scalafmt.format(
-        input,
-        scalafmtConfig,
-        options.range,
-        inputMethod.filename
-      )
-      formatResult match {
-        case Formatted.Success(formatted) =>
-          inputMethod.write(formatted, input, options)
-          ExitCode.Ok
-        case Formatted.Failure(e) =>
-          if (scalafmtConfig.runner.ignoreWarnings) {
-            ExitCode.Ok // do nothing
-          } else {
-            e match {
-              case e @ (_: ParseException | _: TokenizeException) =>
-                options.common.err.println(e.toString)
-                ExitCode.ParseError
-              case _ =>
-                new FailedToFormat(inputMethod.filename, e)
-                  .printStackTrace(options.common.out)
-                ExitCode.UnexpectedError
-            }
-          }
-      }
-    }
-
-    options.scalafmtConfig match {
-      case Configured.NotOk(e) =>
-        if (!options.quiet) options.common.err.println(s"${e.msg}")
-        ExitCode.UnexpectedError
-      case Configured.Ok(scalafmtConf) =>
-        val filterMatcher: FilterMatcher = FilterMatcher(
-          scalafmtConf.project.includeFilters
-            .map(OsSpecific.fixSeparatorsInPathPattern),
-          (scalafmtConf.project.excludeFilters ++ options.customExcludes)
-            .map(OsSpecific.fixSeparatorsInPathPattern)
-        )
-
-        val inputMethods = getInputMethods(options, Some(filterMatcher))
-        if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
-          throw NoMatchingFiles
-
-        val counter = new AtomicInteger()
-        val termDisplay =
-          newTermDisplay(options, inputMethods, termDisplayMessage)
-        val exitCode = new AtomicReference(ExitCode.Ok)
-        inputMethods.par.foreach { inputMethod =>
-          val code = handleFile(inputMethod, options, scalafmtConf)
-          exitCode.getAndUpdate(new UnaryOperator[ExitCode] {
-            override def apply(t: ExitCode): ExitCode =
-              ExitCode.merge(code, t)
-          })
-          PlatformTokenizerCache.megaCache.clear()
-          termDisplay.taskProgress(
-            termDisplayMessage,
-            counter.incrementAndGet())
-        }
-        termDisplay.completedTask(termDisplayMessage, exitCode.get.isOk)
-        termDisplay.stop()
-        exitCode.get()
     }
   }
 }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -153,6 +153,10 @@ object Cli {
       out.println("Working directory: " + pwd)
     }
 
+    // Run format using
+    // - `scalafmt-dynamic` if the specified `version` setting doesn't match build version.
+    // - `scalafmt-core` if the specified `version` setting match with build version
+    //   (or if the `version` is not specified).
     val exit = options.version match {
       case None => runScalafmt(options, termDisplayMessage)
       case Some(v) if v == Versions.version =>
@@ -219,6 +223,10 @@ object Cli {
       .create(this.getClass.getClassLoader)
       .withReporter(reporter)
 
+    // Path names fully qualified by `customFiles`.
+    // If there exists fqpns, create another instance of `scalafmt-dynamic`
+    // that ignores `excludeFilters` because fully qualified files will (try to) be
+    // formatted regardless of what it is or where it is (and excludeFilter).
     val fqpns = inputMethods.filter { input =>
       AbsoluteFile.fromPath(input.filename).forall { file =>
         options.customFiles.contains(file)
@@ -236,6 +244,7 @@ object Cli {
 
     inputMethods.foreach { inputMethod =>
       val instance =
+        // Use scalafmt-dynamic that ignores exclude filters for fully qualified paths
         if (fqpns.contains(inputMethod)) scalafmtInstanceIgnoreFilters
         else scalafmtInstance
       try handleFile(inputMethod, instance, options)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -3,15 +3,20 @@ package org.scalafmt.cli
 import com.martiansoftware.nailgun.NGContext
 import java.io.{InputStream, OutputStreamWriter, PrintStream}
 import java.nio.file.Paths
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.function.UnaryOperator
 
+import metaconfig.Configured
 import org.scalafmt.Error.MisformattedFile
 import org.scalafmt.Error.NoMatchingFiles
-import org.scalafmt.interfaces.Scalafmt
-import org.scalafmt.util.AbsoluteFile
-import org.scalafmt.util.FileOps
+import org.scalafmt.config.{FilterMatcher, ScalafmtConfig}
+import org.scalafmt.{Formatted, Scalafmt, Versions}
+import org.scalafmt.interfaces.{Scalafmt => ScalafmtInterface}
+import org.scalafmt.util.{AbsoluteFile, FileOps, OsSpecific}
 
 import scala.meta.internal.tokenizers.PlatformTokenizerCache
+import scala.meta.parsers.ParseException
+import scala.meta.tokenizers.TokenizeException
 import scala.util.control.NoStackTrace
 
 object Cli {
@@ -80,7 +85,11 @@ object Cli {
   }
 
   /** Returns file paths defined via options.{customFiles,customExclude} */
-  private def getFilesFromCliOptions(options: CliOptions): Seq[AbsoluteFile] = {
+  private def getFilesFromCliOptions(
+      options: CliOptions,
+      filter: Option[FilterMatcher]): Seq[AbsoluteFile] = {
+    def canFormat(f: AbsoluteFile): Boolean =
+      filter.map(_.matches(f)).getOrElse(true)
     val files = options.fileFetchMode match {
       case m @ (GitFiles | RecursiveSearch) =>
         val fetchFiles: AbsoluteFile => Seq[AbsoluteFile] =
@@ -88,11 +97,13 @@ object Cli {
           else FileOps.listFiles(_)
 
         options.files.flatMap {
-          case d if d.jfile.isDirectory => fetchFiles(d)
+          case d if d.jfile.isDirectory => fetchFiles(d).filter(canFormat)
+          // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
+          // formatted regardless of what it is or where it is.
           case f => Seq(f)
         }
       case DiffFiles(branch) =>
-        options.gitOps.diff(branch)
+        options.gitOps.diff(branch).filter(canFormat)
     }
     val excludeRegexp = options.excludeFilterRegexp
     files.filter { f =>
@@ -100,35 +111,16 @@ object Cli {
     }
   }
 
-  private def getInputMethods(options: CliOptions): Seq[InputMethod] = {
+  private def getInputMethods(
+      options: CliOptions,
+      filter: Option[FilterMatcher]): Seq[InputMethod] = {
     if (options.stdIn) {
       Seq(InputMethod.StdinCode(options.assumeFilename, options.common.in))
     } else {
-      val projectFiles: Seq[AbsoluteFile] = getFilesFromCliOptions(options)
+      val projectFiles: Seq[AbsoluteFile] =
+        getFilesFromCliOptions(options, filter)
       projectFiles.map(InputMethod.FileContents.apply)
     }
-  }
-
-  private def handleFile(
-      inputMethod: InputMethod,
-      scalafmtInstance: Scalafmt,
-      options: CliOptions): Unit = {
-    val input = inputMethod.readInput(options)
-
-    // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
-    // formatted regardless of what it is or where it is.
-    val shouldRespectFilters =
-      AbsoluteFile.fromPath(inputMethod.filename).forall { file =>
-        !options.customFiles.contains(file)
-      }
-    val formatResult = scalafmtInstance
-      .withRespectProjectFilters(shouldRespectFilters)
-      .format(
-        options.configPath,
-        Paths.get(inputMethod.filename),
-        input
-      )
-    inputMethod.write(formatResult, input, options)
   }
 
   def newTermDisplay(
@@ -152,11 +144,6 @@ object Cli {
   }
 
   private[cli] def run(options: CliOptions): ExitCode = {
-
-    val inputMethods = getInputMethods(options)
-    if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
-      throw NoMatchingFiles
-    val counter = new AtomicInteger()
     val termDisplayMessage =
       if (options.testing) "Looking for unformatted files..."
       else "Reformatting..."
@@ -164,46 +151,15 @@ object Cli {
       val pwd = options.common.workingDirectory.jfile.getPath
       val out = options.info
       out.println("Working directory: " + pwd)
-      out.println("Formatting files: " + inputMethods.toList)
     }
 
-    val reporter = new ScalafmtCliReporter(options)
-    val scalafmtInstance = Scalafmt
-      .create(this.getClass.getClassLoader)
-      .withReporter(reporter)
-
-    // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
-    // formatted regardless of what it is or where it is.
-    val fqpns = inputMethods.filter { input =>
-      AbsoluteFile.fromPath(input.filename).forall { file =>
-        options.customFiles.contains(file)
-      }
-    }
-    val scalafmtInstanceIgnoreFilters =
-      if (fqpns.isEmpty) scalafmtInstance
-      else
-        Scalafmt
-          .create(this.getClass.getClassLoader)
-          .withReporter(reporter)
-          .withRespectProjectFilters(false)
-
-    val termDisplay = newTermDisplay(options, inputMethods, termDisplayMessage)
-
-    inputMethods.foreach { inputMethod =>
-      val instance =
-        if (fqpns.contains(inputMethod)) scalafmtInstanceIgnoreFilters
-        else scalafmtInstance
-      try handleFile(inputMethod, instance, options)
-      catch {
-        case e: MisformattedFile => reporter.error(e.file.toPath, e)
-      }
-      PlatformTokenizerCache.megaCache.clear()
-      termDisplay.taskProgress(termDisplayMessage, counter.incrementAndGet())
+    val exit = options.version match {
+      case None => runScalafmt(options, termDisplayMessage)
+      case Some(v) if v == Versions.version =>
+        runScalafmt(options, termDisplayMessage)
+      case _ => runDynamic(options, termDisplayMessage)
     }
 
-    val exit = reporter.getExitCode
-    termDisplay.completedTask(termDisplayMessage, exit.isOk)
-    termDisplay.stop()
     if (options.testing) {
       if (exit.isOk) {
         options.common.out.println("All files are formatted with scalafmt :)")
@@ -223,6 +179,166 @@ object Cli {
       ExitCode.Ok
     } else {
       exit
+    }
+  }
+
+  private def runDynamic(
+      options: CliOptions,
+      termDisplayMessage: String
+  ): ExitCode = {
+    def handleFile(
+        inputMethod: InputMethod,
+        scalafmtInstance: ScalafmtInterface,
+        options: CliOptions
+    ): Unit = {
+      val input = inputMethod.readInput(options)
+
+      // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
+      // formatted regardless of what it is or where it is.
+      val shouldRespectFilters =
+        AbsoluteFile.fromPath(inputMethod.filename).forall { file =>
+          !options.customFiles.contains(file)
+        }
+      val formatResult = scalafmtInstance
+        .withRespectProjectFilters(shouldRespectFilters)
+        .format(
+          options.configPath,
+          Paths.get(inputMethod.filename),
+          input
+        )
+      inputMethod.write(formatResult, input, options)
+    }
+
+    val inputMethods = getInputMethods(options, None)
+    if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
+      throw NoMatchingFiles
+
+    val counter = new AtomicInteger()
+    val reporter = new ScalafmtCliReporter(options)
+    val scalafmtInstance = ScalafmtInterface
+      .create(this.getClass.getClassLoader)
+      .withReporter(reporter)
+
+    val fqpns = inputMethods.filter { input =>
+      AbsoluteFile.fromPath(input.filename).forall { file =>
+        options.customFiles.contains(file)
+      }
+    }
+    val scalafmtInstanceIgnoreFilters =
+      if (fqpns.isEmpty) scalafmtInstance
+      else
+        ScalafmtInterface
+          .create(this.getClass.getClassLoader)
+          .withReporter(reporter)
+          .withRespectProjectFilters(false)
+
+    val termDisplay = newTermDisplay(options, inputMethods, termDisplayMessage)
+
+    inputMethods.foreach { inputMethod =>
+      val instance =
+        if (fqpns.contains(inputMethod)) scalafmtInstanceIgnoreFilters
+        else scalafmtInstance
+      try handleFile(inputMethod, instance, options)
+      catch {
+        case e: MisformattedFile => reporter.error(e.file.toPath, e)
+      }
+      PlatformTokenizerCache.megaCache.clear()
+      termDisplay.taskProgress(termDisplayMessage, counter.incrementAndGet())
+    }
+
+    val exit = reporter.getExitCode
+
+    termDisplay.completedTask(termDisplayMessage, exit.isOk)
+    termDisplay.stop()
+
+    exit
+  }
+
+  private def runScalafmt(
+      options: CliOptions,
+      termDisplayMessage: String
+  ): ExitCode = {
+    def handleFile(
+        inputMethod: InputMethod,
+        options: CliOptions,
+        config: ScalafmtConfig): ExitCode = {
+      try unsafeHandleFile(inputMethod, options, config)
+      catch {
+        case MisformattedFile(_, diff) =>
+          options.common.err.println(diff)
+          ExitCode.TestError
+      }
+    }
+    def unsafeHandleFile(
+        inputMethod: InputMethod,
+        options: CliOptions,
+        config: ScalafmtConfig
+    ): ExitCode = {
+      val input = inputMethod.readInput(options)
+      val scalafmtConfig =
+        if (inputMethod.isSbt || inputMethod.isSc) config.forSbt
+        else config
+      val formatResult = Scalafmt.format(
+        input,
+        scalafmtConfig,
+        options.range,
+        inputMethod.filename
+      )
+      formatResult match {
+        case Formatted.Success(formatted) =>
+          inputMethod.write(formatted, input, options)
+          ExitCode.Ok
+        case Formatted.Failure(e) =>
+          if (scalafmtConfig.runner.ignoreWarnings) {
+            ExitCode.Ok // do nothing
+          } else {
+            e match {
+              case e @ (_: ParseException | _: TokenizeException) =>
+                options.common.err.println(e.toString)
+                ExitCode.ParseError
+              case _ =>
+                new FailedToFormat(inputMethod.filename, e)
+                  .printStackTrace(options.common.out)
+                ExitCode.UnexpectedError
+            }
+          }
+      }
+    }
+
+    options.scalafmtConfig match {
+      case Configured.NotOk(e) =>
+        if (!options.quiet) options.common.err.println(s"${e.msg}")
+        ExitCode.UnexpectedError
+      case Configured.Ok(scalafmtConf) =>
+        val filterMatcher: FilterMatcher = FilterMatcher(
+          scalafmtConf.project.includeFilters
+            .map(OsSpecific.fixSeparatorsInPathPattern),
+          (scalafmtConf.project.excludeFilters ++ options.customExcludes)
+            .map(OsSpecific.fixSeparatorsInPathPattern)
+        )
+
+        val inputMethods = getInputMethods(options, Some(filterMatcher))
+        if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
+          throw NoMatchingFiles
+
+        val counter = new AtomicInteger()
+        val termDisplay =
+          newTermDisplay(options, inputMethods, termDisplayMessage)
+        val exitCode = new AtomicReference(ExitCode.Ok)
+        inputMethods.par.foreach { inputMethod =>
+          val code = handleFile(inputMethod, options, scalafmtConf)
+          exitCode.getAndUpdate(new UnaryOperator[ExitCode] {
+            override def apply(t: ExitCode): ExitCode =
+              ExitCode.merge(code, t)
+          })
+          PlatformTokenizerCache.megaCache.clear()
+          termDisplay.taskProgress(
+            termDisplayMessage,
+            counter.incrementAndGet())
+        }
+        termDisplay.completedTask(termDisplayMessage, exitCode.get.isOk)
+        termDisplay.stop()
+        exitCode.get()
     }
   }
 }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -4,9 +4,7 @@ import java.io.File
 import java.util.Date
 
 import org.scalafmt.Versions
-import org.scalafmt.config.Config
 import org.scalafmt.util.AbsoluteFile
-import org.scalafmt.util.FileOps
 import scopt.OptionParser
 
 object CliArgParser {
@@ -24,8 +22,7 @@ object CliArgParser {
        |scalafmt Code1.scala A.scala       # write formatted contents to file.
        |scalafmt --stdout Code.scala       # print formatted contents to stdout.
        |scalafmt --exclude target          # format all files in directory excluding target
-       |scalafmt --config .scalafmt.conf   # read custom style from file
-       |scalafmt --config-str "style=IntelliJ" # define custom style as a flag, must be quoted.""".stripMargin
+       |scalafmt --config .scalafmt.conf   # read custom style from file.""".stripMargin
 
   val scoptParser: OptionParser[CliOptions] =
     new scopt.OptionParser[CliOptions]("scalafmt") {
@@ -42,14 +39,9 @@ object CliArgParser {
       private def readConfigFromFile(
           file: String,
           c: CliOptions): CliOptions = {
-        readConfig(
-          FileOps.readFile(
-            AbsoluteFile.fromFile(new File(file), c.common.workingDirectory)),
-          c
-        )
-      }
-      private def readConfig(contents: String, c: CliOptions): CliOptions = {
-        c.copy(config = Config.fromHoconString(contents).get)
+        val configFile =
+          AbsoluteFile.fromFile(new File(file), c.common.workingDirectory)
+        c.copy(config = Some(configFile.jfile.toPath))
       }
 
       private def addFile(file: File, c: CliOptions): CliOptions = {
@@ -101,9 +93,6 @@ object CliArgParser {
       opt[String]('c', "config")
         .action(readConfigFromFile)
         .text("a file path to .scalafmt.conf.")
-      opt[String]("config-str")
-        .action(readConfig)
-        .text("configuration defined as a string")
       opt[Unit]("stdin")
         .action((_, c) => c.copy(stdIn = true))
         .text("read from stdin and print to stdout")

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -22,7 +22,8 @@ object CliArgParser {
        |scalafmt Code1.scala A.scala       # write formatted contents to file.
        |scalafmt --stdout Code.scala       # print formatted contents to stdout.
        |scalafmt --exclude target          # format all files in directory excluding target
-       |scalafmt --config .scalafmt.conf   # read custom style from file.""".stripMargin
+       |scalafmt --config .scalafmt.conf   # read custom style from file.
+       |scalafmt --config-str "style=IntelliJ" # define custom style as a flag, must be quoted.""".stripMargin
 
   val scoptParser: OptionParser[CliOptions] =
     new scopt.OptionParser[CliOptions]("scalafmt") {
@@ -34,6 +35,10 @@ object CliArgParser {
         else showHeader
         sys.exit
         c
+      }
+
+      private def readConfig(contents: String, c: CliOptions): CliOptions = {
+        c.copy(configStr = Some(contents))
       }
 
       private def readConfigFromFile(
@@ -93,6 +98,9 @@ object CliArgParser {
       opt[String]('c', "config")
         .action(readConfigFromFile)
         .text("a file path to .scalafmt.conf.")
+      opt[String]("config-str")
+        .action(readConfig)
+        .text("configuration defined as a string")
       opt[Unit]("stdin")
         .action((_, c) => c.copy(stdIn = true))
         .text("read from stdin and print to stdout")

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -2,13 +2,15 @@ package org.scalafmt.cli
 
 import java.io.InputStream
 import java.io.PrintStream
-import metaconfig.Configured.NotOk
-import metaconfig.Configured.Ok
-import org.scalafmt.config.Config
-import org.scalafmt.config.FilterMatcher
-import org.scalafmt.config.ProjectFiles
-import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.util._
+import java.nio.charset.UnsupportedCharsetException
+import java.nio.file.Path
+
+import com.typesafe.config.{ConfigException, ConfigFactory}
+import org.scalafmt.util.{AbsoluteFile, GitOps, GitOpsImpl, OsSpecific}
+
+import scala.io.Codec
+import scala.util.control.NonFatal
+import scala.util.matching.Regex
 
 object CliOptions {
   val default = CliOptions()
@@ -28,41 +30,35 @@ object CliOptions {
     */
   def auto(args: Array[String], init: CliOptions)(
       parsed: CliOptions): CliOptions = {
-    val style: Option[ScalafmtConfig] = if (init.config != parsed.config) {
-      Option(parsed.config)
+    val style: Option[Path] = if (init.config != parsed.config) {
+      parsed.config
     } else {
       tryCurrentDirectory(parsed).orElse(tryGit(parsed))
     }
     val newMode = if (parsed.testing) Stdout else parsed.writeMode
     parsed.copy(
       writeMode = newMode,
-      config = style.getOrElse(parsed.config)
+      config = style
     )
   }
 
   private def getConfigJFile(file: AbsoluteFile): AbsoluteFile =
     file / ".scalafmt.conf"
 
-  private def tryDirectory(options: CliOptions)(
-      dir: AbsoluteFile): Option[ScalafmtConfig] = {
+  private def tryDirectory(options: CliOptions)(dir: AbsoluteFile): Path =
+    getConfigJFile(dir).jfile.toPath
+
+  private def tryGit(options: CliOptions): Option[Path] = {
     for {
-      configFile <- Option(getConfigJFile(dir))
-      if configFile.jfile.isFile
-    } yield
-      Config.fromHoconString(FileOps.readFile(configFile)) match {
-        case Ok(value) => value
-        // Fail fast on invalid configuration.
-        case NotOk(error) => throw new IllegalArgumentException(error.msg)
-      }
+      rootDir <- options.gitOps.rootDir
+      path = tryDirectory(options)(rootDir)
+      configFilePath <- if (path.toFile.isFile) Some(path) else None
+    } yield configFilePath
   }
 
-  private def tryGit(options: CliOptions): Option[ScalafmtConfig] = {
-    options.gitOps.rootDir.flatMap(tryDirectory(options))
-  }
-
-  private def tryCurrentDirectory(
-      options: CliOptions): Option[ScalafmtConfig] = {
-    tryDirectory(options)(options.common.workingDirectory)
+  private def tryCurrentDirectory(options: CliOptions): Option[Path] = {
+    val configFilePath = tryDirectory(options)(options.common.workingDirectory)
+    if (configFilePath.toFile.isFile) Some(configFilePath) else None
   }
 }
 
@@ -74,7 +70,7 @@ case class CommonOptions(
 )
 
 case class CliOptions(
-    config: ScalafmtConfig = ScalafmtConfig.default,
+    config: Option[Path] = None,
     range: Set[Range] = Set.empty[Range],
     customFiles: Seq[AbsoluteFile] = Nil,
     customExcludes: Seq[String] = Nil,
@@ -92,13 +88,19 @@ case class CliOptions(
     gitOpsConstructor: AbsoluteFile => GitOps = x => new GitOpsImpl(x),
     noStdErr: Boolean = false
 ) {
+  private[this] val DefaultGit = false
+  private[this] val DefaultFatalWarnings = false
+  private[this] val DefaultIgnoreWarnings = false
+  private[this] val DefaultEncoding = Codec.UTF8
+
+  def configPath: Path = config.getOrElse(
+    (common.workingDirectory / ".scalafmt.conf").jfile.toPath
+  )
 
   val inPlace: Boolean = writeMode == Override
 
   val fileFetchMode: FileFetchMode = {
-
-    diff.map(DiffFiles(_)).getOrElse {
-      val isGit: Boolean = git.getOrElse(config.project.git)
+    diff.map(DiffFiles).getOrElse {
       if (isGit) GitFiles else RecursiveSearch
     }
   }
@@ -110,9 +112,11 @@ case class CliOptions(
       customFiles
 
   val gitOps: GitOps = gitOpsConstructor(common.workingDirectory)
+  /*
   def withProject(projectFiles: ProjectFiles): CliOptions = {
     this.copy(config = config.copy(project = projectFiles))
   }
+   */
 
   def withFiles(files: Seq[AbsoluteFile]): CliOptions = {
     this.copy(customFiles = files)
@@ -122,10 +126,87 @@ case class CliOptions(
     if (noStdErr || (!stdIn && writeMode != Stdout)) common.out else common.err
   }
 
-  lazy val filterMatcher: FilterMatcher =
-    FilterMatcher(
-      config.project.includeFilters.map(OsSpecific.fixSeparatorsInPathPattern),
-      (config.project.excludeFilters ++ customExcludes)
-        .map(OsSpecific.fixSeparatorsInPathPattern)
-    )
+  def excludeFilterRegexp: Regex =
+    mkRegexp(customExcludes.map(OsSpecific.fixSeparatorsInPathPattern))
+
+  private def mkRegexp(filters: Seq[String], strict: Boolean = false): Regex =
+    filters match {
+      case Nil => "$a".r // will never match anything
+      case head :: Nil => head.r
+      case _ if strict => filters.mkString("^(", "|", ")$").r
+      case _ => filters.mkString("(", "|", ")").r
+    }
+
+  private[cli] def isGit: Boolean = readGit(configPath).getOrElse(DefaultGit)
+
+  private[cli] def fatalWarnings: Boolean =
+    readFatalWarnings(configPath).getOrElse(DefaultFatalWarnings)
+
+  private[cli] def ignoreWarnings: Boolean =
+    readIgnoreWarnings(configPath).getOrElse(DefaultIgnoreWarnings)
+
+  private[cli] def onTestFailure: Option[String] = readOnTestFailure(configPath)
+
+  private[cli] def encoding: Codec =
+    readEncoding(configPath).getOrElse(DefaultEncoding)
+
+  private def readGit(config: Path): Option[Boolean] = {
+    try {
+      Some(
+        ConfigFactory
+          .parseFile(config.toFile)
+          .getConfig("project")
+          .getBoolean("git"))
+    } catch {
+      case _: ConfigException.Missing => None
+      case NonFatal(_) => None
+    }
+  }
+
+  private def readOnTestFailure(config: Path): Option[String] = {
+    try {
+      Some(ConfigFactory.parseFile(config.toFile).getString("onTestFailure"))
+    } catch {
+      case _: ConfigException.Missing => None
+      case NonFatal(_) => None
+    }
+  }
+
+  private def readFatalWarnings(config: Path): Option[Boolean] = {
+    try {
+      Some(
+        ConfigFactory
+          .parseFile(config.toFile)
+          .getConfig("runner")
+          .getBoolean("fatalWarnings"))
+    } catch {
+      case _: ConfigException.Missing => None
+      case NonFatal(_) => None
+    }
+  }
+
+  private def readIgnoreWarnings(config: Path): Option[Boolean] = {
+    try {
+      Some(
+        ConfigFactory
+          .parseFile(config.toFile)
+          .atPath("runner")
+          .getBoolean("ignoreWarnings"))
+    } catch {
+      case _: ConfigException.Missing => None
+      case NonFatal(_) => None
+    }
+  }
+
+  private def readEncoding(config: Path): Option[Codec] = {
+    try {
+      val codecStr =
+        ConfigFactory.parseFile(config.toFile).getString("encoding")
+      Some(Codec.apply(codecStr))
+    } catch {
+      case _: ConfigException.Missing => None
+      case _: UnsupportedCharsetException => None
+      case NonFatal(_) => None
+    }
+  }
 }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -196,6 +196,9 @@ case class CliOptions(
   private[cli] def encoding: Codec =
     readEncoding(configPath).getOrElse(DefaultEncoding)
 
+  /** Returns None if .scalafmt.conf is not found or
+    * version setting is missing.
+    */
   private[cli] def version: Option[String] =
     readVersion(configPath)
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -99,7 +99,6 @@ case class CliOptions(
   private[this] val DefaultIgnoreWarnings = false
   private[this] val DefaultEncoding = Codec.UTF8
 
-
   /** Create a temporary file that contains configuration string specified by `--config-str`.
     * This temporary file will be passed to `scalafmt-dynamic`.
     * See https://github.com/scalameta/scalafmt/pull/1367#issuecomment-464744077

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -1,6 +1,5 @@
 package org.scalafmt.cli
 
-import scala.io.Codec
 import scala.io.Source
 
 import java.io.File
@@ -40,7 +39,7 @@ object InputMethod {
   case class FileContents(file: AbsoluteFile) extends InputMethod {
     override def filename = file.path
     def readInput(options: CliOptions): String =
-      FileOps.readFile(filename)(options.config.encoding)
+      FileOps.readFile(filename)(options.encoding)
     override def write(
         formatted: String,
         original: String,
@@ -59,7 +58,7 @@ object InputMethod {
         }
       } else if (options.inPlace) {
         if (codeChanged) {
-          FileOps.writeFile(filename, formatted)(options.config.encoding)
+          FileOps.writeFile(filename, formatted)(options.encoding)
         }
       } else {
         options.common.out.print(formatted)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCliReporter.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCliReporter.scala
@@ -1,0 +1,77 @@
+package org.scalafmt.cli
+import java.io.PrintWriter
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.UnaryOperator
+
+import org.scalafmt.Error.MisformattedFile
+import org.scalafmt.interfaces.{PositionException, ScalafmtReporter}
+import org.scalafmt.dynamic.ScalafmtException
+
+import scala.util.control.NoStackTrace
+
+class ScalafmtCliReporter(options: CliOptions) extends ScalafmtReporter {
+  private val exitCode = new AtomicReference(ExitCode.Ok)
+
+  def getExitCode: ExitCode = exitCode.get()
+
+  override def error(
+      file: Path,
+      message: String
+  ): Unit = {
+    if (!options.ignoreWarnings) {
+      if (!options.quiet) options.common.err.println(s"$message: $file")
+      exitCode.getAndUpdate(new UnaryOperator[ExitCode] {
+        override def apply(t: ExitCode): ExitCode =
+          ExitCode.merge(ExitCode.UnexpectedError, t)
+      })
+    }
+  }
+  override def error(
+      file: Path,
+      e: Throwable
+  ): Unit = {
+    e match {
+      case _: PositionException if !options.ignoreWarnings =>
+        if (!options.quiet) options.common.err.println(s"${e.toString}: $file")
+        exitCode.getAndUpdate(new UnaryOperator[ExitCode] {
+          override def apply(t: ExitCode): ExitCode =
+            ExitCode.merge(ExitCode.ParseError, t)
+        })
+      case MisformattedFile(_, diff) =>
+        options.common.err.println(diff)
+        exitCode.getAndUpdate(new UnaryOperator[ExitCode] {
+          override def apply(t: ExitCode): ExitCode =
+            ExitCode.merge(ExitCode.TestError, t)
+        })
+      case ScalafmtException(_, cause) => error(file, cause)
+      case _ if !options.ignoreWarnings =>
+        if (!options.quiet)
+          new FailedToFormat(file.toString, e)
+            .printStackTrace(options.common.err)
+        exitCode.getAndUpdate(new UnaryOperator[ExitCode] {
+          override def apply(t: ExitCode): ExitCode =
+            ExitCode.merge(ExitCode.UnexpectedError, t)
+        })
+    }
+  }
+
+  override def excluded(file: Path): Unit = {
+    if (options.debug) options.common.out.println(s"file excluded: $file")
+  }
+
+  override def parsedConfig(
+      config: Path,
+      scalafmtVersion: String
+  ): Unit = {
+    if (options.debug)
+      options.common.out.println(s"parsed config (v$scalafmtVersion): $config")
+  }
+
+  override def downloadWriter(): PrintWriter =
+    new PrintWriter(options.common.out)
+}
+
+private class FailedToFormat(filename: String, cause: Throwable)
+    extends Exception(filename, cause)
+    with NoStackTrace

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -4,7 +4,7 @@ import java.util.function.UnaryOperator
 
 import metaconfig.Configured
 import org.scalafmt.Error.{MisformattedFile, NoMatchingFiles}
-import org.scalafmt.{Formatted, Scalafmt}
+import org.scalafmt.{Formatted, Scalafmt, Versions}
 import org.scalafmt.config.{FilterMatcher, ScalafmtConfig}
 import org.scalafmt.util.OsSpecific
 
@@ -22,6 +22,8 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
         if (!options.quiet) options.common.err.println(s"${e.msg}")
         ExitCode.UnexpectedError
       case Configured.Ok(scalafmtConf) =>
+        if (options.debug)
+          options.common.out.println(s"parsed config (v${Versions.version})")
         val filterMatcher: FilterMatcher = FilterMatcher(
           scalafmtConf.project.includeFilters
             .map(OsSpecific.fixSeparatorsInPathPattern),

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -1,0 +1,104 @@
+package org.scalafmt.cli
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.function.UnaryOperator
+
+import metaconfig.Configured
+import org.scalafmt.Error.{MisformattedFile, NoMatchingFiles}
+import org.scalafmt.{Formatted, Scalafmt}
+import org.scalafmt.config.{FilterMatcher, ScalafmtConfig}
+import org.scalafmt.util.OsSpecific
+
+import scala.meta.internal.tokenizers.PlatformTokenizerCache
+import scala.meta.parsers.ParseException
+import scala.meta.tokenizers.TokenizeException
+
+object ScalafmtCoreRunner extends ScalafmtRunner {
+  override private[cli] def run(
+      options: CliOptions,
+      termDisplayMessage: String
+  ): ExitCode = {
+    options.scalafmtConfig match {
+      case Configured.NotOk(e) =>
+        if (!options.quiet) options.common.err.println(s"${e.msg}")
+        ExitCode.UnexpectedError
+      case Configured.Ok(scalafmtConf) =>
+        val filterMatcher: FilterMatcher = FilterMatcher(
+          scalafmtConf.project.includeFilters
+            .map(OsSpecific.fixSeparatorsInPathPattern),
+          (scalafmtConf.project.excludeFilters ++ options.customExcludes)
+            .map(OsSpecific.fixSeparatorsInPathPattern)
+        )
+
+        val inputMethods = getInputMethods(options, Some(filterMatcher))
+        if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
+          throw NoMatchingFiles
+
+        val counter = new AtomicInteger()
+        val termDisplay =
+          newTermDisplay(options, inputMethods, termDisplayMessage)
+        val exitCode = new AtomicReference(ExitCode.Ok)
+        inputMethods.par.foreach { inputMethod =>
+          val code = handleFile(inputMethod, options, scalafmtConf)
+          exitCode.getAndUpdate(new UnaryOperator[ExitCode] {
+            override def apply(t: ExitCode): ExitCode =
+              ExitCode.merge(code, t)
+          })
+          PlatformTokenizerCache.megaCache.clear()
+          termDisplay.taskProgress(
+            termDisplayMessage,
+            counter.incrementAndGet())
+        }
+        termDisplay.completedTask(termDisplayMessage, exitCode.get.isOk)
+        termDisplay.stop()
+        exitCode.get()
+    }
+  }
+
+  private[this] def handleFile(
+      inputMethod: InputMethod,
+      options: CliOptions,
+      config: ScalafmtConfig): ExitCode = {
+    try unsafeHandleFile(inputMethod, options, config)
+    catch {
+      case MisformattedFile(_, diff) =>
+        options.common.err.println(diff)
+        ExitCode.TestError
+    }
+  }
+
+  private[this] def unsafeHandleFile(
+      inputMethod: InputMethod,
+      options: CliOptions,
+      config: ScalafmtConfig
+  ): ExitCode = {
+    val input = inputMethod.readInput(options)
+    val scalafmtConfig =
+      if (inputMethod.isSbt || inputMethod.isSc) config.forSbt
+      else config
+    val formatResult = Scalafmt.format(
+      input,
+      scalafmtConfig,
+      options.range,
+      inputMethod.filename
+    )
+    formatResult match {
+      case Formatted.Success(formatted) =>
+        inputMethod.write(formatted, input, options)
+        ExitCode.Ok
+      case Formatted.Failure(e) =>
+        if (scalafmtConfig.runner.ignoreWarnings) {
+          ExitCode.Ok // do nothing
+        } else {
+          e match {
+            case e @ (_: ParseException | _: TokenizeException) =>
+              options.common.err.println(e.toString)
+              ExitCode.ParseError
+            case _ =>
+              new FailedToFormat(inputMethod.filename, e)
+                .printStackTrace(options.common.out)
+              ExitCode.UnexpectedError
+          }
+        }
+    }
+  }
+}

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
@@ -1,0 +1,88 @@
+package org.scalafmt.cli
+import java.nio.file.Paths
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.scalafmt.Error.{MisformattedFile, NoMatchingFiles}
+import org.scalafmt.interfaces.Scalafmt
+import org.scalafmt.util.AbsoluteFile
+
+import scala.meta.internal.tokenizers.PlatformTokenizerCache
+
+object ScalafmtDynamicRunner extends ScalafmtRunner {
+  override private[cli] def run(
+      options: CliOptions,
+      termDisplayMessage: String
+  ): ExitCode = {
+    val inputMethods = getInputMethods(options, None)
+    if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
+      throw NoMatchingFiles
+
+    val counter = new AtomicInteger()
+    val reporter = new ScalafmtCliReporter(options)
+    val scalafmtInstance = Scalafmt
+      .create(this.getClass.getClassLoader)
+      .withReporter(reporter)
+
+    // Path names fully qualified by `customFiles`.
+    // If there exists fqpns, create another instance of `scalafmt-dynamic`
+    // that ignores `excludeFilters` because fully qualified files will (try to) be
+    // formatted regardless of what it is or where it is (and excludeFilter).
+    val fqpns = inputMethods.filter { input =>
+      AbsoluteFile.fromPath(input.filename).forall { file =>
+        options.customFiles.contains(file)
+      }
+    }
+    val scalafmtInstanceIgnoreFilters =
+      if (fqpns.isEmpty) scalafmtInstance
+      else
+        Scalafmt
+          .create(this.getClass.getClassLoader)
+          .withReporter(reporter)
+          .withRespectProjectFilters(false)
+
+    val termDisplay = newTermDisplay(options, inputMethods, termDisplayMessage)
+
+    inputMethods.foreach { inputMethod =>
+      val instance =
+        // Use scalafmt-dynamic that ignores exclude filters for fully qualified paths
+        if (fqpns.contains(inputMethod)) scalafmtInstanceIgnoreFilters
+        else scalafmtInstance
+      try handleFile(inputMethod, instance, options)
+      catch {
+        case e: MisformattedFile => reporter.error(e.file.toPath, e)
+      }
+      PlatformTokenizerCache.megaCache.clear()
+      termDisplay.taskProgress(termDisplayMessage, counter.incrementAndGet())
+    }
+
+    val exit = reporter.getExitCode
+
+    termDisplay.completedTask(termDisplayMessage, exit.isOk)
+    termDisplay.stop()
+
+    exit
+  }
+
+  private[this] def handleFile(
+      inputMethod: InputMethod,
+      scalafmtInstance: Scalafmt,
+      options: CliOptions
+  ): Unit = {
+    val input = inputMethod.readInput(options)
+
+    // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
+    // formatted regardless of what it is or where it is.
+    val shouldRespectFilters =
+      AbsoluteFile.fromPath(inputMethod.filename).forall { file =>
+        !options.customFiles.contains(file)
+      }
+    val formatResult = scalafmtInstance
+      .withRespectProjectFilters(shouldRespectFilters)
+      .format(
+        options.configPath,
+        Paths.get(inputMethod.filename),
+        input
+      )
+    inputMethod.write(formatResult, input, options)
+  }
+}

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -1,0 +1,71 @@
+package org.scalafmt.cli
+import java.io.OutputStreamWriter
+
+import org.scalafmt.config.FilterMatcher
+import org.scalafmt.util.{AbsoluteFile, FileOps}
+
+trait ScalafmtRunner {
+  private[cli] def run(
+      options: CliOptions,
+      termDisplayMessage: String
+  ): ExitCode
+
+  protected def newTermDisplay(
+      options: CliOptions,
+      inputMethods: Seq[InputMethod],
+      msg: String): TermDisplay = {
+    val termDisplay = new TermDisplay(
+      new OutputStreamWriter(options.info),
+      fallbackMode =
+        options.nonInteractive ||
+          TermDisplay.defaultFallbackMode
+    )
+    if (!options.quiet &&
+      (options.inPlace || options.testing) &&
+      inputMethods.length > 5) {
+      termDisplay.init()
+      termDisplay.startTask(msg, options.common.workingDirectory.jfile)
+      termDisplay.taskLength(msg, inputMethods.length, 0)
+    }
+    termDisplay
+  }
+
+  protected def getInputMethods(
+      options: CliOptions,
+      filter: Option[FilterMatcher]): Seq[InputMethod] = {
+    if (options.stdIn) {
+      Seq(InputMethod.StdinCode(options.assumeFilename, options.common.in))
+    } else {
+      val projectFiles: Seq[AbsoluteFile] =
+        getFilesFromCliOptions(options, filter)
+      projectFiles.map(InputMethod.FileContents.apply)
+    }
+  }
+
+  /** Returns file paths defined via options.{customFiles,customExclude} */
+  private[this] def getFilesFromCliOptions(
+      options: CliOptions,
+      filter: Option[FilterMatcher]): Seq[AbsoluteFile] = {
+    def canFormat(f: AbsoluteFile): Boolean =
+      filter.map(_.matches(f)).getOrElse(true)
+    val files = options.fileFetchMode match {
+      case m @ (GitFiles | RecursiveSearch) =>
+        val fetchFiles: AbsoluteFile => Seq[AbsoluteFile] =
+          if (m == GitFiles) options.gitOps.lsTree(_)
+          else FileOps.listFiles(_)
+
+        options.files.flatMap {
+          case d if d.jfile.isDirectory => fetchFiles(d).filter(canFormat)
+          // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
+          // formatted regardless of what it is or where it is.
+          case f => Seq(f)
+        }
+      case DiffFiles(branch) =>
+        options.gitOps.diff(branch).filter(canFormat)
+    }
+    val excludeRegexp = options.excludeFilterRegexp
+    files.filter { f =>
+      excludeRegexp.findFirstIn(f.path).isEmpty
+    }
+  }
+}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -1,16 +1,13 @@
 package org.scalafmt.cli
 
-import scala.meta.dialects.Paradise211
-import scala.meta.parsers.Parse
+import java.nio.file.{Files, Path, Paths}
 
 import metaconfig.Configured.NotOk
 import metaconfig.Configured.Ok
-import org.scalafmt
-import org.scalafmt.config.AlignToken
-import org.scalafmt.config.ImportSelectors
-import org.scalafmt.config.IndentOperator
-import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.config.{Config, ScalafmtConfig}
 import org.scalatest.FunSuite
+import FileTestOps._
+import org.scalafmt.Versions
 
 class CliOptionsTest extends FunSuite {
 
@@ -34,4 +31,67 @@ class CliOptionsTest extends FunSuite {
         "style = defaultWithAlign"))
   }
 
+  test(
+    ".configPath returns a path to the temporary file that contains configuration specified by --config-str") {
+    val expected = "foo bar"
+    val path: Path = baseCliOptions
+      .copy(configStr =
+        Some(s"""{version="${Versions.version}", onTestFailure="$expected"}"""))
+      .configPath
+    val config = Config.fromHoconFile(path.toFile).get
+    assert(config.onTestFailure == expected)
+  }
+
+  test(".configPath returns path to specified configuration path") {
+    val tempPath = Files.createTempFile(".scalafmt", ".conf")
+    val opt = baseCliOptions.copy(config = Some(tempPath))
+    assert(tempPath == opt.configPath)
+  }
+
+  test(
+    ".configPath returns path to workingDirectory's .scalafmt.conf by default") {
+    val opt = baseCliOptions
+    assert(
+      (opt.common.workingDirectory / ".scalafmt.conf").jfile.toPath == opt.configPath)
+  }
+
+  test(
+    ".scalafmtConfig returns the configuration encoded from configStr if configStr is exists") {
+    val expected = "foo bar"
+    val opt = baseCliOptions.copy(
+      configStr =
+        Some(s"""{version="${Versions.version}", onTestFailure="$expected"}"""))
+    assert(opt.scalafmtConfig.get.onTestFailure == expected)
+  }
+
+  test(
+    ".scalafmtConfig returns the configuration read from configuration file located on configPath") {
+    val expected = "foo bar"
+    val configPath = Files.createTempFile(".scalafmt", ".conf")
+    val config = s"""
+                    |version="${Versions.version}"
+                    |maxColumn=100
+                    |onTestFailure="$expected"
+                    |""".stripMargin
+    Files.write(configPath, config.getBytes)
+
+    val opt = baseCliOptions.copy(config = Some(configPath))
+    assert(opt.scalafmtConfig.get.onTestFailure == expected)
+  }
+
+  test(
+    ".scalafmtConfig returns default ScalafmtConfig is configuration file is missing") {
+    val configDir = Files.createTempDirectory("temp-dir")
+    val configPath = Paths.get(configDir.toString + "/.scalafmt.conf")
+    val opt = baseCliOptions.copy(config = Some(configPath))
+    assert(opt.scalafmtConfig.get == ScalafmtConfig.default)
+  }
+
+  test(".scalafmtConfig returns Configured.NotOk for invalid configuration") {
+    val expected = "foo bar"
+    val opt = baseCliOptions.copy(
+      configStr = Some(
+        s"""{invalidKey="${Versions.version}", onTestFailure="$expected"}"""))
+    assert(opt.scalafmtConfig.isNotOk)
+  }
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -6,6 +6,7 @@ import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+
 import org.scalafmt.Error.NoMatchingFiles
 import org.scalafmt.config.Config
 import org.scalafmt.config.ScalafmtConfig
@@ -17,10 +18,9 @@ import org.scalatest.FunSuite
 import FileTestOps._
 import java.io.IOException
 
+import org.scalafmt.Versions
+
 abstract class AbstractCliTest extends FunSuite with DiffAssertions {
-
-  val ScalafmtVersion = "1.6.0-RC4"
-
   def mkArgs(str: String): Array[String] =
     str.split(' ')
 
@@ -53,17 +53,12 @@ abstract class AbstractCliTest extends FunSuite with DiffAssertions {
   val baseCliOptions: CliOptions = getMockOptions(
     AbsoluteFile
       .fromPath(Files.createTempDirectory("base-dir").toString)
-      .get)
+      .get
+  )
 
   def getConfig(args: Array[String]): CliOptions = {
     Cli.getConfig(args, baseCliOptions).get
   }
-
-  val commonScalafmtConfig: Path = Files.createTempFile(".scalafmt", ".conf")
-  val commonConfig: String = s"""
-                                |version=$ScalafmtVersion
-               """.stripMargin
-  Files.write(commonScalafmtConfig, commonConfig.getBytes)
 
   val unformatted = """
                       |object a    extends   App {
@@ -119,7 +114,7 @@ abstract class AbstractCliTest extends FunSuite with DiffAssertions {
       assertExit(exit)
       val obtained = dir2string(input)
       assertNoDiff(obtained, expected)
-      val configTest = Cli.getConfig(Array("--test"), init).get
+      val configTest = Cli.getConfig(Array("--test"), config).get
       Cli.run(configTest)
       assertOut(out.toString())
     }
@@ -128,565 +123,626 @@ abstract class AbstractCliTest extends FunSuite with DiffAssertions {
 
 }
 
-class CliTest extends AbstractCliTest {
-  test("scalafmt tmpFile tmpFile2") {
-    val originalTmpFile = Files.createTempFile("prefix", ".scala")
-    val originalTmpFile2 = Files.createTempFile("prefix2", ".scala")
-    val scalafmtConfig = Files.createTempFile("scalafmtConfig", ".scala")
-    val config = s"""
-                    |version=$ScalafmtVersion
-                    |maxColumn=7,
-                    |style=IntelliJ
+trait CliTestBehavior { this: AbstractCliTest =>
+  def testCli(version: String) {
+    val label = if (version == Versions.version) "core" else "dynamic"
+    test(s"scalafmt tmpFile tmpFile2: $label") {
+      val originalTmpFile = Files.createTempFile("prefix", ".scala")
+      val originalTmpFile2 = Files.createTempFile("prefix2", ".scala")
+      val scalafmtConfig = Files.createTempFile("scalafmtConfig", ".scala")
+      val config = s"""
+                      |version="$version"
+                      |maxColumn=7
+                      |style=IntelliJ
     """.stripMargin
-    Files.write(originalTmpFile, unformatted.getBytes)
-    Files.write(originalTmpFile2, unformatted.getBytes)
-    Files.write(scalafmtConfig, config.getBytes)
-    val args = Array(
-      "--config",
-      scalafmtConfig.toFile.getPath,
-      originalTmpFile.toFile.getPath,
-      originalTmpFile2.toFile.getPath
-    )
-    val formatInPlace = getConfig(args)
-    Cli.run(formatInPlace)
-    val obtained = FileOps.readFile(originalTmpFile.toString)
-    val obtained2 = FileOps.readFile(originalTmpFile2.toString)
-    assertNoDiff(obtained, expected10)
-    assertNoDiff(obtained2, expected10)
-  }
-
-  test("scalafmt --stdout tmpFile prints to stdout") {
-    val originalTmpFile = Files.createTempFile("prefix", ".scala")
-    Files.write(originalTmpFile, unformatted.getBytes)
-    val args = Array(
-      "--stdout",
-      "--config",
-      commonScalafmtConfig.toFile.getPath,
-      originalTmpFile.toFile.getPath
-    )
-    val baos = new ByteArrayOutputStream()
-    val ps = new PrintStream(baos)
-    val init = baseCliOptions.copy(
-      common = baseCliOptions.common.copy(out = ps)
-    )
-    val auto = Cli.getConfig(args, init).get
-    Cli.run(auto)
-    val obtained = new String(baos.toByteArray, StandardCharsets.UTF_8)
-    assertNoDiff(obtained, formatted)
-    assert(obtained.size == formatted.size)
-  }
-
-  test("scalafmt --stdin --assume-filename") {
-    val scalafmtConfig = Files.createTempFile(".scalafmt", ".conf")
-    val config = s"""
-                    |version=$ScalafmtVersion
-                    |maxColumn=7
-                    |style=IntelliJ
-    """.stripMargin
-    Files.write(scalafmtConfig, config.getBytes)
-
-    val args = Array(
-      "--stdin",
-      "--assume-filename",
-      "build.sbt",
-      "--config",
-      scalafmtConfig.toFile.getPath
-    )
-    val printToStdout = getConfig(args)
-    val bais = new ByteArrayInputStream(sbtOriginal.getBytes)
-    val baos = new ByteArrayOutputStream()
-    val ps = new PrintStream(baos)
-    Cli.run(
-      printToStdout.copy(
-        common = printToStdout.common.copy(
-          out = ps,
-          in = bais
-        )
-      ))
-    val obtained = new String(baos.toByteArray, StandardCharsets.UTF_8)
-    assertNoDiff(obtained, sbtExpected)
-    assert(obtained.size == sbtExpected.size)
-  }
-
-  test("scalafmt --test tmpFile is left unformmated") {
-    val tmpFile = Files.createTempFile("prefix", ".scala")
-    Files.write(tmpFile, unformatted.getBytes)
-    val args = Array(
-      tmpFile.toFile.getPath,
-      "--test",
-      "--config",
-      commonScalafmtConfig.toFile.getPath
-    )
-    val formatInPlace = getConfig(args)
-    val exit = Cli.run(formatInPlace)
-    assert(exit.is(ExitCode.TestError))
-    val str = FileOps.readFile(tmpFile.toString)
-    assertNoDiff(str, unformatted)
-  }
-
-  test("scalafmt foo.randomsuffix is formatted") {
-    val tmpFile = Files.createTempFile("prefix", "randomsuffix")
-    Files.write(tmpFile, unformatted.getBytes)
-    val args = Array(
-      "--config",
-      commonScalafmtConfig.toFile.getPath,
-      tmpFile.toFile.getAbsolutePath
-    )
-    Cli.exceptionThrowingMain(args)
-    val obtained = FileOps.readFile(tmpFile.toString)
-    // TODO: We need to pass customFiles information to ProjectFiles
-    assertNoDiff(obtained, formatted)
-  }
-
-  test("handles .scala, .sbt, and .sc files") {
-    val input = string2dir(
-      s"""|/foobar.scala
-          |object    A {  }
-          |/foo.sbt
-          |lazy   val x   = project
-          |/foo.sc
-          |lazy   val x   = project
-          |""".stripMargin
-    )
-    val expected =
-      s"""|/foo.sbt
-          |lazy val x = project
-          |
-          |/foo.sc
-          |lazy val x = project
-          |
-          |/foobar.scala
-          |object A {}
-          |""".stripMargin
-    val options = getConfig(
-      Array(
-        input.path,
-        "--config",
-        commonScalafmtConfig.toFile.getPath
-      )
-    )
-    Cli.run(options)
-    val obtained = dir2string(input)
-    assertNoDiff(obtained, expected)
-  }
-
-  test("excludefilters are respected") {
-    val input = string2dir(
-      s"""|/foo.sbt
-          |lazy   val x   = project
-          |
-          |/target/FormatMe.scala
-          |object    PleaseFormatMeOtherwiseIWillBeReallySad   {  }
-          |
-          |/target/nested/DoNotFormatMe.scala
-          |object    AAAAAAIgnoreME   {  }
-          |
-          |/target/nested/nested2/DoNotFormatMeToo.scala
-          |object    BBBBBBIgnoreME   {  }
-          |""".stripMargin
-    )
-    val expected =
-      s"""|/foo.sbt
-          |lazy val x = project
-          |
-          |/target/FormatMe.scala
-          |object PleaseFormatMeOtherwiseIWillBeReallySad {}
-          |
-          |/target/nested/DoNotFormatMe.scala
-          |object    AAAAAAIgnoreME   {  }
-          |
-          |/target/nested/nested2/DoNotFormatMeToo.scala
-          |object    BBBBBBIgnoreME   {  }
-          |""".stripMargin
-    val options = getConfig(
-      Array(
-        "--config",
-        commonScalafmtConfig.toFile.getPath,
-        input.path,
-        "--exclude",
-        "target/nested".asFilename
-      ))
-    Cli.run(options)
-    val obtained = dir2string(input)
-    assertNoDiff(obtained, expected)
-  }
-
-  test("scalafmt doesnotexist.scala throws error") {
-    def check(filename: String): Unit = {
+      Files.write(originalTmpFile, unformatted.getBytes)
+      Files.write(originalTmpFile2, unformatted.getBytes)
+      Files.write(scalafmtConfig, config.getBytes)
       val args = Array(
-        s"$filename.scala".asFilename,
         "--config",
-        commonScalafmtConfig.toFile.getPath
+        scalafmtConfig.toFile.getPath,
+        originalTmpFile.toFile.getPath,
+        originalTmpFile2.toFile.getPath
       )
-      intercept[IOException] {
-        Cli.exceptionThrowingMain(args)
-      }
+      val formatInPlace = getConfig(args)
+      Cli.run(formatInPlace)
+      val obtained = FileOps.readFile(originalTmpFile.toString)
+      val obtained2 = FileOps.readFile(originalTmpFile2.toString)
+      assertNoDiff(obtained, expected10)
+      assertNoDiff(obtained2, expected10)
     }
-    check("notfound")
-    check("target/notfound")
-  }
 
-  test("scalafmt (no matching files) throws error") {
-    val options = baseCliOptions.copy(config = Some(commonScalafmtConfig))
-    intercept[NoMatchingFiles.type] {
+    test(s"scalafmt --stdout tmpFile prints to stdout: $label") {
+      val originalTmpFile = Files.createTempFile("prefix", ".scala")
+      Files.write(originalTmpFile, unformatted.getBytes)
+      val args = Array(
+        "--stdout",
+        "--config-str",
+        s"""{version="$version",style=IntelliJ}""",
+        originalTmpFile.toFile.getPath
+      )
+      val baos = new ByteArrayOutputStream()
+      val ps = new PrintStream(baos)
+      val init = baseCliOptions.copy(
+        common = baseCliOptions.common.copy(out = ps)
+      )
+      val auto = Cli.getConfig(args, init).get
+      Cli.run(auto)
+      val obtained = new String(baos.toByteArray, StandardCharsets.UTF_8)
+      assertNoDiff(obtained, formatted)
+      assert(obtained.size == formatted.size)
+    }
+
+    test(s"scalafmt --stdin --assume-filename: $label") {
+      val scalafmtConfig = Files.createTempFile(".scalafmt", ".conf")
+      val config = s"""
+                      |version="$version"
+                      |maxColumn=7
+                      |style=IntelliJ
+    """.stripMargin
+      Files.write(scalafmtConfig, config.getBytes)
+
+      val args = Array(
+        "--stdin",
+        "--assume-filename",
+        "build.sbt",
+        "--config",
+        scalafmtConfig.toFile.getPath
+      )
+      val printToStdout = getConfig(args)
+      val bais = new ByteArrayInputStream(sbtOriginal.getBytes)
+      val baos = new ByteArrayOutputStream()
+      val ps = new PrintStream(baos)
+      Cli.run(
+        printToStdout.copy(
+          common = printToStdout.common.copy(
+            out = ps,
+            in = bais
+          )
+        )
+      )
+      val obtained = new String(baos.toByteArray, StandardCharsets.UTF_8)
+      assertNoDiff(obtained, sbtExpected)
+      assert(obtained.size == sbtExpected.size)
+    }
+
+    test(s"scalafmt --test tmpFile is left unformmated: $label") {
+      val tmpFile = Files.createTempFile("prefix", ".scala")
+      Files.write(tmpFile, unformatted.getBytes)
+      val args = Array(
+        tmpFile.toFile.getPath,
+        "--test",
+        "--config-str",
+        s"""{version="$version",style=IntelliJ}"""
+      )
+      val formatInPlace = getConfig(args)
+      val exit = Cli.run(formatInPlace)
+      assert(exit.is(ExitCode.TestError))
+      val str = FileOps.readFile(tmpFile.toString)
+      assertNoDiff(str, unformatted)
+    }
+
+    test(s"scalafmt foo.randomsuffix is formatted: $label") {
+      val tmpFile = Files.createTempFile("prefix", "randomsuffix")
+      Files.write(tmpFile, unformatted.getBytes)
+      val args = Array(
+        "--config-str",
+        s"""{version="$version",style=IntelliJ}""",
+        tmpFile.toFile.getAbsolutePath
+      )
+      Cli.exceptionThrowingMain(args)
+      val obtained = FileOps.readFile(tmpFile.toString)
+      // TODO: We need to pass customFiles information to ProjectFiles
+      assertNoDiff(obtained, formatted)
+    }
+
+    test(s"handles .scala, .sbt, and .sc files: $label") {
+      val input = string2dir(
+        s"""|/foobar.scala
+            |object    A {  }
+            |/foo.sbt
+            |lazy   val x   = project
+            |/foo.sc
+            |lazy   val x   = project
+            |""".stripMargin
+      )
+      val expected =
+        s"""|/foo.sbt
+            |lazy val x = project
+            |
+            |/foo.sc
+            |lazy val x = project
+            |
+            |/foobar.scala
+            |object A {}
+            |""".stripMargin
+      val options = getConfig(
+        Array(
+          input.path,
+          "--config-str",
+          s"""{version="$version",style=IntelliJ}"""
+        )
+      )
       Cli.run(options)
+      val obtained = dir2string(input)
+      assertNoDiff(obtained, expected)
     }
-  }
 
-  test("scalafmt (no matching files) is okay with --diff and --stdin") {
-    val diff = getConfig(
-      Array("--diff", "--config", commonScalafmtConfig.toFile.getPath))
-    val stdin = getConfig(
-      Array("--stdin", "--config", commonScalafmtConfig.toFile.getPath)).copy(
-      common = CommonOptions(in = new ByteArrayInputStream("".getBytes))
-    )
-    Cli.run(diff)
-    Cli.run(stdin)
-  }
+    test(s"excludefilters are respected: $label") {
+      val input = string2dir(
+        s"""|/foo.sbt
+            |lazy   val x   = project
+            |
+            |/target/FormatMe.scala
+            |object    PleaseFormatMeOtherwiseIWillBeReallySad   {  }
+            |
+            |/target/nested/DoNotFormatMe.scala
+            |object    AAAAAAIgnoreME   {  }
+            |
+            |/target/nested/nested2/DoNotFormatMeToo.scala
+            |object    BBBBBBIgnoreME   {  }
+            |""".stripMargin
+      )
+      val expected =
+        s"""|/foo.sbt
+            |lazy val x = project
+            |
+            |/target/FormatMe.scala
+            |object PleaseFormatMeOtherwiseIWillBeReallySad {}
+            |
+            |/target/nested/DoNotFormatMe.scala
+            |object    AAAAAAIgnoreME   {  }
+            |
+            |/target/nested/nested2/DoNotFormatMeToo.scala
+            |object    BBBBBBIgnoreME   {  }
+            |""".stripMargin
+      val options = getConfig(
+        Array(
+          "--config-str",
+          s"""{version="$version",style=IntelliJ}""",
+          input.path,
+          "--exclude",
+          "target/nested".asFilename
+        )
+      )
+      Cli.run(options)
+      val obtained = dir2string(input)
+      assertNoDiff(obtained, expected)
+    }
 
-  test("scalafmt (no arg) read config from git repo") {
-    val input = string2dir(
-      s"""|/foo.scala
-          |object    FormatMe {
-          |  val x = 1
-          |}
-          |/target/foo.scala
-          |object A   { }
-          |
-          |/.scalafmt.conf
-          |version = $ScalafmtVersion
-          |maxColumn = 2
-          |project.excludeFilters = [target]
-          |""".stripMargin
-    )
+    test(s"scalafmt doesnotexist.scala throws error: $label") {
+      def check(filename: String): Unit = {
+        val args = Array(
+          s"$filename.scala".asFilename,
+          "--config-str",
+          s"""{version="$version",style=IntelliJ}"""
+        )
+        intercept[IOException] {
+          Cli.exceptionThrowingMain(args)
+        }
+      }
+      check("notfound")
+      check("target/notfound")
+    }
 
-    val expected =
-      s"""|/.scalafmt.conf
-          |version = $ScalafmtVersion
-          |maxColumn = 2
-          |project.excludeFilters = [target]
-          |
-          |/foo.scala
-          |object FormatMe {
-          |  val x =
-          |    1
-          |}
-          |
-          |/target/foo.scala
-          |object A   { }
-          |""".stripMargin
-    noArgTest(
-      input,
-      expected,
-      Seq(Array.empty[String], Array("--diff"))
-    )
-  }
-  test("scalafmt (no arg, no config)") {
-    noArgTest(
-      string2dir(
-        """|/foo.scala
-           |object    FormatMe
-           |/foo.sc
-           |object    FormatMe
+    test(s"scalafmt (no matching files) throws error: $label") {
+      val scalafmtConfig: Path = Files.createTempFile(".scalafmt", ".conf")
+      val config: String = s"""
+                              |version="$version"
+               """.stripMargin
+      Files.write(scalafmtConfig, config.getBytes)
+      val options = baseCliOptions.copy(config = Some(scalafmtConfig))
+      intercept[NoMatchingFiles.type] {
+        Cli.run(options)
+      }
+    }
+
+    test(
+      s"scalafmt (no matching files) is okay with --diff and --stdin: $label") {
+      val diff = getConfig(
+        Array(
+          "--diff",
+          "--config-str",
+          s"""{version="$version",style=IntelliJ}"""
+        )
+      )
+      val stdin = getConfig(
+        Array(
+          "--stdin",
+          "--config-str",
+          s"""{version="$version",style=IntelliJ}"""
+        )
+      ).copy(
+        common = CommonOptions(in = new ByteArrayInputStream("".getBytes))
+      )
+      Cli.run(diff)
+      Cli.run(stdin)
+    }
+
+    test(s"scalafmt (no arg) read config from git repo: $label") {
+      val input = string2dir(
+        s"""|/foo.scala
+            |object    FormatMe {
+            |  val x = 1
+            |}
+            |/target/foo.scala
+            |object A   { }
+            |
+            |/.scalafmt.conf
+            |version = "$version"
+            |maxColumn = 2
+            |project.excludeFilters = [target]
+            |""".stripMargin
+      )
+
+      val expected =
+        s"""|/.scalafmt.conf
+            |version = "$version"
+            |maxColumn = 2
+            |project.excludeFilters = [target]
+            |
+            |/foo.scala
+            |object FormatMe {
+            |  val x =
+            |    1
+            |}
+            |
+            |/target/foo.scala
+            |object A   { }
+            |""".stripMargin
+      noArgTest(
+        input,
+        expected,
+        Seq(Array.empty[String], Array("--diff"))
+      )
+    }
+    test(s"scalafmt (no arg, no config): $label") {
+      noArgTest(
+        string2dir(
+          """|/foo.scala
+             |object    FormatMe
+             |/foo.sc
+             |object    FormatMe
+             |""".stripMargin
+        ),
+        """|/foo.sc
+           |object FormatMe
+           |
+           |/foo.scala
+           |object FormatMe
+           |""".stripMargin,
+        Seq(
+          Array("--config-str", s"""{version="$version"}""")
+        )
+      )
+    }
+
+    test(s"config is read even from nested dir: $label") {
+      val original = "object a { val x = 1 }"
+      val expected =
+        """|object a {
+           |  val x =
+           |    1
+           |}
            |""".stripMargin
-      ),
-      """|/foo.sc
-         |object FormatMe
-         |
-         |/foo.scala
-         |object FormatMe
-         |""".stripMargin,
-      Seq(
-        Array("--config", commonScalafmtConfig.toFile.getPath)
+      val input = string2dir(
+        s"""|/nested/foo.scala
+            |$original
+            |/.scalafmt.conf
+            |version="$version"
+            |maxColumn = 2
+            |""".stripMargin
       )
-    )
-  }
-
-  test("config is read even from nested dir") {
-    val original = "object a { val x = 1 }"
-    val expected =
-      """|object a {
-         |  val x =
-         |    1
-         |}
-         |""".stripMargin
-    val input = string2dir(
-      s"""|/nested/foo.scala
-          |$original
-          |/.scalafmt.conf
-          |version=$ScalafmtVersion
-          |maxColumn = 2
-          |""".stripMargin
-    )
-    val workingDir = input / "nested"
-    val options: CliOptions = {
-      val mock = getMockOptions(input, workingDir)
-      mock.copy(common = mock.common.copy(workingDirectory = workingDir))
+      val workingDir = input / "nested"
+      val options: CliOptions = {
+        val mock = getMockOptions(input, workingDir)
+        mock.copy(common = mock.common.copy(workingDirectory = workingDir))
+      }
+      val config = Cli.getConfig(Array("foo.scala"), options).get
+      Cli.run(config)
+      val obtained = FileOps.readFile(workingDir / "foo.scala")
+      assertNoDiff(obtained, expected)
     }
-    val config = Cli.getConfig(Array("foo.scala"), options).get
-    Cli.run(config)
-    val obtained = FileOps.readFile(workingDir / "foo.scala")
-    assertNoDiff(obtained, expected)
-  }
 
-  test(
-    "if project.includeFilters isn't modified (and files aren't passed manually), it should ONLY accept scala and sbt files") {
+    test(
+      s"if project.includeFilters isn't modified (and files aren't passed manually), it should ONLY accept scala and sbt files: $label"
+    ) {
+      val root =
+        string2dir(
+          s"""
+             |/scalafmt.conf
+             |style = default
+             |version="$version"
+             |/scalafile.scala
+             |$unformatted
+             |/scalatex.scalatex
+             |$unformatted
+             |/sbt.sbt
+             |$sbtOriginal
+             |/sbt.sbtfile
+             |$sbtOriginal""".stripMargin
+        )
 
-    val root =
-      string2dir(
-        s"""
-           |/scalafmt.conf
-           |style = default
-           |version = $ScalafmtVersion
-           |/scalafile.scala
-           |$unformatted
-           |/scalatex.scalatex
-           |$unformatted
-           |/sbt.sbt
-           |$sbtOriginal
-           |/sbt.sbtfile
-           |$sbtOriginal""".stripMargin
-      )
+      val config = root / "scalafmt.conf"
+      val args = mkArgs(s"--config $config")
+      val opts = getMockOptions(root)
 
-    val config = root / "scalafmt.conf"
-    val args = mkArgs(s"--config $config")
-    val opts = getMockOptions(root)
+      val conf = Cli.getConfig(args, opts)
+      Cli.run(conf.get)
 
-    val conf = Cli.getConfig(args, opts)
-    Cli.run(conf.get)
+      assertNoDiff(root / "scalatex.scalatex", unformatted)
+      assertNoDiff(root / "sbt.sbtfile", sbtOriginal)
 
-    assertNoDiff(root / "scalatex.scalatex", unformatted)
-    assertNoDiff(root / "sbt.sbtfile", sbtOriginal)
+      assertNoDiff(root / "scalafile.scala", formatted)
+      val sbtFormatted =
+        """|lazy val x = project
+           |lazy val y = project
+           |""".stripMargin
+      assertNoDiff(root / "sbt.sbt", sbtFormatted)
+    }
 
-    assertNoDiff(root / "scalafile.scala", formatted)
-    val sbtFormatted =
-      """|lazy val x = project
-         |lazy val y = project
-         |""".stripMargin
-    assertNoDiff(root / "sbt.sbt", sbtFormatted)
-  }
+    test(
+      s"includeFilters are ignored for full paths but NOT ignore for passed directories: $label"
+    ) {
+      val root =
+        string2dir(
+          s"""
+             |/inner/file1.scala
+             |$unformatted
+             |/inner2/file2.scalahala
+             |$unformatted
+             |/inner2/file3.scalahala
+             |$unformatted""".stripMargin
+        )
+      val inner1 = root / "inner"
+      val inner2 = root / "inner2"
+      val full = inner2 / "file3.scalahala"
 
-  test(
-    "includeFilters are ignored for full paths but NOT ignore for passed directories") {
+      runWith(
+        root,
+        s"""--config-str {version="$version"} $inner1 $inner2 $full""")
 
-    val root =
-      string2dir(
-        s"""
-           |/inner/file1.scala
-           |$unformatted
-           |/inner2/file2.scalahala
-           |$unformatted
-           |/inner2/file3.scalahala
-           |$unformatted""".stripMargin
-      )
-    val inner1 = root / "inner"
-    val inner2 = root / "inner2"
-    val full = inner2 / "file3.scalahala"
+      assertNoDiff(inner1 / "file1.scala", formatted)
+      assertNoDiff(inner2 / "file2.scalahala", unformatted)
+      assertNoDiff(full, formatted)
+    }
 
-    runWith(
-      root,
-      s"--config ${commonScalafmtConfig.toFile.getPath} $inner1 $inner2 $full")
-
-    assertNoDiff(inner1 / "file1.scala", formatted)
-    assertNoDiff(inner2 / "file2.scalahala", unformatted)
-    assertNoDiff(full, formatted)
-  }
-
-  test("--config accepts absolute paths") {
-    val root = string2dir(
-      s"""/scalafmt.conf
-         |version = $ScalafmtVersion
-         |style = intellij
-         |/foo.scala
-         |object    A
+    test(s"--config accepts absolute paths: $label") {
+      val root = string2dir(
+        s"""/scalafmt.conf
+           |version = "$version"
+           |style = intellij
+           |/foo.scala
+           |object    A
       """.stripMargin
-    )
-    val config = (root / "scalafmt.conf").path
-    val toFormat = (root / "foo.scala").path
-    val args = Array[String](
-      "--config",
-      config,
-      toFormat
-    )
-    Cli.exceptionThrowingMain(args) // runs without errors
-    val obtained = FileOps.readFile(toFormat)
-    assertNoDiff(obtained, "object A\n")
-  }
+      )
+      val config = (root / "scalafmt.conf").path
+      val toFormat = (root / "foo.scala").path
+      val args = Array[String](
+        "--config",
+        config,
+        toFormat
+      )
+      Cli.exceptionThrowingMain(args) // runs without errors
+      val obtained = FileOps.readFile(toFormat)
+      assertNoDiff(obtained, "object A\n")
+    }
 
-  // These are tests for deprecated flags
-  test("scalafmt -i -f file1,file2,file3 should still work") {
+    // These are tests for deprecated flags
+    test(s"scalafmt -i -f file1,file2,file3 should still work: $label") {
+      val file1 = Files.createTempFile("prefix", ".scala")
+      val file2 = Files.createTempFile("prefix2", ".scala")
+      val file3 = Files.createTempFile("prefix3", ".scala")
+      Files.write(file1, unformatted.getBytes)
+      Files.write(file2, unformatted.getBytes)
+      Files.write(file3, unformatted.getBytes)
+      def fileStr(fs: Path*) = fs.map(_.toFile.getPath).mkString(",")
+      val args = Array(
+        "--config-str",
+        s"""{version="$version",style=IntelliJ}""",
+        "-i",
+        "-f",
+        fileStr(file1, file2, file3)
+      )
+      val formatInPlace = getConfig(args)
+      Cli.run(formatInPlace)
+      val obtained = FileOps.readFile(file1.toString)
+      val obtained2 = FileOps.readFile(file2.toString)
+      val obtained3 = FileOps.readFile(file3.toString)
+      assertNoDiff(obtained, formatted)
+      assertNoDiff(obtained2, formatted)
+      assertNoDiff(obtained3, formatted)
+    }
 
-    val file1 = Files.createTempFile("prefix", ".scala")
-    val file2 = Files.createTempFile("prefix2", ".scala")
-    val file3 = Files.createTempFile("prefix3", ".scala")
-    Files.write(file1, unformatted.getBytes)
-    Files.write(file2, unformatted.getBytes)
-    Files.write(file3, unformatted.getBytes)
-    def fileStr(fs: Path*) = fs.map(_.toFile.getPath).mkString(",")
-    val args = Array(
-      "--config",
-      commonScalafmtConfig.toFile.getPath,
-      "-i",
-      "-f",
-      fileStr(file1, file2, file3)
-    )
-    val formatInPlace = getConfig(args)
-    Cli.run(formatInPlace)
-    val obtained = FileOps.readFile(file1.toString)
-    val obtained2 = FileOps.readFile(file2.toString)
-    val obtained3 = FileOps.readFile(file3.toString)
-    assertNoDiff(obtained, formatted)
-    assertNoDiff(obtained2, formatted)
-    assertNoDiff(obtained3, formatted)
-  }
-
-  test("parse error is formatted nicely") {
-    val input =
-      """|/foo.scala
-         |object    A { foo( }
-         |""".stripMargin
-    noArgTest(
-      string2dir(input),
-      input,
-      Seq(Array("--config", commonScalafmtConfig.toFile.getPath)),
-      assertExit = { exit =>
-        assert(exit.is(ExitCode.ParseError))
-      },
-      assertOut = out => {
-        assert(
-          out.contains(
-            """foo.scala:1: error: illegal start of simple expression
-              |object    A { foo( }
-              |                   ^""".stripMargin
+    test(s"parse error is formatted nicely: $label") {
+      val input =
+        """|/foo.scala
+           |object    A { foo( }
+           |""".stripMargin
+      noArgTest(
+        string2dir(input),
+        input,
+        Seq(
+          Array(
+            "--config-str",
+            s"""{version="$version",style=IntelliJ}"""
           )
-        )
-      }
-    )
-  }
-
-  test("command line argument error") {
-    val exit = Cli.mainWithOptions(
-      Array("--foobar"),
-      getMockOptions(AbsoluteFile.userDir)
-    )
-    assert(exit.is(ExitCode.CommandLineArgumentError), exit)
-  }
-
-  test("--test failure prints out unified diff") {
-    val input =
-      s"""|/.scalafmt.conf
-          |onTestFailure = "To fix this ..."
-          |version = $ScalafmtVersion
-          |
-          |/foo.scala
-          |object    A { }
-          |""".stripMargin
-    noArgTest(
-      string2dir(input),
-      input,
-      Seq(Array("--test")),
-      assertExit = { exit =>
-        assert(exit.is(ExitCode.TestError))
-      },
-      assertOut = out => {
-        assert(
-          out.contains(
-            """|foo.scala-formatted
-               |@@ -1,1 +1,1 @@
-               |-object    A { }
-               |+object A {}
-               |error: --test failed
-               |To fix this ...""".stripMargin
-          )
-        )
-      }
-    )
-  }
-
-  test("--test succeeds even with parse error") {
-    val input =
-      """|/foo.scala
-         |object A {
-         |""".stripMargin
-    noArgTest(
-      string2dir(input),
-      input,
-      Seq(Array("--test", "--config", commonScalafmtConfig.toFile.getPath)),
-      assertExit = { exit =>
-        assert(exit.isOk)
-      },
-      assertOut = out => {
-        println(s"succeed: $out")
-        assert(
-          out.contains(
-            "foo.scala:2: error: } expected but end of file found"
-          ) &&
+        ),
+        assertExit = { exit =>
+          assert(exit.is(ExitCode.ParseError))
+        },
+        assertOut = out => {
+          assert(
             out.contains(
+              """foo.scala:1: error: illegal start of simple expression
+                |object    A { foo( }
+                |                   ^""".stripMargin
+            )
+          )
+        }
+      )
+    }
+
+    test(s"command line argument error: $label") {
+      val exit = Cli.mainWithOptions(
+        Array("--foobar"),
+        getMockOptions(AbsoluteFile.userDir)
+      )
+      assert(exit.is(ExitCode.CommandLineArgumentError), exit)
+    }
+
+    test(s"--test failure prints out unified diff: $label") {
+      val input =
+        s"""|/.scalafmt.conf
+            |onTestFailure = "To fix this ..."
+            |version = "$version"
+            |
+            |/foo.scala
+            |object    A { }
+            |""".stripMargin
+      noArgTest(
+        string2dir(input),
+        input,
+        Seq(Array("--test")),
+        assertExit = { exit =>
+          assert(exit.is(ExitCode.TestError))
+        },
+        assertOut = out => {
+          assert(
+            out.contains(
+              """|foo.scala-formatted
+                 |@@ -1,1 +1,1 @@
+                 |-object    A { }
+                 |+object A {}
+                 |error: --test failed
+                 |To fix this ...""".stripMargin
+            )
+          )
+        }
+      )
+    }
+
+    test(s"--test succeeds even with parse error: $label") {
+      val input =
+        """|/foo.scala
+           |object A {
+           |""".stripMargin
+      noArgTest(
+        string2dir(input),
+        input,
+        Seq(Array("--test", "--config-str", s"""{version="$version"}""")),
+        assertExit = { exit =>
+          assert(exit.isOk)
+        },
+        assertOut = out => {
+          println(s"succeed: $out")
+          assert(
+            out.contains(
+              "foo.scala:2: error: } expected but end of file found"
+            ) &&
+              out.contains(
+                "error: ParseError=2"
+              )
+          )
+        }
+      )
+    }
+
+    test(s"--test fails with parse error if fatalWarnings=true: $label") {
+      val input =
+        s"""|/.scalafmt.conf
+            |runner.fatalWarnings = true
+            |version = "$version"
+            |/foo.scala
+            |object A {
+            |""".stripMargin
+      noArgTest(
+        string2dir(input),
+        input,
+        Seq(Array("--test")),
+        assertExit = { exit =>
+          assert(exit == ExitCode.ParseError)
+        },
+        assertOut = out => {
+          assert(
+            out.contains(
+              "foo.scala:2: error: } expected but end of file found"
+            ) && out.contains(
               "error: ParseError=2"
             )
-        )
-      }
-    )
-  }
-
-  test("--test fails with parse error if fatalWarnings=true") {
-    val input =
-      s"""|/.scalafmt.conf
-          |runner.fatalWarnings = true
-          |version = $ScalafmtVersion
-          |/foo.scala
-          |object A {
-          |""".stripMargin
-    noArgTest(
-      string2dir(input),
-      input,
-      Seq(Array("--test")),
-      assertExit = { exit =>
-        assert(exit == ExitCode.ParseError)
-      },
-      assertOut = out => {
-        assert(
-          out.contains(
-            "foo.scala:2: error: } expected but end of file found"
-          ) && out.contains(
-            "error: ParseError=2"
           )
-        )
-      }
-    )
-  }
+        }
+      )
+    }
 
-  test("exception is thrown on invalid .scalafmt.conf") {
-    val input =
-      s"""/.scalafmt.conf
-         |version=$ScalafmtVersion
-         |blah = intellij
-         |/foo.scala
-         |object A {}
+    test(s"exception is thrown on invalid .scalafmt.conf: $label") {
+      val input =
+        s"""/.scalafmt.conf
+           |version="$version"
+           |blah = intellij
+           |/foo.scala
+           |object A {}
       """.stripMargin
-    noArgTest(
-      string2dir(input),
-      input,
-      Seq(Array.empty),
-      assertExit = { exit =>
-        assert(exit == ExitCode.UnexpectedError)
-      },
-      assertOut = out => {
-        assert(
-          out.contains(
-            "Invalid field: blah"
+      noArgTest(
+        string2dir(input),
+        input,
+        Seq(Array.empty),
+        assertExit = { exit =>
+          assert(exit == ExitCode.UnexpectedError)
+        },
+        assertOut = out => {
+          assert(
+            out.contains(
+              "Invalid field: blah"
+            )
           )
-        )
-      }
-    )
-  }
+        }
+      )
+    }
 
-  test("eof") {
-    val in = Files.createTempFile("scalafmt", "Foo.scala")
-    Files.write(in, "object A".getBytes(StandardCharsets.UTF_8))
-    val exit = Cli.mainWithOptions(Array(in.toString), CliOptions.default)
-    assert(exit.isOk)
-    val obtained = new String(Files.readAllBytes(in), StandardCharsets.UTF_8)
-    assert(obtained == "object A\n")
+    test(s"eof: $label") {
+      val in = Files.createTempFile("scalafmt", "Foo.scala")
+      Files.write(in, "object A".getBytes(StandardCharsets.UTF_8))
+      val exit = Cli.mainWithOptions(Array(in.toString), CliOptions.default)
+      assert(exit.isOk)
+      val obtained = new String(Files.readAllBytes(in), StandardCharsets.UTF_8)
+      assert(obtained == "object A\n")
+    }
+
+    test(s"--config-str should be used if it is specified: $label") {
+      val expected = "This message should be shown"
+      val unexpected = "This message should not be shown"
+      val input =
+        s"""|/.scalafmt.conf
+            |onTestFailure = "$unexpected"
+            |version = "$version"
+            |
+            |/foo.scala
+            |object      A { }
+            |""".stripMargin
+      noArgTest(
+        string2dir(input),
+        input,
+        Seq(
+          Array(
+            "--config-str",
+            s"""{version="$version",onTestFailure="$expected"}""",
+            "--test")),
+        assertExit = { exit =>
+          assert(exit.is(ExitCode.TestError))
+        },
+        assertOut = out => {
+          assert(
+            out.contains(expected) &&
+              !out.contains(unexpected)
+          )
+        }
+      )
+    }
   }
+}
+
+class CliTest extends AbstractCliTest with CliTestBehavior {
+  testsFor(testCli("1.6.0-RC4")) // test for runDynamic
+  testsFor(testCli(Versions.version)) // test for runScalafmt
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FileTestOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FileTestOps.scala
@@ -1,6 +1,6 @@
 package org.scalafmt.cli
 
-import java.io.File
+import java.io.{File, PrintStream}
 import java.nio.file.Files
 
 import org.scalafmt.util.AbsoluteFile
@@ -46,4 +46,27 @@ object FileTestOps {
       .replace(File.separator, "/") // ensure original separators
   }
 
+  def getMockOptions(baseDir: AbsoluteFile): CliOptions =
+    getMockOptions(baseDir, baseDir)
+
+  def getMockOptions(
+      baseDir: AbsoluteFile,
+      workingDir: AbsoluteFile,
+      out: PrintStream = System.out
+  ): CliOptions = {
+    CliOptions.default.copy(
+      gitOpsConstructor = _ => new FakeGitOps(baseDir),
+      common = CliOptions.default.common.copy(
+        workingDirectory = workingDir,
+        out = out,
+        err = out
+      )
+    )
+  }
+
+  val baseCliOptions: CliOptions = getMockOptions(
+    AbsoluteFile
+      .fromPath(Files.createTempDirectory("base-dir").toString)
+      .get
+  )
 }


### PR DESCRIPTION
This PR makes scalafmt-cli to use `scalafmt-dynamic` and enable it to switch scalafmt version using `version` setting in a `.scalafmt.conf`.

## Related issue
https://github.com/scalameta/scalafmt/issues/1318

## Changed behaviors
### Remove `--config-str` option
Since `scalafmt-interface#format` receive the config as `Path`, we cannot parse the config on the client side as long as we use `scalafmt-dynamic` as a backend.

### When missing `.scalafmt.conf
If scalafmt couldn't find `.scalafmt.conf` the following message will appear repeatedly.

```
file does not exist: /home/tanishiking/dev/src/github.com/scalacenter/scalafix/.scalafmt.conf
```

### When .scalafmt.conf missing `version` setting
If `.scalafmt.conf` doesn't contain `version` setting, scalafmt will tell the following message repeatedly. ( this warning will appear every time scalafmt-cli try to format a file)


```
missing setting 'version'. To fix this problem, add the following line to .scalafmt.conf: 'version=1.6.0-RC4'.: /home/tanishiking/dev/src/github.com/scalacenter/scalafix/.scalafmt.conf
```

### When failed to parse config
Some error message like the following one will appear repeatedly

```
Invalid fields: gt: /home/tanishiking/dev/src/github.com/scalacenter/scalafix/.scalafmt.conf
```




## Testing performance and diff
I built a new version of CLI and tested on some repositories.

```
$ sbt:scalafmtRoot> publishLocal
...
$ coursier bootstrap -f org.scalameta:scalafmt-cli_2.12:1.6.0-RC4+...-SNAPSHOT -o scalafmtCli --main org.scalafmt.cli.Cli
```

- Performance: Unfortunately, a new version of scalafmt-cli is slower than the previous scalafmt-cli because the previous one pre-resolved the scalafmt jar.
- diff: `scalafmtCli` (that use the 1.5.1 version of scalafmt) doesn't cause any diff with the former version of scalafmt(1.5.1). :+1:


<details>
<summary>Tested on scalafix</summary>

```
[tanishiking] ~/dev/src/github.com/tanishiking/scalafix
$ ./scalafmt --version
scalafmt 1.5.1

[tanishiking] ~/dev/src/github.com/scalacenter/scalafix
$ /usr/bin/time ./scalafmt
25.62user 0.53system 0:04.20elapsed 621%CPU (0avgtext+0avgdata 821168maxresident)k
0inputs+64outputs (0major+210917minor)pagefaults 0swaps
```



```
[tanishiking] ~/dev/src/github.com/scalacenter/scalafix
$ git diff -u
diff --git a/.scalafmt.conf b/.scalafmt.conf
index ea1573f6..8dc55bab 100644
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version = 1.5.1
 project.git = true
 docstrings = Javadoc
 optIn.blankLineBeforeDocstring = true

[tanishiking] ~/dev/src/github.com/scalacenter/scalafix
$ /usr/bin/time ./scalafmtCli
Reformatting...
  100.0% [##########] 399 source files formatted
28.40user 0.42system 0:08.60elapsed 334%CPU (0avgtext+0avgdata 657196maxresident)k
0inputs+2424outputs (0major+175552minor)pagefaults 0swaps

[tanishiking] ~/dev/src/github.com/scalacenter/scalafix
$ ./scalafmtCli --test
Looking for unformatted files...
  100.0% [##########] 399 source files formatted
All files are formatted with scalafmt :)

```

</details>

<details>
<summary>Tested on scalafmt</summary>

fat jar

```
[tanishiking] ~/dev/src/github.com/tanishiking/scalafmt
$ ./scalafmt --version
scalafmt 1.5.1

[tanishiking] ~/dev/src/github.com/tanishiking/scalafmt
$ /usr/bin/time ./scalafmt
25.14user 0.53system 0:04.78elapsed 537%CPU (0avgtext+0avgdata 691688maxresident)k
9384inputs+64outputs (1major+173936minor)pagefaults 0swaps
```

dynamic

```
[tanishiking] ~/dev/src/github.com/tanishiking/scalafmt
$ git diff -u
diff --git a/.scalafmt.conf b/.scalafmt.conf
index f93f7ae3..06c8cefd 100644
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=1.6.0-RC4
+version=1.5.1
 project.git = true
 project.excludeFilters = [
   scalafmt-benchmarks/src/resources,

[tanishiking] ~/dev/src/github.com/tanishiking/scalafmt
$ /usr/bin/time ./scalafmtCli
Reformatting...
  100.0% [##########] 425 source files formatted
25.48user 0.44system 0:07.66elapsed 338%CPU (0avgtext+0avgdata 680364maxresident)k
20808inputs+2464outputs (2major+176225minor)pagefaults 0swaps

[tanishiking] ~/dev/src/github.com/tanishiking/scalafmt
$ ./scalafmtCli --test
Looking for unformatted files...
  100.0% [##########] 425 source files formatted
All files are formatted with scalafmt :)

```

</details>

## Future TODO (in another PR)
### Separate scalafmt.util from scalafmt-core
Though scalafmt-cli successfully stops to depend on a specific version of scalafmt, scalafmt-cli still depends on scalafmt-core because scalafmt-cli uses modules in `scalafmt.util` which is located in scalafmt-core.
I believe that removing scalafmt-core from scalafmt-cli will reduce the binary size of scalafmt (command).

### Remove Scalafmt210 ?
Should we leave Scalafmt210 module that depends on scalafmt-core?
As long as I know, no module depends on this.

