### PR TITLE
Avoid newlines after yield keyword.

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -77,6 +77,24 @@ import metaconfig.generic.Surface
   *         .flatMap(f)
   *         .map(g)
   *   }}}
+  * @param avoidAfterYield
+  *   If false (legacy behavior), inserts unconditional line break after `yield`
+  *   if the yield body doesn't fit on a single line.
+  *   For example,
+  *   {{{
+  *     // newlines.avoidAfterYield = true (default)
+  *     for (a <- as)
+  *     yield Future {
+  *       ...
+  *     }
+  *
+  *     // newlines.avoidAfterYield = false (default before v2).
+  *     for (a <- as)
+  *     yield
+  *       Future {
+  *         ...
+  *       }
+  *   }}}
   */
 case class Newlines(
     neverInResultType: Boolean = false,
@@ -91,7 +109,8 @@ case class Newlines(
     @deprecated("Use VerticalMultiline.newlineBeforeImplicitKW instead")
     beforeImplicitKWInVerticalMultiline: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
-    alwaysBeforeMultilineDef: Boolean = true
+    alwaysBeforeMultilineDef: Boolean = true,
+    avoidAfterYield: Boolean = true,
 ) {
   val reader: ConfDecoder[Newlines] = generic.deriveDecoder(this).noTypos
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -110,7 +110,7 @@ case class Newlines(
     beforeImplicitKWInVerticalMultiline: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
-    avoidAfterYield: Boolean = true,
+    avoidAfterYield: Boolean = true
 ) {
   val reader: ConfDecoder[Newlines] = generic.deriveDecoder(this).noTypos
 }

--- a/scalafmt-tests/src/test/resources/default/Unindent.stat
+++ b/scalafmt-tests/src/test/resources/default/Unindent.stat
@@ -224,11 +224,10 @@ assertEquals(1, ((NoContext: Any) match {
         b sort {
           BSONDocument(
               (for (sorter ← sorters)
-                yield
-                  sorter._1 -> BSONInteger(sorter._2 match {
-                    case api.SortOrder.Ascending => 1
-                    case api.SortOrder.Descending => -1
-                  })).toStream)
+                yield sorter._1 -> BSONInteger(sorter._2 match {
+                  case api.SortOrder.Ascending => 1
+                  case api.SortOrder.Descending => -1
+                })).toStream)
         }
       }
     }

--- a/scalafmt-tests/src/test/resources/test/IndentYieldKeyword.stat
+++ b/scalafmt-tests/src/test/resources/test/IndentYieldKeyword.stat
@@ -47,11 +47,26 @@ yield
 >>>
 val sizes =
   for (row <- table)
+  yield (for (cell <- row)
+         yield
+           if (cell == null) 0
+           else cell.toString.length)
+<<< break before `for` 2
+val sizes = for (row <- table) yield (
+  for (cell <- row)
   yield
-    (for (cell <- row)
-     yield
-       if (cell == null) 0
-       else cell.toString.length)
+    if (cell == null) 0
+    else cell.toString.length
+)
+>>>
+val sizes =
+  for (row <- table)
+  yield (
+    for (cell <- row)
+    yield
+      if (cell == null) 0
+      else cell.toString.length
+  )
 <<< normal way #592
 val sizes = for (row <- table) yield {
     for (cell <- row)

--- a/scalafmt-tests/src/test/resources/unit/For.stat
+++ b/scalafmt-tests/src/test/resources/unit/For.stat
@@ -23,12 +23,28 @@ row <- table) yield ( for (
 cell <- row) yield if (cell == null) 0
 else cell.toString.length)
 >>>
-val sizes = for (row <- table)
-  yield
-    (for (cell <- row)
+val sizes =
+  for (row <- table)
+    yield (for (cell <- row)
       yield
         if (cell == null) 0
         else cell.toString.length)
+<<< crazy one-liner 2
+val sizes = for (row <- table) yield (
+  for (cell <- row)
+  yield
+    if (cell == null) 0
+    else cell.toString.length
+)
+>>>
+val sizes =
+  for (row <- table)
+    yield (
+        for (cell <- row)
+          yield
+            if (cell == null) 0
+            else cell.toString.length
+    )
 <<< if singleline
 val k = for {
     _ <- Future(1) if !onlyOne
@@ -158,6 +174,56 @@ for {
 } yield {
   thing(i, j)
 }
+<<< scala.js codingstyle val
+val x = for {
+  i <- 0 until n
+  j <- 0 until i
+} yield {
+  thing(i, j)
+}
+>>>
+val x = for {
+  i <- 0 until n
+  j <- 0 until i
+} yield {
+  thing(i, j)
+}
+<<< scala.js codingstyle val 2
+val x = (for {
+  i <- 0 until n
+  j <- 0 until i
+} yield {
+  thing(i, j)
+}).headOption
+>>>
+val x = (for {
+  i <- 0 until n
+  j <- 0 until i
+} yield {
+  thing(i, j)
+}).headOption
+<<< scala.js codingstyle val 3
+val x = for {
+  i <- 0 until n
+  j <- 0 until i
+} yield List(1)
+  .map(i => i + 1)
+  .foo(
+      a,
+      b,
+      c
+  )
+>>>
+val x = for {
+  i <- 0 until n
+  j <- 0 until i
+} yield List(1)
+  .map(i => i + 1)
+  .foo(
+      a,
+      b,
+      c
+  )
 <<< alignByArrowEnumeratorGenerator
 for {
   x <- new Integer {


### PR DESCRIPTION
```scala
// Before
for (a <- as)
yield
  Future {
    // ...
  }
// After
for (a <- as)
yield Future {
  // ...
}
```

It's possible to get the old behavior with `newlines.avoidAfterYield = false`.

While working on this change, I observed that
`style.indentYieldKeyword=true` (default) has undesirable (and
unexpected) behavior for val definitions.
```scala
// Before
val x = for (a <- as)
  yield a
// After
val x =
  for (a <- as)
    yield a
```
The new behavior is more consistent with how we handle other val
definition bodies. By forcing a line break before `for`, we make
it easier to associate the `for` keyword with its accompanying `yield`.