### PR TITLE
Remove closed issue from Scalafmt documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,9 +55,6 @@ docstrings = JavaDoc
 assumeStandardLibraryStripMargin
 ```
 
-> May cause non-idempotent formatting in rare cases, see
-> https://github.com/scalameta/scalafmt/issues/192.
-
 If `true`, the margin character `|` is aligned with the opening triple quote
 `"""` in interpolated and raw string literals.
 


### PR DESCRIPTION
Noticed that there was a disclaimer of `assumeStandardLibraryStripMargin` not being idempotent in some cases, and linking to an issue that has since been fixed. Figured I'd take the liberty of removing that disclaimer from the docs since it's now obsolete.

Thanks for building and maintaining this tool! It's been hugely helpful for maintaining consistent formatting in Scala projects I maintain. 