### PR TITLE
exclude dangling parens in methods with enabled verticalMultiline

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -32,7 +32,8 @@ sealed abstract class DanglingExclude
 object DanglingExclude {
   case object `class` extends DanglingExclude
   case object `trait` extends DanglingExclude
+  case object `def` extends DanglingExclude
 
   implicit val danglingExcludeReader: ConfCodec[DanglingExclude] =
-    ReaderUtil.oneOf[DanglingExclude](`class`, `trait`)
+    ReaderUtil.oneOf[DanglingExclude](`class`, `trait`, `def`)
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -823,14 +823,18 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
     val isClassLike = owner.is[meta.Ctor.Primary] || owner.is[meta.Defn.Class]
     val isTrait = owner.is[meta.Defn.Trait]
+    val isDef = owner.is[meta.Defn.Def]
     val excludeClass = style.verticalMultiline.excludeDanglingParens
       .contains(DanglingExclude.`class`)
     val excludeTrait = style.verticalMultiline.excludeDanglingParens
       .contains(DanglingExclude.`trait`)
+    val excludeDef = style.verticalMultiline.excludeDanglingParens
+      .contains(DanglingExclude.`def`)
 
     val shouldNotDangle =
       (isClassLike && excludeClass) ||
-        (isTrait && excludeTrait)
+        (isTrait && excludeTrait) ||
+        (isDef && excludeDef)
 
     // Since classes and defs aren't the same (see below), we need to
     // create two (2) OneArgOneLineSplit when dealing with classes. One

--- a/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
@@ -1,0 +1,80 @@
+verticalMultiline = {
+    atDefnSite = true
+    excludeDanglingParens = [class, trait, def]
+}
+
+<<< not modify single line
+def getListing(
+  a: String,
+  b: String,
+  c: String,
+  d: String
+): Future[String] = {
+  a + b + c + d + e
+}
+>>>
+def getListing(a: String, b: String, c: String, d: String): Future[String] = {
+  a + b + c + d + e
+}
+
+<<< with implicit param
+def getListing(
+  a: String,
+  b: String,
+  c: String,
+  d: String
+)(implicit e: String
+): Future[String] = {
+  a + b + c + d + e
+}
+>>>
+def getListing(
+    a: String,
+    b: String,
+    c: String,
+    d: String
+  )(implicit e: String): Future[String] = {
+  a + b + c + d + e
+}
+
+<<< with many param groups
+def getListing(
+  a: String,
+  b: String)(
+  c: String,
+  d: String
+)(implicit e: String
+): Future[String] = {
+  a + b + c + d + e
+}
+>>>
+def getListing(
+    a: String,
+    b: String
+  )(c: String,
+    d: String
+  )(implicit e: String): Future[String] = {
+  a + b + c + d + e
+}
+
+<<< with many implicits
+def getListing(
+  a: String,
+  b: String,
+  c: String,
+  d: String
+)(implicit e: String, g: String, f: String
+): Future[String] = {
+  a + b + c + d + e + g + f
+}
+>>>
+def getListing(
+    a: String,
+    b: String,
+    c: String,
+    d: String
+  )(implicit e: String,
+    g: String,
+    f: String): Future[String] = {
+  a + b + c + d + e + g + f
+}


### PR DESCRIPTION
This PR adds new configuration flag to avoid dangling parens in method definitions

`verticalMultiline.excludeDanglingParens = [ def ]`

Example:
```scala
def getListing(a: String, b: String, c: String, d: String)(implicit e: String): Future[String] = {
  a + b + c + d + e
}
```

Without flag formats to:
```scala
def getListing(
    a: String, 
    b: String, 
    c: String, 
    d: String
  )(implicit e: String
  ): Future[String] = {
  a + b + c + d + e
}
```

With new flag:
```scala
def getListing(
    a: String, 
    b: String, 
    c: String, 
    d: String
  )(implicit e: String): Future[String] = {
  a + b + c + d + e
}
```