### PR TITLE
Remove `avoidEmptyLinesAroundBlock` option

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -110,8 +110,7 @@ case class Newlines(
     beforeImplicitKWInVerticalMultiline: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
-    avoidAfterYield: Boolean = true,
-    avoidEmptyLinesAroundBlock: Option[Boolean] = None
+    avoidAfterYield: Boolean = true
 ) {
   val reader: ConfDecoder[Newlines] = generic.deriveDecoder(this).noTypos
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -194,7 +194,7 @@ case class ScalafmtConfig(
   )
 
   val avoidEmptyLinesAroundBlock: Boolean =
-    newlines.avoidEmptyLinesAroundBlock.getOrElse(edition > Edition(2019, 10))
+    edition > Edition(2019, 10)
 }
 
 object ScalafmtConfig {

--- a/scalafmt-tests/src/test/resources/newlines/avoidEmptyLinesAroundBlock.stat
+++ b/scalafmt-tests/src/test/resources/newlines/avoidEmptyLinesAroundBlock.stat
@@ -1,6 +1,4 @@
 maxColumn = 80
-newlines.avoidEmptyLinesAroundBlock = true
-
 <<< should remove empty lines at the beginning of a def block
 def other: String = {
 


### PR DESCRIPTION
Followup from https://github.com/scalameta/scalafmt/pull/1431. This setting is already covered by the `edition` option. 

An important aspect of editions is that users will not be able to pick and choose individual changes to the default formatting behavior. The motivation for this restriction is to

* make the project more maintainable: it's difficult to reason how all possible combinations of off-by-default settings work in practice
* improve the user experience: currently, users can mix and match individual settings that hit on bugs such as #1539.


