### PR TITLE
Add a space between constructor annotations and their parameter lists

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -373,6 +373,7 @@ class Router(formatOps: FormatOps) {
           } =>
         val modification: Modification = leftOwner match {
           case _: Mod => Space
+          case _: Init => Space
           case t: Term.Name
               if style.spaces.afterTripleEquals &&
                 t.tokens.map(_.syntax) == Seq("===") =>

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
@@ -144,7 +144,7 @@ object A {
   @Annotation
   class B
   @Singleton
-  class B @Inject()(val x: Int)
+  class B @Inject() (val x: Int)
   @js.native
   class C() {
     def c = 5
@@ -157,7 +157,7 @@ object A {
   class B
 
   @Singleton
-  class B @Inject()(val x: Int)
+  class B @Inject() (val x: Int)
 
   @js.native
   class C() {
@@ -294,7 +294,7 @@ object a {
   }
 
   /** Implements the ..... /status/about, etc */
-  class Status @Inject()(ws: WSClient) {
+  class Status @Inject() (ws: WSClient) {
     ???
   }
 

--- a/scalafmt-tests/src/test/resources/spaces/Hacking.stat
+++ b/scalafmt-tests/src/test/resources/spaces/Hacking.stat
@@ -3,3 +3,7 @@ maxColumn = 40
 function(a, b, c)
 >>>
 function( a, b, c )
+<<< Space between annotation and ctor argument list
+class A @Inject()(b: C)
+>>>
+class A @Inject() (b: C)


### PR DESCRIPTION
Fixes #618 which, although closed due to inactivity, describes an improvement to spacing after constructor annotations - specifically, it'd be nice to retain a space between the constructor annotation and the first parameter list of the constructor. The desired spacing looks like:

```scala
class Foo @Inject() (bar: Bar) {
```

Whereas, currently, we'd remove the space, producing:

```scala
class Foo @Inject()(bar: Bar) {
```