### PR TITLE
Update .gitignore for metals and bloop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ intellij/out
 
 *~
 docs/xx.md
+
+# metals
+.metals/
+.bloop/


### PR DESCRIPTION
Just updated .gitignore for metals based on
http://scalameta.org/metals/docs/editors/sublime.html#gitignore-metals-and-bloop

Merging after CI passes.