### PR TITLE
Return exit code 1 for `scalafmt --list` if there are any files that require re-formatting

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -63,7 +63,9 @@ object InputMethod {
       } else if (options.inPlace) {
         if (codeChanged) {
           if (options.list) {
-            options.common.out.println(filename)
+            options.common.out.println(
+              options.common.workingDirectory.jfile.toURI().relativize(file.jfile.toURI())
+            )
             ExitCode.TestError
           } else {
             FileOps.writeFile(filename, formatted)(options.encoding)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -14,7 +14,7 @@ sealed abstract class InputMethod {
   def isSc: Boolean = filename.endsWith(".sc")
   def readInput(options: CliOptions): String
   def filename: String
-  def write(formatted: String, original: String, options: CliOptions): Unit
+  def write(formatted: String, original: String, options: CliOptions): ExitCode
 }
 
 object InputMethod {
@@ -33,8 +33,9 @@ object InputMethod {
         code: String,
         original: String,
         options: CliOptions
-    ): Unit = {
+    ): ExitCode = {
       options.common.out.print(code)
+      ExitCode.Ok
     }
   }
   case class FileContents(file: AbsoluteFile) extends InputMethod {
@@ -45,7 +46,7 @@ object InputMethod {
         formatted: String,
         original: String,
         options: CliOptions
-    ): Unit = {
+    ): ExitCode = {
       val codeChanged = formatted != original
       if (options.testing) {
         if (codeChanged) {
@@ -57,17 +58,21 @@ object InputMethod {
               formatted
             )
           )
-        }
+          ExitCode.TestError
+        } else ExitCode.Ok
       } else if (options.inPlace) {
         if (codeChanged) {
           if (options.list) {
             options.common.out.println(filename)
+            ExitCode.TestError
           } else {
             FileOps.writeFile(filename, formatted)(options.encoding)
+            ExitCode.Ok
           }
-        }
+        } else ExitCode.Ok
       } else {
         options.common.out.print(formatted)
+        ExitCode.Ok
       }
     }
   }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -64,7 +64,9 @@ object InputMethod {
         if (codeChanged) {
           if (options.list) {
             options.common.out.println(
-              options.common.workingDirectory.jfile.toURI().relativize(file.jfile.toURI())
+              options.common.workingDirectory.jfile
+                .toURI()
+                .relativize(file.jfile.toURI())
             )
             ExitCode.TestError
           } else {

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -87,7 +87,6 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
     formatResult match {
       case Formatted.Success(formatted) =>
         inputMethod.write(formatted, input, options)
-        ExitCode.Ok
       case Formatted.Failure(e) =>
         if (scalafmtConfig.runner.ignoreWarnings) {
           ExitCode.Ok // do nothing

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -722,6 +722,38 @@ trait CliTestBehavior { this: AbstractCliTest =>
         }
       )
     }
+
+    test(s"--list enable scalafmt to output a list of unformatted files with ExitCode.TestError: ${label}") {
+      val input =
+        s"""|/.scalafmt.conf
+            |version = "$version"
+            |
+            |/bar.scala
+            |object    A { }
+            |
+            |/baz.scala
+            |object A {}
+            |
+            |/foo.scala
+            |object   A { }
+            |""".stripMargin
+      val dir = string2dir(input)
+      noArgTest(
+        dir,
+        input,
+        Seq(Array("--list")),
+        assertExit = { exit =>
+          assert(exit.isOk)
+        },
+        assertOut = out => {
+          assert(
+            out.contains(s"${dir}/bar.scala") &&
+            !out.contains(s"${dir}/baz.scala") &&
+            out.contains(s"${dir}/foo.scala")
+          )
+        }
+      )
+    }
   }
 }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -723,7 +723,9 @@ trait CliTestBehavior { this: AbstractCliTest =>
       )
     }
 
-    test(s"--list enable scalafmt to output a list of unformatted files with ExitCode.TestError: ${label}") {
+    test(
+      s"--list enable scalafmt to output a list of unformatted files with ExitCode.TestError: ${label}"
+    ) {
       val input =
         s"""|/.scalafmt.conf
             |version = "$version"
@@ -748,8 +750,8 @@ trait CliTestBehavior { this: AbstractCliTest =>
         assertOut = out => {
           assert(
             out.contains("bar.scala") &&
-            !out.contains("baz.scala") &&
-            out.contains("dir/foo.scala")
+              !out.contains("baz.scala") &&
+              out.contains("dir/foo.scala")
           )
         }
       )

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -734,7 +734,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
             |/baz.scala
             |object A {}
             |
-            |/foo.scala
+            |/dir/foo.scala
             |object   A { }
             |""".stripMargin
       val dir = string2dir(input)
@@ -747,9 +747,9 @@ trait CliTestBehavior { this: AbstractCliTest =>
         },
         assertOut = out => {
           assert(
-            out.contains(s"${dir}/bar.scala") &&
-            !out.contains(s"${dir}/baz.scala") &&
-            out.contains(s"${dir}/foo.scala")
+            out.contains("bar.scala") &&
+            !out.contains("baz.scala") &&
+            out.contains("dir/foo.scala")
           )
         }
       )

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -743,7 +743,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
         input,
         Seq(Array("--list")),
         assertExit = { exit =>
-          assert(exit.isOk)
+          assert(exit.is(ExitCode.TestError))
         },
         assertOut = out => {
           assert(


### PR DESCRIPTION
https://github.com/scalameta/scalafmt/issues/1459

Follow up for https://github.com/scalameta/scalafmt/pull/1466

This PR make `--list` option to
- Return exit code 1 for `scalafmt --list` if there are any files that require re-formatting
- Print the relative path for the files (instead of absolute paths)

This behavior is pretty similar to [prettier's --check option](https://prettier.io/docs/en/cli.html#check)