### PR TITLE
Add support for COURSIER_REPOSITORIES in scalafmt-dynamic

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
@@ -64,12 +64,27 @@ class ScalafmtDynamicDownloader(
       "org.scalameta"
     }
 
-  private def repositories: List[Repository] = List(
-    Repository.MavenCentral,
-    Repository.Ivy2Local,
-    Repository.SonatypeReleases,
-    Repository.SonatypeSnapshots
-  )
+  private def repositories: List[Repository] =
+    coursierEnvironmentRepositories.getOrElse(
+      List(
+        Repository.MavenCentral,
+        Repository.Ivy2Local,
+        Repository.SonatypeReleases,
+        Repository.SonatypeSnapshots
+      )
+    )
+
+  // Structure of COURSIER_REPOSITORIES as described at: https://get-coursier.io/blog/2019/02/05/1.1.0-M11
+  private def coursierEnvironmentRepositories: Option[List[Repository]] = {
+    sys.env
+      .get("COURSIER_REPOSITORIES")
+      .map(
+        _.split('|')
+          .filter(_.trim.nonEmpty)
+          .map(new Repository.Maven(_))
+          .toList
+      )
+  }
 }
 
 object ScalafmtDynamicDownloader {


### PR DESCRIPTION
- scalafmt-dynamic hard codes a set of repositories
- Many users (especially corporates) use local caches of dependencies to speed up builds, these aren't always transparent proxies. (e.g. dependencies may live at `http://myproxy.local/repo.maven.org/...` etc.). These aren't currently supported by `scalafmt-dynamic` because of the hard coded set of repositories.
- Unfortunately coursier-small has now been discontinued/archived, but is used as a dependency here. Coursier-small does not respect COURSIER_REPOSITORIES

Rather than attempting to replace coursier-small, this patch lets enterprise users (like me) move on with using scalafmt-dynamic with our dependency caches/proxies, by setting the COURSIER_REPOSITORIES variable. Like in [Coursier itself](https://github.com/coursier/coursier/blob/2abcacee5f73c9890eeb7854d246ddb232433df1/modules/coursier/jvm/src/main/scala/coursier/PlatformResolve.scala#L53) if it's set it overrides all repositories (rather than being added to them).

By using the existing coursier format for adding additional dependencies we avoid anything scalafmt-specific, and increase the chances of it "just working" in many environments that are already using coursier.