### PR TITLE
Coursier-small library replaced with Coursier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,6 @@ lazy val dynamic = project
     buildInfoObject := "BuildInfo",
     libraryDependencies ++= List(
       "io.get-coursier" %% "coursier" % coursier,
-      "io.get-coursier" %% "coursier-cache" % coursier,
       "com.typesafe" % "config" % "1.3.3",
       scalatest.value % Test,
       scalametaTestkit % Test

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,8 @@ lazy val dynamic = project
     buildInfoPackage := "org.scalafmt.dynamic",
     buildInfoObject := "BuildInfo",
     libraryDependencies ++= List(
-      "com.geirsson" %% "coursier-small" % "1.3.1",
+      "io.get-coursier" %% "coursier" % coursier,
+      "io.get-coursier" %% "coursier-cache" % coursier,
       "com.typesafe" % "config" % "1.3.3",
       scalatest.value % Test,
       scalametaTestkit % Test
@@ -126,9 +127,7 @@ lazy val cli = project
     libraryDependencies ++= Seq(
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "com.martiansoftware" % "nailgun-server" % "0.9.1",
-      "com.github.scopt" %% "scopt" % "3.5.0",
-      // undeclared transitive dependency of coursier-small
-      "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
+      "com.github.scopt" %% "scopt" % "3.5.0"
     ),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val scalametaV = "4.2.0"
   val scalatestV = "3.2.0-SNAP10"
   val scalacheckV = "1.13.5"
-  val coursier = "1.0.3"
+  val coursier = "2.0.0-RC2-5"
 
   val scalapb = Def.setting {
     ExclusionRule(

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Head over to [the user docs][docs] for instructions on how to install scalafmt.
 
 - `sbt compile` on a clean machine will fail to compile the `scalafmt-intellij` project.
   - if you plan to develop the intellij plugin, run `downloadIdea` first to fetch the IntelliJ SDK (~600mb).
-  - or, run `sbt test` or `sbt core/compile` (specific project).
+  - or, run `sbt test` or `sbt coreJVM/compile` (specific project).
 - Run all unit tests: `sbt test`
 - Run only formatting tests: `tests/testOnly *FormatTests`.
 - Write new formatting test: read [this doc](scalafmt-tests/src/test/resources/readme.md).

--- a/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
@@ -165,6 +165,7 @@ class DynamicSuite extends FunSuite with DiffAssertions {
   }
 
   private val testedVersions = Seq(
+    "2.0.0",
     "2.0.0-RC4",
     "1.6.0-RC4",
     "1.5.1",


### PR DESCRIPTION
Now scalafmt depends on [coursier-small](https://github.com/olafurpg/coursier-small) library ― tiny wrapper around coursier. But it is archived and no longer supported.

I see some problems with it:
1. Scala 2.13 update #1434 
2. Old version of coursier
3. coursier features support https://github.com/scalameta/scalafmt/pull/1436

I tried to replace it with coursier itself. Strict code review is necessary! I tested it locally with sbt plugin and cli client, but we need more complex testing. Any ideas how to do it?

@olafurpg what do you think about this replacement?