### PR TITLE
Fixed bug with private[x] after class definitions (#1491)

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -799,8 +799,11 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         case FormatToken(RightParenOrBracket(), l @ LeftParen(), _) =>
           loop(l)
         case f @ FormatToken(left @ RightParenOrBracket(), right, _) =>
+          lazy val isCtorModifier =
+            ownersMap(hash(right)).parent.exists(_.is[meta.Ctor])
           right match {
-            case Modifier() =>
+            // modifier for constructor if class definition has type parameters: [class A[T, K, C] private (a: Int)]
+            case Modifier() if isCtorModifier =>
               // This case only applies to classes
               next(f).right match {
                 case x @ (_: Token.LeftParen | _: Token.LeftBracket) =>

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -279,3 +279,13 @@ object Recorder {
   sealed abstract class Ast[A]
   final case class Record()
 }
+<<< don't fail on private[x] after class definitions (#1491)
+object Flurp {
+  class Banana(foo: String)
+  private[somepackage] object Dummy
+}
+>>>
+object Flurp {
+  class Banana(foo: String)
+  private[somepackage] object Dummy
+}


### PR DESCRIPTION
Fixes (#1491, #1383)

Current last brace search algorithm is too "greedy" and captures non-constructor modifiers