### PR TITLE
Discord label in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 [![Build Status](https://travis-ci.org/scalameta/scalafmt.svg?branch=master)](https://travis-ci.org/scalameta/scalafmt)
 [![Build status](https://ci.appveyor.com/api/projects/status/7gha7cxm5lw8fsc3)](https://ci.appveyor.com/project/olafurpg/scalafmt/branch/master)
 [![Join the chat at https://gitter.im/scalameta/scalafmt](https://badges.gitter.im/scalameta/scalafmt.svg)](https://gitter.im/scalameta/scalafmt?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the discord chat](https://img.shields.io/discord/632642981228314653?label=discord)](https://discordapp.com/channels/632642981228314653/632665341864181780)
 [![Latest version](https://index.scala-lang.org/scalameta/scalafmt/scalafmt-core/latest.svg?color=orange)](https://index.scala-lang.org/scalameta/scalafmt/scalafmt-core)
 
 ### [User documentation][docs]


### PR DESCRIPTION
I think that discord is more handy than gitter. It's not good that scalameta server is not marked on the README.