### PR TITLE
Use openjdk8 instead of oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ stages:
 jobs:
   include:
     - env: TEST="scalafmt"
-      jdk: oraclejdk8
+      jdk: openjdk8
       script: ./scalafmt --test
     - env: TEST="2.11"
-      jdk: oraclejdk8
+      jdk: openjdk8
       script: sbt ci-test
     - env: TEST="2.12"
-      jdk: oraclejdk8
+      jdk: openjdk8
       script: sbt ci-test
     - env: TEST="2.11"
       jdk: openjdk11
@@ -23,7 +23,7 @@ jobs:
       jdk: openjdk11
       script: sbt ci-test
     - stage: release
-      jdk: oraclejdk8
+      jdk: openjdk8
       script: sbt ci-release docs/docusaurusPublishGhpages
 
 cache:


### PR DESCRIPTION
> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be
retrieved from Oracle itself anymore. We'd suggest using either openjdk,
or the currently supported Oracle JDK.

https://github.com/travis-ci/travis-ci/issues/10290