### PR TITLE
adding possibility to specify custom repositories for coursier (#1521)

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
@@ -5,7 +5,6 @@ import java.net.URL
 
 import coursierapi._
 import org.scalafmt.dynamic.ScalafmtDynamicDownloader._
-import org.scalafmt.dynamic.ScalafmtVersion
 import org.scalafmt.dynamic.ScalafmtVersion.InvalidVersionException
 
 import scala.collection.JavaConverters._
@@ -14,6 +13,7 @@ import scala.util.Try
 
 class ScalafmtDynamicDownloader(
     downloadProgressWriter: OutputStreamWriter,
+    customRepositories: List[Repository],
     ttl: Option[Duration] = None
 ) {
 
@@ -86,7 +86,9 @@ class ScalafmtDynamicDownloader(
 
   private def repositories: Array[Repository] = {
     // Default repositories are ivy2local, central and also anything in COURSIER_REPOSITORIES overrides
-    Repository.defaults().asScala.toArray ++ Array(
+    customRepositories.toArray ++ Repository
+      .defaults()
+      .asScala ++ Array(
       MavenRepository.of(
         "https://oss.sonatype.org/content/repositories/snapshots"
       ),

--- a/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/Scalafmt.java
+++ b/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/Scalafmt.java
@@ -1,6 +1,5 @@
 package org.scalafmt.interfaces;
 
-import java.io.Writer;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -73,6 +72,11 @@ public interface Scalafmt {
      * Use this reporter to report errors and information messages.
      */
     Scalafmt withReporter(ScalafmtReporter reporter);
+
+    /**
+     * Use this repositories to resolve dependencies.
+     */
+    Scalafmt withMavenRepositories(String ... repositories);
 
     /**
      * Clear internal caches such as classloaded Scalafmt instances.


### PR DESCRIPTION
I'm kind of lost in tests. I would need help with writing a test for ScalafmtDynamicDownloader, if necessary (I haven't found any).
I'm also struggling with sbt-scalafmt part. I can't find a way how to map resolvers configuration into list of string urls. Any ideas?