### PR TITLE
FormatOps: consider comment for RHS optimal token

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -205,11 +205,13 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     nextNonCommentWithCount(curr)._2
 
   @tailrec
-  final def rhsOptimalToken(start: FormatToken): Token = {
+  final def rhsOptimalToken(
+      start: FormatToken
+  )(implicit style: ScalafmtConfig): Token = {
     start.right match {
       case T.Comma() | T.LeftParen() | T.RightParen() | T.RightBracket() |
           T.Semicolon() | T.RightArrow() | T.Equals()
-          if next(start) != start &&
+          if (1 + start.meta.idx) != tokens.length &&
             !startsNewBlock(start.right) &&
             start.newlinesBetween == 0 =>
         rhsOptimalToken(next(start))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -215,6 +215,9 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             !startsNewBlock(start.right) &&
             start.newlinesBetween == 0 =>
         rhsOptimalToken(next(start))
+      case c: T.Comment
+          if style.activeForEdition_2020_01 && start.newlinesBetween == 0 =>
+        c
       case _ => start.left
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -439,15 +439,6 @@ class FormatWriter(formatOps: FormatOps) {
     }
   }
 
-  import scala.meta.internal.classifiers.classifier
-
-  @classifier
-  private trait CloseParenOrBracket
-  private object CloseParenOrBracket {
-    def unapply(token: Token): Boolean =
-      token.is[T.RightParen] || token.is[T.RightBracket]
-  }
-
   private def handleTrailingCommasAndWhitespace(
       formatToken: FormatToken,
       state: State,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -951,9 +951,16 @@ class Router(formatOps: FormatOps) {
                 0
             }
             val singleLineComment = isSingleLineComment(right)
+            val noNewline = newlines == 0 && {
+              singleLineComment || style.activeForEdition_2020_01 && {
+                val nextTok = nextNonComment(tok).right
+                // perhaps a trailing comma
+                (nextTok ne right) && nextTok.is[CloseParenOrBracket]
+              }
+            }
             Seq(
               Split(Space, 0, ignoreIf = newlines != 0 && singleLineComment),
-              Split(Newline, 1, ignoreIf = newlines == 0 && singleLineComment)
+              Split(Newline, 1, ignoreIf = noNewline)
                 .withIndent(indent, right, ExpiresOn.Right)
             )
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -741,12 +741,15 @@ class Router(formatOps: FormatOps) {
 
         val tooManyArguments = args.length > 100
 
+        val mustDangle = style.activeForEdition_2020_01 && (
+          expirationToken.is[T.Comment]
+        )
         val wouldDangle =
           if (defnSite) style.danglingParentheses.defnSite
           else style.danglingParentheses.callSite
 
         val newlinePolicy: Policy =
-          if (wouldDangle) {
+          if (wouldDangle || mustDangle) {
             newlinesOnlyBeforeClosePolicy(close)
           } else {
             Policy.empty(close)
@@ -796,7 +799,7 @@ class Router(formatOps: FormatOps) {
             }
 
         val noSplitPolicy =
-          if (wouldDangle)
+          if (wouldDangle || mustDangle && isBracket)
             SingleLineBlock(close, exclude = excludeRanges)
           else
             singleLine(10)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -787,13 +787,20 @@ class Router(formatOps: FormatOps) {
                 case b: Term.Block => b.tokens.head
                 case _ => assign.tokens.find(_.is[T.Equals]).get
               }
+              val assignFT = tokens(assignToken)
+              val hasComment = isAttachedSingleLineComment(assignFT)
+              val breakToken = if (hasComment) assignFT.right else assignToken
+              val newlineAfterAssignDecision =
+                if (newlinePolicy.isEmpty) Policy.emptyPf
+                else decideNewlinesOnlyAfterToken(breakToken)
               val noSplitCost = 1 + nestedPenalty + lhsPenalty
               Seq(
                 Split(NoSplit, noSplitCost)
-                  .withOptimalToken(assignToken)
+                  .withOptimalToken(breakToken)
                   .withPolicy(
                     newlinePolicy
-                      .andThen(SingleLineBlock(assignToken))
+                      .andThen(newlineAfterAssignDecision)
+                      .andThen(SingleLineBlock(breakToken))
                   )
               )
             }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -801,6 +801,8 @@ class Router(formatOps: FormatOps) {
         val noSplitPolicy =
           if (wouldDangle || mustDangle && isBracket)
             SingleLineBlock(close, exclude = excludeRanges)
+          else if (splitsForAssign.isDefined)
+            singleLine(3)
           else
             singleLine(10)
         Seq(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -794,7 +794,11 @@ class Router(formatOps: FormatOps) {
                 if (newlinePolicy.isEmpty) Policy.emptyPf
                 else decideNewlinesOnlyAfterToken(breakToken)
               val noSplitCost = 1 + nestedPenalty + lhsPenalty
+              val newlineCost = Constants.ExceedColumnPenalty + noSplitCost
               Seq(
+                Split(Newline, newlineCost)
+                  .withPolicy(newlinePolicy)
+                  .withIndent(indent, close, Right),
                 Split(NoSplit, noSplitCost)
                   .withOptimalToken(breakToken)
                   .withPolicy(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -752,11 +752,6 @@ class Router(formatOps: FormatOps) {
             Policy.empty(close)
           }
 
-        val noSplitPolicy =
-          if (wouldDangle) {
-            SingleLineBlock(close, exclude = excludeRanges)
-          } else singleLine(10)
-
         val noSplitIndent =
           if (isSingleLineComment(right)) indent
           else Num(0)
@@ -794,6 +789,11 @@ class Router(formatOps: FormatOps) {
                 .withOptimalToken(assignToken)
             }
 
+        val noSplitPolicy =
+          if (wouldDangle)
+            SingleLineBlock(close, exclude = excludeRanges)
+          else
+            singleLine(10)
         Seq(
           Split(noSplitModification, 0, policy = noSplitPolicy)
             .withOptimalToken(expirationToken)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -741,17 +741,19 @@ class Router(formatOps: FormatOps) {
 
         val tooManyArguments = args.length > 100
 
+        val wouldDangle =
+          if (defnSite) style.danglingParentheses.defnSite
+          else style.danglingParentheses.callSite
+
         val newlinePolicy: Policy =
-          if (style.danglingParentheses.defnSite && defnSite ||
-            style.danglingParentheses.callSite && !defnSite) {
+          if (wouldDangle) {
             newlinesOnlyBeforeClosePolicy(close)
           } else {
             Policy.empty(close)
           }
 
         val noSplitPolicy =
-          if (style.danglingParentheses.defnSite && defnSite ||
-            style.danglingParentheses.callSite && !defnSite) {
+          if (wouldDangle) {
             SingleLineBlock(close, exclude = excludeRanges)
           } else singleLine(10)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -2,6 +2,7 @@ package org.scalafmt.util
 
 import scala.meta.{Defn, Pkg, Template, Tree}
 import scala.meta.dialects.Scala211
+import scala.meta.internal.classifiers.classifier
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
 
@@ -252,4 +253,12 @@ object TokenOps {
     "// @formatter:on", // IntelliJ
     "// format: on" // scalariform
   )
+
+  @classifier
+  trait CloseParenOrBracket
+  object CloseParenOrBracket {
+    def unapply(token: Token): Boolean =
+      token.is[Token.RightParen] || token.is[Token.RightBracket]
+  }
+
 }

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -624,9 +624,9 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 }
 >>>
 {
-  val config = WSClientConfig(SSLConfig(loose =
-    SSLLooseConfig(allowLegacyHelloMessages = None) /*comment 123 comment 234*/
-  )) //comment 345 comment 456
+  val config =
+    WSClientConfig(SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages =
+      None) /*comment 123 comment 234*/ )) //comment 345 comment 456
 }
 <<< #1604 3: apply with assign and attached comments
 {

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -611,9 +611,11 @@ SSLConfig(SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 2
 }
 >>>
 {
-  val config =
-    WSClientConfig(ssl = SSLConfig(SSLLooseConfig(allowLegacyHelloMessages =
-      None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+  val config = WSClientConfig(ssl = SSLConfig(
+      SSLLooseConfig(allowLegacyHelloMessages = None
+      ) /*comment 123 comment 234*/
+  )
+  ) //comment 345 comment 456
 }
 <<< #1604 2: apply without then with assign, and attached comments
 {
@@ -622,9 +624,9 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 }
 >>>
 {
-  val config =
-    WSClientConfig(SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages =
-      None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+  val config = WSClientConfig(SSLConfig(loose =
+    SSLLooseConfig(allowLegacyHelloMessages = None) /*comment 123 comment 234*/
+  )) //comment 345 comment 456
 }
 <<< #1604 3: apply with assign and attached comments
 {
@@ -633,9 +635,10 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 }
 >>>
 {
-  val config =
-    WSClientConfig(ssl = SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages =
-      None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+  val config = WSClientConfig(ssl = SSLConfig(loose =
+    SSLLooseConfig(allowLegacyHelloMessages = None) /*comment 123 comment 234*/
+  )
+  ) //comment 345 comment 456
 }
 <<< #1604 4: apply without assign and attached comments
 {
@@ -645,5 +648,6 @@ SSLConfig(SSLLooseConfig(None)/*comment 123 comment 234*/)) //comment 345 commen
 >>>
 {
   val config = WSClientConfig(
-      SSLConfig(SSLLooseConfig(None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+      SSLConfig(SSLLooseConfig(None) /*comment 123 comment 234*/ )
+  ) //comment 345 comment 456
 }

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -604,3 +604,46 @@ opt[String]("json-extractor") action { (x, c) =>
         CastleLastMoveTime.init.copy(castles = game.board.history.castles),
       daysPerTurn = daysPerTurn)
 }
+<<< #1604 1: apply with then without assign, and attached comments
+{
+       val config =         WSClientConfig(          ssl =
+SSLConfig(SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 234*/)) //comment 345 comment 456
+}
+>>>
+{
+  val config =
+    WSClientConfig(ssl = SSLConfig(SSLLooseConfig(allowLegacyHelloMessages =
+      None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+}
+<<< #1604 2: apply without then with assign, and attached comments
+{
+       val config =         WSClientConfig(
+SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 234*/)) //comment 345 comment 456
+}
+>>>
+{
+  val config =
+    WSClientConfig(SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages =
+      None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+}
+<<< #1604 3: apply with assign and attached comments
+{
+       val config =         WSClientConfig(ssl =
+SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 234*/)) //comment 345 comment 456
+}
+>>>
+{
+  val config =
+    WSClientConfig(ssl = SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages =
+      None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+}
+<<< #1604 4: apply without assign and attached comments
+{
+       val config =         WSClientConfig(
+SSLConfig(SSLLooseConfig(None)/*comment 123 comment 234*/)) //comment 345 comment 456
+}
+>>>
+{
+  val config = WSClientConfig(
+      SSLConfig(SSLLooseConfig(None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+}

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -611,10 +611,12 @@ SSLConfig(SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 2
 }
 >>>
 {
-  val config = WSClientConfig(ssl = SSLConfig(
-      SSLLooseConfig(allowLegacyHelloMessages = None
-      ) /*comment 123 comment 234*/
-  )
+  val config = WSClientConfig(ssl =
+    SSLConfig(
+        SSLLooseConfig(allowLegacyHelloMessages =
+          None
+        ) /*comment 123 comment 234*/
+    )
   ) //comment 345 comment 456
 }
 <<< #1604 2: apply without then with assign, and attached comments
@@ -637,8 +639,7 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 {
   val config = WSClientConfig(ssl = SSLConfig(loose =
     SSLLooseConfig(allowLegacyHelloMessages = None) /*comment 123 comment 234*/
-  )
-  ) //comment 345 comment 456
+  )) //comment 345 comment 456
 }
 <<< #1604 4: apply without assign and attached comments
 {

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -357,3 +357,34 @@ object a {
   while (isEmptyChar(ext.getContainingFile.getText.charAt(end - 1)))
     end = end - 1
 }
+<<< #1604 1: apply with single too-long assign of trailing comment then infix
+{
+  Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(ccccccccccccccccccccccccccccccccc = // comment
+  dddddddd + eeeeeeee /* comment */)
+}
+>>>
+{
+  Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(ccccccccccccccccccccccccccccccccc = // comment
+    dddddddd + eeeeeeee /* comment */ )
+}
+<<< #1604 2: apply with single a bit long assign of trailing comment then block
+{
+  Bbbbbbbbbbbbb(cccccccccccc = // comment
+{dddddddd + eeeeeeee  /* comment */ })
+}
+>>>
+{
+  Bbbbbbbbbbbbb(cccccccccccc = // comment
+    { dddddddd + eeeeeeee /* comment */ })
+}
+<<< #1604 3: apply with single a bit long assign of block with trailing comment
+{
+  Bbbbbbbbbbbbb(cccccccccccc = { // comment
+dddddddd + eeeeeeee /* comment */ })
+}
+>>>
+{
+  Bbbbbbbbbbbbb(cccccccccccc = { // comment
+    dddddddd + eeeeeeee /* comment */
+  })
+}

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -364,8 +364,9 @@ object a {
 }
 >>>
 {
-  Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(ccccccccccccccccccccccccccccccccc = // comment
-    dddddddd + eeeeeeee /* comment */ )
+  Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb(
+      ccccccccccccccccccccccccccccccccc = // comment
+        dddddddd + eeeeeeee /* comment */ )
 }
 <<< #1604 2: apply with single a bit long assign of trailing comment then block
 {

--- a/scalafmt-tests/src/test/resources/default/SearchState.stat
+++ b/scalafmt-tests/src/test/resources/default/SearchState.stat
@@ -470,15 +470,18 @@ EventsResponse.fromJson(json, run).success.value.events should be(
 val TodoApp = ReactComponentB[Unit]("TodoApp")
   .initialState(State(Nil, ""))
   .renderS(($, s) =>
-    <.div(
-        <.h3("TODO"),
-        TodoList(s.items),
-        <.form(
-            ^.onSubmit ==> $._runState(handleSubmit), // runState runs a state monad and applies the result.
-            <.input( // _runState is similar but takes a function-to-a-state-monad.
-                ^.onChange ==> $._runState(acceptChange), // In these cases, the function will be fed the JS event.
-                ^.value := s.text),
-            <.button("Add #", s.items.length + 1))))
+    <.div(<.h3("TODO"),
+          TodoList(s.items),
+          <.form(
+              ^.onSubmit ==> $._runState(
+                  handleSubmit
+              ), // runState runs a state monad and applies the result.
+              <.input( // _runState is similar but takes a function-to-a-state-monad.
+                  ^.onChange ==> $._runState(
+                      acceptChange
+                  ), // In these cases, the function will be fed the JS event.
+                  ^.value := s.text),
+              <.button("Add #", s.items.length + 1))))
   .build
 <<< #745
 object SharedPolicyAmounts {

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -102,7 +102,8 @@ private def extractRhino(e: js.Dynamic): js.Array[String] = {
     .getOrElse("")
     .jsReplace("""^\s+at\s+""".re("gm"), "") // remove 'at' and indentation
     .jsReplace("""^(.+?)(?: \((.+)\))?$""".re("gm"), "$2@$1")
-    .jsReplace("""\r\n?""".re("gm"), "\n") // Rhino has platform-dependent EOL's
+    .jsReplace("""\r\n?""".re("gm"),
+               "\n") // Rhino has platform-dependent EOL's
     .jsSplit("\n")
 }
 <<< select is cheaper

--- a/scalafmt-tests/src/test/resources/optIn/SelectChains.stat
+++ b/scalafmt-tests/src/test/resources/optIn/SelectChains.stat
@@ -16,7 +16,9 @@ val design: Design =
 val design: Design =
   newDesign // Create an empty design
     .bind[A].to[AImpl] // Bind a concrete class AImpl to A
-    .bind[B].toInstance(new B(1)) // Bind a concrete instance to B (This instance will be a singleton)
+    .bind[B].toInstance(
+      new B(1)
+    ) // Bind a concrete instance to B (This instance will be a singleton)
     .bind[S].toSingleton // S will be a singleton within the session
     .bind[ES].toEagerSingleton // ES will be initialized as a singleton at session start time
     .bind[D1]

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -188,8 +188,9 @@ SSLConfig(SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 2
 {
   val config = WSClientConfig(ssl =
     SSLConfig(
-        SSLLooseConfig(allowLegacyHelloMessages =
-          None
+        SSLLooseConfig(
+            allowLegacyHelloMessages =
+              None
         ) /*comment 123 comment 234*/
     )
   ) //comment 345 comment 456
@@ -203,8 +204,9 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 {
   val config = WSClientConfig(
       SSLConfig(loose =
-        SSLLooseConfig(allowLegacyHelloMessages =
-          None
+        SSLLooseConfig(
+            allowLegacyHelloMessages =
+              None
         ) /*comment 123 comment 234*/
       )
   ) //comment 345 comment 456
@@ -233,8 +235,9 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 {
   val config = WSClientConfig(ssl =
     SSLConfig(loose =
-      SSLLooseConfig(allowLegacyHelloMessages =
-        None
+      SSLLooseConfig(
+          allowLegacyHelloMessages =
+            None
       ) /*comment 123 comment 234*/
     )
   ) //comment 345 comment 456
@@ -278,8 +281,9 @@ dddddddd)
 }
 >>>
 {
-  Bbbbbbbbbbbbb(cccccccccccc = // comment
-    dddddddd
+  Bbbbbbbbbbbbb(
+      cccccccccccc = // comment
+        dddddddd
   )
 }
 <<< #1604 9: apply with single a bit long assign of trailing comment then block
@@ -288,7 +292,6 @@ dddddddd)
 {dddddddd})
 }
 >>>
-error: Unable to format file due to bug in scalafmt
 {
   Bbbbbbbbbbbbb(
       cccccccccccc = // comment
@@ -302,7 +305,9 @@ dddddddd})
 }
 >>>
 {
-  Bbbbbbbbbbbbb(cccccccccccc = { // comment
-    dddddddd
-  })
+  Bbbbbbbbbbbbb(
+      cccccccccccc = { // comment
+        dddddddd
+      }
+  )
 }

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -256,7 +256,8 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 }
 >>>
 {
-  Bbbbbbbbbbbbb(cccccccccccc = dddddddd /* comment */
+  Bbbbbbbbbbbbb(cccccccccccc =
+    dddddddd /* comment */
   )
 }
 <<< #1604 7: apply with single a bit long assign and trailing comment
@@ -266,7 +267,8 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 }
 >>>
 {
-  Bbbbbbbbbbbbb(cccccccccccc = dddddddd // comment
+  Bbbbbbbbbbbbb(cccccccccccc =
+    dddddddd // comment
   )
 }
 <<< #1604 8: apply with single a bit long assign and trailing comment

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -218,7 +218,9 @@ SSLConfig(SSLLooseConfig(None)/*comment 123 comment 234*/)) //comment 345 commen
 {
   val config = WSClientConfig(
       SSLConfig(
-          SSLLooseConfig(None) /*comment 123 comment 234*/
+          SSLLooseConfig(
+              None
+          ) /*comment 123 comment 234*/
       )
   ) //comment 345 comment 456
 }

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -179,3 +179,126 @@ Props(
     dddddddd + eeeeeeee /* comment */
   )
 }
+<<< #1604 1: apply with and without assign and attached comments
+{
+       val config =         WSClientConfig(          ssl =
+SSLConfig(SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 234*/)) //comment 345 comment 456
+}
+>>>
+{
+  val config = WSClientConfig(ssl =
+    SSLConfig(
+        SSLLooseConfig(allowLegacyHelloMessages =
+          None
+        ) /*comment 123 comment 234*/
+    )
+  ) //comment 345 comment 456
+}
+<<< #1604 2: apply with and without assign and attached comments 2
+{
+       val config =         WSClientConfig(
+SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 234*/)) //comment 345 comment 456
+}
+>>>
+{
+  val config = WSClientConfig(
+      SSLConfig(loose =
+        SSLLooseConfig(allowLegacyHelloMessages =
+          None
+        ) /*comment 123 comment 234*/
+      )
+  ) //comment 345 comment 456
+}
+<<< #1604 3: apply without assign and attached comments
+{
+       val config =         WSClientConfig(
+SSLConfig(SSLLooseConfig(None)/*comment 123 comment 234*/)) //comment 345 comment 456
+}
+>>>
+{
+  val config = WSClientConfig(
+      SSLConfig(
+          SSLLooseConfig(None) /*comment 123 comment 234*/
+      )
+  ) //comment 345 comment 456
+}
+<<< #1604 4: apply with assign and attached comments
+{
+       val config =         WSClientConfig(ssl =
+SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 234*/)) //comment 345 comment 456
+}
+>>>
+{
+  val config = WSClientConfig(ssl =
+    SSLConfig(loose =
+      SSLLooseConfig(allowLegacyHelloMessages =
+        None
+      ) /*comment 123 comment 234*/
+    )
+  ) //comment 345 comment 456
+}
+<<< #1604 5: apply with single too-long assign of trailing comment then infix
+{
+  Bbbbbbbbbbbbbbbbbbbb(ccccccccccccccc = // comment
+  dddddddd + eeeeeeee /* comment */)
+}
+>>>
+{
+  Bbbbbbbbbbbbbbbbbbbb(ccccccccccccccc = // comment
+    dddddddd + eeeeeeee /* comment */
+  )
+}
+<<< #1604 6: apply with single a bit long assign and inline comment
+{
+  Bbbbbbbbbbbbb(cccccccccccc = dddddddd /* comment */)
+}
+>>>
+{
+  Bbbbbbbbbbbbb(cccccccccccc = dddddddd /* comment */
+  )
+}
+<<< #1604 7: apply with single a bit long assign and trailing comment
+{
+  Bbbbbbbbbbbbb(cccccccccccc = dddddddd // comment
+)
+}
+>>>
+{
+  Bbbbbbbbbbbbb(cccccccccccc = dddddddd // comment
+  )
+}
+<<< #1604 8: apply with single a bit long assign and trailing comment
+{
+  Bbbbbbbbbbbbb(cccccccccccc = // comment
+dddddddd)
+}
+>>>
+{
+  Bbbbbbbbbbbbb(cccccccccccc = // comment
+    dddddddd
+  )
+}
+<<< #1604 9: apply with single a bit long assign of trailing comment then block
+{
+  Bbbbbbbbbbbbb(cccccccccccc = // comment
+{dddddddd})
+}
+>>>
+error: Unable to format file due to bug in scalafmt
+{
+  Bbbbbbbbbbbbb(
+      cccccccccccc = // comment
+        { dddddddd }
+  )
+}
+<<< #1604 10: apply with single a bit long assign of block with trailing comment
+{
+  Bbbbbbbbbbbbb(cccccccccccc = { // comment
+dddddddd})
+}
+>>>
+{
+  Bbbbbbbbbbbbb(cccccccccccc = { // comment
+    dddddddd
+  })
+}

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -210,11 +210,9 @@ object Foo {
   dddddddd + eeeeeeee /* comment */)
 }
 >>>
-Idempotency violated
 {
   Bbbbbbbbbbbbbb(ccccccccccc = // comment
-    dddddddd + eeeeeeee,
-  /* comment */
+    dddddddd + eeeeeeee, /* comment */
   )
 }
 <<< #1604 2: avoid single-arg assign closing paren split keeping trailing comma
@@ -226,7 +224,6 @@ Idempotency violated
 >>>
 {
   Bbbbbbbbbbbbbb(ccccccccccc = // comment
-    dddddddd + eeeeeeee,
-  /* comment */
+    dddddddd + eeeeeeee, /* comment */
   )
 }

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -204,3 +204,29 @@ object Foo {
     }
   }
 }
+<<< #1604 1: avoid single-arg assign closing paren split adding trailing comma
+{
+  Bbbbbbbbbbbbbb(ccccccccccc = // comment
+  dddddddd + eeeeeeee /* comment */)
+}
+>>>
+Idempotency violated
+{
+  Bbbbbbbbbbbbbb(ccccccccccc = // comment
+    dddddddd + eeeeeeee,
+  /* comment */
+  )
+}
+<<< #1604 2: avoid single-arg assign closing paren split keeping trailing comma
+{
+  Bbbbbbbbbbbbbb(ccccccccccc = // comment
+    dddddddd + eeeeeeee, /* comment */
+  )
+}
+>>>
+{
+  Bbbbbbbbbbbbbb(ccccccccccc = // comment
+    dddddddd + eeeeeeee,
+  /* comment */
+  )
+}

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -211,8 +211,9 @@ object Foo {
 }
 >>>
 {
-  Bbbbbbbbbbbbbb(ccccccccccc = // comment
-    dddddddd + eeeeeeee, /* comment */
+  Bbbbbbbbbbbbbb(
+    ccccccccccc = // comment
+      dddddddd + eeeeeeee, /* comment */
   )
 }
 <<< #1604 2: avoid single-arg assign closing paren split keeping trailing comma
@@ -223,7 +224,8 @@ object Foo {
 }
 >>>
 {
-  Bbbbbbbbbbbbbb(ccccccccccc = // comment
-    dddddddd + eeeeeeee, /* comment */
+  Bbbbbbbbbbbbbb(
+    ccccccccccc = // comment
+      dddddddd + eeeeeeee, /* comment */
   )
 }

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -75,7 +75,8 @@ Thing(implicit ctx =>
       aaaaaaaaaaaaa(
           bbbbbbbbbbbbbbbbbbb,
           cccccccccc,
-          ddddddddddddddddddddj)) // coooooooooooooooomment
+          ddddddddddddddddddddj
+      )) // coooooooooooooooomment
 <<< single line uncurried
 Thing() { implicit ctx =>
       ???

--- a/scalafmt-tests/src/test/resources/unit/TermApply.stat
+++ b/scalafmt-tests/src/test/resources/unit/TermApply.stat
@@ -109,7 +109,10 @@ Seq(
 )
 >>>
 Seq(
-    Split(Space, 0), // End files with trailing newline
+    Split(
+        Space,
+        0
+    ), // End files with trailing newline
     Split(Newline, 1)
 )
 <<< seq to var arg, #178

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -69,7 +69,9 @@ def format_![
     T <: Tree // Some type comment
   ](code: String, // The code!
     code2: String
-  )(implicit ev: Parse[T], // The Parser!!! Some very long comment that goes over limit
+  )(implicit ev: Parse[
+      T
+    ], // The Parser!!! Some very long comment that goes over limit
     ex: D
   ): String = 1
 


### PR DESCRIPTION
We are also moving the optimal break point to before a close parenthesis
if a comment follows it and doesn't fit.

Since we don't break just before a comment, it occasionally led to very
long lines. While this change can't guarantee the lines won't be longer
than maxColumn either, they will be shorter because we will induce a
break before the close parenthesis:

instead of
```
  a(b) // comment
```
we'll format as
```
  a(
    b
  ) // comment
```
An unexpectedly related (through failing idempotency checks) but somewhat different problem is with breaking on assign in apply; it's follow-on change to the feature introduced 2.3, and modifies
```
  a(b = c) // comment
```
to (if the original form exceeds `maxColumn`)
```
  a(b =
    c
  ) // comment
```
or (if the previous form exceeds `maxColumn`)
```
  a(
    b = c
  ) // comment
```

`scala-repos` diffs:
* try break before a comment in apply: https://github.com/kitbellew/scala-repos/commit/83c792bf41b187013d552d8ef4b817d5950409a3?w=1
* reduce break penalty for assign: https://github.com/kitbellew/scala-repos/commit/f38073e70fdbd1be2f98074e20762585e8b356d8?w=1
* break on assign in apply if dangle: https://github.com/kitbellew/scala-repos/commit/ba5d78b262419e9c8cc8a03b724461496efa15e6?w=1
* newline split for assign in apply: https://github.com/kitbellew/scala-repos/commit/d576f9ffaea4ced6f3ab40c9ac1bfa4dadc5348c?w=1