### PR TITLE
Performance improvements

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -90,7 +90,12 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     }
     def addOptional(tree: Tree): Unit =
       tree.tokens.headOption.foreach(x => optional += hash(x))
-    def iter(tree: Tree): Unit = {
+
+    import scala.collection.mutable
+    val workList: mutable.Queue[Tree] = new mutable.Queue[Tree]()
+    workList.enqueue(tree)
+    while(workList.nonEmpty) {
+      val tree = workList.dequeue()
       tree match {
         case p: Pkg => packages ++= p.ref.tokens
         case i: Import => imports ++= i.tokens
@@ -101,9 +106,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
           addOptional(t.name)
         case _ =>
       }
-      tree.children.foreach(iter)
+      workList.enqueue(tree.children: _*)
     }
-    iter(tree)
     (packages.result(), imports.result(), arguments.toMap, optional)
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1,5 +1,7 @@
 package org.scalafmt.internal
 
+import java.{util => ju}
+import scala.collection.JavaConverters._
 import org.scalafmt.Error.CaseMissingArrow
 import org.scalafmt.config.{DanglingExclude, ScalafmtConfig}
 import org.scalafmt.internal.ExpiresOn.{Left, Right}
@@ -92,10 +94,10 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       tree.tokens.headOption.foreach(x => optional += hash(x))
 
     import scala.collection.mutable
-    val workList: mutable.Queue[Tree] = new mutable.Queue[Tree]()
-    workList.enqueue(tree)
-    while(workList.nonEmpty) {
-      val tree = workList.dequeue()
+    val workList = new ju.LinkedList[Tree]()
+    workList.add(tree)
+    while (!workList.isEmpty) {
+      val tree = workList.poll()
       tree match {
         case p: Pkg => packages ++= p.ref.tokens
         case i: Import => imports ++= i.tokens
@@ -106,7 +108,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
           addOptional(t.name)
         case _ =>
       }
-      workList.enqueue(tree.children: _*)
+      workList.addAll(tree.children.asJava)
     }
     (packages.result(), imports.result(), arguments.toMap, optional)
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -22,7 +22,7 @@ import scala.meta.Init
 class StyleMap(
     tokens: Array[FormatToken],
     init: ScalafmtConfig,
-    owners: Map[TokenHash, Tree],
+    owners: collection.Map[TokenHash, Tree],
     matching: Map[TokenHash, Token]
 ) {
   import TokenOps.hash

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -192,15 +192,33 @@ object TreeOps {
     * Creates lookup table from token offset to its closest scala.meta tree.
     */
   def getOwners(tree: Tree): Map[TokenHash, Tree] = {
-    val result = Map.newBuilder[TokenHash, Tree]
-    def loop(x: Tree): Unit = {
+    val result = new java.util.HashMap[TokenHash, Tree](2048)
+    import scala.collection.mutable
+    val workList: mutable.Queue[Tree] = new mutable.Queue[Tree]()
+    workList.enqueue(tree)
+    while (workList.nonEmpty) {
+      val x = workList.dequeue()
       x.tokens.foreach { tok =>
-        result += hash(tok) -> x
+        result.put(hash(tok), x)
       }
-      x.children.foreach(loop)
+      workList.enqueue(x.children: _*)
     }
-    loop(tree)
-    result.result()
+    import scala.collection.JavaConverters._
+    import scala.collection.immutable
+    new immutable.AbstractMap[TokenHash, Tree]
+    with immutable.MapLike[TokenHash, Tree, Map[TokenHash, Tree]] {
+      override def +[V1 >: Tree](kv: (TokenHash, V1)): Map[TokenHash, V1] =
+        throw new NotImplementedError("+ is not implemented")
+      override def -(key: TokenHash): Map[TokenHash, Tree] =
+        throw new NotImplementedError("- is not implemented")
+
+      override def get(key: TokenHash): Option[Tree] =
+        if (result.containsKey(key)) Some(result.get(key)) else None
+      override def iterator: Iterator[(TokenHash, Tree)] =
+        result.keySet().iterator().asScala.map(k => k -> apply(k))
+
+      override def apply(key: TokenHash): Tree = result.get(key)
+    }
   }
 
   @tailrec


### PR DESCRIPTION
Incorporates changes from #1386 and makes them compile on 2.11/2.12/2.13. The performance improvements are small but noticeable!

```
[info] Benchmark                          Mode  Cnt     Score     Error  Units
[info] Micro.ExtraLarge.scalafmtAfter     avgt   10   826.260 ± 139.865  ms/op
[info] Micro.ExtraLarge.scalafmtBefore    avgt   10   960.471 ± 157.597  ms/op
```
