### PR TITLE
Fixed unindentTopLevelOperator behavior without indentOperator=spray

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -202,8 +202,6 @@ object ScalafmtConfig {
 
   val indentOperatorsIncludeAkka = "^.*=$"
   val indentOperatorsExcludeAkka = "^$"
-  val indentOperatorsIncludeDefault = ".*"
-  val indentOperatorsExcludeDefault = "^(&&|\\|\\|)$"
 
   val default = ScalafmtConfig()
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -18,7 +18,12 @@ import scala.meta.prettyprinters.Structure
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
 import org.scalafmt.Error.CaseMissingArrow
-import org.scalafmt.config.{DanglingExclude, ScalafmtConfig, VerticalMultiline}
+import org.scalafmt.config.{
+  DanglingExclude,
+  IndentOperator,
+  ScalafmtConfig,
+  VerticalMultiline
+}
 import org.scalafmt.internal.ExpiresOn.Left
 import org.scalafmt.internal.ExpiresOn.Right
 import org.scalafmt.internal.Length.Num
@@ -527,6 +532,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       if (style.verticalAlignMultilineOperators) {
         if (formatToken.left.text == "=") 2 else 0
       } else if (style.unindentTopLevelOperators &&
+        style.indentOperator == IndentOperator.akka &&
         !isTopLevelInfixApplication(owner) &&
         style.indentOperator.includeRegexp
           .findFirstIn(formatToken.left.syntax)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -532,7 +532,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       if (style.verticalAlignMultilineOperators) {
         if (formatToken.left.text == "=") 2 else 0
       } else if (style.unindentTopLevelOperators &&
-        style.indentOperator == IndentOperator.akka &&
+        rhsArgs.headOption.forall(_.isNot[Term.Block]) &&
         !isTopLevelInfixApplication(owner) &&
         style.indentOperator.includeRegexp
           .findFirstIn(formatToken.left.syntax)

--- a/scalafmt-tests/src/test/resources/test/i1439.stat
+++ b/scalafmt-tests/src/test/resources/test/i1439.stat
@@ -17,3 +17,15 @@ class TestSpec extends FlatSpec with Matchers {
   }
 
 }
+<<< test
+object test {
+  val x = 1 + {
+    2 + 3
+  }
+}
+>>>
+object test {
+  val x = 1 + {
+    2 + 3
+  }
+}

--- a/scalafmt-tests/src/test/resources/test/i1439.stat
+++ b/scalafmt-tests/src/test/resources/test/i1439.stat
@@ -1,0 +1,19 @@
+unindentTopLevelOperators = true 
+<<< unindentTopLevelOperators should not break code blocks
+class TestSpec extends FlatSpec with Matchers {
+
+"Foo" should "do things" in {
+def bar: String = "test"
+bar should endWith("st")
+}
+
+}
+>>>
+class TestSpec extends FlatSpec with Matchers {
+
+  "Foo" should "do things" in {
+    def bar: String = "test"
+    bar should endWith("st")
+  }
+
+}


### PR DESCRIPTION
Fixes (#1439)

I discovered that fix in https://github.com/scalameta/scalafmt/pull/1372 works fine only with `indentOperator = spray` configuration. Otherwise it breaks correct code.

I **don't like** this solution, it looks hacky. Any ideas how to do it better?

Also I don't use `unindentTopLevelOperator` configuration in my codebase. Can anyone provide more test cases for it? I am afraid that my fix can break anything else :smile: 