### PR TITLE
Add --list cli option #1459

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -170,6 +170,9 @@ object CliArgParser {
       opt[Unit]("non-interactive")
         .action((_, c) => c.copy(nonInteractive = true))
         .text("disable fancy progress bar, useful in ci or sbt plugin.")
+      opt[Unit]("list")
+        .action((_, c) => c.copy(list = true))
+        .text("list files that are different from scalafmt formatting")
       opt[(Int, Int)]("range")
         .hidden()
         .action({

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -52,7 +52,7 @@ object CliOptions {
       config = style,
       common = parsed.common.copy(
         out = guardPrintStream(parsed.quiet)(parsed.common.out),
-        info = guardPrintStream(parsed.quiet)(auxOut),
+        info = guardPrintStream(parsed.quiet || parsed.list)(auxOut),
         debug = guardPrintStream(parsed.quiet)(
           if (parsed.debug) auxOut else init.common.debug
         ),
@@ -122,7 +122,8 @@ case class CliOptions(
     debug: Boolean = false,
     quiet: Boolean = false,
     stdIn: Boolean = false,
-    noStdErr: Boolean = false
+    noStdErr: Boolean = false,
+    list: Boolean = false
 ) {
   // These default values are copied from here.
   // https://github.com/scalameta/scalafmt/blob/f2154330afa0bc4a0a556598adeb116eafecb8e3/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala#L127-L162

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -60,7 +60,11 @@ object InputMethod {
         }
       } else if (options.inPlace) {
         if (codeChanged) {
-          FileOps.writeFile(filename, formatted)(options.encoding)
+          if (options.list) {
+            options.common.out.println(filename)
+          } else {
+            FileOps.writeFile(filename, formatted)(options.encoding)
+          }
         }
       } else {
         options.common.out.print(formatted)


### PR DESCRIPTION
This PR introduces option for cli: `--list` which would:
* Print full path for files that are different from `scalafmt` formatting without changing them
* Disable `info` in order to hide fancy one (and not fancy another) progress bar

#1459 