### PR TITLE
Policy: always pass sourcecode.Line implicitly

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -751,17 +751,19 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     else onBreakPolicy.copy(f = { case OnBreakDecision(d) => d })
   }
 
-  def newlinesOnlyBeforeClosePolicy(close: Token) =
-    Policy(decideNewlinesOnlyBeforeClose)(close)
+  def newlinesOnlyBeforeClosePolicy(close: Token)(
+      implicit line: sourcecode.Line
+  ): Policy =
+    Policy(decideNewlinesOnlyBeforeClose(Split(Newline, 0)))(close)
 
-  def decideNewlinesOnlyBeforeClose(close: Token): Policy.Pf = {
+  def decideNewlinesOnlyBeforeClose(split: Split)(close: Token): Policy.Pf = {
     case d: Decision if d.formatToken.right eq close =>
-      d.onlyNewlinesWithFallback(Split(Newline, 0))
+      d.onlyNewlinesWithFallback(split)
   }
 
-  def decideNewlinesOnlyAfterClose(close: Token): Policy.Pf = {
+  def decideNewlinesOnlyAfterClose(split: Split)(close: Token): Policy.Pf = {
     case d: Decision if d.formatToken.left eq close =>
-      d.onlyNewlinesWithFallback(Split(Newline, 0))
+      d.onlyNewlinesWithFallback(split)
   }
 
   def decideNewlinesOnlyAfterToken(token: Token): Policy.Pf = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -57,27 +57,26 @@ case class Policy(
     }
   }
 
-  override def toString = s"P:${line.value}(D=$noDequeue)"
+  override def toString = s"P:${line.value}(D=$noDequeue)E:$expire"
 }
 
 object Policy {
 
   type Pf = PartialFunction[Decision, Decision]
 
-  val IdentityPolicy: Pf = {
-    case d => throw NoopDefaultPolicyApplied(d)
-  }
-
   val emptyPf: Pf = PartialFunction.empty
 
-  val NoPolicy = new Policy(IdentityPolicy, Integer.MAX_VALUE) {
-
+  val NoPolicy = new Policy(emptyPf, Integer.MAX_VALUE)(sourcecode.Line(0)) {
     override def toString: String = "NoPolicy"
   }
 
-  def empty(token: Token): Policy = Policy(emptyPf, token.end)
+  def empty(token: Token)(
+      implicit line: sourcecode.Line
+  ): Policy = Policy(emptyPf, token.end)
 
-  def apply(func: Token => Pf)(token: Token): Policy =
+  def apply(func: Token => Pf)(token: Token)(
+      implicit line: sourcecode.Line
+  ): Policy =
     new Policy(func(token), token.end)
 
   def isEmpty(pf: Pf): Boolean = pf == emptyPf

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -236,7 +236,7 @@ class Router(formatOps: FormatOps) {
             classifiers.exists(_(afterClose))
           }
           if (!breakSingleLineAfterClose) Policy.emptyPf
-          else decideNewlinesOnlyAfterClose(close)
+          else decideNewlinesOnlyAfterClose(Split(Newline, 0))(close)
         }
         def getSingleLineDecision: Policy.Pf =
           if (newlines > 0) null


### PR DESCRIPTION
Without it, errors are reported with the wrong line (albeit without the
source file anyway).