### PR TITLE
SortModifiers: Use .syntax on tokens, not tree

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -48,9 +48,12 @@ object SortModifiers extends Rewrite {
 
       ctx.addPatchSet(sortedMods.zip(sanitized).flatMap {
         case (next, old) =>
-          val removeOld = old.tokens.map(TokenPatch.Remove)
-          val addNext = TokenPatch.AddRight(old.tokens.head, next.syntax)
-          removeOld :+ addNext
+          if (next eq old) Seq.empty
+          else {
+            val removeOld = old.tokens.tail.map(TokenPatch.Remove)
+            val addNext = TokenPatch.Replace(old.tokens.head, next.syntax)
+            removeOld :+ addNext
+          }
       }: _*)
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -51,7 +51,8 @@ object SortModifiers extends Rewrite {
           if (next eq old) Seq.empty
           else {
             val removeOld = old.tokens.tail.map(TokenPatch.Remove)
-            val addNext = TokenPatch.Replace(old.tokens.head, next.syntax)
+            val nextSyntax = next.tokens.syntax // XXX: not next.syntax!
+            val addNext = TokenPatch.Replace(old.tokens.head, nextSyntax)
             removeOld :+ addNext
           }
       }: _*)

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers.stat
@@ -226,7 +226,9 @@ trait test {
     " won't and is forced to be on a single line."
 >>>
 @annotation(
-  "Here is a really long string, which needs to be wrapped." + " scalafmt forces this concatenated string onto a single line" + " but it would be preferable for it to behave like it does for the string below."
+  "Here is a really long string, which needs to be wrapped." +
+    " scalafmt forces this concatenated string onto a single line" +
+    " but it would be preferable for it to behave like it does for the string below."
 )
 val SomeLongString = "Here is a really long string, which needs to be wrapped." +
   " This split string will stay wrapped properly, but the same string in the annotation" +

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers.stat
@@ -215,3 +215,19 @@ trait test {
   private[test] final implicit override var bad: Int
   private final implicit override def bar: Int
 }
+<<< #1506: make sure annotation syntax is preserved
+@annotation(
+    "Here is a really long string, which needs to be wrapped." +
+      " scalafmt forces this concatenated string onto a single line" +
+      " but it would be preferable for it to behave like it does for the string below."
+  )
+  val SomeLongString = "Here is a really long string, which needs to be wrapped." +
+    " This split string will stay wrapped properly, but the same string in the annotation" +
+    " won't and is forced to be on a single line."
+>>>
+@annotation(
+  "Here is a really long string, which needs to be wrapped." + " scalafmt forces this concatenated string onto a single line" + " but it would be preferable for it to behave like it does for the string below."
+)
+val SomeLongString = "Here is a really long string, which needs to be wrapped." +
+  " This split string will stay wrapped properly, but the same string in the annotation" +
+  " won't and is forced to be on a single line."


### PR DESCRIPTION
Whether a bug or a feature, but for Mod.Annotation, syntax loses all NL tokens. So instead of tree.syntax, let's use tree.tokens.syntax which doesn't have that problem.

Fixes #1506.