### PR TITLE
Router: break between curly and catch, like else

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -201,6 +201,8 @@ case class ScalafmtConfig(
   val activeForEdition_2019_11: Boolean = activeFor(Edition(2019, 11))
   val newlinesBeforeSingleArgParenLambdaParams: Boolean =
     newlines.alwaysBeforeCurlyBraceLambdaParams || !activeForEdition_2019_11
+  val newlinesBetweenCurlyAndCatchFinally: Boolean =
+    newlines.alwaysBeforeElseAfterCurlyIf && activeForEdition_2019_11
 }
 
 object ScalafmtConfig {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1516,13 +1516,19 @@ class Router(formatOps: FormatOps) {
         Seq(
           Split(mod, 0)
         )
-      case FormatToken(left, kw @ Keyword(), _) =>
-        if (!left.is[T.RightBrace] &&
-          Set("finally", "catch").contains(kw.syntax)) {
-          Seq(Split(Newline, 0))
-        } else {
-          Seq(Split(Space, 0))
-        }
+
+      case FormatToken(left, _: T.KwCatch | _: T.KwFinally, _)
+          if style.newlinesBetweenCurlyAndCatchFinally
+            || !left.is[T.RightBrace] =>
+        Seq(
+          Split(Newline, 0)
+        )
+
+      case FormatToken(_, Keyword(), _) =>
+        Seq(
+          Split(Space, 0)
+        )
+
       case FormatToken(Keyword() | Modifier(), _, _) =>
         Seq(
           Split(Space, 0)

--- a/scalafmt-tests/src/test/resources/newlines/newlineBetweenCurlyAndCatchFinally.stat
+++ b/scalafmt-tests/src/test/resources/newlines/newlineBetweenCurlyAndCatchFinally.stat
@@ -1,0 +1,72 @@
+maxColumn = 80
+newlines.alwaysBeforeElseAfterCurlyIf = true
+<<< 1: try with curly, catch/finally without
+object Foo {
+  try {
+    a
+    b
+  } catch c  finally d
+}
+>>>
+object Foo {
+  try {
+    a
+    b
+  } catch c
+  finally d
+}
+<<< 2: try/catch with curly, finally without
+object Foo {
+  try { a
+    b}   catch { case c => } finally d
+}
+>>>
+object Foo {
+  try {
+    a
+    b
+  } catch { case c => }
+  finally d
+}
+<<< 3: try/catch/finally with curly
+object Foo {
+  try { a
+    b}   catch { case c => } finally { d
+    e}
+}
+>>>
+object Foo {
+  try {
+    a
+    b
+  } catch { case c => }
+  finally {
+    d
+    e
+  }
+}
+<<< 4: catch with curly, try/finally without
+object Foo {
+  try a  catch { case c =>
+  case d => } finally e
+}
+>>>
+object Foo {
+  try a
+  catch {
+    case c =>
+    case d =>
+  } finally e
+}
+<<< 5: try with curly, finally without
+object Foo {
+  try { a
+    b}  finally e
+}
+>>>
+object Foo {
+  try {
+    a
+    b
+  } finally e
+}

--- a/scalafmt-tests/src/test/resources/newlines/newlineBetweenCurlyAndCatchFinally.stat
+++ b/scalafmt-tests/src/test/resources/newlines/newlineBetweenCurlyAndCatchFinally.stat
@@ -12,7 +12,8 @@ object Foo {
   try {
     a
     b
-  } catch c
+  }
+  catch c
   finally d
 }
 <<< 2: try/catch with curly, finally without
@@ -25,7 +26,8 @@ object Foo {
   try {
     a
     b
-  } catch { case c => }
+  }
+  catch { case c => }
   finally d
 }
 <<< 3: try/catch/finally with curly
@@ -39,7 +41,8 @@ object Foo {
   try {
     a
     b
-  } catch { case c => }
+  }
+  catch { case c => }
   finally {
     d
     e
@@ -56,7 +59,8 @@ object Foo {
   catch {
     case c =>
     case d =>
-  } finally e
+  }
+  finally e
 }
 <<< 5: try with curly, finally without
 object Foo {
@@ -68,5 +72,6 @@ object Foo {
   try {
     a
     b
-  } finally e
+  }
+  finally e
 }


### PR DESCRIPTION
Use the setting for 'else' after curly 'if' to determine whether to add
newlines before 'catch' and 'finally'.

Those who prefer
```
  if (a) {
    b
  }
  else c
```
over
```
  if (a) {
    b
  } else c
```
likely also prefer
```
  try {
    a
  }
  finally b
```
over
```
  try {
    a
  } finally b
```