### PR TITLE
Allow setting newlines at EOF to false (#1605)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -454,6 +454,29 @@ else {
 }
 ```
 
+### `newlines.alwaysAtTheEndOfFile`
+
+```scala mdoc:defaults
+newlines.alwaysAtTheEndOfFile
+```
+
+```scala mdoc:scalafmt
+newlines.alwaysAtTheEndOfFile = true
+---
+object A {
+  val foo = 3
+}
+//here is a newline
+```
+
+```scala mdoc:scalafmt
+newlines.alwaysAtTheEndOfFile = false
+---
+object A {
+  val foo = 3
+} //file ends here
+```
+
 ## Rewrite Rules
 
 To enable a rewrite rule, add it to the config like this
@@ -516,7 +539,7 @@ q"Hello ${name}"
 
 Configuration options and default values:
 
-// TODO(olafur): multiline defaults
+<!--  TODO(olafur): multiline defaults -->
 
 - `rewrite.redundantBraces.maxLines = 100`
 - `rewrite.redundantBraces.includeUnitMethods = true`

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -110,7 +110,8 @@ case class Newlines(
     beforeImplicitKWInVerticalMultiline: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
-    avoidAfterYield: Boolean = true
+    avoidAfterYield: Boolean = true,
+    alwaysAtTheEndOfFile: Boolean = true
 ) {
   val reader: ConfDecoder[Newlines] = generic.deriveDecoder(this).noTypos
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -72,8 +72,10 @@ class Router(formatOps: FormatOps) {
           Split(NoSplit, 0)
         )
       case FormatToken(_, _: T.EOF, _) =>
+        val modification =
+          if (style.newlines.alwaysAtTheEndOfFile) Newline else NoSplit
         Seq(
-          Split(Newline, 0) // End files with trailing newline
+          Split(modification, 0)
         )
       case FormatToken(start @ T.Interpolation.Start(), _, _) =>
         val isStripMargin = isMarginizedString(start)

--- a/scalafmt-core/shared/src/test/scala/org/scalafmt/ScalafmtTest.scala
+++ b/scalafmt-core/shared/src/test/scala/org/scalafmt/ScalafmtTest.scala
@@ -37,7 +37,22 @@ class ScalafmtTest extends scalatest.funsuite.AnyFunSuite {
        |  val xx = 3
        |}
        |""".stripMargin,
-    config.ScalafmtConfig.defaultWithAlign
+    ScalafmtConfig.defaultWithAlign
+  )
+  val newlinesAtTheEOFConfig = ScalafmtConfig.default.copy(newlines =
+    ScalafmtConfig.default.newlines.copy(alwaysAtTheEndOfFile = false)
+  )
+  check(
+    """object A {
+      |  val foo = 3
+      |}
+      |
+      |
+      |""".stripMargin,
+    """object A {
+      |  val foo = 3
+      |}""".stripMargin,
+    newlinesAtTheEOFConfig
   )
   check(
     """|object A { function(aaaaaaaa, bbbbbbbbbb, ddddd(eeeeeeeeee, fffffff, gggggggg)) }
@@ -50,7 +65,7 @@ class ScalafmtTest extends scalatest.funsuite.AnyFunSuite {
        |  )
        |}
        |""".stripMargin,
-    config.ScalafmtConfig.default40
+    ScalafmtConfig.default40
   )
 
 }


### PR DESCRIPTION
This PR adds ability to configure newlines at the end of file.
At first I tried to add test in `scalafmt-tests` module, but then I've found out that method `HasTests.trimmed` always adds newline to each test case. I guess that changing this behaviour based on `ScalafmtConfig.newlines.alwaysAtTheEndOfFile` would be confusing, so I've added regular test in `ScalafmtTest` instead.