### PR TITLE
Various bugfixes for single-arg apply of a lambda

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -651,11 +651,15 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       else
         last -> Left
     }
+    def dropComment(rtoks: Seq[Token]) =
+      if (rtoks.head.is[T.Comment]) dropWS(rtoks.tail) else rtoks
 
     def getRToks = dropWS(function.tokens.reverse)
     function.parent match {
       case Some(b: Term.Block) if b.stats.length == 1 =>
         b.tokens.last -> Right
+      case Some(Case(_, _, `function`)) =>
+        orElse(dropComment(getRToks))
       case _ =>
         orElse(getRToks)
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -484,12 +484,11 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     curr.left
   }
 
-  def getRightAttachedComment(token: Token): Token = {
-    val formatToken = leftTok2tok(token)
-    if (isAttachedSingleLineComment(formatToken))
-      formatToken.right
-    else token
-  }
+  def getOptimalTokenFor(token: Token): Token =
+    getOptimalTokenFor(leftTok2tok(token))
+
+  def getOptimalTokenFor(ft: FormatToken): Token =
+    if (isAttachedSingleLineComment(ft)) ft.right else ft.left
 
   def chainOptimalToken(chain: Vector[Term.Select]): Token = {
     val lastDotIndex = chain.last.tokens.lastIndexWhere(_.is[T.Dot])

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -640,21 +640,15 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     case _ => false
   }
 
