### PR TITLE
Use Coursier defaults, which also adds support for COURSIER_REPOSITORIES

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
@@ -1,20 +1,14 @@
 package org.scalafmt.dynamic
 
-import java.io.PrintWriter
+import java.io.OutputStreamWriter
 import java.net.URL
-import java.nio.file.Path
 
 import coursierapi._
-
-import scala.collection.JavaConverters._
 import org.scalafmt.dynamic.ScalafmtDynamicDownloader._
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
 import scala.util.Try
-import java.io.OutputStream
-import java.io.PrintStream
-import java.io.OutputStreamWriter
-import scala.concurrent.JavaConversions._
 
 class ScalafmtDynamicDownloader(
     downloadProgressWriter: OutputStreamWriter,

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
@@ -5,6 +5,7 @@ import java.net.URL
 import java.nio.file.Path
 
 import coursierapi._
+
 import scala.collection.JavaConverters._
 import org.scalafmt.dynamic.ScalafmtDynamicDownloader._
 
@@ -13,6 +14,7 @@ import scala.util.Try
 import java.io.OutputStream
 import java.io.PrintStream
 import java.io.OutputStreamWriter
+import scala.concurrent.JavaConversions._
 
 class ScalafmtDynamicDownloader(
     downloadProgressWriter: OutputStreamWriter,
@@ -75,14 +77,16 @@ class ScalafmtDynamicDownloader(
       "org.scalameta"
     }
 
-  private def repositories: Array[Repository] = Array(
-    Repository.central(),
-    Repository.ivy2Local(),
-    MavenRepository.of(
-      "https://oss.sonatype.org/content/repositories/snapshots"
-    ),
-    MavenRepository.of("https://oss.sonatype.org/content/repositories/public")
-  )
+  private def repositories: Array[Repository] = {
+    // Default repositories are ivy2local, central and also anything in COURSIER_REPOSITORIES overrides
+    Repository.defaults().asScala.toArray ++ Array(
+      MavenRepository.of(
+        "https://oss.sonatype.org/content/repositories/snapshots"
+      ),
+      MavenRepository.of("https://oss.sonatype.org/content/repositories/public")
+    )
+  }
+
 }
 
 object ScalafmtDynamicDownloader {


### PR DESCRIPTION
This is another crack at https://github.com/scalameta/scalafmt/pull/1436 which I think is a bit easier now we've got the Coursier interface on board.

I believe that fetching Coursier's default repositories also prompts Couriser to check COURSIER_REPOSITORIES env var and `couriser.repositories` property - so by using defaults here we get COURSIER_REPOSITORIES compatibility

Previously the default repositories were being totally overwritten by the hard coded repository list

I believe this fulfils https://github.com/scalameta/scalafmt/issues/1521