### PR TITLE
fix include resolution for cli and sbt plugin

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -111,7 +111,8 @@ inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings
 ### Share configuration between builds
 
 To share configuration across different sbt builds, create a custom sbt plugin
-that generates `.scalafmt.conf` on build reload.
+that generates `.scalafmt-common.conf` on build reload, then include the
+generated file from `.scalafmt.conf`
 
 ```scala
 // project/MyScalafmtPlugin.scala
@@ -123,12 +124,17 @@ object MyScalafmtPlugin extends AutoPlugin {
     SettingKey[Unit]("scalafmtGenerateConfig") :=
       IO.write(
         // writes to file once when build is loaded
-        file(".scalafmt.conf"),
+        file(".scalafmt-common.conf"),
         "maxColumn = 100".stripMargin.getBytes("UTF-8")
       )
   }
 }
 ```
+
+```
+// .scalafmt.conf
+include ".scalafmt-common.conf"
+``` 
 
 ## CLI
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -157,15 +157,12 @@ case class CliOptions(
     */
   def scalafmtConfig: Configured[ScalafmtConfig] = {
     (configStr match {
-      case Some(contents) => Some(contents)
+      case Some(contents) => Some(Config.fromHoconString(contents))
       case None =>
         val file =
           AbsoluteFile.fromFile(configPath.toFile, common.workingDirectory)
-        catching(classOf[IOException]).opt(FileOps.readFile(file))
-    }).map { content =>
-        Config.fromHoconString(content)
-      }
-      .getOrElse(Configured.Ok(ScalafmtConfig.default))
+        catching(classOf[IOException]).opt(Config.fromHoconFile(file.jfile))
+    }).getOrElse(Configured.Ok(ScalafmtConfig.default))
   }
 
   val inPlace: Boolean = writeMode == Override

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -1,12 +1,11 @@
 package org.scalafmt.dynamic
 
+import com.typesafe.config.ConfigFactory
 import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
-
 import org.scalafmt.dynamic.exceptions._
 import org.scalafmt.dynamic.utils.ReflectUtils._
-
 import scala.util.Try
 
 case class ScalafmtReflect(
@@ -63,8 +62,7 @@ case class ScalafmtReflect(
   }
 
   def parseConfig(configPath: Path): ScalafmtReflectConfig = {
-    val configBytes = Files.readAllBytes(configPath)
-    val configText = new String(configBytes, StandardCharsets.UTF_8)
+    val configText = ConfigFactory.parseFile(configPath.toFile).root.render()
     parseConfigFromString(configText)
   }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -94,7 +94,7 @@ class CliOptionsTest extends FunSuite {
   }
 
   test(
-    ".scalafmtConfig returns default ScalafmtConfig is configuration file is missing"
+    ".scalafmtConfig returns default ScalafmtConfig if configuration file is missing"
   ) {
     val configDir = Files.createTempDirectory("temp-dir")
     val configPath = Paths.get(configDir.toString + "/.scalafmt.conf")


### PR DESCRIPTION
`ConfigFactory.parseFile` is able to resolve relative includes of the form `include "my/dir/my-defaults.conf"`. However, Scalafmt sticks to reading the main config and then parses it as text—without resolving includes.

This PR alters how config files are parsed. `ConfigFactory.parseFile` is used, followed by `.root.render()` to obtain configuration text with fully resolved includes.

Note that caching consideration within `ScalafmtDynamic` have not yet been addressed—configuration modification date will have to be obtained from all included configuration files. (this can be achieved by using a custom `ConfigIncluder`).