### PR TITLE
Replace slash with two backslashes on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ build_script:
   - sbt downloadIdea tests/compile
 
 test_script:
+  - sbt coreJVM/test
   - sbt ci-test
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,29 @@
-version: '{build}'
-os: Windows Server 2012
+image:
+- Visual Studio 2017
+build: off
+
+init:
+  - git config --global core.autocrlf input
+
 install:
   - ps: iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
   - ps: scoop bucket add versions
-  - ps: scoop install sbt0.13
+  - ps: scoop install sbt
+  - SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g -Dsbt.supershell=never -Dfile.encoding=UTF8
+
 environment:
-  CI_SCALA_VERSION: 2.12.2
+  CI_SCALA_VERSION: 2.12.8
+
 build_script:
   - sbt downloadIdea tests/compile
+
 test_script:
-  - sbt tests/test
+  - sbt ci-test
+
 cache:
-  - C:\Users\appveyor\.m2
-  - C:\Users\appveyor\.ivy2
-  - C:\Users\appveyor\.coursier
-  - C:\Users\appveyor\scoop\cache
+  - '%USERPROFILE%\.m2'
+  - '%USERPROFILE%\.ivy2\cache'
+  - '%USERPROFILE%\.sbt'
+  - '%USERPROFILE%\.coursier'
+  - '%USERPROFILE%\scoop\cache'
   - scalafmt-intellij\idea

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/OsSpecific.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/OsSpecific.scala
@@ -7,8 +7,10 @@ object OsSpecific {
     // on Node.js + Window and also in the browser.
     java.io.File.separatorChar == '\\'
 
+  // We need double backslashes here because Regex needs to be escaped.
   def fixSeparatorsInPathPattern(unixSpecificPattern: String): String =
-    unixSpecificPattern.replace('/', java.io.File.separatorChar)
+    if (isWindows) unixSpecificPattern.replaceAllLiterally("/", "\\\\")
+    else unixSpecificPattern
 
   implicit class XtensionStringAsFilename(string: String) {
     def asFilename: String = fixSeparatorsInPathPattern(string)

--- a/scalafmt-core/shared/src/test/scala/org/scalafmt/ScalafmtConfigTest.scala
+++ b/scalafmt-core/shared/src/test/scala/org/scalafmt/ScalafmtConfigTest.scala
@@ -8,14 +8,14 @@ class ScalafmtConfigTest extends org.scalatest.FunSuite {
         """
           |project.excludeFilters = [
           |  "scalafmt-benchmarks/src/resources"
-          |  "sbt-test"
+          |  "/sbt-test/"
           |  "bin/issue"
           |]
       """.stripMargin
       )
       .get
     assert(config.project.matcher.matches("qux/Kazbar.scala"))
-    assert(!config.project.matcher.matches("sbt-test/src/main"))
+    assert(!config.project.matcher.matches("foo/sbt-test/src/main"))
   }
 
 }


### PR DESCRIPTION
Fixes #1404

I tested this on AppVeyor.

## before

```
[info] ScalafmtConfigTest:
[info] - project.matcher *** FAILED ***
[info]   java.util.regex.PatternSyntaxException: Illegal/unsupported escape sequence near index 50
[info] (scalafmt-benchmarks\src\resources|\sbt-test\|bin\issue)
[info]                                                   ^
[info]   at java.util.regex.Pattern.error(Pattern.java:1957)
[info]   at java.util.regex.Pattern.escape(Pattern.java:2473)
[info]   at java.util.regex.Pattern.atom(Pattern.java:2200)
[info]   at java.util.regex.Pattern.sequence(Pattern.java:2132)
[info]   at java.util.regex.Pattern.expr(Pattern.java:1998)
[info]   at java.util.regex.Pattern.group0(Pattern.java:2907)
[info]   at java.util.regex.Pattern.sequence(Pattern.java:2053)
[info]   at java.util.regex.Pattern.expr(Pattern.java:1998)
[info]   at java.util.regex.Pattern.compile(Pattern.java:1698)
[info]   at java.util.regex.Pattern.<init>(Pattern.java:1351)
[info]   ...
[info] ScalafmtRunnerTest:
[info] - sbt dialect supports trailing commas
[info] ScalafmtTest:
[info] - ¶object∙A∙∙∙∙{∙∙println∙∙∙("HE
[info] - object∙A∙{¶∙∙val∙x∙=∙2¶∙∙val∙x
[info] - object∙A∙{∙function(aaaaaaaa,∙
[info] ScalaTest
[info] Run completed in 1 second, 379 milliseconds.
[info] Total number of tests run: 5
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 4, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed: Total 5, Failed 1, Errors 0, Passed 4
[error] Failed tests:
[error] 	org.scalafmt.ScalafmtConfigTest
[error] (coreJVM / Test / test) sbt.TestsFailedException: Tests unsuccessfu
```

## after

```
[info] ScalafmtConfigTest:
[info] - project.matcher
[info] ScalafmtRunnerTest:
[info] ScalafmtTest:
[info] - ¶object∙A∙∙∙∙{∙∙println∙∙∙("HE
[info] - object∙A∙{¶∙∙val∙x∙=∙2¶∙∙val∙x
[info] - object∙A∙{∙function(aaaaaaaa,∙
[info] - sbt dialect supports trailing commas
[info] ScalaTest
[info] Run completed in 1 second, 327 milliseconds.
[info] Total number of tests run: 5
[info] Suites: completed 3, aborted 0
[info] Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Passed: Total 5, Failed 0, Errors 0, Passed 5
```
