### PR TITLE
 Prints out the paths of files subjected to formating before the beginning of formatting in debug mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,13 +119,13 @@ lazy val coreJS = core.js
 
 import sbtassembly.AssemblyPlugin.defaultUniversalScript
 
-
 lazy val cli = project
   .in(file("scalafmt-cli"))
   .settings(
     moduleName := "scalafmt-cli",
     mainClass in assembly := Some("org.scalafmt.cli.Cli"),
-    assemblyOption in assembly := (assemblyOption in assembly).value.copy(prependShellScript = Some(defaultUniversalScript(shebang = false))),
+    assemblyOption in assembly := (assemblyOption in assembly).value
+      .copy(prependShellScript = Some(defaultUniversalScript(shebang = false))),
     assemblyJarName.in(assembly) := "scalafmt.jar",
     libraryDependencies ++= Seq(
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",

--- a/build.sbt
+++ b/build.sbt
@@ -117,11 +117,15 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
 
+import sbtassembly.AssemblyPlugin.defaultUniversalScript
+
+
 lazy val cli = project
   .in(file("scalafmt-cli"))
   .settings(
     moduleName := "scalafmt-cli",
     mainClass in assembly := Some("org.scalafmt.cli.Cli"),
+    assemblyOption in assembly := (assemblyOption in assembly).value.copy(prependShellScript = Some(defaultUniversalScript(shebang = false))),
     assemblyJarName.in(assembly) := "scalafmt.jar",
     libraryDependencies ++= Seq(
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -79,11 +79,9 @@ object Cli {
     val termDisplayMessage =
       if (options.testing) "Looking for unformatted files..."
       else "Reformatting..."
-    if (options.debug) {
-      val pwd = options.common.workingDirectory.jfile.getPath
-      val out = options.info
-      out.println("Working directory: " + pwd)
-    }
+    options.common.info.println(
+      "Working directory: " + options.common.workingDirectory.jfile.getPath
+    )
 
     // Run format using
     // - `scalafmt-dynamic` if the specified `version` setting doesn't match build version.

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -79,7 +79,7 @@ object Cli {
     val termDisplayMessage =
       if (options.testing) "Looking for unformatted files..."
       else "Reformatting..."
-    options.common.info.println(
+    options.common.debug.println(
       "Working directory: " + options.common.workingDirectory.jfile.getPath
     )
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -165,7 +165,7 @@ object CliArgParser {
         .action((_, c) => c.copy(quiet = true))
         .text("don't print out stuff to console.")
       opt[Unit]("debug")
-        .action((_, c) => c.copy(common = c.common.copy(debug = System.out)))
+        .action((_, c) => c.copy(debug = true))
         .text("print out diagnostics to console.")
       opt[Unit]("non-interactive")
         .action((_, c) => c.copy(nonInteractive = true))

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -165,7 +165,7 @@ object CliArgParser {
         .action((_, c) => c.copy(quiet = true))
         .text("don't print out stuff to console.")
       opt[Unit]("debug")
-        .action((_, c) => c.copy(debug = true))
+        .action((_, c) => c.copy(common = c.common.copy(debug = System.out)))
         .text("print out diagnostics to console.")
       opt[Unit]("non-interactive")
         .action((_, c) => c.copy(nonInteractive = true))

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -80,6 +80,10 @@ object CliOptions {
 object NoopOutputStream extends OutputStream { self =>
   override def write(b: Int): Unit = ()
 
+  override def write(b : Array[Byte]) : Unit = ()
+
+  override def write(b : Array[Byte], off : Int, len : Int) : Unit = ()
+
   val printStream = new PrintStream(self)
 }
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -80,9 +80,9 @@ object CliOptions {
 object NoopOutputStream extends OutputStream { self =>
   override def write(b: Int): Unit = ()
 
-  override def write(b : Array[Byte]) : Unit = ()
+  override def write(b: Array[Byte]): Unit = ()
 
-  override def write(b : Array[Byte], off : Int, len : Int) : Unit = ()
+  override def write(b: Array[Byte], off: Int, len: Int): Unit = ()
 
   val printStream = new PrintStream(self)
 }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCliReporter.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCliReporter.scala
@@ -56,17 +56,14 @@ class ScalafmtCliReporter(options: CliOptions) extends ScalafmtReporter {
     }
   }
 
-  override def excluded(file: Path): Unit = {
-    if (options.debug) options.common.out.println(s"file excluded: $file")
-  }
+  override def excluded(file: Path): Unit =
+    options.common.debug.println(s"file excluded: $file")
 
   override def parsedConfig(
       config: Path,
       scalafmtVersion: String
-  ): Unit = {
-    if (options.debug)
-      options.common.out.println(s"parsed config (v$scalafmtVersion): $config")
-  }
+  ): Unit =
+    options.common.debug.println(s"parsed config (v$scalafmtVersion): $config")
 
   override def downloadWriter(): PrintWriter =
     new PrintWriter(options.common.out)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -22,8 +22,7 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
         if (!options.quiet) options.common.err.println(s"${e.msg}")
         ExitCode.UnexpectedError
       case Configured.Ok(scalafmtConf) =>
-        if (options.debug)
-          options.common.out.println(s"parsed config (v${Versions.version})")
+        options.common.debug.println(s"parsed config (v${Versions.version})")
         val filterMatcher: FilterMatcher = FilterMatcher(
           scalafmtConf.project.includeFilters
             .map(OsSpecific.fixSeparatorsInPathPattern),

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -16,7 +16,7 @@ trait ScalafmtRunner {
       msg: String
   ): TermDisplay = {
     val termDisplay = new TermDisplay(
-      new OutputStreamWriter(options.info),
+      new OutputStreamWriter(options.common.info),
       fallbackMode =
         options.nonInteractive ||
           TermDisplay.defaultFallbackMode
@@ -40,6 +40,8 @@ trait ScalafmtRunner {
     } else {
       val projectFiles: Seq[AbsoluteFile] =
         getFilesFromCliOptions(options, filter)
+      options.common.debug
+        .print(s"Files to be formatted:\n${projectFiles.mkString("\n")}\n")
       projectFiles.map(InputMethod.FileContents.apply)
     }
   }


### PR DESCRIPTION
That's a minor change I've used to debug few cases locally. Thought it could come in handy for the broader audience.

P.S. Sorry for the typos in the commit message.