### PR TITLE
Fixed spaces.beforeContextBoundColon=IfMultipleBounds behavior for case with subtyping

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -883,7 +883,8 @@ class Router(formatOps: FormatOps) {
         val mod: Modification = rightOwner match {
           case tp: Type.Param =>
             val contextOption = style.spaces.beforeContextBoundColon
-            if (contextOption.isIfMultipleBounds && tp.cbounds.size > 1 || contextOption.isAlways)
+            val summaryTypeBoundsCount = tp.tbounds.lo.size + tp.tbounds.hi.size + tp.cbounds.size
+            if (contextOption.isIfMultipleBounds && summaryTypeBoundsCount > 1 || contextOption.isAlways)
               Space
             else NoSplit
 

--- a/scalafmt-tests/src/test/resources/spaces/BeforeContextBoundColonIfMultipleBounds.stat
+++ b/scalafmt-tests/src/test/resources/spaces/BeforeContextBoundColonIfMultipleBounds.stat
@@ -11,3 +11,7 @@ def orderLaws[A : Eq : Arbitrary] = O
 def myMethod[F[_]:Functor](): Foo
 >>>
 def myMethod[F[_]: Functor](): Foo
+<<< space before colon with subtype bound #1391
+final class Test[A <: B: ClassTag]
+>>>
+final class Test[A <: B : ClassTag]


### PR DESCRIPTION
Fixes (#1391)