### PR TITLE
dont uppercase long hex literal 0x prefix

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -40,7 +40,14 @@ class FormatWriter(formatOps: FormatOps) {
             sb.append(formatMarginizedString(token, state.indentation))
           case Constant.String(_) => // Ignore, see below.
           case c: Constant.Long =>
-            sb.append(initStyle.literals.long.process(c.syntax))
+            val syntax = c.syntax
+            // longs can be written as hex literals like 0xFF123L. Dont uppercase the X
+            if (syntax.startsWith("0x")) {
+              sb.append("0x")
+              sb.append(initStyle.literals.long.process(syntax.substring(2)))
+            } else {
+              sb.append(initStyle.literals.long.process(syntax))
+            }
           case c: Constant.Float =>
             sb.append(initStyle.literals.float.process(c.syntax))
           case c: Constant.Double =>

--- a/scalafmt-tests/src/test/resources/unit/Lit.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lit.stat
@@ -23,3 +23,7 @@
  1d
 >>>
 1d
+<<< hex long
+0xFFFFFFFFl
+>>>
+0xFFFFFFFFL


### PR DESCRIPTION
When uppercasing hex long literals take care not to change the 0x.
```
0x123l    # this
0X123L   # shouldnt become this
0x123L   # it should be this
```
resolves https://github.com/scalameta/scalafmt/issues/1437