### PR TITLE
Do not add space between constructor parameters

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -372,7 +372,11 @@ class Router(formatOps: FormatOps) {
           } =>
         val modification: Modification = leftOwner match {
           case _: Mod => Space
-          case _: Init => Space
+          // Add a space between constructor annotations and their parameter lists
+          // see:
+          // https://github.com/scalameta/scalafmt/pull/1516
+          // https://github.com/scalameta/scalafmt/issues/1528
+          case init: Init if init.parent.forall(_.is[Mod.Annot]) => Space
           case t: Term.Name
               if style.spaces.afterTripleEquals &&
                 t.tokens.map(_.syntax) == Seq("===") =>

--- a/scalafmt-tests/src/test/resources/spaces/Constructor.stat
+++ b/scalafmt-tests/src/test/resources/spaces/Constructor.stat
@@ -1,0 +1,15 @@
+maxColumn = 100
+<<< Space between annotation and ctor argument list
+class A @Inject()(b: C)
+>>>
+class A @Inject() (b: C)
+
+<<< Space between annotation and ctor argument list (with multiple argument list)
+class MyComponent @Inject()(ctx: Context)(ws: WSClient)
+>>>
+class MyComponent @Inject() (ctx: Context)(ws: WSClient)
+
+<<< Do not add add a space when a constructor has multiple argument lists #1528
+new ShardEntity(rts) (onMessage)
+>>>
+new ShardEntity(rts)(onMessage)

--- a/scalafmt-tests/src/test/resources/spaces/Hacking.stat
+++ b/scalafmt-tests/src/test/resources/spaces/Hacking.stat
@@ -3,7 +3,3 @@ maxColumn = 40
 function(a, b, c)
 >>>
 function( a, b, c )
-<<< Space between annotation and ctor argument list
-class A @Inject()(b: C)
->>>
-class A @Inject() (b: C)


### PR DESCRIPTION
This PR is follow up of https://github.com/scalameta/scalafmt/pull/1516 that fixes https://github.com/scalameta/scalafmt/issues/1528 (the regression from 2.1.1)

