### PR TITLE
Router: fix split rule after catch in try

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -227,13 +227,14 @@ class Router(formatOps: FormatOps) {
           } else {
             def isCatch = leftOwner match {
               // for catch with case, we should go up only one level
-              // see if this is a single-case catch block
               case _: Term.Try if rightOwner.is[Case] => true
               case _ => false
             }
 
+            val afterClose = next(close)
             val breakSingleLineAfterClose =
-              !next(close).is[T.RightParen] && isCatch
+              if (isCatch) afterClose.is[T.KwFinally]
+              else false
             if (!breakSingleLineAfterClose) Policy.emptyPf
             else decideNewlineAfterToken(close)
           }

--- a/scalafmt-tests/src/test/resources/default/Try.stat
+++ b/scalafmt-tests/src/test/resources/default/Try.stat
@@ -146,8 +146,7 @@ finally qux
 try foo catch { case e => bar; case c if { true } => baz } // comment
 >>>
 try foo
-catch { case e => bar; case c if { true } => baz }
-// comment
+catch { case e => bar; case c if { true } => baz } // comment
 <<< #350 statement: multi-line with catch and semicolon
 object a {
 try foo catch { case e => "very long statement, needs to split line very soon" }; x = 43
@@ -159,10 +158,10 @@ try {
 >>>
 object a {
   try foo
-  catch { case e => "very long statement, needs to split line very soon" }
-  ; x = 43
+  catch { case e => "very long statement, needs to split line very soon" };
+  x = 43
   try {
     foo
-  } catch { case e => "very long statement, needs to split line very soon" }
-  ; x = 43
+  } catch { case e => "very long statement, needs to split line very soon" };
+  x = 43
 }

--- a/scalafmt-tests/src/test/resources/default/Try.stat
+++ b/scalafmt-tests/src/test/resources/default/Try.stat
@@ -142,3 +142,27 @@ try foo catch { case e => bar; case c => baz } finally qux
 try foo
 catch { case e => bar; case c => baz }
 finally qux
+<<< #350 statement: short single line with multi-catch and comment
+try foo catch { case e => bar; case c if { true } => baz } // comment
+>>>
+try foo
+catch { case e => bar; case c if { true } => baz }
+// comment
+<<< #350 statement: multi-line with catch and semicolon
+object a {
+try foo catch { case e => "very long statement, needs to split line very soon" }; x = 43
+try {
+  foo
+   } catch { case e => "very long statement, needs to split line very soon" }
+   ; x = 43
+}
+>>>
+object a {
+  try foo
+  catch { case e => "very long statement, needs to split line very soon" }
+  ; x = 43
+  try {
+    foo
+  } catch { case e => "very long statement, needs to split line very soon" }
+  ; x = 43
+}


### PR DESCRIPTION
Instead of maintaining exceptions to an otherwise mandated line break,
let's specify explicitly when this could happen. That is, rather than
break always except when followed by a parenthesis, we should break
only if followed by the finally clause.

Follow-on to #1554.