### PR TITLE
Don't silence stdout when it is the only output

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -51,7 +51,7 @@ object CliOptions {
       writeMode = newMode,
       config = style,
       common = parsed.common.copy(
-        out = guardPrintStream(parsed.quiet)(parsed.common.out),
+        out = guardPrintStream(parsed.quiet && !parsed.stdIn)(parsed.common.out),
         info = guardPrintStream(parsed.quiet || parsed.list)(auxOut),
         debug = guardPrintStream(parsed.quiet)(
           if (parsed.debug) auxOut else init.common.debug


### PR DESCRIPTION
When using `stdin` as a command line flag the output is sent to stdout, in this
case the output should not be silenced as it is the formatting output. All other
output stays silenced as it goes to stderr.