### PR TITLE
Router bugfix: break on else, indent for block within case

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -334,15 +334,13 @@ class Router(formatOps: FormatOps) {
       // Case arrow
       case tok @ FormatToken(arrow @ T.RightArrow(), right, between)
           if leftOwner.isInstanceOf[Case] =>
+        val caseStat = leftOwner.asInstanceOf[Case]
         right match {
-          case T.LeftBrace() =>
+          case _: T.LeftBrace if caseStat.body eq rightOwner =>
             // Redundant {} block around case statements.
             Seq(
-              Split(Space, 0).withIndent(
-                -2,
-                leftOwner.asInstanceOf[Case].body.tokens.last,
-                Left
-              )
+              Split(Space, 0)
+                .withIndent(-2, rightOwner.tokens.last, Left)
             )
           case _ =>
             Seq(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -297,11 +297,12 @@ object TreeOps {
     *
     * `(a(1))` will parse into the same tree as `a(1)`.
     */
-  def isSuperfluousParenthesis(open: Token, owner: Tree): Boolean = {
+  def isSuperfluousParenthesis(open: Token, owner: Tree): Boolean =
     open.is[LeftParen] &&
-    !isTuple(owner) &&
-    owner.tokens.headOption.contains(open)
-  }
+      isSuperfluousParenthesis(open.asInstanceOf[LeftParen], owner)
+
+  def isSuperfluousParenthesis(open: LeftParen, owner: Tree): Boolean =
+    !isTuple(owner) && owner.tokens.headOption.contains(open)
 
   def isFirstOrLastToken(token: Token, owner: Tree): Boolean = {
     owner.tokens.headOption.contains(token) ||

--- a/scalafmt-tests/src/test/resources/default/Case.stat
+++ b/scalafmt-tests/src/test/resources/default/Case.stat
@@ -92,3 +92,31 @@ x match {
       .count()
   }
 }
+<<< nested block in body, verify correct indentation
+object a {
+  b match {
+    case c => {}
+     d
+     case e => {
+      f
+     }
+     g
+    case h => {
+        i
+      } // comment
+  }
+}
+>>>
+object a {
+  b match {
+    case c => {}
+    d
+  case e => {
+      f
+    }
+    g
+  case h => {
+      i
+    } // comment
+  }
+}

--- a/scalafmt-tests/src/test/resources/default/Case.stat
+++ b/scalafmt-tests/src/test/resources/default/Case.stat
@@ -110,12 +110,12 @@ object a {
 object a {
   b match {
     case c => {}
-    d
-  case e => {
-      f
-    }
-    g
-  case h => {
+      d
+    case e => {
+        f
+      }
+      g
+    case h => {
       i
     } // comment
   }

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -148,7 +148,8 @@ if (Keys.useCoursier.value)
 if (Keys.useCoursier.value)
   Def.task {
     CoursierDependencyResolution(Keys.csrConfiguration.value)
-  } else
+  }
+else
   Def.task {
     IvyDependencyResolution(
         Keys.ivyConfiguration.value,

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -132,3 +132,26 @@ if (fullInfo)
     .flatMap(_.toSeq)
     .map(_._1)
     .toSet
+<<< #1413
+if (Keys.useCoursier.value)
+      Def.task {
+        CoursierDependencyResolution(Keys.csrConfiguration.value)
+      }
+    else
+      Def.task {
+        IvyDependencyResolution(
+          Keys.ivyConfiguration.value,
+          CustomHttp.okhttpClient.value
+        )
+      }
+>>>
+if (Keys.useCoursier.value)
+  Def.task {
+    CoursierDependencyResolution(Keys.csrConfiguration.value)
+  } else
+  Def.task {
+    IvyDependencyResolution(
+        Keys.ivyConfiguration.value,
+        CustomHttp.okhttpClient.value
+    )
+  }


### PR DESCRIPTION
We generally don't break on "} else"; however, if the closing brace does
not enclose the "if" block but is unrelated, we should include it.
    
Fixes #1413.

`scala-repos` diffs:
* find breakable else terms correctly
  * https://github.com/kitbellew/scala-repos/commit/b20655f80996aa1ce1387cbd26fba4977c670477?w=1
* indentation for block within case
  * https://github.com/kitbellew/scala-repos/commit/467d4f262d0b5963eff3a1742871d6942c035818