### PR TITLE
Fix inconsistent spaces with verticalMultiline and spaces.inParentheses

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -956,8 +956,11 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       else NoSplit
 
     Seq(
-      Split(singleLineModification, 0, ignoreIf = !isBracket && aboveArityThreshold)
-        .withPolicy(SingleLineBlock(singleLineExpire)),
+      Split(
+        singleLineModification,
+        0,
+        ignoreIf = !isBracket && aboveArityThreshold
+      ).withPolicy(SingleLineBlock(singleLineExpire)),
       Split(Newline, 1) // Otherwise split vertically
         .withIndent(firstIndent, close, Right)
         .withPolicy(policy)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -951,8 +951,12 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
     val aboveArityThreshold = (maxArity >= style.verticalMultiline.arityThreshold) || (maxArity >= style.verticalMultilineAtDefinitionSiteArityThreshold)
 
+    val singleLineModification =
+      if (style.spaces.inParentheses) Space
+      else NoSplit
+
     Seq(
-      Split(NoSplit, 0, ignoreIf = !isBracket && aboveArityThreshold)
+      Split(singleLineModification, 0, ignoreIf = !isBracket && aboveArityThreshold)
         .withPolicy(SingleLineBlock(singleLineExpire)),
       Split(Newline, 1) // Otherwise split vertically
         .withIndent(firstIndent, close, Right)

--- a/scalafmt-tests/src/test/resources/vertical-multiline/withSpacesInParentheses.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/withSpacesInParentheses.stat
@@ -1,0 +1,7 @@
+spaces.inParentheses = true
+maxColumn = 40
+verticalMultiline.atDefnSite = true
+<<< def
+def x(foo: Int) = 2
+>>>
+def x( foo: Int ) = 2


### PR DESCRIPTION
- **Configuration**:
```
version = 2.1.0
spaces.inParentheses = true
maxColumn = 40
verticalMultiline.atDefnSite = true
```

## Steps

Given code like this:
```scala
def x(foo: Int) = 2
```

## Problem

Scalafmt formats code like this:
```scala
def x(foo: Int ) = 2
```

## Expectation

I would like the formatted output to look like this:
```scala
def x( foo: Int ) = 2
```
