### PR TITLE
Add test for issues #1420 and #1227

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
@@ -64,3 +64,19 @@ object a {
 object a {
   s"Hello ${d.toString}"
 }
+<<< SKIP identifier started with underscore
+object a {
+  s"Hello ${_id}"
+}
+>>>
+object a {
+  s"Hello ${_id}"
+}
+<<< SKIP literal identifier
+object a {
+  s"Hello ${`type`}"
+}
+>>>
+object a {
+  s"Hello ${`type`}"
+}


### PR DESCRIPTION
Add tests for redundantBraces.stringInterpolation:
- identifier started with underscore
- literal identifier

https://github.com/scalameta/scalafmt/issues/1420
https://github.com/scalameta/scalafmt/issues/1227