### PR TITLE
Don't treat commas in lambda bodies as "trailing commas"

### DIFF
--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -22,6 +22,38 @@ def method(
     b: String,
 )
 
+<<< should not add a comma in a lambda body
+object Foo {
+  Some(1).map(data => {
+    data
+  })
+}
+>>>
+object Foo {
+  Some(1).map(data => {
+    data
+  })
+}
+
+<<< should not add a comma in a constructor body
+def this() = {
+  this(1)
+}
+>>>
+def this() = {
+  this(1)
+}
+
+<<< does not remove a legal (but weird) comma in a constructor body
+def this() = {
+  this(1),
+}
+>>>
+def this() = {
+  this(1),
+}
+
+
 <<< should not add a trailing comma when not breaking into multiple lines
 def m(a: Int, b: Int)
 >>>


### PR DESCRIPTION
Fixes #1464. This PR makes the code simply ignore these weird cases as opposed to trying to remove them. I think this means that no code will suddenly fail `scalafmtCheck` after this change, but people will have to manually remove any of those weird commas.

Thanks for the great software!