### PR TITLE
fix running with the diff branch file filter

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -150,7 +150,7 @@ object CliArgParser {
              |        changed - format files listed in `git status` (latest changes against previous commit)""".stripMargin
         )
       opt[String]("diff-branch")
-        .action((branch, c) => c.copy(diff = Some(branch)))
+        .action((branch, c) => c.copy(mode = Option(DiffFiles(branch))))
         .text(
           "If set, only format edited files in git diff against provided branch. Has no effect if mode set to `changed`."
         )

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -113,7 +113,6 @@ case class CliOptions(
     git: Option[Boolean] = None,
     nonInteractive: Boolean = false,
     mode: Option[FileFetchMode] = None,
-    diff: Option[String] = None,
     assumeFilename: String = "stdin.scala", // used when read from stdin
     migrate: Option[AbsoluteFile] = None,
     common: CommonOptions = CommonOptions(),


### PR DESCRIPTION
I think this fixes https://github.com/scalameta/scalafmt/issues/1456
Sorry I have not been able to test it manually yet.