### PR TITLE
Make it easier to test scalafmt local snapshot build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import Dependencies._
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
+def localSnapshotVersion = "2.2.3-SNAPSHOT"
+def isCI = System.getenv("CI") != null
 
 def scala211 = "2.11.12"
 def scala212 = "2.12.8"
@@ -7,6 +9,10 @@ def scala213 = "2.13.1"
 
 inThisBuild(
   List(
+    version ~= { dynVer =>
+      if (isCI) dynVer
+      else localSnapshotVersion // only for local publishng
+    },
     organization := "org.scalameta",
     homepage := Some(url("https://github.com/scalameta/scalafmt")),
     licenses := List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,12 @@
 import Dependencies._
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
-def localSnapshotVersion = "2.2.3-SNAPSHOT"
+
+def parseTagVersion: String = {
+  import scala.sys.process._
+  // drop `v` prefix
+  "git describe --abbrev=0 --tags".!!.drop(1).trim
+}
+def localSnapshotVersion: String = s"$parseTagVersion-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 
 def scala211 = "2.11.12"

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
@@ -22,7 +22,7 @@ object ScalafmtVersion {
       extends Exception(s"Invalid scalafmt version $version")
       with NoStackTrace
 
-  private val versionRegex = """(\d)\.(\d)\.(\d)(-RC(\d))?""".r
+  private val versionRegex = """(\d)\.(\d)\.(\d)(-RC(\d))?(?:-SNAPSHOT)?""".r
 
   def parse(version: String): Either[InvalidVersionException, ScalafmtVersion] =
     try {

--- a/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
@@ -323,9 +323,10 @@ class DynamicSuite extends FunSuite with DiffAssertions {
   check("wrong-version") { f =>
     f.setVersion("1.0")
     f.assertError(
-      "error: path/.scalafmt.conf: failed to resolve Scalafmt version '1.0'"
+      """|error: path/.scalafmt.conf: org.scalafmt.dynamic.exceptions.ScalafmtException: failed to resolve Scalafmt version '1.0'
+         |Caused by: org.scalafmt.dynamic.ScalafmtVersion$InvalidVersionException: Invalid scalafmt version 1.0""".stripMargin
     )
-    assert(f.downloadLogs.nonEmpty)
+    assert(f.downloadLogs.isEmpty)
   }
 
   check("sbt") { f =>

--- a/scalafmt-dynamic/src/test/scala/tests/ScalafmtVersionSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/tests/ScalafmtVersionSuite.scala
@@ -12,6 +12,15 @@ class ScalafmtVersionSuite extends FunSuite {
       ScalafmtVersion.parse("2.0.0-RC4") == Right(ScalafmtVersion(2, 0, 0, 4))
     )
     assert(ScalafmtVersion.parse("2.1.1") == Right(ScalafmtVersion(2, 1, 1, 0)))
+    assert(
+      ScalafmtVersion
+        .parse("2.2.3-SNAPSHOT") == Right(ScalafmtVersion(2, 2, 3, 0))
+    )
+    assert(
+      ScalafmtVersion.parse("2.0.0-RC1-SNAPSHOT") == Right(
+        ScalafmtVersion(2, 0, 0, 1)
+      )
+    )
   }
 
   test("fail on invalid versions") {
@@ -50,6 +59,11 @@ class ScalafmtVersionSuite extends FunSuite {
     assert(
       ScalafmtVersion
         .parse("2.1.0-RC1-M4") == Left(InvalidVersionException("2.1.0-RC1-M4"))
+    )
+    assert(
+      ScalafmtVersion.parse("2.0.0-RC1+metadata") == Left(
+        InvalidVersionException("2.0.0-RC1+metadata")
+      )
     )
   }
 


### PR DESCRIPTION
While I tried to test https://github.com/scalameta/scalafmt/pull/1549 locally, I found that scalafmt has mainly two things that make it cumbersome to test locally.

## scala build version mismatch
- Before this commit, `sbt publishLocal` publish the build to local ivy with the version something like `2.1.0+xxxx-SNAPSHOT` (if people didn't fetch the latest tags to local)
- when scalafmt-dynamic tries to download scalafmt-core whose version was `2.1.0+xxxx-SNAPSHOT`, it looks for scalafmt built with 2.12 (see: https://github.com/scalameta/scalafmt/blob/778c75f728a7a039fa63499ae3f97c69b4a018f0/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala#L68-L71)
- However, the default scala version is now 2.13 (as of https://github.com/scalameta/scalafmt/pull/1522) and `sbt publishLocal` would build scalafmt with 2.13 and publish it as `2.1.0+xxxx-SNAPSHOT`.
- As a result, scalafmt-dynamic cannot resolve the local build.
  - because `sbt publishLocal` publish 2.13 build with `2.1.0+xxxx-SNAPSHOT` to local, but if we specify `version=2.1.0+xxxx-SNAPSHOT`, scalafmt would look for 2.12 build.

I know we can avoid this situation by building snapshot build with 2.12 instead of 2.13, but it would be handy if we can test the snapshot version only with `sbt publishLocal` instead of `sbt +publishLocal`.

### Solution
https://github.com/scalameta/scalafmt/commit/c416668ee8c313fc18a3f083ce29aaf581578ede
Introduced `localSnapshotVersion` for specifying the version in local publishing.
The idea of localSnapshotVersion comes from [metals](https://github.com/scalameta/metals/blob/05017dc44e384ab8e0a8202ebd128f697594d686/build.sbt#L1-L19)

## scalafmt-dynamic doesn't accept SNAPSHOT version
scalafmt-dynamic introduced `ScalafmtVersion.scala` in https://github.com/scalameta/scalafmt/pull/1522. It parses the scalafmt version specified in `.scalafmt.conf`, and if the version string is invalid, it rejects to resolve with an error.

For example, if `.scalafmt.conf` contains `version=2.2.3-SNAPSHOT` for testing local build, scalafmt-dynamic parse `2.2.3-SNAPSHOT` as invalid version.

### Solution
So with that, I tweaked the regex for scalafmtVersion https://github.com/scalameta/scalafmt/commit/67f6f0a152ef80d577e65d61a1739539b94a2f19 so that scalafmt-dynamic can parse snapshot version as a valid scalafmtVersion, and we can test the local builds.