### PR TITLE
Enable to download and run snapshot version from dynamic

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
@@ -66,19 +66,19 @@ class ScalafmtDynamicDownloader(
 
   @inline
   private def scalaBinaryVersion(version: ScalafmtVersion): String =
-    if (version < ScalafmtVersion(0, 7, 0, 0, false)) "2.11"
-    else if (version < ScalafmtVersion(2, 1, 2, 0, false)) "2.12"
+    if (version < ScalafmtVersion(0, 7, 0, 0)) "2.11"
+    else if (version < ScalafmtVersion(2, 1, 2, 0)) "2.12"
     else "2.13"
 
   @inline
   private def scalaVersion(version: ScalafmtVersion): String =
-    if (version < ScalafmtVersion(0, 7, 0, 0, false)) BuildInfo.scala211
-    else if (version < ScalafmtVersion(2, 1, 2, 0, false)) BuildInfo.scala212
+    if (version < ScalafmtVersion(0, 7, 0, 0)) BuildInfo.scala211
+    else if (version < ScalafmtVersion(2, 1, 2, 0)) BuildInfo.scala212
     else BuildInfo.scala
 
   @inline
   private def organization(version: ScalafmtVersion): String =
-    if (version < ScalafmtVersion(2, 0, 0, 2, false)) {
+    if (version < ScalafmtVersion(2, 0, 0, 2)) {
       "com.geirsson"
     } else {
       "org.scalameta"

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
@@ -66,19 +66,19 @@ class ScalafmtDynamicDownloader(
 
   @inline
   private def scalaBinaryVersion(version: ScalafmtVersion): String =
-    if (version < ScalafmtVersion(0, 7, 0, 0)) "2.11"
-    else if (version < ScalafmtVersion(2, 1, 2, 0)) "2.12"
+    if (version < ScalafmtVersion(0, 7, 0, 0, false)) "2.11"
+    else if (version < ScalafmtVersion(2, 1, 2, 0, false)) "2.12"
     else "2.13"
 
   @inline
   private def scalaVersion(version: ScalafmtVersion): String =
-    if (version < ScalafmtVersion(0, 7, 0, 0)) BuildInfo.scala211
-    else if (version < ScalafmtVersion(2, 1, 2, 0)) BuildInfo.scala212
+    if (version < ScalafmtVersion(0, 7, 0, 0, false)) BuildInfo.scala211
+    else if (version < ScalafmtVersion(2, 1, 2, 0, false)) BuildInfo.scala212
     else BuildInfo.scala
 
   @inline
   private def organization(version: ScalafmtVersion): String =
-    if (version < ScalafmtVersion(2, 0, 0, 2)) {
+    if (version < ScalafmtVersion(2, 0, 0, 2, false)) {
       "com.geirsson"
     } else {
       "org.scalameta"

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
@@ -2,7 +2,13 @@ package org.scalafmt.dynamic
 
 import scala.util.control.{NonFatal, NoStackTrace}
 
-case class ScalafmtVersion(major: Int, minor: Int, patch: Int, rc: Int) {
+case class ScalafmtVersion(
+    major: Int,
+    minor: Int,
+    patch: Int,
+    rc: Int,
+    snapshot: Boolean
+) {
   private val integerRepr: Int =
     major * 100 + minor * 10 + patch
 
@@ -14,7 +20,9 @@ case class ScalafmtVersion(major: Int, minor: Int, patch: Int, rc: Int) {
   def >(other: ScalafmtVersion): Boolean = this != other && !(this < other)
 
   override def toString: String =
-    s"$major.$minor.$patch" + (if (rc > 0) s"-RC$rc" else "")
+    s"$major.$minor.$patch" +
+      (if (rc > 0) s"-RC$rc" else "") +
+      (if (snapshot) "-SNAPSHOT" else "")
 }
 
 object ScalafmtVersion {
@@ -22,27 +30,29 @@ object ScalafmtVersion {
       extends Exception(s"Invalid scalafmt version $version")
       with NoStackTrace
 
-  private val versionRegex = """(\d)\.(\d)\.(\d)(-RC(\d))?(?:-SNAPSHOT)?""".r
+  private val versionRegex = """(\d)\.(\d)\.(\d)(-RC(\d))?(-SNAPSHOT)?""".r
 
   def parse(version: String): Either[InvalidVersionException, ScalafmtVersion] =
     try {
       version match {
-        case versionRegex(major, minor, patch, null, null) =>
+        case versionRegex(major, minor, patch, null, null, snapshot) =>
           Right(
             ScalafmtVersion(
               positiveInt(major),
               positiveInt(minor),
               positiveInt(patch),
-              0
+              0,
+              snapshot != null
             )
           )
-        case versionRegex(major, minor, patch, _, rc) =>
+        case versionRegex(major, minor, patch, _, rc, snapshot) =>
           Right(
             ScalafmtVersion(
               positiveInt(major),
               positiveInt(minor),
               positiveInt(patch),
-              positiveInt(rc)
+              positiveInt(rc),
+              snapshot != null
             )
           )
         case _ => Left(InvalidVersionException(version))

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
@@ -7,7 +7,7 @@ case class ScalafmtVersion(
     minor: Int,
     patch: Int,
     rc: Int,
-    snapshot: Boolean
+    snapshot: Boolean = false
 ) {
   private val integerRepr: Int =
     major * 100 + minor * 10 + patch

--- a/scalafmt-dynamic/src/test/scala/tests/ScalafmtVersionSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/tests/ScalafmtVersionSuite.scala
@@ -6,20 +6,55 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ScalafmtVersionSuite extends AnyFunSuite {
   test("parse valid versions") {
-    assert(ScalafmtVersion.parse("2.0.0") == Right(ScalafmtVersion(2, 0, 0, 0)))
-    assert(ScalafmtVersion.parse("0.1.3") == Right(ScalafmtVersion(0, 1, 3, 0)))
-    assert(
-      ScalafmtVersion.parse("2.0.0-RC4") == Right(ScalafmtVersion(2, 0, 0, 4))
-    )
-    assert(ScalafmtVersion.parse("2.1.1") == Right(ScalafmtVersion(2, 1, 1, 0)))
     assert(
       ScalafmtVersion
-        .parse("2.2.3-SNAPSHOT") == Right(ScalafmtVersion(2, 2, 3, 0))
+        .parse("2.0.0") == Right(ScalafmtVersion(2, 0, 0, 0, false))
+    )
+    assert(
+      ScalafmtVersion
+        .parse("0.1.3") == Right(ScalafmtVersion(0, 1, 3, 0, false))
+    )
+    assert(
+      ScalafmtVersion.parse("2.0.0-RC4") == Right(
+        ScalafmtVersion(2, 0, 0, 4, false)
+      )
+    )
+    assert(
+      ScalafmtVersion
+        .parse("2.1.1") == Right(ScalafmtVersion(2, 1, 1, 0, false))
+    )
+    assert(
+      ScalafmtVersion
+        .parse("2.2.3-SNAPSHOT") == Right(ScalafmtVersion(2, 2, 3, 0, true))
     )
     assert(
       ScalafmtVersion.parse("2.0.0-RC1-SNAPSHOT") == Right(
-        ScalafmtVersion(2, 0, 0, 1)
+        ScalafmtVersion(2, 0, 0, 1, true)
       )
+    )
+    assert(
+      ScalafmtVersion.parse("2.2.2-SNAPSHOT") == Right(
+        ScalafmtVersion(2, 2, 2, 0, true)
+      )
+    )
+  }
+
+  test("toString") {
+    assert(ScalafmtVersion.parse("2.2.2-RC2").right.get.toString == "2.2.2-RC2")
+    assert(ScalafmtVersion.parse("2.2.2").right.get.toString == "2.2.2")
+    assert(
+      ScalafmtVersion
+        .parse("2.2.2-SNAPSHOT")
+        .right
+        .get
+        .toString == "2.2.2-SNAPSHOT"
+    )
+    assert(
+      ScalafmtVersion
+        .parse("2.2.2-RC2-SNAPSHOT")
+        .right
+        .get
+        .toString == "2.2.2-RC2-SNAPSHOT"
     )
   }
 
@@ -68,16 +103,38 @@ class ScalafmtVersionSuite extends AnyFunSuite {
   }
 
   test("order versions") {
-    assert(ScalafmtVersion(2, 0, 0, 0) > ScalafmtVersion(1, 5, 1, 0))
-    assert(ScalafmtVersion(2, 0, 0, 0) > ScalafmtVersion(2, 0, 0, 1))
-    assert(ScalafmtVersion(2, 0, 0, 4) > ScalafmtVersion(1, 9, 9, 9))
-    assert(ScalafmtVersion(0, 1, 2, 0) > ScalafmtVersion(0, 1, 1, 0))
-    assert(ScalafmtVersion(0, 2, 2, 0) > ScalafmtVersion(0, 1, 2, 0))
-    assert(ScalafmtVersion(2, 0, 0, 2) < ScalafmtVersion(2, 0, 0, 4))
-    assert(ScalafmtVersion(2, 0, 0, 2) < ScalafmtVersion(2, 0, 0, 0))
-    assert(ScalafmtVersion(0, 1, 2, 0) < ScalafmtVersion(1, 0, 0, 0))
-    assert(ScalafmtVersion(0, 1, 8, 0) < ScalafmtVersion(0, 2, 2, 0))
-    assert(!(ScalafmtVersion(2, 0, 0, 0) < ScalafmtVersion(1, 5, 1, 0)))
-    assert(!(ScalafmtVersion(0, 1, 8, 0) > ScalafmtVersion(0, 2, 2, 0)))
+    assert(
+      ScalafmtVersion(2, 0, 0, 0, false) > ScalafmtVersion(1, 5, 1, 0, false)
+    )
+    assert(
+      ScalafmtVersion(2, 0, 0, 0, false) > ScalafmtVersion(2, 0, 0, 1, false)
+    )
+    assert(
+      ScalafmtVersion(2, 0, 0, 4, false) > ScalafmtVersion(1, 9, 9, 9, false)
+    )
+    assert(
+      ScalafmtVersion(0, 1, 2, 0, false) > ScalafmtVersion(0, 1, 1, 0, false)
+    )
+    assert(
+      ScalafmtVersion(0, 2, 2, 0, false) > ScalafmtVersion(0, 1, 2, 0, false)
+    )
+    assert(
+      ScalafmtVersion(2, 0, 0, 2, false) < ScalafmtVersion(2, 0, 0, 4, false)
+    )
+    assert(
+      ScalafmtVersion(2, 0, 0, 2, false) < ScalafmtVersion(2, 0, 0, 0, false)
+    )
+    assert(
+      ScalafmtVersion(0, 1, 2, 0, false) < ScalafmtVersion(1, 0, 0, 0, false)
+    )
+    assert(
+      ScalafmtVersion(0, 1, 8, 0, false) < ScalafmtVersion(0, 2, 2, 0, false)
+    )
+    assert(
+      !(ScalafmtVersion(2, 0, 0, 0, false) < ScalafmtVersion(1, 5, 1, 0, false))
+    )
+    assert(
+      !(ScalafmtVersion(0, 1, 8, 0, false) > ScalafmtVersion(0, 2, 2, 0, false))
+    )
   }
 }

--- a/scalafmt-dynamic/src/test/scala/tests/ScalafmtVersionSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/tests/ScalafmtVersionSuite.scala
@@ -7,21 +7,16 @@ import org.scalatest.funsuite.AnyFunSuite
 class ScalafmtVersionSuite extends AnyFunSuite {
   test("parse valid versions") {
     assert(
-      ScalafmtVersion
-        .parse("2.0.0") == Right(ScalafmtVersion(2, 0, 0, 0, false))
+      ScalafmtVersion.parse("2.0.0") == Right(ScalafmtVersion(2, 0, 0, 0))
     )
     assert(
-      ScalafmtVersion
-        .parse("0.1.3") == Right(ScalafmtVersion(0, 1, 3, 0, false))
+      ScalafmtVersion.parse("0.1.3") == Right(ScalafmtVersion(0, 1, 3, 0))
     )
     assert(
-      ScalafmtVersion.parse("2.0.0-RC4") == Right(
-        ScalafmtVersion(2, 0, 0, 4, false)
-      )
+      ScalafmtVersion.parse("2.0.0-RC4") == Right(ScalafmtVersion(2, 0, 0, 4))
     )
     assert(
-      ScalafmtVersion
-        .parse("2.1.1") == Right(ScalafmtVersion(2, 1, 1, 0, false))
+      ScalafmtVersion.parse("2.1.1") == Right(ScalafmtVersion(2, 1, 1, 0))
     )
     assert(
       ScalafmtVersion
@@ -103,38 +98,16 @@ class ScalafmtVersionSuite extends AnyFunSuite {
   }
 
   test("order versions") {
-    assert(
-      ScalafmtVersion(2, 0, 0, 0, false) > ScalafmtVersion(1, 5, 1, 0, false)
-    )
-    assert(
-      ScalafmtVersion(2, 0, 0, 0, false) > ScalafmtVersion(2, 0, 0, 1, false)
-    )
-    assert(
-      ScalafmtVersion(2, 0, 0, 4, false) > ScalafmtVersion(1, 9, 9, 9, false)
-    )
-    assert(
-      ScalafmtVersion(0, 1, 2, 0, false) > ScalafmtVersion(0, 1, 1, 0, false)
-    )
-    assert(
-      ScalafmtVersion(0, 2, 2, 0, false) > ScalafmtVersion(0, 1, 2, 0, false)
-    )
-    assert(
-      ScalafmtVersion(2, 0, 0, 2, false) < ScalafmtVersion(2, 0, 0, 4, false)
-    )
-    assert(
-      ScalafmtVersion(2, 0, 0, 2, false) < ScalafmtVersion(2, 0, 0, 0, false)
-    )
-    assert(
-      ScalafmtVersion(0, 1, 2, 0, false) < ScalafmtVersion(1, 0, 0, 0, false)
-    )
-    assert(
-      ScalafmtVersion(0, 1, 8, 0, false) < ScalafmtVersion(0, 2, 2, 0, false)
-    )
-    assert(
-      !(ScalafmtVersion(2, 0, 0, 0, false) < ScalafmtVersion(1, 5, 1, 0, false))
-    )
-    assert(
-      !(ScalafmtVersion(0, 1, 8, 0, false) > ScalafmtVersion(0, 2, 2, 0, false))
-    )
+    assert(ScalafmtVersion(2, 0, 0, 0) > ScalafmtVersion(1, 5, 1, 0))
+    assert(ScalafmtVersion(2, 0, 0, 0) > ScalafmtVersion(2, 0, 0, 1))
+    assert(ScalafmtVersion(2, 0, 0, 4) > ScalafmtVersion(1, 9, 9, 9))
+    assert(ScalafmtVersion(0, 1, 2, 0) > ScalafmtVersion(0, 1, 1, 0))
+    assert(ScalafmtVersion(0, 2, 2, 0) > ScalafmtVersion(0, 1, 2, 0))
+    assert(ScalafmtVersion(2, 0, 0, 2) < ScalafmtVersion(2, 0, 0, 4))
+    assert(ScalafmtVersion(2, 0, 0, 2) < ScalafmtVersion(2, 0, 0, 0))
+    assert(ScalafmtVersion(0, 1, 2, 0) < ScalafmtVersion(1, 0, 0, 0))
+    assert(ScalafmtVersion(0, 1, 8, 0) < ScalafmtVersion(0, 2, 2, 0))
+    assert(!(ScalafmtVersion(2, 0, 0, 0) < ScalafmtVersion(1, 5, 1, 0)))
+    assert(!(ScalafmtVersion(0, 1, 8, 0) > ScalafmtVersion(0, 2, 2, 0)))
   }
 }


### PR DESCRIPTION
Close https://github.com/scalameta/scalafmt/issues/1655

### Problem
As described in the issue, before this PR, scalafmt-dynamic (and so scalafmt-cli, sbt-scalafmt, every module that depends on scalafmt-dynamic) couldn't resolve the SNAPSHOT version of scalafmt-core.

- Run `sbt publishLocal` and publish the snapshot version (e.g. `2.2.2-SNAPSHOT`)
- Set `version` field in `.scalafmt.conf` to `2.2.2-SNAPSHOT`
- Try to run scalafmt using CLI / sbt-scalafmt

got

```
org.scalafmt.cli.FailedToFormat: /Users/tanishiking/dev/src/github.com/tanishiking/scalafmt/scalafmt-tests/src/test/scala/org/scalafmt/util/Tabulator.scala
Caused by: org.scalafmt.dynamic.exceptions.VersionMismatch: Scalafmt version mismatch. Version in .scalafmt.conf is '2.2.2-SNAPSHOT' and running version is '2.2.2'.
        at org.scalafmt.dynamic.ScalafmtReflect.checkVersionMismatch(ScalafmtReflect.scala:164)
        at org.scalafmt.dynamic.ScalafmtReflect.format(ScalafmtReflect.scala:98)
        at org.scalafmt.dynamic.ScalafmtDynamic.$anonfun$tryFormat$1(ScalafmtDynamic.scala:215)
        at scala.util.Try$.apply(Try.scala:213)
        at org.scalafmt.dynamic.ScalafmtDynamic.tryFormat(ScalafmtDynamic.scala:203)
        at org.scalafmt.dynamic.ScalafmtDynamic.$anonfun$formatDetailed$1(ScalafmtDynamic.scala:109)
        at scala.util.Either.flatMap(Either.scala:341)
        at org.scalafmt.dynamic.ScalafmtDynamic.formatDetailed(ScalafmtDynamic.scala:108)
        at org.scalafmt.dynamic.ScalafmtDynamic.format(ScalafmtDynamic.scala:70)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.handleFile(ScalafmtDynamicRunner.scala:96)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.$anonfun$run$4(ScalafmtDynamicRunner.scala:55)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.$anonfun$run$4$adapted(ScalafmtDynamicRunner.scala:49)
        at scala.collection.immutable.List.foreach(List.scala:392)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.$anonfun$run$3(ScalafmtDynamicRunner.scala:49)
        at scala.util.control.Breaks.breakable(Breaks.scala:42)
        at org.scalafmt.cli.ScalafmtDynamicRunner$.run(ScalafmtDynamicRunner.scala:49)
        at org.scalafmt.cli.Cli$.runWithRunner(Cli.scala:135)
        at org.scalafmt.cli.Cli$.run(Cli.scala:84)
        at org.scalafmt.cli.Cli$.mainWithOptions(Cli.scala:69)
        at org.scalafmt.cli.Cli$.main(Cli.scala:58)
        at org.scalafmt.cli.Cli.main(Cli.scala)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at coursier.bootstrap.launcher.a.a(Unknown Source)
        at coursier.bootstrap.launcher.Launcher.main(Unknown Source)
```

### Cause

- That stacktrace comes from https://github.com/adampauls/scalafmt/blob/0b8b3da0b46b41767bedf3a059b29163c38f605f/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala#L159-L166
  - If the version in `.scalafmt.conf` set to SNAPSHOT version, it always throws the VersionMismatchException because
    - ScalafmtReflect received parsed to `toString`ed `ScalafmtVersion` https://github.com/adampauls/scalafmt/blob/0b8b3da0b46b41767bedf3a059b29163c38f605f/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala#L156-L180
    - but [`ScalafmtVersion` doesn't have SNAPSHOT information](https://github.com/scalameta/scalafmt/blob/784d242f09f6c6aa83e6f2d129aa631cf24b762f/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala#L5), as a result, `2.2.2-SNAPSHOT` down to `2.2.2`.

### Solution
To fix this, this PR

- enables `ScalafmtVersion` to have SNAPSHOT information
- if the version is SNAPSHOT, add `-SNAPSHOT` suffix on `toString` of `ScalafmtVersion`