### PR TITLE
Router: format lambda in 1-arg call as with braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -199,6 +199,8 @@ case class ScalafmtConfig(
 
   // Edition 2019-11
   val activeForEdition_2019_11: Boolean = activeFor(Edition(2019, 11))
+  val newlinesBeforeSingleArgParenLambdaParams: Boolean =
+    newlines.alwaysBeforeCurlyBraceLambdaParams || !activeForEdition_2019_11
 }
 
 object ScalafmtConfig {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -9,7 +9,7 @@ case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
   import org.scalafmt.util.TokenOps._
 
   def noNewlines: Decision =
-    Decision(formatToken, splits.filter(_.modification.isNewline))
+    Decision(formatToken, splits.filterNot(_.modification.isNewline))
 
   def onlyNewlines(implicit line: sourcecode.Line): Decision = {
     val filtered = splits.filter(_.modification.isNewline)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -728,7 +728,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     )
   }
 
-  def newlineBeforeClosingCurlyPolicy(close: Token) =
+  def newlineOnTokenPolicy(close: Token) =
     Policy({
       case d @ Decision(t @ FormatToken(_, `close`, _), s) =>
         d.onlyNewlines

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -40,15 +40,19 @@ case class Policy(
     * first pf is not defined at argument.
     */
   def andThen(otherF: PartialFunction[Decision, Decision]): Policy = {
-    // TODO(olafur) optimize?
-    val newPf: PartialFunction[Decision, Decision] = {
-      case x =>
-        otherF.applyOrElse(
-          f.applyOrElse(x, identity[Decision]),
-          identity[Decision]
-        )
+    if (otherF == Policy.emptyPf) this
+    else if (this.f == Policy.emptyPf) copy(f = otherF)
+    else {
+      // TODO(olafur) optimize?
+      val newPf: PartialFunction[Decision, Decision] = {
+        case x =>
+          otherF.applyOrElse(
+            f.applyOrElse(x, identity[Decision]),
+            identity[Decision]
+          )
+      }
+      copy(f = newPf)
     }
-    copy(f = newPf)
   }
 
   override def toString = s"P:${line.value}(D=$noDequeue)"

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -125,7 +125,7 @@ class Router(formatOps: FormatOps) {
           close,
           disallowSingleLineComments = disallowSingleLineComments
         )
-        val newlineBeforeClosingCurly = newlineBeforeClosingCurlyPolicy(close)
+        val newlineBeforeClosingCurly = newlineOnTokenPolicy(close)
 
         val newlinePolicy = style.importSelectors match {
           case ImportSelectors.noBinPack =>
@@ -172,7 +172,7 @@ class Router(formatOps: FormatOps) {
       // { ... } Blocks
       case tok @ FormatToken(open @ T.LeftBrace(), right, between) =>
         val close = matchingParentheses(hash(open))
-        val newlineBeforeClosingCurly = newlineBeforeClosingCurlyPolicy(close)
+        val newlineBeforeClosingCurly = newlineOnTokenPolicy(close)
         val selfAnnotation: Option[Tokens] = leftOwner match {
           // Self type: trait foo { self => ... }
           case t: Template => Some(t.self.name.tokens).filter(_.nonEmpty)
@@ -664,11 +664,7 @@ class Router(formatOps: FormatOps) {
         val newlinePolicy: Policy =
           if (style.danglingParentheses.defnSite && defnSite ||
             style.danglingParentheses.callSite && !defnSite) {
-            val breakOnClosing = Policy({
-              case d @ Decision(FormatToken(_, `close`, _), s) =>
-                d.onlyNewlines
-            }, close.end)
-            breakOnClosing
+            newlineOnTokenPolicy(close)
           } else {
             Policy(PartialFunction.empty[Decision, Decision], close.end)
           }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -147,14 +147,14 @@ object TokenOps {
   )(implicit line: sourcecode.Line): Policy = {
     Policy(
       {
-        case Decision(tok, splits)
+        case d @ Decision(tok, _)
             if !tok.right.is[EOF] && tok.right.end <= expire.end &&
               exclude.forall(!_.contains(tok.left.start)) &&
               (disallowSingleLineComments || !isSingleLineComment(tok.left)) =>
           if (penaliseNewlinesInsideTokens && tok.leftHasNewline) {
             Decision(tok, Seq.empty[Split])
           } else {
-            Decision(tok, splits.filterNot(_.modification.isNewline))
+            d.noNewlines
           }
       },
       expire.end,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -536,4 +536,10 @@ object TreeOps {
       case _ => None
     }
 
+  def getLambdaAtSingleArgCallSite(tree: Tree): Option[Term.Function] =
+    tree match {
+      case Term.Apply(_, List(fun: Term.Function)) => Some(fun)
+      case _ => None
+    }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -530,4 +530,10 @@ object TreeOps {
     case _ => false
   }
 
+  def getAssignAtSingleArgCallSite(tree: Tree): Option[Term.Assign] =
+    tree match {
+      case Term.Apply(_, List(fun: Term.Assign)) => Some(fun)
+      case _ => None
+    }
+
 }

--- a/scalafmt-tests/src/test/resources/align/ArrayIndexOutOfBounds800.source
+++ b/scalafmt-tests/src/test/resources/align/ArrayIndexOutOfBounds800.source
@@ -1,4 +1,5 @@
 style = defaultWithAlign
+edition = 2019-10
 onTestFailure = "Search state"
 align = most
 danglingParentheses = false

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -581,8 +581,8 @@ opt[String]("json-extractor") action { (x, c) =>
 }
 >>>
 opt[String]("json-extractor") action { (x, c) =>
-  c.copy(
-      common = c.common.copy(jsonExtractor = JsonExtractorOption.withName(x)))
+  c.copy(common =
+    c.common.copy(jsonExtractor = JsonExtractorOption.withName(x)))
 }
 <<< nested apply with assign 2
  {
@@ -597,9 +597,8 @@ opt[String]("json-extractor") action { (x, c) =>
 >>>
 {
   val config =
-    WSClientConfig(
-        ssl =
-          SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)))
+    WSClientConfig(ssl =
+      SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)))
   val game = Game(
       castleLastMoveTime =
         CastleLastMoveTime.init.copy(castles = game.board.history.castles),

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -573,3 +573,35 @@ def startSharding(system: ActorSystem,
     }
   }
 }
+<<< nested apply with assign
+opt[String]("json-extractor") action { (x, c) =>
+    c.copy(         common =
+            c.common.copy(
+            jsonExtractor = JsonExtractorOption.withName(x)))
+}
+>>>
+opt[String]("json-extractor") action { (x, c) =>
+  c.copy(
+      common = c.common.copy(jsonExtractor = JsonExtractorOption.withName(x)))
+}
+<<< nested apply with assign 2
+ {
+       val config =
+         WSClientConfig(          ssl =
+            SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)))
+        val game = Game(              castleLastMoveTime =
+                CastleLastMoveTime.init.copy(castles = game.board.history.castles),
+                    daysPerTurn = daysPerTurn
+                    )
+                    }
+>>>
+{
+  val config =
+    WSClientConfig(
+        ssl =
+          SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)))
+  val game = Game(
+      castleLastMoveTime =
+        CastleLastMoveTime.init.copy(castles = game.board.history.castles),
+      daysPerTurn = daysPerTurn)
+}

--- a/scalafmt-tests/src/test/resources/default/SearchState.stat
+++ b/scalafmt-tests/src/test/resources/default/SearchState.stat
@@ -455,8 +455,8 @@ EventsResponse.fromJson(json, run).success.value.events should be(
     ))
 <<< react #458
   val TodoApp = ReactComponentB[Unit]("TodoApp")
-    .initialState(State(Nil, ""))
-    .renderS(($, s) =>
+    .initialState(State(Nil, "")).renderS(
+    ($, s) =>
       <.div(
         <.h3("TODO"),
         TodoList(s.items),
@@ -469,16 +469,16 @@ EventsResponse.fromJson(json, run).success.value.events should be(
 >>>
 val TodoApp = ReactComponentB[Unit]("TodoApp")
   .initialState(State(Nil, ""))
-  .renderS(
-      ($, s) =>
-        <.div(<.h3("TODO"),
-              TodoList(s.items),
-              <.form(
-                  ^.onSubmit ==> $._runState(handleSubmit), // runState runs a state monad and applies the result.
-                  <.input( // _runState is similar but takes a function-to-a-state-monad.
-                      ^.onChange ==> $._runState(acceptChange), // In these cases, the function will be fed the JS event.
-                      ^.value := s.text),
-                  <.button("Add #", s.items.length + 1))))
+  .renderS(($, s) =>
+    <.div(
+        <.h3("TODO"),
+        TodoList(s.items),
+        <.form(
+            ^.onSubmit ==> $._runState(handleSubmit), // runState runs a state monad and applies the result.
+            <.input( // _runState is similar but takes a function-to-a-state-monad.
+                ^.onChange ==> $._runState(acceptChange), // In these cases, the function will be fed the JS event.
+                ^.value := s.text),
+            <.button("Add #", s.items.length + 1))))
   .build
 <<< #745
 object SharedPolicyAmounts {

--- a/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
@@ -1,6 +1,7 @@
 style = default
 <<< forAll
-forAll(table)((reqProto, headReq, reqCH, resProto, resCH, resCD, renCH, close) ⇒
+forAll(table)(
+  (reqProto, headReq, reqCH, resProto, resCH, resCD, renCH, close) ⇒
   ResponseRenderingContext(
     response = HttpResponse(200, headers = resCH.toList,
       entity = if (resCD) HttpEntity.CloseDelimited(ContentTypes.`text/plain(UTF-8)`,
@@ -16,33 +17,32 @@ forAll(table)((reqProto, headReq, reqCH, resProto, resCH, resCD, renCH, close) �
            |${if (resCD) "" else "Content-Length: 6\n"}
            |${if (headReq) "" else "ENTITY"}""", close))
 >>>
-forAll(table)(
-  (reqProto, headReq, reqCH, resProto, resCH, resCD, renCH, close) ⇒
-    ResponseRenderingContext(
-      response = HttpResponse(
-        200,
-        headers = resCH.toList,
-        entity =
-          if (resCD)
-            HttpEntity.CloseDelimited(
-              ContentTypes.`text/plain(UTF-8)`,
-              Source.single(ByteString("ENTITY"))
-            )
-          else HttpEntity("ENTITY"),
-        protocol = resProto
-      ),
-      requestMethod = if (headReq) HttpMethods.HEAD else HttpMethods.GET,
-      requestProtocol = reqProto,
-      closeRequested = HttpMessage.connectionCloseExpected(reqProto, reqCH)
-    ) should renderTo(
-      s"""${resProto.value} 200 OK
+forAll(table)((reqProto, headReq, reqCH, resProto, resCH, resCD, renCH, close) ⇒
+  ResponseRenderingContext(
+    response = HttpResponse(
+      200,
+      headers = resCH.toList,
+      entity =
+        if (resCD)
+          HttpEntity.CloseDelimited(
+            ContentTypes.`text/plain(UTF-8)`,
+            Source.single(ByteString("ENTITY"))
+          )
+        else HttpEntity("ENTITY"),
+      protocol = resProto
+    ),
+    requestMethod = if (headReq) HttpMethods.HEAD else HttpMethods.GET,
+    requestProtocol = reqProto,
+    closeRequested = HttpMessage.connectionCloseExpected(reqProto, reqCH)
+  ) should renderTo(
+    s"""${resProto.value} 200 OK
            |Server: akka-http/1.0.0
            |Date: Thu, 25 Aug 2011 09:10:29 GMT
            |${renCH.fold("")(_ + "\n")}Content-Type: text/plain; charset=UTF-8
            |${if (resCD) "" else "Content-Length: 6\n"}
            |${if (headReq) "" else "ENTITY"}""",
-      close
-    )
+    close
+  )
 )
 <<< don't force me
 val boss = system.actorOf(Props(new Actor {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -12,12 +12,10 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => {
-      g(x)
-      g(y)
-    }
-  )
+  something.call((x, y) => {
+    g(x)
+    g(y)
+  })
 }
 <<< 2: single-arg single-stmt block long-body lambda call
 def f = {
@@ -29,11 +27,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => {
-      g("some very very very very long string which exceeds 80 columns")
-    }
-  )
+  something.call(x => {
+    g("some very very very very long string which exceeds 80 columns")
+  })
 }
 <<< 3: single-arg single-stmt non-block long-body lambda call
 def f = {
@@ -44,9 +40,8 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => g("some very very very very long string which exceeds 80 columns")
-  )
+  something.call(x =>
+    g("some very very very very long string which exceeds 80 columns"))
 }
 <<< 4: single-arg single-stmt non-block multi-line long-body lambda call
 def f = {
@@ -60,13 +55,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => // comment
-      g(
-        "some very very very very long string which exceeds 80 columns" +
-          " with some extra information"
-      )
-  )
+  something.call(x => // comment
+    g(
+      "some very very very very long string which exceeds 80 columns" +
+        " with some extra information"
+    ))
 }
 <<< 5: multi-arg single-stmt block long-body lambda call
 def f = {
@@ -78,11 +71,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => {
-      g("some very very very very long string which we don't want to be split")
-    }
-  )
+  something.call((x, y) => {
+    g("some very very very very long string which we don't want to be split")
+  })
 }
 <<< 6: multi-arg multi-stmt long-body lambda call
 def f = {
@@ -96,13 +87,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => {
-      g(x)
-      g(y)
-      g("some very very very very long string which we don't want to be split")
-    }
-  )
+  something.call((x, y) => {
+    g(x)
+    g(y)
+    g("some very very very very long string which we don't want to be split")
+  })
 }
 <<< 7: multi-long-arg single-stmt short-body lambda call
 def f = {
@@ -136,9 +125,7 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => g(x)
-  )
+  something.call(x => g(x))
 }
 <<< 10: single-arg single-stmt short-splittable-body lambda call
 def f = {
@@ -149,9 +136,7 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => g.copy(a = x)
-  )
+  something.call(x => g.copy(a = x))
 }
 <<< 11: single-arg single-stmt medium-splittable-body lambda call
 def f = {
@@ -162,11 +147,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x =>
-      g.copy(a =
-        "some very very very very long string which we don't want to be split")
-  )
+  something.call(x =>
+    g.copy(a =
+      "some very very very very long string which we don't want to be split"))
 }
 <<< 12: single-arg single-stmt long-splittable-body lambda call
 def f = {
@@ -177,11 +160,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x =>
-      g.copy(a =
-        "some very very very very long string which we don't want to be split at all")
-  )
+  something.call(x =>
+    g.copy(a =
+      "some very very very very long string which we don't want to be split at all"))
 }
 <<< 13: single-arg single-stmt medium-splittable-body with multiple args lambda call
 def f = {
@@ -193,14 +174,10 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x =>
-      g.copy(
-        a =
-          "some very very very very long string which we don't want to be split",
-        b =
-          "some very very very very long string which we don't want to be split")
-  )
+  something.call(x =>
+    g.copy(
+      a = "some very very very very long string which we don't want to be split",
+      b = "some very very very very long string which we don't want to be split"))
 }
 <<< 14: lambda with many nested apply
        EventFilter[ActorInitializationException](occurrences = 1) intercept {
@@ -216,9 +193,9 @@ def f = {
 >>>
 EventFilter[ActorInitializationException](occurrences = 1) intercept {
   intercept[akka.actor.ActorInitializationException] {
-    wrap(
-      result ⇒
-        actorOf(Props(new OuterActor(
+    wrap(result ⇒
+      actorOf(
+        Props(new OuterActor(
           actorOf(Props(promiseIntercept(new FailingInnerActor)(result)))))))
   }
 
@@ -297,10 +274,9 @@ List(10, 11, 12).map(x =>
   - 5
 )
 >>>
-List(10, 11, 12).map(
-  x =>
-    x
-      - 5)
+List(10, 11, 12).map(x =>
+  x
+    - 5)
 <<< 18: keep line breaks to preserve semantics
 List(10, 11, 12).map(x => {
   x

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -1,0 +1,313 @@
+edition = 2019-11
+newlines.alwaysBeforeCurlyBraceLambdaParams = false
+danglingParentheses.callSite = false
+<<< 1: multi-arg multi-stmt lambda call
+def f = {
+  something.call (
+     (x, y) => {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    (x, y) => {
+      g(x)
+      g(y)
+    }
+  )
+}
+<<< 2: single-arg single-stmt block long-body lambda call
+def f = {
+  something.call (
+     x => {
+       g("some very very very very long string which exceeds 80 columns")
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => {
+      g("some very very very very long string which exceeds 80 columns")
+    }
+  )
+}
+<<< 3: single-arg single-stmt non-block long-body lambda call
+def f = {
+  something.call (
+     x =>
+       g("some very very very very long string which exceeds 80 columns")
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => g("some very very very very long string which exceeds 80 columns")
+  )
+}
+<<< 4: single-arg single-stmt non-block multi-line long-body lambda call
+def f = {
+  something.call (
+     x => // comment
+       g(
+         "some very very very very long string which exceeds 80 columns" +
+         " with some extra information"
+       )
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => // comment
+      g(
+        "some very very very very long string which exceeds 80 columns" +
+          " with some extra information"
+      )
+  )
+}
+<<< 5: multi-arg single-stmt block long-body lambda call
+def f = {
+  something.call (
+     (x,y) => {
+       g("some very very very very long string which we don't want to be split")
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    (x, y) => {
+      g("some very very very very long string which we don't want to be split")
+    }
+  )
+}
+<<< 6: multi-arg multi-stmt long-body lambda call
+def f = {
+  something.call (
+     (x,y) => {
+       g(x)
+       g(y)
+       g("some very very very very long string which we don't want to be split")
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    (x, y) => {
+      g(x)
+      g(y)
+      g("some very very very very long string which we don't want to be split")
+    }
+  )
+}
+<<< 7: multi-long-arg single-stmt short-body lambda call
+def f = {
+  something_very_very_very_long.call_another_long_method ((a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) =>
+       g(x)
+  )
+}
+>>>
+def f = {
+  something_very_very_very_long.call_another_long_method(
+    (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => g(x))
+}
+<<< 8: multi-long-arg single-stmt longer-body lambda call
+def f = {
+  something_very_very_very_long.call_another_long_method ((a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) =>
+       this_method_is_also_not_very_short(x, y, z)
+  )
+}
+>>>
+def f = {
+  something_very_very_very_long.call_another_long_method(
+    (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) =>
+      this_method_is_also_not_very_short(x, y, z))
+}
+<<< 9: single-arg single-stmt short-body lambda call
+def f = {
+  something.call (
+  x =>
+       g(x)
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => g(x)
+  )
+}
+<<< 10: single-arg single-stmt short-splittable-body lambda call
+def f = {
+  something.call (
+  x =>
+       g.copy(a = x)
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => g.copy(a = x)
+  )
+}
+<<< 11: single-arg single-stmt medium-splittable-body lambda call
+def f = {
+  something.call (
+  x =>
+       g.copy(a = "some very very very very long string which we don't want to be split")
+  )
+}
+>>>
+def f = {
+  something.call(
+    x =>
+      g.copy(a =
+        "some very very very very long string which we don't want to be split")
+  )
+}
+<<< 12: single-arg single-stmt long-splittable-body lambda call
+def f = {
+  something.call (
+  x =>
+       g.copy(a = "some very very very very long string which we don't want to be split at all")
+  )
+}
+>>>
+def f = {
+  something.call(
+    x =>
+      g.copy(a =
+        "some very very very very long string which we don't want to be split at all")
+  )
+}
+<<< 13: single-arg single-stmt medium-splittable-body with multiple args lambda call
+def f = {
+  something.call (
+  x =>
+       g.copy(a = "some very very very very long string which we don't want to be split",
+              b = "some very very very very long string which we don't want to be split")
+  )
+}
+>>>
+def f = {
+  something.call(
+    x =>
+      g.copy(
+        a =
+          "some very very very very long string which we don't want to be split",
+        b =
+          "some very very very very long string which we don't want to be split")
+  )
+}
+<<< 14: lambda with many nested apply
+       EventFilter[ActorInitializationException](occurrences = 1) intercept {
+         intercept[akka.actor.ActorInitializationException] {
+          wrap(
+            result ⇒
+              actorOf(Props(new OuterActor(actorOf(
+                 Props(promiseIntercept(new FailingInnerActor)(result)))))))
+         }
+
+         contextStackMustBeEmpty()
+       }
+>>>
+EventFilter[ActorInitializationException](occurrences = 1) intercept {
+  intercept[akka.actor.ActorInitializationException] {
+    wrap(
+      result ⇒
+        actorOf(Props(new OuterActor(
+          actorOf(Props(promiseIntercept(new FailingInnerActor)(result)))))))
+  }
+
+  contextStackMustBeEmpty()
+}
+<<< 15: lambda with many nested apply using braces for comparison
+       EventFilter[ActorInitializationException](occurrences = 1) intercept {
+         intercept[akka.actor.ActorInitializationException] {
+          wrap{
+            result ⇒
+              actorOf(Props(new OuterActor(actorOf(
+                 Props(promiseIntercept(new FailingInnerActor)(result))))))}
+         }
+
+         contextStackMustBeEmpty()
+       }
+>>>
+EventFilter[ActorInitializationException](occurrences = 1) intercept {
+  intercept[akka.actor.ActorInitializationException] {
+    wrap { result ⇒
+      actorOf(
+        Props(new OuterActor(
+          actorOf(Props(promiseIntercept(new FailingInnerActor)(result))))))
+    }
+  }
+
+  contextStackMustBeEmpty()
+}
+<<< 16: prefer split on equals vs split on arrow in includedTerms
+     terms.foreach {
+       case Deletion(term: Term) =>
+         term match {
+           case inner: ColumnRef =>
+             includedTerms = includedTerms.filter(_ != Seq(inner.value))
+           case ColumnInteraction(cols) =>
+             val fromInteraction = expandInteraction(schema, cols).map(_.toSet)
+            includedTerms =
+              includedTerms.filter(t => !fromInteraction.contains(t.toSet))
+           case Dot =>
+             // e.g. "- .", which removes all first-order terms
+             includedTerms = includedTerms.filter {
+               case Seq(t) => !dotTerms.contains(t)
+               case _      => true
+             }
+           case _: Deletion =>
+             throw new RuntimeException("Deletion terms cannot be nested")
+           case _: Intercept =>
+         }
+       case _: Intercept =>
+     }
+>>>
+terms.foreach {
+  case Deletion(term: Term) =>
+    term match {
+      case inner: ColumnRef =>
+        includedTerms = includedTerms.filter(_ != Seq(inner.value))
+      case ColumnInteraction(cols) =>
+        val fromInteraction = expandInteraction(schema, cols).map(_.toSet)
+        includedTerms =
+          includedTerms.filter(t => !fromInteraction.contains(t.toSet))
+      case Dot =>
+        // e.g. "- .", which removes all first-order terms
+        includedTerms = includedTerms.filter {
+          case Seq(t) => !dotTerms.contains(t)
+          case _      => true
+        }
+      case _: Deletion =>
+        throw new RuntimeException("Deletion terms cannot be nested")
+      case _: Intercept =>
+    }
+  case _: Intercept =>
+}
+<<< 17: keep line breaks to preserve semantics
+List(10, 11, 12).map(x =>
+  x
+  - 5
+)
+>>>
+List(10, 11, 12).map(
+  x =>
+    x
+      - 5)
+<<< 18: keep line breaks to preserve semantics
+List(10, 11, 12).map(x => {
+  x
+  - 5
+})
+>>>
+List(10, 11, 12).map(x => {
+  x
+  -5
+})

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -1,0 +1,329 @@
+edition = 2019-11
+newlines.alwaysBeforeCurlyBraceLambdaParams = false
+danglingParentheses.callSite = true
+<<< 1: multi-arg multi-stmt lambda call
+def f = {
+  something.call (
+     (x, y) => {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    (x, y) => {
+      g(x)
+      g(y)
+    }
+  )
+}
+<<< 2: single-arg single-stmt block long-body lambda call
+def f = {
+  something.call (
+     x => {
+       g("some very very very very long string which exceeds 80 columns")
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => {
+      g("some very very very very long string which exceeds 80 columns")
+    }
+  )
+}
+<<< 3: single-arg single-stmt non-block long-body lambda call
+def f = {
+  something.call (
+     x =>
+       g("some very very very very long string which exceeds 80 columns")
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => g("some very very very very long string which exceeds 80 columns")
+  )
+}
+<<< 4: single-arg single-stmt non-block multi-line long-body lambda call
+def f = {
+  something.call (
+     x => // comment
+       g(
+         "some very very very very long string which exceeds 80 columns" +
+         " with some extra information"
+       )
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => // comment
+      g(
+        "some very very very very long string which exceeds 80 columns" +
+          " with some extra information"
+      )
+  )
+}
+<<< 5: multi-arg single-stmt block long-body lambda call
+def f = {
+  something.call (
+     (x,y) => {
+       g("some very very very very long string which we don't want to be split")
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    (x, y) => {
+      g("some very very very very long string which we don't want to be split")
+    }
+  )
+}
+<<< 6: multi-arg multi-stmt long-body lambda call
+def f = {
+  something.call (
+     (x,y) => {
+       g(x)
+       g(y)
+       g("some very very very very long string which we don't want to be split")
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    (x, y) => {
+      g(x)
+      g(y)
+      g("some very very very very long string which we don't want to be split")
+    }
+  )
+}
+<<< 7: multi-long-arg single-stmt short-body lambda call
+def f = {
+  something_very_very_very_long.call_another_long_method ((a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) =>
+       g(x)
+  )
+}
+>>>
+def f = {
+  something_very_very_very_long.call_another_long_method(
+    (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) => g(x)
+  )
+}
+<<< 8: multi-long-arg single-stmt longer-body lambda call
+def f = {
+  something_very_very_very_long.call_another_long_method ((a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) =>
+       this_method_is_also_not_very_short(x, y, z)
+  )
+}
+>>>
+def f = {
+  something_very_very_very_long.call_another_long_method(
+    (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) =>
+      this_method_is_also_not_very_short(x, y, z)
+  )
+}
+<<< 9: single-arg single-stmt short-body lambda call
+def f = {
+  something.call (
+  x =>
+       g(x)
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => g(x)
+  )
+}
+<<< 10: single-arg single-stmt short-splittable-body lambda call
+def f = {
+  something.call (
+  x =>
+       g.copy(a = x)
+  )
+}
+>>>
+def f = {
+  something.call(
+    x => g.copy(a = x)
+  )
+}
+<<< 11: single-arg single-stmt medium-splittable-body lambda call
+def f = {
+  something.call (
+  x =>
+       g.copy(a = "some very very very very long string which we don't want to be split")
+  )
+}
+>>>
+def f = {
+  something.call(
+    x =>
+      g.copy(a =
+        "some very very very very long string which we don't want to be split"
+      )
+  )
+}
+<<< 12: single-arg single-stmt long-splittable-body lambda call (fails idempotency)
+def f = {
+  something.call (
+  x =>
+  g.copy(a = "some very very very very long string which we don't want to be split at all")
+  )
+}
+>>>
+def f = {
+  something.call(
+    x =>
+      g.copy(a =
+        "some very very very very long string which we don't want to be split at all"
+      )
+  )
+}
+<<< 13: single-arg single-stmt medium-splittable-body with multiple args lambda call
+def f = {
+  something.call (
+  x =>
+       g.copy(a = "some very very very very long string which we don't want to be split",
+              b = "some very very very very long string which we don't want to be split")
+  )
+}
+>>>
+def f = {
+  something.call(
+    x =>
+      g.copy(
+        a =
+          "some very very very very long string which we don't want to be split",
+        b =
+          "some very very very very long string which we don't want to be split"
+      )
+  )
+}
+<<< 14: lambda with many nested apply
+       EventFilter[ActorInitializationException](occurrences = 1) intercept {
+         intercept[akka.actor.ActorInitializationException] {
+          wrap(
+            result ⇒
+              actorOf(Props(new OuterActor(actorOf(
+                 Props(promiseIntercept(new FailingInnerActor)(result)))))))
+         }
+
+         contextStackMustBeEmpty()
+       }
+>>>
+EventFilter[ActorInitializationException](occurrences = 1) intercept {
+  intercept[akka.actor.ActorInitializationException] {
+    wrap(
+      result ⇒
+        actorOf(
+          Props(
+            new OuterActor(
+              actorOf(Props(promiseIntercept(new FailingInnerActor)(result)))
+            )
+          )
+        )
+    )
+  }
+
+  contextStackMustBeEmpty()
+}
+<<< 15: lambda with many nested apply using braces for comparison
+       EventFilter[ActorInitializationException](occurrences = 1) intercept {
+         intercept[akka.actor.ActorInitializationException] {
+          wrap{
+            result ⇒
+              actorOf(Props(new OuterActor(actorOf(
+                 Props(promiseIntercept(new FailingInnerActor)(result))))))}
+         }
+
+         contextStackMustBeEmpty()
+       }
+>>>
+EventFilter[ActorInitializationException](occurrences = 1) intercept {
+  intercept[akka.actor.ActorInitializationException] {
+    wrap { result ⇒
+      actorOf(
+        Props(
+          new OuterActor(
+            actorOf(Props(promiseIntercept(new FailingInnerActor)(result)))
+          )
+        )
+      )
+    }
+  }
+
+  contextStackMustBeEmpty()
+}
+<<< 16: prefer split on equals vs split on arrow in includedTerms
+     terms.foreach {
+       case Deletion(term: Term) =>
+         term match {
+           case inner: ColumnRef =>
+             includedTerms = includedTerms.filter(_ != Seq(inner.value))
+           case ColumnInteraction(cols) =>
+             val fromInteraction = expandInteraction(schema, cols).map(_.toSet)
+            includedTerms =
+              includedTerms.filter(t => !fromInteraction.contains(t.toSet))
+           case Dot =>
+             // e.g. "- .", which removes all first-order terms
+             includedTerms = includedTerms.filter {
+               case Seq(t) => !dotTerms.contains(t)
+               case _      => true
+             }
+           case _: Deletion =>
+             throw new RuntimeException("Deletion terms cannot be nested")
+           case _: Intercept =>
+         }
+       case _: Intercept =>
+     }
+>>>
+terms.foreach {
+  case Deletion(term: Term) =>
+    term match {
+      case inner: ColumnRef =>
+        includedTerms = includedTerms.filter(_ != Seq(inner.value))
+      case ColumnInteraction(cols) =>
+        val fromInteraction = expandInteraction(schema, cols).map(_.toSet)
+        includedTerms =
+          includedTerms.filter(t => !fromInteraction.contains(t.toSet))
+      case Dot =>
+        // e.g. "- .", which removes all first-order terms
+        includedTerms = includedTerms.filter {
+          case Seq(t) => !dotTerms.contains(t)
+          case _      => true
+        }
+      case _: Deletion =>
+        throw new RuntimeException("Deletion terms cannot be nested")
+      case _: Intercept =>
+    }
+  case _: Intercept =>
+}
+<<< 17: keep line breaks to preserve semantics
+List(10, 11, 12).map(x =>
+  x
+  - 5
+)
+>>>
+List(10, 11, 12).map(
+  x =>
+    x
+      - 5
+)
+<<< 18: keep line breaks to preserve semantics
+List(10, 11, 12).map(x => {
+  x
+  - 5
+})
+>>>
+List(10, 11, 12).map(x => {
+  x
+  -5
+})

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -12,12 +12,10 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => {
-      g(x)
-      g(y)
-    }
-  )
+  something.call((x, y) => {
+    g(x)
+    g(y)
+  })
 }
 <<< 2: single-arg single-stmt block long-body lambda call
 def f = {
@@ -29,11 +27,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => {
-      g("some very very very very long string which exceeds 80 columns")
-    }
-  )
+  something.call(x => {
+    g("some very very very very long string which exceeds 80 columns")
+  })
 }
 <<< 3: single-arg single-stmt non-block long-body lambda call
 def f = {
@@ -44,8 +40,8 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => g("some very very very very long string which exceeds 80 columns")
+  something.call(x =>
+    g("some very very very very long string which exceeds 80 columns")
   )
 }
 <<< 4: single-arg single-stmt non-block multi-line long-body lambda call
@@ -60,12 +56,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => // comment
-      g(
-        "some very very very very long string which exceeds 80 columns" +
-          " with some extra information"
-      )
+  something.call(x => // comment
+    g(
+      "some very very very very long string which exceeds 80 columns" +
+        " with some extra information"
+    )
   )
 }
 <<< 5: multi-arg single-stmt block long-body lambda call
@@ -78,11 +73,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => {
-      g("some very very very very long string which we don't want to be split")
-    }
-  )
+  something.call((x, y) => {
+    g("some very very very very long string which we don't want to be split")
+  })
 }
 <<< 6: multi-arg multi-stmt long-body lambda call
 def f = {
@@ -96,13 +89,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => {
-      g(x)
-      g(y)
-      g("some very very very very long string which we don't want to be split")
-    }
-  )
+  something.call((x, y) => {
+    g(x)
+    g(y)
+    g("some very very very very long string which we don't want to be split")
+  })
 }
 <<< 7: multi-long-arg single-stmt short-body lambda call
 def f = {
@@ -138,9 +129,7 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => g(x)
-  )
+  something.call(x => g(x))
 }
 <<< 10: single-arg single-stmt short-splittable-body lambda call
 def f = {
@@ -151,9 +140,7 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x => g.copy(a = x)
-  )
+  something.call(x => g.copy(a = x))
 }
 <<< 11: single-arg single-stmt medium-splittable-body lambda call
 def f = {
@@ -164,14 +151,13 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x =>
-      g.copy(a =
-        "some very very very very long string which we don't want to be split"
-      )
+  something.call(x =>
+    g.copy(a =
+      "some very very very very long string which we don't want to be split"
+    )
   )
 }
-<<< 12: single-arg single-stmt long-splittable-body lambda call (fails idempotency)
+<<< 12: single-arg single-stmt long-splittable-body lambda call
 def f = {
   something.call (
   x =>
@@ -180,11 +166,10 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x =>
-      g.copy(a =
-        "some very very very very long string which we don't want to be split at all"
-      )
+  something.call(x =>
+    g.copy(a =
+      "some very very very very long string which we don't want to be split at all"
+    )
   )
 }
 <<< 13: single-arg single-stmt medium-splittable-body with multiple args lambda call
@@ -197,14 +182,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    x =>
-      g.copy(
-        a =
-          "some very very very very long string which we don't want to be split",
-        b =
-          "some very very very very long string which we don't want to be split"
-      )
+  something.call(x =>
+    g.copy(
+      a = "some very very very very long string which we don't want to be split",
+      b = "some very very very very long string which we don't want to be split"
+    )
   )
 }
 <<< 14: lambda with many nested apply
@@ -221,15 +203,14 @@ def f = {
 >>>
 EventFilter[ActorInitializationException](occurrences = 1) intercept {
   intercept[akka.actor.ActorInitializationException] {
-    wrap(
-      result ⇒
-        actorOf(
-          Props(
-            new OuterActor(
-              actorOf(Props(promiseIntercept(new FailingInnerActor)(result)))
-            )
+    wrap(result ⇒
+      actorOf(
+        Props(
+          new OuterActor(
+            actorOf(Props(promiseIntercept(new FailingInnerActor)(result)))
           )
         )
+      )
     )
   }
 
@@ -312,10 +293,9 @@ List(10, 11, 12).map(x =>
   - 5
 )
 >>>
-List(10, 11, 12).map(
-  x =>
-    x
-      - 5
+List(10, 11, 12).map(x =>
+  x
+    - 5
 )
 <<< 18: keep line breaks to preserve semantics
 List(10, 11, 12).map(x => {

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -69,14 +69,13 @@ Thing(implicit ctx => j => ???)
 <<< long curried with ()
 Thing(implicit ctx => j => k => aaaaaaaaaaaaa(bbbbbbbbbbbbbbbbbbb, cccccccccc, ddddddddddddddddddddj)) // coooooooooooooooomment
 >>>
-Thing(
-    implicit ctx =>
-      j =>
-        k =>
-          aaaaaaaaaaaaa(
-              bbbbbbbbbbbbbbbbbbb,
-              cccccccccc,
-              ddddddddddddddddddddj)) // coooooooooooooooomment
+Thing(implicit ctx =>
+  j =>
+    k =>
+      aaaaaaaaaaaaa(
+          bbbbbbbbbbbbbbbbbbb,
+          cccccccccc,
+          ddddddddddddddddddddj)) // coooooooooooooooomment
 <<< single line uncurried
 Thing() { implicit ctx =>
       ???
@@ -90,11 +89,10 @@ val groupedData = Array(topic1, topic2).flatMap(
         topic =>
           partitionDataFetchResponseMap.map(foobar))
 >>>
-val groupedData =
-  Array(topic1, topic2).flatMap(
-      topic =>
-        partitionDataFetchResponseMap
-          .map(foobar))
+val groupedData = Array(topic1, topic2)
+  .flatMap(topic =>
+    partitionDataFetchResponseMap.map(
+        foobar))
 <<< 1.8 upgrade
 val x: Int => Int =  { y =>
   y + 1


### PR DESCRIPTION
N.B. fork of `scala-repos` showing the difference: https://github.com/kitbellew/scala-repos/commits/scalafmt-1551

Fixes #667

It is desirable to have an option to format paren lambda in calls just
like a curly-brace lambda. For instance, currently:

```
  call { parameter =>
    long_body
  }
```

but

```
  call(
    parameter =>
      long_body
  )
```

instead of the similar (and more compact)

```
  call(parameter =>
    long_body
  )
```

Obviously, when the call refers to multiple arguments (which is never
the case with curly-brace lambda), this formatting wouldn't make sense
and would continue to be

```
  call(
    parameter =>
      long_body,
    another_argument
  )
```

N.B. Using the existing `alwaysBeforeCurlyBraceLambdaParams` configuration parameter is also possible but it magically fixed an error with `align/ArrayIndexOutOfBounds800.source` test (even if I explicitly flipped the `alwaysBeforeCurlyBraceLambdaParams` setting) which, I think, is intended to fail.