### PR TITLE
FormatOps: allow break after assign in infixSplit

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Scalafmt210.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Scalafmt210.scala
@@ -51,7 +51,7 @@ class Scalafmt210 {
       if (filename.endsWith(".sbt")) SRunner.sbt
       else SRunner.default
     val style = scalafmtStyle.copy(runner = runner)
-    Scalafmt.format(code, style) match {
+    Scalafmt.format(code, style, filename = filename) match {
       case Formatted.Success(formattedCode) => formattedCode
       case error =>
         error match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -40,9 +40,9 @@ object Scalafmt {
     */
   def format(
       code: String,
-      style: ScalafmtConfig,
-      range: Set[Range],
-      filename: String
+      style: ScalafmtConfig = ScalafmtConfig.default,
+      range: Set[Range] = Set.empty,
+      filename: String = "<input>"
   ): Formatted = {
     try {
       val runner = style.runner
@@ -80,14 +80,6 @@ object Scalafmt {
       // TODO(olafur) add more fine grained errors.
       case NonFatal(e) => Formatted.Failure(e)
     }
-  }
-
-  def format(
-      code: String,
-      style: ScalafmtConfig = ScalafmtConfig.default,
-      range: Set[Range] = Set.empty[Range]
-  ): Formatted = {
-    format(code, style, range, "<input>")
   }
 
   def parseHoconConfig(configString: String): Configured[ScalafmtConfig] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -203,6 +203,9 @@ case class ScalafmtConfig(
     newlines.alwaysBeforeCurlyBraceLambdaParams || !activeForEdition_2019_11
   val newlinesBetweenCurlyAndCatchFinally: Boolean =
     newlines.alwaysBeforeElseAfterCurlyIf && activeForEdition_2019_11
+
+  // Edition 2020-01
+  val activeForEdition_2020_01: Boolean = activeFor(Edition(2020, 1))
 }
 
 object ScalafmtConfig {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -18,7 +18,7 @@ case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
   }
 
   def forceNewline(implicit line: sourcecode.Line): Decision = {
-    if (isAttachedSingleLineComment(formatToken.right, formatToken.between))
+    if (isAttachedSingleLineComment(formatToken))
       this
     else {
       Decision(formatToken, splits.filter(_.modification.isNewline))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -3,7 +3,6 @@ package org.scalafmt.internal
 import scala.meta.tokens.Token
 import scala.meta.tokens.Tokens
 
-import org.scalafmt.util.TokenOps
 import org.scalafmt.util.TokenOps._
 import org.scalafmt.util.Whitespace
 
@@ -27,7 +26,7 @@ case class FormatToken(left: Token, right: Token, between: Vector[Token]) {
     else range.exists(_.contains(right.pos.endLine))
   }
 
-  def newlinesBetween: Int = TokenOps.newlinesBetween(between)
+  lazy val newlinesBetween: Int = between.count(_.is[Token.LF])
 
   val leftHasNewline = left.syntax.contains('\n')
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1214,17 +1214,17 @@ class Router(formatOps: FormatOps) {
             .withPolicy(SingleLineBlock(expire)),
           Split(Space, 1).withPolicy(breakOnlyBeforeElse)
         )
-      case FormatToken(close @ T.RightParen(), right, between)
-          if (leftOwner match {
+      case FormatToken(close: T.RightParen, _, _) if (leftOwner match {
             case _: Term.If | _: Term.For => true
-            case _: Term.ForYield if style.indentYieldKeyword => true
+            case _: Term.ForYield => style.indentYieldKeyword
+            case _: Term.While => style.activeForEdition_2020_01
             case _ => false
-          }) &&
-            !isFirstOrLastToken(close, leftOwner) =>
+          }) && !isFirstOrLastToken(close, leftOwner) =>
         val expire = leftOwner match {
           case t: Term.If => t.thenp.tokens.last
           case t: Term.For => t.body.tokens.last
           case t: Term.ForYield => t.body.tokens.last
+          case t: Term.While => t.body.tokens.last
         }
         // Inline comment attached to closing RightParen
         val attachedComment = isAttachedSingleLineComment(formatToken)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -60,7 +60,7 @@ class Router(formatOps: FormatOps) {
   import formatOps._
 
   private def getSplits(formatToken: FormatToken): Seq[Split] = {
-    val style = styleMap.at(formatToken)
+    implicit val style = styleMap.at(formatToken)
     val leftOwner = owners(formatToken.left)
     val rightOwner = owners(formatToken.right)
     val newlines = formatToken.newlinesBetween
@@ -664,10 +664,6 @@ class Router(formatOps: FormatOps) {
         val excludeRanges = exclude.map(parensRange)
 
         val indent = getApplyIndent(leftOwner)
-        val noUnindent = {
-          val toSkip = insideBlock(tok, close, skipUnindent).map(parensRange)
-          exclude.filterNot(x => toSkip.exists(_.contains(x.start)))
-        }
 
         val singleArgument = args.length == 1
 
@@ -708,8 +704,6 @@ class Router(formatOps: FormatOps) {
             Space
           else if (right.is[T.LeftBrace]) NoSplit
           else Newline
-
-        val charactersInside = (close.start - open.end) - 2
 
         val defnSite = isDefnSite(leftOwner)
         val expirationToken: Token =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -994,9 +994,7 @@ class Router(formatOps: FormatOps) {
           insideBlock(formatToken, expire, _.isInstanceOf[T.LeftBrace])
         rhs match {
           case t: Term.ApplyInfix =>
-            Seq(
-              infixSplit(t, formatToken)
-            )
+            infixSplit(t, formatToken)
           case _ =>
             def twoBranches: Policy = {
               val excludeRanges = exclude.map(parensRange)
@@ -1315,11 +1313,11 @@ class Router(formatOps: FormatOps) {
           if isApplyInfix(op, leftOwner) =>
         // TODO(olafur) move extractor into pattern match.
         val InfixApplication(_, op, args) = leftOwner.parent.get
-        Seq(infixSplit(leftOwner, op, args, formatToken))
+        infixSplit(leftOwner, op, args, formatToken)
       case FormatToken(left, op @ T.Ident(_), between)
           if isApplyInfix(op, rightOwner) =>
         val InfixApplication(_, op, args) = rightOwner.parent.get
-        Seq(infixSplit(rightOwner, op, args, formatToken))
+        infixSplit(rightOwner, op, args, formatToken)
       case opt
           if style.optIn.annotationNewlines &&
             optionalNewlines(hash(opt.right)) =>

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -388,7 +388,8 @@ object mixed {
   else {
     val chars = s.toCharArray
   }
-  val prefix = "sbt.paths." + projectName + "." + uncapitalize(config.name) + "."
+  val prefix =
+    "sbt.paths." + projectName + "." + uncapitalize(config.name) + "."
 }
 <<< #521
 x match {

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -339,3 +339,19 @@ val overrides =
     "hostname" ::
     "port" ::
     Nil
+<<< #1608: apply with single too-long assign of infix
+{
+  Bbbbbbbbbbbbbbbbbbbbbbb(cccccccccccccccccc = dddddddd + eeeeeeee /* comment */)
+}
+>>>
+{
+  Bbbbbbbbbbbbbbbbbbbbbbb(cccccccccccccccccc = dddddddd + eeeeeeee /* comment */ )
+}
+<<< #1608: while with infix
+object a {
+        while (isEmptyChar(ext.getContainingFile.getText.charAt(end - 1))) end = end - 1
+        }
+>>>
+object a {
+  while (isEmptyChar(ext.getContainingFile.getText.charAt(end - 1))) end = end - 1
+}

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -345,7 +345,8 @@ val overrides =
 }
 >>>
 {
-  Bbbbbbbbbbbbbbbbbbbbbbb(cccccccccccccccccc = dddddddd + eeeeeeee /* comment */ )
+  Bbbbbbbbbbbbbbbbbbbbbbb(cccccccccccccccccc =
+    dddddddd + eeeeeeee /* comment */ )
 }
 <<< #1608: while with infix
 object a {
@@ -353,5 +354,6 @@ object a {
         }
 >>>
 object a {
-  while (isEmptyChar(ext.getContainingFile.getText.charAt(end - 1))) end = end - 1
+  while (isEmptyChar(ext.getContainingFile.getText.charAt(end - 1))) end =
+    end - 1
 }

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -354,6 +354,6 @@ object a {
         }
 >>>
 object a {
-  while (isEmptyChar(ext.getContainingFile.getText.charAt(end - 1))) end =
-    end - 1
+  while (isEmptyChar(ext.getContainingFile.getText.charAt(end - 1)))
+    end = end - 1
 }

--- a/scalafmt-tests/src/test/resources/spaces/NeverAroundInfixTypes.stat
+++ b/scalafmt-tests/src/test/resources/spaces/NeverAroundInfixTypes.stat
@@ -3,8 +3,8 @@ maxColumn = 40
 <<< never around infix types
 val hlistForFoo: Generic[Foo] ## Repr = 1 :: "xxx" :: HNil
 >>>
-val hlistForFoo
-    : Generic[Foo]##Repr = 1 :: "xxx" :: HNil
+val hlistForFoo: Generic[Foo]##Repr =
+  1 :: "xxx" :: HNil
 <<< never around infix types (not an infix term)
 val x: F[X] ## B = f##b
 >>>

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -175,6 +175,7 @@ Props(
 }
 >>>
 {
-  Bbbbbbbbbbbbbbbbbbb(cccccccccccccc = dddddddd + eeeeeeee /* comment */
+  Bbbbbbbbbbbbbbbbbbb(cccccccccccccc =
+    dddddddd + eeeeeeee /* comment */
   )
 }

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -169,3 +169,12 @@ Props(
         c
     )
 )
+<<< #1608: apply with single too-long assign of infix
+{
+  Bbbbbbbbbbbbbbbbbbb(cccccccccccccc = dddddddd + eeeeeeee /* comment */)
+}
+>>>
+{
+  Bbbbbbbbbbbbbbbbbbb(cccccccccccccc = dddddddd + eeeeeeee /* comment */
+  )
+}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -43,7 +43,7 @@ class FidelityTest extends AnyFunSuite with FormatAssertions {
   examples.foreach { example =>
     test(example.filename) {
       val formatted =
-        Scalafmt.format(example.code, ScalafmtConfig.default).get
+        Scalafmt.format(example.code, filename = example.filename).get
       assertFormatPreservesAst(example.code, formatted)(
         scala.meta.parsers.Parse.parseSource,
         Scala211

--- a/scalafmt-tests/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/FormatTests.scala
@@ -52,19 +52,22 @@ class FormatTests
 
   def run(t: DiffTest, parse: Parse[_ <: Tree]): Unit = {
     val runner = scalafmtRunner(t.style.runner).copy(parser = parse)
-    val obtained =
-      Scalafmt.format(t.original, t.style.copy(runner = runner)) match {
-        case Formatted.Failure(e)
-            if t.style.onTestFailure.nonEmpty && e.getMessage.contains(
-              e.getMessage
-            ) =>
-          t.expected
-        case Formatted.Failure(e: Incomplete) => e.formattedCode
-        case Formatted.Failure(e: SearchStateExploded) =>
-          logger.elem(e)
-          e.partialOutput
-        case x => x.get
-      }
+    val obtained = Scalafmt.format(
+      t.original,
+      t.style.copy(runner = runner),
+      filename = t.filename
+    ) match {
+      case Formatted.Failure(e)
+          if t.style.onTestFailure.nonEmpty && e.getMessage.contains(
+            e.getMessage
+          ) =>
+        t.expected
+      case Formatted.Failure(e: Incomplete) => e.formattedCode
+      case Formatted.Failure(e: SearchStateExploded) =>
+        logger.elem(e)
+        e.partialOutput
+      case x => x.get
+    }
     debugResults += saveResult(t, obtained, onlyOne)
     if (t.style.rewrite.rules.isEmpty &&
       !t.style.assumeStandardLibraryStripMargin &&
@@ -74,8 +77,13 @@ class FormatTests
         t.style.runner.dialect
       )
     }
-    val formattedAgain =
-      Scalafmt.format(obtained, t.style.copy(runner = runner)).get
+    val formattedAgain = Scalafmt
+      .format(
+        obtained,
+        t.style.copy(runner = runner),
+        filename = t.filename
+      )
+      .get
 //          getFormatOutput(t.style, true) // uncomment to debug
     assertNoDiff(formattedAgain, obtained, "Idempotency violated")
     if (!onlyManual) {

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -183,8 +183,13 @@ trait HasTests extends AnyFunSuiteLike with FormatAssertions {
 
   def defaultRun(t: DiffTest, parse: Parse[_ <: Tree]): Unit = {
     val runner = scalafmtRunner(t.style.runner).copy(parser = parse)
-    val obtained =
-      Scalafmt.format(t.original, t.style.copy(runner = runner)).get
+    val obtained = Scalafmt
+      .format(
+        t.original,
+        t.style.copy(runner = runner),
+        filename = t.filename
+      )
+      .get
     if (t.style.rewrite.rules.isEmpty) {
       assertFormatPreservesAst(t.original, obtained)(
         parse,


### PR DESCRIPTION
This fix improves some formatting and also removes some idempotency issues while fixing the larger assign break.

`scala-repos` diffs:
* break after assign in infixSplit: https://github.com/kitbellew/scala-repos/commit/a318836fe35b44f62892d23c3aff6ba9bb0057a2?w=1
* handle split after "while ()": https://github.com/kitbellew/scala-repos/commit/bed9ada263f79577063aa60880579ae81f1c6ca3?w=1