### PR TITLE
Remove irregular files, including symbolic links, from `git ls-files`.

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -55,8 +55,12 @@ trait ScalafmtRunner {
     val files = options.fileFetchMode match {
       case m @ (GitFiles | RecursiveSearch) =>
         val fetchFiles: AbsoluteFile => Seq[AbsoluteFile] =
-          if (m == GitFiles) options.gitOps.lsTree(_)
-          else FileOps.listFiles(_)
+          if (m == GitFiles)
+            options.gitOps
+              .lsTree(_)
+              .filter(file => FileOps.isRegularFile(file.jfile))
+          else
+            FileOps.listFiles(_)
 
         options.files.flatMap {
           case d if d.jfile.isDirectory => fetchFiles(d).filter(canFormat)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -55,12 +55,8 @@ trait ScalafmtRunner {
     val files = options.fileFetchMode match {
       case m @ (GitFiles | RecursiveSearch) =>
         val fetchFiles: AbsoluteFile => Seq[AbsoluteFile] =
-          if (m == GitFiles)
-            options.gitOps
-              .lsTree(_)
-              .filter(file => FileOps.isRegularFile(file.jfile))
-          else
-            FileOps.listFiles(_)
+          if (m == GitFiles) options.gitOps.lsTree
+          else FileOps.listFiles
 
         options.files.flatMap {
           case d if d.jfile.isDirectory => fetchFiles(d).filter(canFormat)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -1,10 +1,8 @@
 package org.scalafmt.util
 
-import scala.io.Codec
 import java.io._
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
+import java.nio.file.{Files, LinkOption, Path, Paths}
+import scala.io.Codec
 
 object FileOps {
 
@@ -13,7 +11,7 @@ object FileOps {
     else new File(workingDir, file.getPath)
 
   def isRegularFile(file: File): Boolean =
-    Files.isRegularFile(file.toPath)
+    Files.isRegularFile(file.toPath, LinkOption.NOFOLLOW_LINKS)
 
   def listFiles(path: String): Vector[String] = {
     listFiles(new File(path))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -12,6 +12,9 @@ object FileOps {
     if (file.isAbsolute) file
     else new File(workingDir, file.getPath)
 
+  def isRegularFile(file: File): Boolean =
+    Files.isRegularFile(file.toPath)
+
   def listFiles(path: String): Vector[String] = {
     listFiles(new File(path))
   }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/DeleteTree.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/DeleteTree.scala
@@ -1,0 +1,44 @@
+package org.scalafmt.util
+
+import java.io.IOException
+import java.nio.file.{FileVisitResult, FileVisitor, Files, Path}
+import java.nio.file.attribute.BasicFileAttributes
+
+object DeleteTree {
+  def deleteTree(path: Path): Unit = {
+    Files.walkFileTree(path, new DeleteTree)
+    ()
+  }
+}
+
+class DeleteTree extends FileVisitor[Path] {
+  override def preVisitDirectory(
+      dir: Path,
+      attrs: BasicFileAttributes
+  ): FileVisitResult = {
+    FileVisitResult.CONTINUE
+  }
+
+  override def visitFile(
+      file: Path,
+      attrs: BasicFileAttributes
+  ): FileVisitResult = {
+    Files.delete(file)
+    FileVisitResult.CONTINUE
+  }
+
+  override def visitFileFailed(
+      file: Path,
+      exc: IOException
+  ): FileVisitResult = {
+    throw exc
+  }
+
+  override def postVisitDirectory(
+      dir: Path,
+      exc: IOException
+  ): FileVisitResult = {
+    Files.delete(dir)
+    FileVisitResult.CONTINUE
+  }
+}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -3,15 +3,15 @@ package org.scalafmt.util
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
-
 import scala.util._
-import org.scalatest._
 import org.scalactic.source.Position
+import org.scalafmt.util.DeleteTree.deleteTree
+import org.scalatest._
 
 class GitOpsTest extends fixture.FunSuite {
 
-  import Matchers._
   import GitOpsTest._
+  import Matchers._
 
   val root = AbsoluteFile.userDir
   val dirName = "gitTestDir"
@@ -20,7 +20,7 @@ class GitOpsTest extends fixture.FunSuite {
 
   // DESNOTE(2017-08-16, pjrt): Create a temporary git directory for each
   // test.
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val f = Files.createTempDirectory(dirName)
     val absFile = AbsoluteFile.fromPath(f.toString).get
     val ops = new GitOpsImpl(absFile)
@@ -29,9 +29,8 @@ class GitOpsTest extends fixture.FunSuite {
     val initF = touch("initialfile")(ops)
     add(initF)(ops)
     commit(ops)
-    val t = try test.toNoArgTest(ops)
-    finally f.toFile.delete
-    withFixture(t)
+    try withFixture(test.toNoArgTest(ops))
+    finally deleteTree(f)
   }
 
   def touch(
@@ -252,7 +251,6 @@ class GitOpsTest extends fixture.FunSuite {
 
 private object GitOpsTest {
 
-  import OptionValues._
   import Matchers._
 
   // Filesystem commands


### PR DESCRIPTION
Currently, if you run with `project.git = true` on a repository with symbolic links, we get an `IOException`.

No idea how to write a unit test for this (can't find any coverage for `ScalafmtRunner`). If it's OK to move this behavior into `GitOps::lsTree`, then it becomes easier to test. Please let me know!

Full stack trace when running with version 2.2.2:

```
Exception in thread "main" java.io.IOException: Is a directory
        at sun.nio.ch.FileDispatcherImpl.read0(Native Method)
        at sun.nio.ch.FileDispatcherImpl.read(FileDispatcherImpl.java:46)
        at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:223)
        at sun.nio.ch.IOUtil.read(IOUtil.java:197)
        at sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:159)
        at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:65)
        at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:109)
        at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:103)
        at java.nio.file.Files.read(Files.java:3105)
        at java.nio.file.Files.readAllBytes(Files.java:3158)
        at org.scalafmt.util.FileOps$.readFile(FileOps.scala:57)
        at org.scalafmt.util.FileOps$.readFile(FileOps.scala:48)
        at org.scalafmt.cli.InputMethod$FileContents.readInput(InputMethod.scala:44)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.handleFile(ScalafmtDynamicRunner.scala:83)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.$anonfun$run$4(ScalafmtDynamicRunner.scala:55)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.$anonfun$run$4$adapted(ScalafmtDynamicRunner.scala:49)
        at scala.collection.immutable.List.foreach(List.scala:392)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.$anonfun$run$3(ScalafmtDynamicRunner.scala:49)
        at scala.util.control.Breaks.breakable(Breaks.scala:42)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.run(ScalafmtDynamicRunner.scala:49)
        at org.scalafmt.cli.Cli$.run(Cli.scala:96)
        at org.scalafmt.cli.Cli$.mainWithOptions(Cli.scala:69)
        at org.scalafmt.cli.Cli$.main(Cli.scala:58)
        at org.scalafmt.cli.Cli.main(Cli.scala)
```