### PR TITLE
Upgrade to the latest Scalameta

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.4"
-  val scalametaV = "4.2.3"
+  val scalametaV = "4.3.0"
   val scalatestV = "3.0.8"
   val scalacheckV = "1.14.2"
   val coursier = "1.0.3"


### PR DESCRIPTION
This release removes the awful usage of the global
`PlatformTokenizerCache` cache, which caused both correctness and
performance issues.