### PR TITLE
Move CI to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  unit:
+    name: Test with java ${{ matrix.java }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        java: [1.8, 1.11]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Run unit tests
+        run: sbt +ci-test
+        shell: bash
+        env:
+          CI: true
+  check:
+    name: Run Scalafmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: olafurpg/setup-scala@v7
+      - name: Run Scalafmt
+        run: ./scalafmt --test
+

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,8 +1,9 @@
--Dfile.encoding=UTF8
+-Xss4m
 -Xms1G
--Xmx3G
+-Xmx4G
 -XX:MaxMetaspaceSize=512M
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
 -XX:+CMSClassUnloadingEnabled
+-Dfile.encoding=UTF8

--- a/build.sbt
+++ b/build.sbt
@@ -49,16 +49,8 @@ skip in publish := true
 addCommandAlias("native-image", "cli/graalvm-native-image:packageBin")
 
 commands += Command.command("ci-test") { s =>
-  val scalaVersion = sys.env.get("TEST") match {
-    case Some("2.11") => scala211
-    case Some("2.12") => scala212
-    case _ => scala213
-  }
-  val docsTest = if (scalaVersion == scala212) "docs/run" else "version"
-  s"++$scalaVersion" ::
-    s"tests/test" ::
-    // s"coreJS/test" ::
-    docsTest ::
+  s"+tests/test" ::
+    s"+docs/run" ::
     s
 }
 


### PR DESCRIPTION
- Now GitHub actions is generally available https://github.com/features/actions
- With GitHub Actions, we can rejuvenate the CI on Windows easily without using two different CI platforms (Travis and appveyor).
  - So with that, we might be able to take advantages from moving to GitHub Actions