### PR TITLE
Improve imports rewriters

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -606,7 +606,7 @@ import java.{bar, foo}
 
 import scala.fmt
 
-import com.my.class
+import com.my.clazz
 ```
 
 ## Vertical Multiline

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -591,6 +591,24 @@ rewrite.rules = [AsciiSortImports]
 import foo.{~>, `symbol`, bar, Random}
 ```
 
+### `GroupImports`
+
+Groups imports by the first part, sorts them inside groups using
+the traditional ASCII sorting. Groups and their order can be customized using `groups`
+setting, use `"_"` placeholder to define "the rest" group
+
+```scala mdoc:scalafmt
+rewrite.rules = [GroupImports]
+rewrite.groupImports.groups = ["java", "scala", "_"]
+rewrite.groupImports.emptyLineBetweenGroups = true
+---
+import java.{bar, foo}
+
+import scala.fmt
+
+import com.my.class
+```
+
 ## Vertical Multiline
 
 Since: v1.6.0.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/GroupImportsSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/GroupImportsSettings.scala
@@ -1,0 +1,20 @@
+package org.scalafmt.config
+
+import metaconfig._
+
+case class GroupImportsSettings(
+    groups: Seq[String] = Seq("java", "scala", "_"),
+    emptyLineBetweenGroups: Boolean = true
+) {
+  val reader: ConfDecoder[GroupImportsSettings] =
+    generic.deriveDecoder(this).noTypos
+}
+
+object GroupImportsSettings {
+  implicit lazy val surface: generic.Surface[GroupImportsSettings] =
+    generic.deriveSurface
+  implicit lazy val encoder: ConfEncoder[GroupImportsSettings] =
+    generic.deriveEncoder
+
+  def default = GroupImportsSettings()
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RedundantBracesSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RedundantBracesSettings.scala
@@ -7,6 +7,7 @@ case class RedundantBracesSettings(
     includeUnitMethods: Boolean = true,
     maxLines: Int = 100,
     stringInterpolation: Boolean = false,
+    imports: Boolean = false,
     // Re-enable generalExpressions once
     // https://github.com/scalameta/scalafmt/issues/1147 is fixed
     generalExpressions: Boolean = false

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
@@ -7,10 +7,12 @@ import org.scalafmt.rewrite.{AvoidInfix, Rewrite}
 case class RewriteSettings(
     rules: Seq[Rewrite] = Nil,
     redundantBraces: RedundantBracesSettings = RedundantBracesSettings(),
+    groupImports: GroupImportsSettings = GroupImportsSettings.default,
     sortModifiers: SortSettings = SortSettings.default,
     neverInfix: Pattern = Pattern.neverInfix
 ) {
   private implicit val redundantBracesReader = redundantBraces.reader
+  private implicit val groupImportsReader = groupImports.reader
   private implicit val patternReader = neverInfix.reader
   val reader: ConfDecoder[RewriteSettings] = generic.deriveDecoder(this).noTypos
   Rewrite.validateRewrites(rules) match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/GroupImports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/GroupImports.scala
@@ -1,0 +1,150 @@
+package org.scalafmt.rewrite
+
+import org.scalafmt.config.GroupImportsSettings
+
+import scala.meta.{
+  Tree,
+  Importer => MetaImporter,
+  Importee,
+  Token,
+  Import => MetaImport
+}
+import scala.meta.tokens.Token.LF
+import scala.meta.tokens.Token.Space
+import scala.meta.tokens.Token.Tab
+import scala.meta.tokens.Token.CR
+import scala.meta.tokens.Token.Comment
+import scala.meta.tokens.Tokens
+
+case object GroupImports extends Rewrite {
+
+  @inline private def settings(
+      implicit ctx: RewriteCtx
+  ): GroupImportsSettings =
+    ctx.style.rewrite.groupImports
+
+  override def rewrite(code: Tree, ctx: RewriteCtx): Seq[Patch] = {
+    implicit def _ctx = ctx
+
+    import ctx.dialect
+    val groupedImports =
+      code.collect { case i: MetaImport => i }.groupBy(_.parent)
+
+    groupedImports.flatMap {
+      case (parent, imports) => sortImports(parent.get, imports)
+    }.toSeq
+  }
+
+  private def sortImports(parent: Tree, imports: List[MetaImport])(
+      implicit ctx: RewriteCtx
+  ): Seq[Patch] = {
+    val firstToken = imports.head.tokens.head
+
+    // comments in the end of line should be deleted separately
+    val (imps, comments) = imports.flatMap { i =>
+      val lastComment = findComments(parent, i)
+      val comments = i.tokens.collect { case c: Comment => c }
+
+      val commentByImporter = i.importers
+        .sliding(2)
+        .map { pair =>
+          pair.head -> comments.filter { c =>
+            c.start >= pair.head.pos.end && c.end <= pair.last.pos.start
+          }
+        }
+        .toMap
+        .withDefaultValue(Seq.empty) + (i.importers.last -> lastComment)
+
+      i.importers.map { im =>
+        (Import(i, Importer(im, commentByImporter(im))), lastComment)
+      }
+    }.unzip
+
+    val deleteImports =
+      imps.map(_.orig).distinct.flatMap(deleteImport(parent, _))
+    val deleteComments = comments.flatMap(_.map(TokenPatch.Remove))
+
+    val sorted = imps.sorted(ImportOrdering).toSeq
+    val grouped = group(sorted)
+
+    val lineBetween = if (settings.emptyLineBetweenGroups) "\n\n" else "\n"
+
+    deleteImports ++ deleteComments :+ TokenPatch.AddLeft(
+      firstToken,
+      grouped
+        .map(_.map(_.toString()).mkString("\n"))
+        .mkString(lineBetween) + "\n"
+    )
+  }
+
+  /**
+    * Groups imports according settings
+    *
+    * @param col (<import text>, <import ref>, <the first ident>) sequence
+    */
+  private def group(
+      col: Seq[Import]
+  )(implicit ctx: RewriteCtx): Seq[Seq[Import]] = {
+    val groups = settings.groups
+
+    groups
+      .map {
+        case g if g == "_" =>
+          col.filter { i =>
+            !groups.contains(i.importer.first)
+          }
+        case g =>
+          col.filter { i =>
+            i.importer.first.toString == g
+          }
+      }
+      .filter(_.nonEmpty)
+  }
+
+  /**
+    * Deletes import and all "space" symbols between it and the next identifier
+    */
+  private def deleteImport(parent: Tree, `import`: MetaImport): Seq[Patch] = {
+    val spaces = parent.tokens
+      .dropWhile(t => t.isNot[LF] || t.pos.startLine != `import`.pos.endLine)
+      .takeWhile { t =>
+        t.is[LF] || t.is[Space] || t.is[Tab] || t.is[CR]
+      }
+
+    `import`.tokens.map(TokenPatch.Remove) ++ spaces.map(TokenPatch.Remove)
+  }
+
+  private def findComments(parent: Tree, `import`: MetaImport): Seq[Comment] =
+    parent.tokens
+      .collect { case c: Comment => c }
+      .filter(
+        c =>
+          c.pos.startLine == `import`.pos.endLine && c.pos.start >= `import`.pos.end
+      )
+
+  private case class Import(
+      orig: MetaImport,
+      importer: Importer
+  ) {
+    override def toString(): String =
+      s"import ${importer.toString()}"
+  }
+
+  private case class Importer(
+      orig: MetaImporter,
+      comments: Seq[Comment] = List.empty
+  ) {
+    def first: String = orig.tokens.head.toString()
+
+    override def toString(): String = {
+      val commentsStr =
+        if (comments.nonEmpty) " " + comments.mkString(" ") else ""
+      orig.toString() + commentsStr
+    }
+  }
+
+  private object ImportOrdering extends Ordering[Import] {
+    def compare(a: Import, b: Import) =
+      a.importer.orig.ref.toString compare b.importer.orig.ref.toString
+  }
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -26,6 +26,7 @@ object Rewrite {
     ReaderUtil.oneOf[Rewrite](
       RedundantBraces,
       RedundantParens,
+      GroupImports,
       SortImports,
       AsciiSortImports,
       PreferCurlyFors,
@@ -41,6 +42,7 @@ object Rewrite {
   val name2rewrite: Map[String, Rewrite] = nameMap[Rewrite](
     RedundantBraces,
     RedundantParens,
+    GroupImports,
     SortImports,
     AsciiSortImports,
     PreferCurlyFors,
@@ -56,7 +58,10 @@ object Rewrite {
   private def incompatibleRewrites: List[(Rewrite, Rewrite)] = List(
     SortImports -> ExpandImportSelectors,
     SortImports -> AsciiSortImports,
-    AsciiSortImports -> ExpandImportSelectors
+    AsciiSortImports -> ExpandImportSelectors,
+    SortImports -> GroupImports,
+    AsciiSortImports -> GroupImports,
+    ExpandImportSelectors -> GroupImports
   )
 
   def validateRewrites(rewrites: Seq[Rewrite]): Seq[String] = {

--- a/scalafmt-tests/src/test/resources/rewrite/GroupImports-comments.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/GroupImports-comments.stat
@@ -1,0 +1,46 @@
+rewrite.rules = [GroupImports]
+<<< importees
+{
+  import b.c.{
+    d, // c1
+    e /* c2 */, f // c3
+  }
+}
+>>>
+{
+  import b.c.{
+    d, // c1
+    e /* c2 */,
+    f // c3
+  }
+}
+<<< sort imports with comments
+{
+  import b.b // c1
+  import a.b /* c2 */
+}
+>>>
+{
+  import a.b /* c2 */
+  import b.b // c1
+}
+<<< inline imports with comments
+{
+  import d.e /* c1 */, c.d /* c2 */, b.c /* c3 */, a.b /* c4 */
+}
+>>>
+{
+  import a.b /* c4 */
+  import b.c /* c3 */
+  import c.d /* c2 */
+  import d.e /* c1 */
+}
+<<< multi comments per import
+{
+  import a.b /* c1 */ /* c2 */, b.c /* c3 */ // c4
+}
+>>>
+{
+  import a.b /* c1 */ /* c2 */
+  import b.c /* c3 */ // c4
+}

--- a/scalafmt-tests/src/test/resources/rewrite/GroupImports-custom_groups.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/GroupImports-custom_groups.stat
@@ -1,0 +1,23 @@
+rewrite.rules = [GroupImports]
+rewrite.groupImports.groups = ["x", "y", "_", "z"]
+rewrite.groupImports.emptyLineBetweenGroups = false
+<<< group
+{
+  import x.b.z, z.b, x.a.b
+  import b.a.c
+
+  import y.c
+  import y._
+  
+  import a.b.x
+}
+>>>
+{
+  import x.a.b
+  import x.b.z
+  import y.c
+  import y._
+  import a.b.x
+  import b.a.c
+  import z.b
+}

--- a/scalafmt-tests/src/test/resources/rewrite/GroupImports.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/GroupImports.stat
@@ -1,0 +1,102 @@
+rewrite.rules = [GroupImports]
+<<< basic
+{
+  import b.c.{d, e}
+  import a.b.c
+  object a {
+    import c.e.z
+    import c.d.e
+  }
+}
+>>>
+{
+  import a.b.c
+  import b.c.{d, e}
+  object a {
+    import c.d.e
+    import c.e.z
+  }
+}
+<<< multiline imports
+{
+  import b.c.{
+    d => z,
+    e => x
+  }
+  import a.b.c
+}
+>>>
+{
+  import a.b.c
+  import b.c.{d => z, e => x}
+}
+<<< multi importers
+{
+  import b.c.d, f.{d, e}
+  import a.b.c
+}
+>>>
+{
+  import a.b.c
+  import b.c.d
+  import f.{d, e}
+}
+<<< extra lines between imports
+{
+  import a.b
+
+
+  import a.c
+  object a {
+    import c.b
+
+    
+    import c.c
+  }
+}
+>>>
+{
+  import a.b
+  import a.c
+  object a {
+    import c.b
+    import c.c
+  }
+}
+<<< extra lines after imports
+{
+  import a.b
+  import a.c
+
+
+  object a {
+    import c.b
+    import c.c
+
+
+  }
+}
+>>>
+{
+  import a.b
+  import a.c
+  object a {
+    import c.b
+    import c.c
+  }
+}
+<<< group
+{
+  import java.b.z, com.b
+  import scala.c
+  import java.a.x
+}
+>>>
+{
+  import java.a.x
+  import java.b.z
+
+  import scala.c
+
+  import com.b
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-import.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-import.stat
@@ -1,0 +1,23 @@
+rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.imports = true
+
+<<< remove braces around single importee
+{
+import a.{b}
+import a.b.{ c }, k.{f}
+import a.b.{_}
+}
+>>>
+{
+  import a.b
+  import a.b.c, k.f
+  import a.b._
+}
+<<< leave braces around multiple importees
+import a.{b, c}
+>>>
+import a.{b, c}
+<<< leave braces around named importees
+import a.{b => c}
+>>>
+import a.{b => c}


### PR DESCRIPTION
Removing redundant braces around imports has been added.

Grouping imports rewriter has been added. Groups and their order could be customized using settings. It's useful to have imports grouping and sorting functionality outside Intellij world.