### PR TITLE
Add the CLI option to fetch only recently changed files for formating.

### DIFF
--- a/bin/_scalafmt
+++ b/bin/_scalafmt
@@ -16,7 +16,7 @@ _scalafmt() {
     '--assume-filename[when using --stdin, use --assume-filename to hint to scalafmt that the input is an .sbt file]:value:' \
     '--test[test for mis-formatted code, exits with status 1 on failure]' \
     '--migrate2hocon[migrate .scalafmt CLI style configuration to hocon style configuration in .scalafmt.conf]:value:' \
-    '--diff[if set, only format edited files in git diff against master]' \
+    '--mode diff[if set, only format edited files in git diff against master]' \
     '--diff-branch[if set, only format edited files in git diff against provided branch]:value:' \
     '--build-info[prints build information]' \
     '--quiet[do not print out stuff to console]' \

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -15,7 +15,8 @@ object CliArgParser {
        |         # 2. .scalafmt.conf inside root directory of current git repo
        |         # 3. no configuration, default style
        |scalafmt --test # throw exception on mis-formatted files, won't write to files.
-       |scalafmt --diff # Format all files that were edited in git diff against master branch.
+       |scalafmt --mode diff # Format all files that were edited in git diff against master branch.
+       |scalafmt --mode changed # Format files listed in `git status` (latest changes against previous commit.
        |scalafmt --diff-branch 2.x # same as --diff, except against branch 2.x
        |scalafmt --stdin # read from stdin and print to stdout
        |scalafmt --stdin --assume-filename foo.sbt < foo.sbt # required when using --stdin to format .sbt files.
@@ -134,14 +135,18 @@ object CliArgParser {
         .text(
           """migrate .scalafmt CLI style configuration to hocon style configuration in .scalafmt.conf"""
         )
-      opt[Unit]("diff")
-        .action((_, c) => c.copy(diff = Some("master")))
-        .text("If set, only format edited files in git diff against master.")
+      opt[FileFetchMode]("mode")
+        .action((m, c) => c.copy(mode = Option(m)))
+        .text(
+          s"""Sets the files to be formatted fetching mode.
+             |Options:
+             |        diff - format files listed in `git diff` against master
+             |        changed - format files listed in `git status` (latest changes against previous commit)""".stripMargin)
       opt[String]("diff-branch")
         .action((branch, c) => c.copy(diff = Some(branch)))
-        .text(
-          "If set, only format edited files in git diff against provided branch."
-        )
+        .text("If set, only format edited files in git diff against provided branch. Has no effect if mode set to `changed`.")
+      opt[Unit]('c', "changed-only")
+          .action((_, c) => c.copy())
       opt[Unit]("build-info")
         .action({
           case (_, c) =>

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -135,6 +135,12 @@ object CliArgParser {
         .text(
           """migrate .scalafmt CLI style configuration to hocon style configuration in .scalafmt.conf"""
         )
+      opt[Unit]("diff")
+        .action((_, c) => c.copy(mode = Option(DiffFiles("master"))))
+        .text(
+          s"""Format files listed in `git diff` against master.
+             |Deprecated: use --mode diff instead""".stripMargin
+        )
       opt[FileFetchMode]("mode")
         .action((m, c) => c.copy(mode = Option(m)))
         .text(

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -141,10 +141,13 @@ object CliArgParser {
           s"""Sets the files to be formatted fetching mode.
              |Options:
              |        diff - format files listed in `git diff` against master
-             |        changed - format files listed in `git status` (latest changes against previous commit)""".stripMargin)
+             |        changed - format files listed in `git status` (latest changes against previous commit)""".stripMargin
+        )
       opt[String]("diff-branch")
         .action((branch, c) => c.copy(diff = Some(branch)))
-        .text("If set, only format edited files in git diff against provided branch. Has no effect if mode set to `changed`.")
+        .text(
+          "If set, only format edited files in git diff against provided branch. Has no effect if mode set to `changed`."
+        )
       opt[Unit]("build-info")
         .action({
           case (_, c) =>

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -145,8 +145,6 @@ object CliArgParser {
       opt[String]("diff-branch")
         .action((branch, c) => c.copy(diff = Some(branch)))
         .text("If set, only format edited files in git diff against provided branch. Has no effect if mode set to `changed`.")
-      opt[Unit]('c', "changed-only")
-          .action((_, c) => c.copy())
       opt[Unit]("build-info")
         .action({
           case (_, c) =>

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -45,6 +45,7 @@ object CliOptions {
       config = style
     )
   }
+
   private def getConfigJFile(file: AbsoluteFile): AbsoluteFile =
     file / ".scalafmt.conf"
 
@@ -85,6 +86,7 @@ case class CliOptions(
     debug: Boolean = false,
     git: Option[Boolean] = None,
     nonInteractive: Boolean = false,
+    mode: Option[FileFetchMode] = None,
     diff: Option[String] = None,
     assumeFilename: String = "stdin.scala", // used when read from stdin
     migrate: Option[AbsoluteFile] = None,
@@ -145,11 +147,8 @@ case class CliOptions(
 
   val inPlace: Boolean = writeMode == Override
 
-  val fileFetchMode: FileFetchMode = {
-    diff.map(DiffFiles).getOrElse {
-      if (isGit) GitFiles else RecursiveSearch
-    }
-  }
+  val fileFetchMode: FileFetchMode =
+    mode.orElse(Some(GitFiles).filter(_ => isGit)).getOrElse(RecursiveSearch)
 
   val files: Seq[AbsoluteFile] =
     if (customFiles.isEmpty)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/FileFetchMode.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/FileFetchMode.scala
@@ -1,9 +1,23 @@
 package org.scalafmt.cli
 
+import scopt.Read
+
 /**
   * Determines how we fetch files for formatting
   */
 sealed trait FileFetchMode
+
+object FileFetchMode {
+
+  /**
+  * The read instance is practically is not exhaustive due to the RecursiveSearch and GitFiles are the fallback used in the absence of
+    * other options
+    */
+  implicit val read : Read[FileFetchMode] = Read.reads {
+    case "diff" => DiffFiles("master")
+    case "changed" => ChangedFiles
+  }
+}
 
 /**
   * A simple recursive strategy where each directory is expanded
@@ -21,3 +35,11 @@ final case object GitFiles extends FileFetchMode
   * When this is set, files passed via the cli are ignored.
   */
 final case class DiffFiles(branch: String) extends FileFetchMode
+
+
+/**
+  * A call to `git status --porcelain`
+  *
+  * When this is set, files passed via the cli are ignored.
+  */
+final case object ChangedFiles extends FileFetchMode

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/FileFetchMode.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/FileFetchMode.scala
@@ -10,10 +10,10 @@ sealed trait FileFetchMode
 object FileFetchMode {
 
   /**
-  * The read instance is practically is not exhaustive due to the RecursiveSearch and GitFiles are the fallback used in the absence of
+    * The read instance is practically is not exhaustive due to the RecursiveSearch and GitFiles are the fallback used in the absence of
     * other options
     */
-  implicit val read : Read[FileFetchMode] = Read.reads {
+  implicit val read: Read[FileFetchMode] = Read.reads {
     case "diff" => DiffFiles("master")
     case "changed" => ChangedFiles
   }
@@ -35,7 +35,6 @@ final case object GitFiles extends FileFetchMode
   * When this is set, files passed via the cli are ignored.
   */
 final case class DiffFiles(branch: String) extends FileFetchMode
-
 
 /**
   * A call to `git status --porcelain`

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -32,7 +32,7 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
         )
 
         val inputMethods = getInputMethods(options, Some(filterMatcher))
-        if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
+        if (inputMethods.isEmpty && options.mode.isEmpty && !options.stdIn)
           throw NoMatchingFiles
 
         val counter = new AtomicInteger()

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
@@ -14,7 +14,7 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
       termDisplayMessage: String
   ): ExitCode = {
     val inputMethods = getInputMethods(options, None)
-    if (inputMethods.isEmpty && options.diff.isEmpty && !options.stdIn)
+    if (inputMethods.isEmpty && options.mode.isEmpty && !options.stdIn)
       throw NoMatchingFiles
 
     val counter = new AtomicInteger()

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/AbsoluteFile.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/AbsoluteFile.scala
@@ -5,6 +5,7 @@ import java.io.File
 /** Wrapper around java.io.File with an absolute path. */
 sealed abstract case class AbsoluteFile(jfile: File) {
   def path: String = jfile.getAbsolutePath
+  def exists: Boolean = jfile.exists()
   def /(other: String) = new AbsoluteFile(new File(jfile, other)) {}
 
   override def toString(): String = path

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -71,6 +71,7 @@ abstract class AbstractCliTest extends FunSuite with DiffAssertions {
 
   def gimmeConfig(string: String): ScalafmtConfig =
     Config.fromHoconString(string).get
+
   def noArgTest(
       input: AbsoluteFile,
       expected: String,
@@ -314,11 +315,12 @@ trait CliTestBehavior { this: AbstractCliTest =>
     }
 
     test(
-      s"scalafmt (no matching files) is okay with --diff and --stdin: $label"
+      s"scalafmt (no matching files) is okay with --mode diff and --stdin: $label"
     ) {
       val diff = getConfig(
         Array(
-          "--diff",
+          "--mode",
+          "diff",
           "--config-str",
           s"""{version="$version",style=IntelliJ}"""
         )
@@ -370,9 +372,10 @@ trait CliTestBehavior { this: AbstractCliTest =>
       noArgTest(
         input,
         expected,
-        Seq(Array.empty[String], Array("--diff"))
+        Seq(Array.empty[String], Array("--mode", "diff"))
       )
     }
+
     test(s"scalafmt (no arg, no config): $label") {
       noArgTest(
         string2dir(
@@ -459,7 +462,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
     }
 
     test(
-      s"includeFilters are ignored for full paths but NOT ignore for passed directories: $label"
+      s"includeFilters are ignored for full paths but NOT test for passed directories: $label"
     ) {
       val root =
         string2dir(

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
@@ -8,6 +8,6 @@ class FakeGitOps(root: AbsoluteFile) extends GitOps {
   override def lsTree(dir: AbsoluteFile): Vector[AbsoluteFile] =
     FileOps.listFiles(dir)
   override def rootDir: Option[AbsoluteFile] = Some(root)
-  override def status : Seq[AbsoluteFile] = lsTree(root)
+  override def status: Seq[AbsoluteFile] = lsTree(root)
   override def diff(branch: String): Seq[AbsoluteFile] = lsTree(root)
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
@@ -8,5 +8,6 @@ class FakeGitOps(root: AbsoluteFile) extends GitOps {
   override def lsTree(dir: AbsoluteFile): Vector[AbsoluteFile] =
     FileOps.listFiles(dir)
   override def rootDir: Option[AbsoluteFile] = Some(root)
+  override def status : Seq[AbsoluteFile] = lsTree(root)
   override def diff(branch: String): Seq[AbsoluteFile] = lsTree(root)
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -8,8 +8,6 @@ import scala.util._
 import org.scalatest._
 import org.scalactic.source.Position
 
-import scala.reflect.io.Directory
-
 class GitOpsTest extends fixture.FunSuite {
 
   import Matchers._
@@ -243,6 +241,13 @@ class GitOpsTest extends fixture.FunSuite {
     status should contain only f1
   }
 
+  test("status should return files with spaces in the path") { implicit o =>
+    val dir = mkDir("dir 1")
+    val f = touch(dir = Option(dir))
+    add(f)
+    status should contain only f
+  }
+
 }
 
 private object GitOpsTest {
@@ -255,8 +260,8 @@ private object GitOpsTest {
     file.jfile.delete
 
   // Git commands
-  def git(str: String)(implicit ops: GitOpsImpl, pos: Position): Seq[String] =
-    ops.exec("git" +: str.split(' ').toSeq) match {
+  def git(str: String*)(implicit ops: GitOpsImpl, pos: Position): Seq[String] =
+    ops.exec("git" +: str) match {
       case Failure(f) => fail(s"Failed git command. Got: $f")
       case Success(s) => s
     }
@@ -265,17 +270,17 @@ private object GitOpsTest {
     git("init")
 
   def add(file: AbsoluteFile)(implicit ops: GitOpsImpl): Unit =
-    git(s"add $file")
+    git("add", file.toString())
 
   def rm(file: AbsoluteFile)(implicit ops: GitOpsImpl): Unit =
-    git(s"rm $file")
+    git("rm", file.toString())
 
   def commit(implicit ops: GitOpsImpl): Unit =
-    git(s"commit -m 'some-message'")
+    git("commit", "-m", "'some-message'")
 
   def checkout(br: String)(implicit ops: GitOpsImpl): Unit =
-    git(s"checkout $br")
+    git("checkout", "$br")
 
   def checkoutBr(newBr: String)(implicit ops: GitOpsImpl): Unit =
-    git(s"checkout -b $newBr")
+    git("checkout", "-b", "$newBr")
 }


### PR DESCRIPTION
The premise is the desire to reduce testing/reformatting time by limiting the workload surface.
While working as part of the team on the same repo the master's head could go quite significantly farther potentially enlarging the `diff` which causes the formatting slowdown. The impact is quite dramatic if the `scalafmt --diff --test` is used as part of pre-commit hook.

Current PR revisits the `--diff` option turning it into `--mode [diff/changed]` to switch between two modes.
While `--mode diff` preserves the behaviour of `scalafmt --diff` the `--mode changed` utilises the `git status` to fetch the files for formatting limiting the surface down to the very minimum of the recent changes.