### PR TITLE
RedundantBraces: fix various bugs with general expressions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -554,6 +554,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       }
     } yield token).getOrElse(owner.tokens.last)
 
+    // we don't modify line breaks generally around infix expressions
+    // TODO: if that ever changes, modify how rewrite rules handle infix
     val modification = newlines2Modification(
       formatToken.newlinesBetween,
       isNoIndent(formatToken)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
@@ -30,8 +30,11 @@ case object PreferCurlyFors extends Rewrite {
 
     for {
       forToken <- forTokens.find(_.is[Token.KwFor])
-      leftParen <- find(forToken)(_.isNot[Whitespace])
-        .filter(_.is[Token.LeftParen])
+      leftParen <- findAfter(forToken) {
+        case _: Token.LeftParen => Some(true)
+        case Whitespace() => None
+        case _ => Some(false)
+      }
       rightParen <- ctx.matchingParens.get(TokenOps.hash(leftParen))
     } yield (leftParen, rightParen)
   }
@@ -47,9 +50,11 @@ case object PreferCurlyFors extends Rewrite {
         .tokens(ctx.style.runner.dialect)
         .headOption
         .toIterable
-      semicolon <- reverseFind(token)(_.isNot[Whitespace])
-        .filter(_.is[Token.Semicolon])
-        .toIterable
+      semicolon <- findBefore(token) {
+        case _: Token.Semicolon => Some(true)
+        case Whitespace() => None
+        case _ => Some(false)
+      }.toIterable
     } yield semicolon
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -222,17 +222,24 @@ case object RedundantBraces extends Rewrite {
           }
           insideIfThen && parentIfHasAnElse && blockIsIfWithoutElse
 
-        case parent =>
-          val side = parent match {
-            case t: Term.ApplyInfix
-                if t.args.lengthCompare(1) == 0 && (t.args.head eq b) =>
-              Side.Right
-            case _ => Side.Left
+        case p: Term.ApplyInfix =>
+          stat match {
+            case _: Term.ApplyInfix =>
+              val useRight = p.args.lengthCompare(1) == 0 && (p.args.head eq b)
+              SyntacticGroupOps.groupNeedsParenthesis(
+                TreeSyntacticGroup(p),
+                TreeSyntacticGroup(stat),
+                if (useRight) Side.Right else Side.Left
+              )
+            case _: Name | _: Lit => false
+            case _ => true // don't allow other non-infix
           }
+
+        case parent =>
           SyntacticGroupOps.groupNeedsParenthesis(
             TreeSyntacticGroup(parent),
             TreeSyntacticGroup(stat),
-            side
+            Side.Left
           )
       }
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -131,7 +131,7 @@ case object RedundantBraces extends Rewrite {
         builder += TokenPatch.Remove(rbrace)
         removeTrailingLF(lbrace.pos, rbrace)
         ctx.tokenTraverser
-          .reverseFind(rbrace)(!Whitespace.unapply(_))
+          .findBefore(rbrace)(x => Some(!Whitespace.unapply(x)))
           .foreach(t => removeTrailingLF(t.pos, rbrace))
         ctx.addPatchSet(builder.result(): _*)
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -208,7 +208,7 @@ case object RedundantBraces extends Rewrite {
   )(implicit ctx: RewriteCtx): Boolean =
     getSingleStatIfLineSpanOk(b).exists { stat =>
       !b.parent.exists {
-        case parentIf: Term.If =>
+        case parentIf: Term.If if stat.is[Term.If] =>
           // if (a) { if (b) c } else d
           //   ↑ cannot be replaced by ↓
           // if (a) if (b) c else d
@@ -216,10 +216,8 @@ case object RedundantBraces extends Rewrite {
           // if (a) { if (b) c else d }
           def insideIfThen = parentIf.thenp eq b
           def parentIfHasAnElse = parentIf.elsep.tokens.nonEmpty
-          def blockIsIfWithoutElse = stat match {
-            case childIf: Term.If => childIf.elsep.tokens.isEmpty
-            case _ => false
-          }
+          def blockIsIfWithoutElse =
+            stat.asInstanceOf[Term.If].elsep.tokens.isEmpty
           insideIfThen && parentIfHasAnElse && blockIsIfWithoutElse
 
         case p: Term.ApplyInfix =>

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -251,8 +251,9 @@ class Test extends AnyWordSpec {
 class Test extends AnyWordSpec {
   "SUT" when {
     "statement about test" should {
-      "some test" in
-      val s = 1
+      "some test" in {
+        val s = 1
+      }
     }
   }
 }
@@ -289,8 +290,9 @@ object a {
 object a {
   def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
     case None =>
-      delegate.findAccountByAPIKey(apiKey) map
+      delegate.findAccountByAPIKey(apiKey) map {
         _ map _ tap (add(apiKey, _)) unsafePerformIO
+      }
   }
 }
 <<< #1633 1.3: func with placeholder and infix
@@ -380,7 +382,7 @@ object a {
 }
 >>>
 object a {
-  b getOrElse c(d)
+  b getOrElse { c(d) }
 }
 <<< #1633 3.2: function block in a val statement
 object a {
@@ -388,7 +390,7 @@ object a {
 }
 >>>
 object a {
-  b getOrElse c.d { e }
+  b getOrElse { c.d { e } }
 }
 <<< #1633 3.3: function block in a val statement
 object a {
@@ -404,7 +406,7 @@ object a {
 }
 >>>
 object a {
-  b map _.select
+  b map { _.select }
 }
 <<< #1633 3.5: function block in a val statement
 object a {
@@ -412,7 +414,7 @@ object a {
 }
 >>>
 object a {
-  b map _.apply(_)
+  b map { _.apply(_) }
 }
 <<< #1633 4.1: infix with literal
 object a {
@@ -471,9 +473,9 @@ object a {
 }
 >>>
 object a {
-  1 +
+  1 + {
     a(b)
-  +3
+  } + 3
 }
 <<< #1633 4.6: infix with apply and no break before
 object a {
@@ -482,8 +484,9 @@ object a {
 }
 >>>
 object a {
-  1 +
-    a(b) + 3
+  1 + {
+    a(b)
+  } + 3
 }
 <<< #1633 4.7: infix with apply and comment
 object a {
@@ -493,9 +496,9 @@ object a {
 }
 >>>
 object a {
-  1 +
+  1 + {
     a(b) // comment
-  +3
+  } + 3
 }
 <<< #1633 4.8: infix with apply and two comments
 object a {
@@ -505,12 +508,11 @@ object a {
    3
 }
 >>>
-test does not parse
 object a {
-  1 +
+  1 + {
     a(b) // comment
-  + // comment
-  3
+  } + // comment
+    3
 }
 <<< #1633 5.1: verify correct newline removal
 object a {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -426,9 +426,9 @@ object a {
 }
 >>>
 object a {
-  1 +
+  1 + {
     2
-  +3
+  } + 3
 }
 <<< #1633 4.2: infix with literal and no break before
 object a {
@@ -448,9 +448,9 @@ object a {
 }
 >>>
 object a {
-  1 +
+  1 + {
     2 // comment
-  +3
+  } + 3
 }
 <<< #1633 4.4: infix with literal and two comments
 object a {
@@ -460,12 +460,11 @@ object a {
    3
 }
 >>>
-test does not parse
 object a {
-  1 +
+  1 + {
     2 // comment
-  + // comment
-  3
+  } + // comment
+    3
 }
 <<< #1633 4.5: infix with apply
 object a {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -237,3 +237,304 @@ object a {
     4
   }
 }
+<<< #1631
+class Test extends AnyWordSpec {
+  "SUT" when {
+    "statement about test" should {
+      "some test" in {
+        val s = 1
+      }
+    }
+  }
+}
+>>>
+class Test extends AnyWordSpec {
+  "SUT" when {
+    "statement about test" should {
+      "some test" in
+      val s = 1
+    }
+  }
+}
+<<< #1633 1.1: multiline infix
+    "properly extract the value of www-urlencoded form fields" in {
+      println
+      Post("/", urlEncodedForm) ~> {
+        formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) {
+          (firstName, age, sex, vip) ⇒
+            complete(firstName + age + sex + vip)
+        }
+      } ~> check { responseAs[String] shouldEqual "Mike42Nonefalse" }
+    }
+>>>
+"properly extract the value of www-urlencoded form fields" in {
+  println
+  Post("/", urlEncodedForm) ~> {
+    formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) {
+      (firstName, age, sex, vip) ⇒
+        complete(firstName + age + sex + vip)
+    }
+  } ~> check { responseAs[String] shouldEqual "Mike42Nonefalse" }
+}
+<<< #1633 1.2: func with placeholder and select
+object a {
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map {
+         _ map _ tap (add(apiKey, _)) unsafePerformIO
+      }
+  }
+}
+>>>
+object a {
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map
+        _ map _ tap (add(apiKey, _)) unsafePerformIO
+  }
+}
+<<< #1633 1.3: func with placeholder and infix
+object a {
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map {
+         _ map(_) tap (add(apiKey, _)) unsafePerformIO(foo)
+      }
+  }
+}
+>>>
+object a {
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map {
+        _ map (_) tap (add(apiKey, _)) unsafePerformIO (foo)
+      }
+  }
+}
+<<< #1633 1.4: func
+object a {
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map { x =>
+         x._1 map x._2 tap (add(apiKey, _)) unsafePerformIO
+      }
+  }
+}
+>>>
+object a {
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map { x =>
+        x._1 map x._2 tap (add(apiKey, _)) unsafePerformIO
+      }
+  }
+}
+<<< #1633 1.5: partial func
+object a {
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map { case (x,y) =>
+         x map y tap (add(apiKey, _)) unsafePerformIO
+      }
+  }
+}
+>>>
+object a {
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map {
+        case (x, y) =>
+          x map y tap (add(apiKey, _)) unsafePerformIO
+      }
+  }
+}
+<<< #1633 2.1: function block in an if-statement
+object a {
+    val select = if (max) { (a: CTuple, b: CTuple) =>
+      (a.compareTo(b) >= 0)
+    } else { (a: CTuple, b: CTuple) =>
+      (a.compareTo(b) <= 0)
+    }
+}
+>>>
+object a {
+  val select =
+    if (max)(a: CTuple, b: CTuple) => (a.compareTo(b) >= 0)
+    else (a: CTuple, b: CTuple) => (a.compareTo(b) <= 0)
+}
+<<< #1633 2.2: function block in a val statement
+object a {
+    val select = { (a: CTuple, b: CTuple) =>
+      (a.compareTo(b) >= 0)
+    }
+}
+>>>
+object a {
+  val select = { (a: CTuple, b: CTuple) =>
+    (a.compareTo(b) >= 0)
+  }
+}
+<<< #1633 3.1: function block in a val statement
+object a {
+  b getOrElse { c(d) }
+}
+>>>
+object a {
+  b getOrElse c(d)
+}
+<<< #1633 3.2: function block in a val statement
+object a {
+  b getOrElse { c.d {e} }
+}
+>>>
+object a {
+  b getOrElse c.d { e }
+}
+<<< #1633 3.3: function block in a val statement
+object a {
+  b getOrElse { c }
+}
+>>>
+object a {
+  b getOrElse c
+}
+<<< #1633 3.4: function block in a val statement
+object a {
+  b map { _.select }
+}
+>>>
+object a {
+  b map _.select
+}
+<<< #1633 3.5: function block in a val statement
+object a {
+  b map { _.apply(_) }
+}
+>>>
+object a {
+  b map _.apply(_)
+}
+<<< #1633 4.1: infix with literal
+object a {
+  1 + {
+    2
+  } + 3
+}
+>>>
+object a {
+  1 +
+    2
+  +3
+}
+<<< #1633 4.2: infix with literal and no break before
+object a {
+  1 + {
+    2  } + 3
+}
+>>>
+object a {
+  1 +
+    2 + 3
+}
+<<< #1633 4.3: infix with literal and comment
+object a {
+  1 + {
+    2 // comment
+  } + 3
+}
+>>>
+object a {
+  1 +
+    2 // comment
+  +3
+}
+<<< #1633 4.4: infix with literal and two comments
+object a {
+  1 + {
+    2 // comment
+  } + // comment
+   3
+}
+>>>
+test does not parse
+object a {
+  1 +
+    2 // comment
+  + // comment
+  3
+}
+<<< #1633 4.5: infix with apply
+object a {
+  1 + {
+    a(b)
+  } + 3
+}
+>>>
+object a {
+  1 +
+    a(b)
+  +3
+}
+<<< #1633 4.6: infix with apply and no break before
+object a {
+  1 + {
+    a(b)  } + 3
+}
+>>>
+object a {
+  1 +
+    a(b) + 3
+}
+<<< #1633 4.7: infix with apply and comment
+object a {
+  1 + {
+    a(b) // comment
+  } + 3
+}
+>>>
+object a {
+  1 +
+    a(b) // comment
+  +3
+}
+<<< #1633 4.8: infix with apply and two comments
+object a {
+  1 + {
+    a(b) // comment
+  } + // comment
+   3
+}
+>>>
+test does not parse
+object a {
+  1 +
+    a(b) // comment
+  + // comment
+  3
+}
+<<< #1633 5.1: verify correct newline removal
+object a {
+  val b = c(d => {
+    e } // comment1
+    /* comment2 */ )
+    /* comment3 */
+}
+>>>
+object a {
+  val b = c { d =>
+    e
+  } // comment1
+  /* comment2 */ /* comment3 */
+}
+<<< #1633 5.2: keep config style
+object a {
+  val b = c(
+    d,
+    e => {
+     f }
+  )
+}
+>>>
+object a {
+  val b = c(d, e => f)
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -360,9 +360,11 @@ object a {
 }
 >>>
 object a {
-  val select =
-    if (max)(a: CTuple, b: CTuple) => (a.compareTo(b) >= 0)
-    else (a: CTuple, b: CTuple) => (a.compareTo(b) <= 0)
+  val select = if (max) { (a: CTuple, b: CTuple) =>
+    (a.compareTo(b) >= 0)
+  } else { (a: CTuple, b: CTuple) =>
+    (a.compareTo(b) <= 0)
+  }
 }
 <<< #1633 2.2: function block in a val statement
 object a {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -528,7 +528,8 @@ object a {
   val b = c { d =>
     e
   } // comment1
-  /* comment2 */ /* comment3 */
+  /* comment2 */
+  /* comment3 */
 }
 <<< #1633 5.2: keep config style
 object a {
@@ -540,5 +541,8 @@ object a {
 }
 >>>
 object a {
-  val b = c(d, e => f)
+  val b = c(
+    d,
+    e => f
+  )
 }


### PR DESCRIPTION
* If the block is part of an infix expression, rewrite only if it also contains an infix expression
* do not rewrite infix block if its closing brace is the first non-whitespace character on the line
* don't apply the special if-within-if logic when the nested expression is not `if`
* change how and when we remove newlines after a brace is removed

Fixes #1631.
Fixes #1633.