### PR TITLE
Router: preserve single-line formatting for if/try

### DIFF
--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -385,9 +385,7 @@ object mixed {
 >>>
 {
   if (cond) foo
-  else {
-    val chars = s.toCharArray
-  }
+  else { val chars = s.toCharArray }
   val prefix =
     "sbt.paths." + projectName + "." + uncapitalize(config.name) + "."
 }

--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -88,9 +88,8 @@ val createAsStat = if (semantics.asInstanceOfs == Unchecked) {
 def processOptions(): Unit = {
   if (option.startsWith("relSourceMap:")) {
     val uriStr = option.stripPrefix("relSourceMap:")
-    try {
-      relSourceMap = Some(new URI(uriStr))
-    } catch {
+    try { relSourceMap = Some(new URI(uriStr)) }
+    catch {
       case e: URISyntaxException => error(s"$uriStr is not a valid URI")
     }
   } else {

--- a/scalafmt-tests/src/test/resources/default/Try.stat
+++ b/scalafmt-tests/src/test/resources/default/Try.stat
@@ -62,33 +62,26 @@ object Foo {
 }
 >>>
 object Foo {
-  try {
-    foo()
-  } finally {
-    bar()
-  }
+  try { foo() }
+  finally { bar() }
 }
 <<< try/catch/finally curly no single line blocks
 object Foo {
-  try { foo()  }
+   try{foo()}
   catch { case bar => baz }
-  finally {  qux()  }
+ finally {qux()  }
 }
 >>>
 object Foo {
-  try {
-    foo()
-  } catch { case bar => baz }
-  finally {
-    qux()
-  }
+  try { foo() }
+  catch { case bar => baz }
+  finally { qux() }
 }
 <<< try/catch with handler
 try { foo()  } catch handler
 >>>
-try {
-  foo()
-} catch handler
+try { foo() }
+catch handler
 <<< #350 assignment: short single line
 val template: String = try source.mkString finally source.close()
 >>>

--- a/scalafmt-tests/src/test/resources/unit/If.stat
+++ b/scalafmt-tests/src/test/resources/unit/If.stat
@@ -132,17 +132,31 @@ else println(1)
 if (true) return
 else println(1)
 <<< #1043
-      if ('0' <= ch && ch <= '9') { ch - '0' }
-      else if ('A' <= ch && ch <= 'F') { ch - 'A' + 10 }
-      else if ('a' <= ch && ch <= 'f') { ch - 'a' + 10 }
+      if ('0' <= c && c <= '9') { c - '0' }
+      else if ('A' <= c && c <= 'F') { c - 'A' + 10 }
+      else if ('a' <= c && c <= 'f') { c - 'a' + 10 }
       else { -1 }
 >>>
-if ('0' <= ch && ch <= '9') {
-  ch - '0'
-} else if ('A' <= ch && ch <= 'F') {
-  ch - 'A' + 10
-} else if ('a' <= ch && ch <= 'f') {
-  ch - 'a' + 10
+if ('0' <= c && c <= '9') {
+  c - '0'
+} else if ('A' <= c && c <= 'F') {
+  c - 'A' + 10
+} else if ('a' <= c && c <= 'f') {
+  c - 'a' + 10
+} else {
+  -1
+}
+<<< #1043 with lines joined
+      if ('0' <= c && c <= '9') { c - '0' }      else if ('A' <= c && c <= 'F') { c - 'A' + 10 }
+      else if ('a' <= c && c <= 'f') { c - 'a' + 10 }
+      else { -1 }
+>>>
+if ('0' <= c && c <= '9') {
+  c - '0'
+} else if ('A' <= c && c <= 'F') {
+  c - 'A' + 10
+} else if ('a' <= c && c <= 'f') {
+  c - 'a' + 10
 } else {
   -1
 }

--- a/scalafmt-tests/src/test/resources/unit/If.stat
+++ b/scalafmt-tests/src/test/resources/unit/If.stat
@@ -120,11 +120,8 @@ object Bar {
 if (true) { a }
 else { 2 }
 >>>
-if (true) {
-  a
-} else {
-  2
-}
+if (true) { a }
+else { 2 }
 <<< #930 return
 if (true) return
 else println(1)
@@ -137,26 +134,20 @@ else println(1)
       else if ('a' <= c && c <= 'f') { c - 'a' + 10 }
       else { -1 }
 >>>
-if ('0' <= c && c <= '9') {
-  c - '0'
-} else if ('A' <= c && c <= 'F') {
+if ('0' <= c && c <= '9') { c - '0' }
+else if ('A' <= c && c <= 'F') {
   c - 'A' + 10
 } else if ('a' <= c && c <= 'f') {
   c - 'a' + 10
-} else {
-  -1
-}
+} else { -1 }
 <<< #1043 with lines joined
       if ('0' <= c && c <= '9') { c - '0' }      else if ('A' <= c && c <= 'F') { c - 'A' + 10 }
       else if ('a' <= c && c <= 'f') { c - 'a' + 10 }
       else { -1 }
 >>>
-if ('0' <= c && c <= '9') {
-  c - '0'
-} else if ('A' <= c && c <= 'F') {
+if ('0' <= c && c <= '9') { c - '0' }
+else if ('A' <= c && c <= 'F') {
   c - 'A' + 10
 } else if ('a' <= c && c <= 'f') {
   c - 'a' + 10
-} else {
-  -1
-}
+} else { -1 }


### PR DESCRIPTION
Fixes #271 #1002 #1043.

Follow-on to #1554.

The diffs on `scala-repos` (obtained by running 2.3.0-rc2 and this build independently on the original, never before formatted base code, and then comparing): https://github.com/kitbellew/scala-repos/commit/73a76cb8dc9e97be06497ece131b0131586ffaaa?w=1