### PR TITLE
Router: fix def body indent with a comment #1240

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -438,15 +438,18 @@ class Router(formatOps: FormatOps) {
             // The block will take care of indenting by 2.
             Seq(Split(Space, 0))
           case _ =>
+            val rhsIsComment = isSingleLineComment(right)
             Seq(
               Split(
                 Space,
                 0,
-                ignoreIf = newlines > 0 && !rhsIsJsNative,
+                ignoreIf = rhsIsComment || newlines > 0 && !rhsIsJsNative,
                 policy =
                   if (!style.newlines.alwaysBeforeMultilineDef) NoPolicy
                   else SingleLineBlock(expire, exclude = exclude)
               ),
+              Split(Space, 0, ignoreIf = newlines != 0 || !rhsIsComment)
+                .withIndent(2, expire, Left),
               Split(Newline, 1, ignoreIf = rhsIsJsNative)
                 .withIndent(2, expire, Left)
             )

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeMultilineDef.stat
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeMultilineDef.stat
@@ -18,3 +18,32 @@ def foo = Future({
   val bar = fetchBar()
   bar.map(_ + 10)
 })
+<<< Indent without comment
+def foo(a: Int): Int =
+      ???
+>>>
+def foo(a: Int): Int =
+  ???
+<<< Indent without comment with block
+def foo(a: Int): Int =
+{
+  ??? }
+>>>
+def foo(a: Int): Int = {
+  ???
+}
+<<< Indent after comment
+def foo(a: Int): Int = // a comment
+      ???
+>>>
+def foo(a: Int): Int = // a comment
+???
+<<< Indent after comment with block
+def foo(a: Int): Int = // a comment
+{
+  ??? }
+>>>
+def foo(a: Int): Int = // a comment
+{
+  ???
+}

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeMultilineDef.stat
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeMultilineDef.stat
@@ -37,13 +37,13 @@ def foo(a: Int): Int = // a comment
       ???
 >>>
 def foo(a: Int): Int = // a comment
-???
+  ???
 <<< Indent after comment with block
 def foo(a: Int): Int = // a comment
 {
   ??? }
 >>>
 def foo(a: Int): Int = // a comment
-{
-  ???
-}
+  {
+    ???
+  }


### PR DESCRIPTION
Fixes #1240 

NB: this change produces no diffs on `scala-repos`.