### PR TITLE
Update the release process document, and upgrade docusaurus

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -eux
-
-version=$1
-
-coursier fetch org.scalameta:scalafmt-dynamic_2.12:$version -r sonatype:public
-coursier fetch \
-    "org.scalameta:sbt-scalafmt;sbtVersion=1.0;scalaVersion=2.12:$version" \
-    --sbt-plugin-hack -r sonatype:public

--- a/docs/contributing-scalafmt.md
+++ b/docs/contributing-scalafmt.md
@@ -45,11 +45,6 @@ Please always include concrete code examples with obtained and expected output.
 - Write release notes here: https://github.com/scalameta/scalafmt/releases/new
 - Pushing a git tag should trigger a release to Maven Central from the CI.
 - Once CI has finished releasing, update sbt-scalafmt to the latest release.
-- Validate that sbt-scalafmt and scalafmt-core have published successfully by
-  running the following script (assumming you have `coursier` installed)
-```
-./bin/test-release.sh $VERSION
-```
 - Update the changelog on the website with the following command (assuming you
   have `docker` installed)
 ```

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,6 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "^1.4.0"
+    "docusaurus": "^1.11.1"
   }
 }


### PR DESCRIPTION
- Remove a process for checking whether the versions of scalafmt and sbt-scalafmt match, because after scalafmt 2.0.0, scalafmt-core and sbt-scalafmt have different versioning.
- Update docusaurus to the latest.