### PR TITLE
Strict filters for exclude files in project (#1645)

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -2,6 +2,7 @@ package org.scalafmt.config
 
 import metaconfig._
 import org.scalafmt.util.OsSpecific
+import FilterMatcher.mkRegexp
 
 case class ProjectFiles(
     git: Boolean = false,
@@ -11,9 +12,12 @@ case class ProjectFiles(
 ) {
   val reader: ConfDecoder[ProjectFiles] = generic.deriveDecoder(this).noTypos
   lazy val matcher: FilterMatcher =
-    FilterMatcher(
-      includeFilters.map(OsSpecific.fixSeparatorsInPathPattern),
-      excludeFilters.map(OsSpecific.fixSeparatorsInPathPattern)
+    new FilterMatcher(
+      mkRegexp(includeFilters.map(OsSpecific.fixSeparatorsInPathPattern)),
+      mkRegexp(
+        excludeFilters.map(OsSpecific.fixSeparatorsInPathPattern),
+        strict = true
+      )
     )
 }
 object ProjectFiles {


### PR DESCRIPTION
Fixes #1645 

Description of problem in the related issue. Or may be just set `strict = true` for _all_ `FilterMatcher`'s exclude filters?