### PR TITLE
Indent Operator Fix

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -504,7 +504,15 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       formatToken.between,
       rightIsComment = formatToken.right.isInstanceOf[Comment])
     val indent = {
-      if ((style.unindentTopLevelOperators ||
+      if (style.unindentTopLevelOperators &&
+        !isTopLevelInfixApplication(owner) &&
+        style.indentOperator.includeRegexp
+          .findFirstIn(formatToken.left.syntax)
+          .isDefined &&
+        style.indentOperator.excludeRegexp
+          .findFirstIn(formatToken.left.syntax)
+          .isEmpty) 2
+      else if ((style.unindentTopLevelOperators ||
         isTopLevelInfixApplication(owner)) &&
         (style.indentOperator.includeRegexp
           .findFirstIn(op.tokens.head.syntax)

--- a/scalafmt-tests/src/test/resources/test/UnindentTopLevelOperatorsOperatorSpray.stat
+++ b/scalafmt-tests/src/test/resources/test/UnindentTopLevelOperatorsOperatorSpray.stat
@@ -15,6 +15,12 @@ object TestRoutes {
       3 \
       4
 
+      val foo = 1 +
+      2 -
+      2 *
+      3 \
+      4
+
       a >
       b
 
@@ -51,6 +57,12 @@ object TestRoutes {
     2 *
     3 \
     4
+
+    val foo = 1 +
+      2 -
+      2 *
+      3 \
+      4
 
     a >
     b
@@ -94,24 +106,24 @@ object TestRoutes {
       ???
     }
 }
-<<< #848 known limitation - right-hand side of assignment is unindented
+<<< #848
   val x =
   1 +
   2 +
   3
 >>>
 val x =
-1 +
-2 +
-3
-<<< #848 known limitation 2 - right-hand side of assignment is unindented
+  1 +
+  2 +
+  3
+<<< #848 Test 2
   val x = 1 +
   2 +
   3
 >>>
 val x = 1 +
-2 +
-3
+  2 +
+  3
 <<< #1223 assignment + regular application
 val x = a + B(
     a,
@@ -119,22 +131,22 @@ val x = a + B(
 )
 >>>
 val x = a + B(
-  a,
-  2
-)
-<<< #1223 assignment + right-associative + regular application
+    a,
+    2
+  )
+<<< #1223 assignment + right-associative
 val x = a :: B(
     a,
     2
 )
 >>>
 val x = a :: B(
-  a,
-  2
-)
-<<< #1282 known limitation - counter-example why PR insufficient
+    a,
+    2
+  )
+<<< #1282
 val x = 1 + 2 +
   3
 >>>
 val x = 1 + 2 +
-3
+  3


### PR DESCRIPTION
This builds ontop of vanilla tests https://github.com/scalameta/scalafmt/pull/1371 to show the desired behavior changes.  The updated code makes the `unindentTopLevelOperators` consistent with the `style.indentOperator .includeRegexp` and `style. indentOperator.excludeRegExp`