### PR TITLE
Edition docs fix

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,14 +95,14 @@ The end goal for users should be to remove the `edition` setting from
 `.scalafmt.conf` in order to enjoy the latest improvements to the formatting
 output.
 
-```scala mdoc:defaults
-edition
-```
-
 The `edition` setting is formatted as `"$year-$month"` and should be interpreted
-as: "use the default settings at that given date". For example the setting
-`edition = 2019-10` means that the default settings from October 2019 should be
-used.
+as: "use the default settings at that given date". The latest edition is selected by default.
+
+Example:
+
+```scala config
+edition = 2019-10 // default settings from October 2019 should be used 
+```
 
 ## Indentation
 


### PR DESCRIPTION
Default params for `edition` (`Int.MaxValue`) is not reasonable for documentation:

<img width="358" alt="Screen Shot 2019-10-29 at 5 20 06 PM" src="https://user-images.githubusercontent.com/4687050/67775730-64723c00-fa70-11e9-9db2-25b9b9dc917c.png">

It is not clear that `2147483647` is the year and `2147483647` is the month. So I removed them and restructured docs a little bit.