-  def functionExpire(function: Term.Function): (Token, ExpiresOn) = {
-    (for {
-      parent <- function.parent
-      blockEnd <- parent match {
+  def functionExpire(function: Term.Function): (Token, ExpiresOn) =
+    function.parent
+      .collect {
         case b: Term.Block if b.stats.length == 1 =>
-          Some(b.tokens.last -> Right)
-        case _ => None
+          b.tokens.last -> Right
       }
-    } yield blockEnd).getOrElse {
-      function.tokens.last match {
-        case tok @ Whitespace() => tok -> Right
-        case tok => tok -> Left
+      .getOrElse {
+        function.tokens.findLast(!_.is[Whitespace]).get -> Left
       }
-    }
-  }
 
   def noOptimizationZones(tree: Tree): Set[Token] = {
     val result = Set.newBuilder[Token]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -203,6 +203,15 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     prevNonCommentWithCount(curr)._2
 
   @tailrec
+  final def nextNonCommentSameLine(curr: FormatToken): FormatToken =
+    if (curr.newlinesBetween != 0 || !curr.right.is[T.Comment]) curr
+    else {
+      val tok = next(curr)
+      if (tok == curr) curr
+      else nextNonCommentSameLine(tok)
+    }
+
+  @tailrec
   final def nextNonCommentWithCount(
       curr: FormatToken,
       accum: Int = 0

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1371,9 +1371,8 @@ class Router(formatOps: FormatOps) {
         // TODO(olafur) expire on token.end to avoid this bug.
         val expire = Option(owner.body)
           .filter(_.tokens.exists(!_.is[Trivia]))
-          .map(lastToken)
-          .map(getRightAttachedComment)
-          .getOrElse(arrow) // edge case, if body is empty expire on arrow.
+          // edge case, if body is empty expire on arrow
+          .fold(arrow)(t => getOptimalTokenFor(lastToken(t)))
 
         Seq(
           // Either everything fits in one line or break on =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -307,12 +307,14 @@ class Router(formatOps: FormatOps) {
             if (!hasBlock && (nonComment eq formatToken))
               Seq(newlineSplit)
             else {
+              // break after the brace or comment if fits, or now if doesn't
               // if brace, don't add indent, the LeftBrace rule will do that
               val spaceIndent = if (hasBlock) 0 else indent
               Seq(
                 Split(Space, 0)
                   .withIndent(spaceIndent, endOfFunction, expiresOn)
-                  .withOptimalToken(getOptimalTokenFor(next(nonComment)))
+                  .withOptimalToken(getOptimalTokenFor(next(nonComment))),
+                newlineSplit
               )
             }
           }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -303,7 +303,8 @@ class Router(formatOps: FormatOps) {
           } else {
             // 2020-01: break after same-line comments, and any open brace
             val nonComment = nextNonCommentSameLine(formatToken)
-            val hasBlock = nonComment.right.is[T.LeftBrace]
+            val hasBlock = nonComment.right.is[T.LeftBrace] &&
+              (matching(nonComment.right) eq endOfFunction)
             if (!hasBlock && (nonComment eq formatToken))
               Seq(newlineSplit)
             else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -283,13 +283,14 @@ class Router(formatOps: FormatOps) {
         val (endOfFunction, expiresOn) = functionExpire(
           leftOwner.asInstanceOf[Term.Function]
         )
-        val hasBlock =
+        val hasSingleLineComment = isSingleLineComment(right)
+        val hasBlock = !hasSingleLineComment &&
           nextNonComment(formatToken).right.isInstanceOf[T.LeftBrace]
         val indent = // don't indent if the body is empty `{ x => }`
           if (isEmptyFunctionBody(leftOwner) && !right.is[T.Comment]) 0
           else 2
         Seq(
-          Split(Space, 0, ignoreIf = isSingleLineComment(right))
+          Split(Space, 0, ignoreIf = hasSingleLineComment)
             .withPolicy(SingleLineBlock(endOfFunction)),
           Split(Space, 0, ignoreIf = !hasBlock),
           Split(Newline, 1 + nestedApplies(leftOwner), ignoreIf = hasBlock)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -498,14 +498,11 @@ class Router(formatOps: FormatOps) {
         val lambda = getLambdaAtSingleArgCallSite(leftOwner).get
         val lambdaLeft: Option[Token] =
           matchingOpt(functionExpire(lambda)._1).filter(_.is[T.LeftBrace])
-        val lambdaToken = lambda.body match {
-          case b: Term.Block =>
-            b.tokens.head
-          case _ =>
-            val arrow = lambda.tokens.find(_.is[T.RightArrow]).get
-            lambdaLeft.filter(_ eq next(arrow)).getOrElse(arrow)
-        }
-        val lambdaIsABlock = lambdaLeft.exists(_ eq lambdaToken)
+
+        val arrowFt = leftTok2tok(lambda.tokens.find(_.is[T.RightArrow]).get)
+        val lambdaIsABlock = lambdaLeft.exists(_ eq arrowFt.right)
+        val lambdaToken =
+          getOptimalTokenFor(if (lambdaIsABlock) next(arrowFt) else arrowFt)
 
         val close = matchingParentheses(hash(formatToken.left))
         val newlinePolicy =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -544,6 +544,11 @@ object TreeOps {
   def getLambdaAtSingleArgCallSite(tree: Tree): Option[Term.Function] =
     tree match {
       case Term.Apply(_, List(fun: Term.Function)) => Some(fun)
+      case fun: Term.Function if fun.parent.exists({
+            case Term.ApplyInfix(_, _, _, List(`fun`)) => true
+            case _ => false
+          }) =>
+        Some(fun)
       case _ => None
     }
 

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -199,9 +199,8 @@ def f = {
 }
 >>>
 def f = {
-  something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => {
-    val x = 1; x + 1
-  } match { case 1 => 1; case _ => 0 })
+  something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+    { val x = 1; x + 1 } match { case 1 => 1; case _ => 0 })
 }
 <<< 1.11: multi-stat block lambda called via infix
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -572,3 +572,50 @@ object a {
     )
   }
 }
+<<< 19: lambdas with trailing comment in case stats
+val f = {
+  // c1
+  case (a, b) =>
+    c: Int => {
+      d
+      e
+      }
+
+  // c2
+  case (a, b) =>
+    c: Int => {
+      d
+      e
+      }
+
+  // c3
+  case (a, b) =>
+    c: Int => ({
+      d
+      e
+    })
+}
+>>>
+val f = {
+  // c1
+  case (a, b) =>
+    c: Int => {
+      d
+      e
+    }
+
+  // c2
+  case (a, b) =>
+    c: Int => {
+      d
+      e
+    }
+
+  // c3
+  case (a, b) =>
+    c: Int =>
+      ({
+        d
+        e
+      })
+}

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -63,10 +63,10 @@ def f = {
 def f = {
   something.call(
     (x, y) => // comment
-    {
-      g(x)
-      g(y)
-    })
+      {
+        g(x)
+        g(y)
+      })
 }
 <<< 1.4: multi-arg multi-stmt lambda call with multiple split comments
 def f = {
@@ -83,11 +83,12 @@ def f = {
 >>>
 def f = {
   something.call(
-    (x, y) => // comment
-    /* comment */ {
-      g(x)
-      g(y)
-    })
+    (x, y) =>
+      // comment
+      /* comment */ {
+        g(x)
+        g(y)
+      })
 }
 <<< 1.5: multi-arg multi-stmt lambda call with multiple attached comments
 def f = {
@@ -104,10 +105,10 @@ def f = {
 def f = {
   something.call(
     (x, y) => // comment
-    /* comment */ {
-      g(x)
-      g(y)
-    })
+      /* comment */ {
+        g(x)
+        g(y)
+      })
 }
 <<< 1.6: multi-arg multi-stmt lambda call with multiple inline comments
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -152,10 +152,8 @@ def f = {
 >>>
 def f = {
   something.call(
-    (
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    ) => /* comment1 */
+    (aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+      /* comment1 */
       /* comment2 */ {
         g(x)
         g(y)
@@ -188,13 +186,11 @@ def f = {
 >>>
 def f = {
   something.call(
-    (
-        aaaaaaaaaaaaaaaaaaaaaaaaaaa,
-        bbbbbbbbbbbbbbbbbbbbbbbbbbb
-    ) => { // long comment
-      g(x)
-      g(y)
-    })
+    (aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+      { // long comment
+        g(x)
+        g(y)
+      })
 }
 <<< 1.10: multi-arg multi-stmt lambda call with long params and block with long comment
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -61,12 +61,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => // comment
-      {
-        g(x)
-        g(y)
-      })
+  something.call((x, y) => // comment
+    {
+      g(x)
+      g(y)
+    })
 }
 <<< 1.4: multi-arg multi-stmt lambda call with multiple split comments
 def f = {
@@ -82,13 +81,12 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) =>
-      // comment
-      /* comment */ {
-        g(x)
-        g(y)
-      })
+  something.call((x, y) =>
+    // comment
+    /* comment */ {
+      g(x)
+      g(y)
+    })
 }
 <<< 1.5: multi-arg multi-stmt lambda call with multiple attached comments
 def f = {
@@ -103,12 +101,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => // comment
-      /* comment */ {
-        g(x)
-        g(y)
-      })
+  something.call((x, y) => // comment
+    /* comment */ {
+      g(x)
+      g(y)
+    })
 }
 <<< 1.6: multi-arg multi-stmt lambda call with multiple inline comments
 def f = {
@@ -123,12 +120,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => /* comment1 */
-    /* comment2 */ {
-      g(x)
-      g(y)
-    })
+  something.call((x, y) => /* comment1 */
+  /* comment2 */ {
+    g(x)
+    g(y)
+  })
 }
 <<< 1.7: multi-arg multi-stmt lambda call with long params
 def f = {
@@ -162,10 +158,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => { // comment
-    g(x)
-    g(y)
-  })
+  something.call(
+    (aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => { // comment
+      g(x)
+      g(y)
+    })
 }
 <<< 1.9: multi-arg multi-stmt lambda call with long params and block with long comment
 def f = {
@@ -177,10 +174,14 @@ def f = {
 }
 >>>
 def f = {
-  something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => { // long comment
-    g(x)
-    g(y)
-  })
+  something.call(
+    (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ) => { // long comment
+      g(x)
+      g(y)
+    })
 }
 <<< 1.10: multi-arg multi-stmt lambda call with long params and block with long comment
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -126,6 +126,21 @@ def f = {
     g(y)
   })
 }
+<<< 1.61: multi-arg single-stmt lambda call with multiple inline comments
+def f = {
+  something.call (
+     (x, y) =>     /* comment1 */ /* comment2 */
+     /* comment3 */
+       g(x)
+  )
+}
+>>>
+def f = {
+  something.call((x, y) =>
+    /* comment1 */ /* comment2 */
+    /* comment3 */
+    g(x))
+}
 <<< 1.7: multi-arg multi-stmt lambda call with long params
 def f = {
   something.call ((aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>     /* comment1 */

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -215,11 +215,9 @@ def f = {
 }
 >>>
 def f = {
-  activeValuesIterator foreach (
-      v => {
-        1 + 1
-      }
-  )
+  activeValuesIterator foreach (v => {
+    1 + 1
+  })
 }
 <<< 2: single-arg single-stmt block long-body lambda call
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -216,9 +216,10 @@ def f = {
 }
 >>>
 def f = {
-  activeValuesIterator foreach (v => {
-    1 + 1
-  })
+  activeValuesIterator foreach (
+    v => {
+      1 + 1
+    })
 }
 <<< 2: single-arg single-stmt block long-body lambda call
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -1,4 +1,3 @@
-edition = 2019-11
 newlines.alwaysBeforeCurlyBraceLambdaParams = false
 danglingParentheses.callSite = false
 <<< 1: multi-arg multi-stmt lambda call
@@ -121,10 +120,10 @@ def f = {
 >>>
 def f = {
   something.call((x, y) => /* comment1 */
-  /* comment2 */ {
-    g(x)
-    g(y)
-  })
+    /* comment2 */ {
+      g(x)
+      g(y)
+    })
 }
 <<< 1.61: multi-arg single-stmt lambda call with multiple inline comments
 def f = {
@@ -136,8 +135,7 @@ def f = {
 }
 >>>
 def f = {
-  something.call((x, y) =>
-    /* comment1 */ /* comment2 */
+  something.call((x, y) => /* comment1 */ /* comment2 */
     /* comment3 */
     g(x))
 }
@@ -158,10 +156,10 @@ def f = {
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
         bbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     ) => /* comment1 */
-    /* comment2 */ {
-      g(x)
-      g(y)
-    })
+      /* comment2 */ {
+        g(x)
+        g(y)
+      })
 }
 <<< 1.8: multi-arg multi-stmt lambda call with long params and block with short comment
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -63,10 +63,10 @@ def f = {
 def f = {
   something.call(
     (x, y) => // comment
-    {
-      g(x)
-      g(y)
-    }
+      {
+        g(x)
+        g(y)
+      }
   )
 }
 <<< 1.4: multi-arg multi-stmt lambda call with multiple split comments
@@ -84,11 +84,12 @@ def f = {
 >>>
 def f = {
   something.call(
-    (x, y) => // comment
-    /* comment */ {
-      g(x)
-      g(y)
-    }
+    (x, y) =>
+      // comment
+      /* comment */ {
+        g(x)
+        g(y)
+      }
   )
 }
 <<< 1.5: multi-arg multi-stmt lambda call with multiple attached comments
@@ -106,10 +107,10 @@ def f = {
 def f = {
   something.call(
     (x, y) => // comment
-    /* comment */ {
-      g(x)
-      g(y)
-    }
+      /* comment */ {
+        g(x)
+        g(y)
+      }
   )
 }
 <<< 1.6: multi-arg multi-stmt lambda call with multiple inline comments

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -61,12 +61,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => // comment
-      {
-        g(x)
-        g(y)
-      }
+  something.call((x, y) => // comment
+    {
+      g(x)
+      g(y)
+    }
   )
 }
 <<< 1.4: multi-arg multi-stmt lambda call with multiple split comments
@@ -83,13 +82,12 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) =>
-      // comment
-      /* comment */ {
-        g(x)
-        g(y)
-      }
+  something.call((x, y) =>
+    // comment
+    /* comment */ {
+      g(x)
+      g(y)
+    }
   )
 }
 <<< 1.5: multi-arg multi-stmt lambda call with multiple attached comments
@@ -105,12 +103,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => // comment
-      /* comment */ {
-        g(x)
-        g(y)
-      }
+  something.call((x, y) => // comment
+    /* comment */ {
+      g(x)
+      g(y)
+    }
   )
 }
 <<< 1.6: multi-arg multi-stmt lambda call with multiple inline comments
@@ -126,12 +123,11 @@ def f = {
 }
 >>>
 def f = {
-  something.call(
-    (x, y) => /* comment1 */
-    /* comment2 */ {
-      g(x)
-      g(y)
-    }
+  something.call((x, y) => /* comment1 */
+  /* comment2 */ {
+    g(x)
+    g(y)
+  }
   )
 }
 <<< 1.7: multi-arg multi-stmt lambda call with long params
@@ -167,10 +163,12 @@ def f = {
 }
 >>>
 def f = {
-  something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => { // comment
-    g(x)
-    g(y)
-  })
+  something.call(
+    (aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => { // comment
+      g(x)
+      g(y)
+    }
+  )
 }
 <<< 1.9: multi-arg multi-stmt lambda call with long params and block with long comment
 def f = {
@@ -182,10 +180,15 @@ def f = {
 }
 >>>
 def f = {
-  something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => { // long comment
-    g(x)
-    g(y)
-  })
+  something.call(
+    (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ) => { // long comment
+      g(x)
+      g(y)
+    }
+  )
 }
 <<< 1.10: multi-arg multi-stmt lambda call with long params and block with long comment
 def f = {
@@ -209,7 +212,8 @@ def f = {
 def f = {
   activeValuesIterator foreach (v => {
     val nn = canNormS(v); sum += nn * nn
-  })
+  }
+  )
 }
 <<< 1.12: single-stat block lambda called via infix
 maxColumn = 37
@@ -223,7 +227,8 @@ def f = {
 def f = {
   activeValuesIterator foreach (v => {
     1 + 1
-  })
+  }
+  )
 }
 <<< 2: single-arg single-stmt block long-body lambda call
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -212,8 +212,7 @@ def f = {
 def f = {
   activeValuesIterator foreach (v => {
     val nn = canNormS(v); sum += nn * nn
-  }
-  )
+  })
 }
 <<< 1.12: single-stat block lambda called via infix
 maxColumn = 37
@@ -225,9 +224,10 @@ def f = {
 }
 >>>
 def f = {
-  activeValuesIterator foreach (v => {
-    1 + 1
-  }
+  activeValuesIterator foreach (
+    v => {
+      1 + 1
+    }
   )
 }
 <<< 2: single-arg single-stmt block long-body lambda call

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -591,3 +591,50 @@ object a {
     )
   }
 }
+<<< 19: lambdas with trailing comment in case stats
+val f = {
+  // c1
+  case (a, b) =>
+    c: Int => {
+      d
+      e
+      }
+
+  // c2
+  case (a, b) =>
+    c: Int => {
+      d
+      e
+      }
+
+  // c3
+  case (a, b) =>
+    c: Int => ({
+      d
+      e
+    })
+}
+>>>
+val f = {
+  // c1
+  case (a, b) =>
+    c: Int => {
+      d
+      e
+    }
+
+  // c2
+  case (a, b) =>
+    c: Int => {
+      d
+      e
+    }
+
+  // c3
+  case (a, b) =>
+    c: Int =>
+      ({
+        d
+        e
+      })
+}

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -157,10 +157,8 @@ def f = {
 >>>
 def f = {
   something.call(
-    (
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-        bbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    ) => /* comment1 */
+    (aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+      /* comment1 */
       /* comment2 */ {
         g(x)
         g(y)
@@ -195,13 +193,11 @@ def f = {
 >>>
 def f = {
   something.call(
-    (
-        aaaaaaaaaaaaaaaaaaaaaaaaaaa,
-        bbbbbbbbbbbbbbbbbbbbbbbbbbb
-    ) => { // long comment
-      g(x)
-      g(y)
-    }
+    (aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+      { // long comment
+        g(x)
+        g(y)
+      }
   )
 }
 <<< 1.10: multi-arg multi-stmt lambda call with long params and block with long comment

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -221,11 +221,9 @@ def f = {
 }
 >>>
 def f = {
-  activeValuesIterator foreach (
-      v => {
-        1 + 1
-      }
-  )
+  activeValuesIterator foreach (v => {
+    1 + 1
+  })
 }
 <<< 2: single-arg single-stmt block long-body lambda call
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -1,4 +1,3 @@
-edition = 2019-11
 newlines.alwaysBeforeCurlyBraceLambdaParams = false
 danglingParentheses.callSite = true
 <<< 1: multi-arg multi-stmt lambda call
@@ -124,10 +123,10 @@ def f = {
 >>>
 def f = {
   something.call((x, y) => /* comment1 */
-  /* comment2 */ {
-    g(x)
-    g(y)
-  }
+    /* comment2 */ {
+      g(x)
+      g(y)
+    }
   )
 }
 <<< 1.61: multi-arg single-stmt lambda call with multiple inline comments
@@ -140,8 +139,7 @@ def f = {
 }
 >>>
 def f = {
-  something.call((x, y) =>
-    /* comment1 */ /* comment2 */
+  something.call((x, y) => /* comment1 */ /* comment2 */
     /* comment3 */
     g(x)
   )
@@ -163,10 +161,10 @@ def f = {
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
         bbbbbbbbbbbbbbbbbbbbbbbbbbbbb
     ) => /* comment1 */
-    /* comment2 */ {
-      g(x)
-      g(y)
-    }
+      /* comment2 */ {
+        g(x)
+        g(y)
+      }
   )
 }
 <<< 1.8: multi-arg multi-stmt lambda call with long params and block with short comment

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -196,7 +196,8 @@ def f = {
 def f = {
   something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => {
     val x = 1; x + 1
-  } match { case 1 => 1; case _ => 0 })
+  } match { case 1 => 1; case _ => 0 }
+  )
 }
 <<< 1.11: multi-stat block lambda called via infix
 def f = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -130,6 +130,22 @@ def f = {
   }
   )
 }
+<<< 1.61: multi-arg single-stmt lambda call with multiple inline comments
+def f = {
+  something.call (
+     (x, y) =>     /* comment1 */ /* comment2 */
+     /* comment3 */
+       g(x)
+  )
+}
+>>>
+def f = {
+  something.call((x, y) =>
+    /* comment1 */ /* comment2 */
+    /* comment3 */
+    g(x)
+  )
+}
 <<< 1.7: multi-arg multi-stmt lambda call with long params
 def f = {
   something.call ((aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>     /* comment1 */

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -207,9 +207,8 @@ def f = {
 }
 >>>
 def f = {
-  something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) => {
-    val x = 1; x + 1
-  } match { case 1 => 1; case _ => 0 }
+  something.call((aaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+    { val x = 1; x + 1 } match { case 1 => 1; case _ => 0 }
   )
 }
 <<< 1.11: multi-stat block lambda called via infix


### PR DESCRIPTION
Follow-on to #1551 

Diffs on `scala-repos`:
* fold lambda paren after matching delim: https://github.com/kitbellew/scala-repos/commit/2053d6754d2a62b9e65a6175ad32a43d87f09043?w=1
* get lambda if called in ApplyInfix: https://github.com/kitbellew/scala-repos/commit/04a7c21b5a72fdc90e686f1815c8f86816190204?w=1
* functionExpire for ApplyInfix: https://github.com/kitbellew/scala-repos/commit/7e791affa14beb02db9f741196bdcc842082879c?w=1
* functionExpire with case comment: https://github.com/kitbellew/scala-repos/commit/b199e6b3e2255c6c2a773e916dbbeb28f2bed508?w=1
  * NB: scalafmt simply couldn't format one of the files before this change
* fix lambda block determination: https://github.com/kitbellew/scala-repos/commit/8114f8d8dd000907b9f3973ce5864a6cfb83a923?w=1

No `scala-repos` diffs on other functional commits:
* fix functionExpire, avoid whitespace
* lambda arrow with trailing comment
* correct arrow break in 1-arg lambda
* comment handling after lambda arrow
* break on arrow in lambda if line too long

These two are purely cosmetic:
* refactor lambda arrow rule, prepare to fix
* cosmetic, clarify getRightAttachedComment