### PR TITLE
Some performance optimizations for FormatToken

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FormatEvent.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FormatEvent.scala
@@ -2,6 +2,7 @@ package org.scalafmt.config
 
 import org.scalafmt.internal.FormatOps
 import org.scalafmt.internal.FormatToken
+import org.scalafmt.internal.FormatTokens
 import org.scalafmt.internal.Split
 import org.scalafmt.internal.State
 
@@ -18,6 +19,6 @@ object FormatEvent {
   case class CompleteFormat(
       totalExplored: Int,
       finalState: State,
-      tokens: Array[FormatToken]
+      tokens: FormatTokens
   ) extends FormatEvent
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -42,7 +42,7 @@ object FormatToken {
     * @param idx The token's index in the FormatTokens array
     */
   case class Meta(
-      between: Vector[Token],
+      between: Array[Token],
       idx: Int
   )
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -42,15 +42,18 @@ object FormatTokens {
     var left = tokens.head
     val result = Array.newBuilder[FormatToken]
     var ftIdx = 0
-    val whitespace = Vector.newBuilder[Token]
-    tokens.toArray.foreach {
-      case t @ Whitespace() => whitespace += t
+    var wsIdx = 0
+    var tokIdx = 0
+    val arr = tokens.toArray
+    arr.foreach {
+      case Whitespace() => tokIdx += 1
       case right =>
-        val meta = FormatToken.Meta(whitespace.result, ftIdx)
+        val meta = FormatToken.Meta(arr.slice(wsIdx, tokIdx), ftIdx)
         result += FormatToken(left, right, meta)
         left = right
         ftIdx += 1
-        whitespace.clear()
+        tokIdx += 1
+        wsIdx = tokIdx
     }
     new FormatTokens(result.result)
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -1,0 +1,58 @@
+package org.scalafmt.internal
+
+import scala.meta.tokens.Token
+import scala.meta.tokens.Tokens
+
+import org.scalafmt.util.Whitespace
+
+class FormatTokens(val arr: Array[FormatToken])
+    extends IndexedSeq[FormatToken] {
+
+  private val leftTok2tok: Map[Token, FormatToken] = {
+    val result = Map.newBuilder[Token, FormatToken]
+    result.sizeHint(arr.length)
+    arr.foreach(t => result += t.left -> t)
+    result += (arr.last.right -> arr.last)
+    result.result()
+  }
+
+  override def length: Int = arr.length
+  override def apply(idx: Int): FormatToken = arr(idx)
+
+  def at(off: Int): FormatToken =
+    if (off < 0) arr.head else if (off < arr.length) arr(off) else arr.last
+
+  def get(tok: Token): Option[FormatToken] = leftTok2tok.get(tok)
+  def apply(tok: Token): FormatToken = leftTok2tok(tok)
+
+  def apply(tok: Token, off: Int): FormatToken = apply(apply(tok), off)
+  def apply(ft: FormatToken, off: Int): FormatToken = at(ft.meta.idx + off)
+
+}
+
+object FormatTokens {
+
+  /**
+    * Convert scala.meta Tokens to FormatTokens.
+    *
+    * Since tokens might be very large, we try to allocate as
+    * little memory as possible.
+    */
+  def apply(tokens: Tokens): FormatTokens = {
+    var left = tokens.head
+    val result = Array.newBuilder[FormatToken]
+    var ftIdx = 0
+    val whitespace = Vector.newBuilder[Token]
+    tokens.toArray.foreach {
+      case t @ Whitespace() => whitespace += t
+      case right =>
+        val meta = FormatToken.Meta(whitespace.result, ftIdx)
+        result += FormatToken(left, right, meta)
+        left = right
+        ftIdx += 1
+        whitespace.clear()
+    }
+    new FormatTokens(result.result)
+  }
+
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -21,7 +21,7 @@ class FormatWriter(formatOps: FormatOps) {
   def mkString(splits: Vector[Split]): String = {
     val sb = new StringBuilder()
     var lastState = State.start // used to calculate start of formatToken.right.
-    reconstructPath(tokens, splits, debug = false) {
+    reconstructPath(tokens.arr, splits, debug = false) {
       case (state, formatToken, whitespace, tokenAligns) =>
         formatToken.left match {
           case c: T.Comment =>
@@ -230,8 +230,7 @@ class FormatWriter(formatOps: FormatOps) {
         case Term.Block(_) =>
           ()
         case TreeOps.MaybeTopLevelStat(t) =>
-          val tok = leftTok2tok(t.tokens.head)
-          val result = leadingComment(prev(tok))
+          val result = leadingComment(tokens(t.tokens.head, -1))
           val hashed = hash(result)
           buffer += hashed
           super.apply(tree)
@@ -277,7 +276,7 @@ class FormatWriter(formatOps: FormatOps) {
             }
             .flatten
             .map {
-              case pkg: Pkg => next(pkg.ref.tokens.last).is[T.LeftBrace]
+              case pkg: Pkg => tokens(pkg.ref.tokens.last).right.is[T.LeftBrace]
               case _ => true
             }
 
@@ -562,7 +561,7 @@ class FormatWriter(formatOps: FormatOps) {
       // Remove the comma after b
       case _
           if left.is[T.Comma] && rightIsCloseDelim &&
-            !next(formatToken).left.is[T.Comment] && !isNewline =>
+            !formatToken.right.is[T.Comment] && !isNewline =>
         sb.deleteCharAt(sb.length - 1)
 
       case _ => sb.append(whitespace)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -6,21 +6,20 @@ import scala.meta.Term
 import scala.meta.Tree
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token.Comment
-import scala.meta.tokens.Token.Ident
 import scala.meta.tokens.Token.LeftParen
 import scala.meta.tokens.Token.RightParen
-import scala.meta.tokens.Tokens
 import metaconfig.Configured
 import org.scalafmt.config.Config
 import org.scalafmt.config.FilterMatcher
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.FormatToken
+import org.scalafmt.internal.FormatTokens
 import org.scalafmt.util.TokenOps.TokenHash
 import org.scalameta.logger
 import scala.meta.Init
 
 class StyleMap(
-    tokens: Array[FormatToken],
+    tokens: FormatTokens,
     init: ScalafmtConfig,
     owners: collection.Map[TokenHash, Tree],
     matching: Map[TokenHash, Token]
@@ -34,7 +33,7 @@ class StyleMap(
     var empty = true
     val map = Map.newBuilder[FormatToken, ScalafmtConfig]
     val disableBinPack = mutable.Set.empty[Token]
-    tokens.foreach { tok =>
+    tokens.arr.foreach { tok =>
       tok.left match {
         case Comment(c) if prefix.findFirstIn(c).isDefined =>
           Config.fromHoconString(c, Some("scalafmt"), init) match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -74,7 +74,7 @@ object TokenOps {
     else tree.tokens(Scala211)(lastIndex)
   }
 
-  def endsWithNoIndent(between: Vector[Token]): Boolean =
+  def endsWithNoIndent(between: Seq[Token]): Boolean =
     between.lastOption.exists(_.is[LF])
 
   def rhsIsCommentedOut(formatToken: FormatToken): Boolean =

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -46,7 +46,7 @@ trait HasTests extends AnyFunSuiteLike with FormatAssertions {
       case CompleteFormat(explored, state, tokens) =>
         Debug.explored += explored
         Debug.state = state
-        Debug.tokens = tokens
+        Debug.tokens = tokens.arr
       case _ =>
     }
   )


### PR DESCRIPTION
They seem to bring about 5-10% speedup while running on `scala-repos`.

P.S. `bin/run_benchmarks.sh` doesn't seem to work, because `sbt test` keeps failing.