### PR TITLE
Add a format(String config, ...) method to scalafmt-interface

### DIFF
--- a/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/Scalafmt.java
+++ b/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/Scalafmt.java
@@ -39,6 +39,17 @@ public interface Scalafmt {
      */
     String format(Path config, Path file, String code);
 
+    /**
+     * Format a single file with the given configuration defined as a string.
+     *
+     * @param config the configuration for scalafmt defined as a string.
+     * @param file relative or absolute path to the file being formatted. Used only for the path
+     *             name, the file does not have to exist on disk.
+     * @param code the text contents to format.
+     * @return the formatted contents if formatting was successful, otherwise the original text
+     * contents.
+     */
+    String format(String config, Path file, String code);
 
     /**
      * Whether to respect the 'project.{excludeFilters,includeFilters}' setting in .scalafmt.conf.


### PR DESCRIPTION
This PR adds a method `String format(String config, Path file, String code)` to `scalafmt-interface` (and scalafmt-dynamic) so that we can continue to support `--config-str` option of scalafmt-cli
when it begins to use scalafmt-dynamic module.
See: https://github.com/scalameta/scalafmt/pull/1366#issuecomment-461782061