### PR TITLE
Router: allow single-line curly lambdas

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -3,7 +3,7 @@ package org.scalafmt.internal
 import java.{util => ju}
 import scala.collection.JavaConverters._
 import org.scalafmt.Error.CaseMissingArrow
-import org.scalafmt.config.{DanglingExclude, ScalafmtConfig}
+import org.scalafmt.config.{DanglingExclude, NewlineCurlyLambda, ScalafmtConfig}
 import org.scalafmt.internal.ExpiresOn.{Left, Right}
 import org.scalafmt.internal.Length.Num
 import org.scalafmt.internal.Policy.NoPolicy
@@ -1017,4 +1017,15 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     case _: Term.Xml | _: Pat.Xml => NoSplit
     case _ => Space
   }
+
+  def getSpaceAndNewlineAfterCurlyLambda(
+      newlines: Int
+  )(implicit style: ScalafmtConfig): NewlineT =
+    style.newlines.afterCurlyLambda match {
+      case NewlineCurlyLambda.never => Newline
+      case NewlineCurlyLambda.always => Newline2x
+      case NewlineCurlyLambda.preserve =>
+        if (newlines >= 2) Newline2x else Newline
+    }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1043,12 +1043,12 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
   def getSpaceAndNewlineAfterCurlyLambda(
       newlines: Int
-  )(implicit style: ScalafmtConfig): NewlineT =
+  )(implicit style: ScalafmtConfig): (Boolean, NewlineT) =
     style.newlines.afterCurlyLambda match {
-      case NewlineCurlyLambda.never => Newline
-      case NewlineCurlyLambda.always => Newline2x
+      case NewlineCurlyLambda.never => (true, Newline)
+      case NewlineCurlyLambda.always => (false, Newline2x)
       case NewlineCurlyLambda.preserve =>
-        if (newlines >= 2) Newline2x else Newline
+        (newlines == 0, if (newlines >= 2) Newline2x else Newline)
     }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -28,6 +28,9 @@ class FormatTokens(val arr: Array[FormatToken])
   def apply(tok: Token, off: Int): FormatToken = apply(apply(tok), off)
   def apply(ft: FormatToken, off: Int): FormatToken = at(ft.meta.idx + off)
 
+  @inline def hasNext(ft: FormatToken): Boolean = ft.meta.idx < (arr.length - 1)
+  @inline def hasPrev(ft: FormatToken): Boolean = ft.meta.idx > 0
+
 }
 
 object FormatTokens {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -259,7 +259,7 @@ class Router(formatOps: FormatOps) {
           else {
             val expire = endOfSingleLineBlock(closeFT)
             val policy =
-              SingleLineBlock(expire)
+              SingleLineBlock(expire, penaliseNewlinesInsideTokens = true)
                 .andThen(singleLineDecision)
             Split(xmlSpace(leftOwner), 0, policy = policy)
               .withOptimalToken(close, killOnFail = true)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -280,14 +280,12 @@ class Router(formatOps: FormatOps) {
         val canBeSpace =
           statementStarts(hash(right)).isInstanceOf[Term.Function]
         val afterCurlyNewlines =
-          style.newlines.afterCurlyLambda match {
-            case NewlineCurlyLambda.never => Newline
-            case NewlineCurlyLambda.always => Newline2x
-            case NewlineCurlyLambda.preserve =>
-              if (newlines >= 2) Newline2x else Newline
-          }
+          getSpaceAndNewlineAfterCurlyLambda(newlines)
+        val spaceSplit =
+          if (canBeSpace) Split(Space, 0)
+          else Split.ignored
         Seq(
-          Split(Space, 0, ignoreIf = !canBeSpace),
+          spaceSplit,
           Split(afterCurlyNewlines, 1).withIndent(2, endOfFunction, Left)
         )
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -210,8 +210,9 @@ class Router(formatOps: FormatOps) {
         val lambdaPolicy =
           if (lambdaExpire == null) null
           else {
+            val arrowOptimal = getOptimalTokenFor(lambdaExpire)
             newlineBeforeClosingCurly
-              .andThen(SingleLineBlock(lambdaExpire))
+              .andThen(SingleLineBlock(arrowOptimal))
           }
 
         def getSingleLineDecisionPre2019Nov = leftOwner.parent match {
@@ -803,9 +804,7 @@ class Router(formatOps: FormatOps) {
                 case b: Term.Block => b.tokens.head
                 case _ => assign.tokens.find(_.is[T.Equals]).get
               }
-              val assignFT = tokens(assignToken)
-              val hasComment = isAttachedSingleLineComment(assignFT)
-              val breakToken = if (hasComment) assignFT.right else assignToken
+              val breakToken = getOptimalTokenFor(assignToken)
               val newlineAfterAssignDecision =
                 if (newlinePolicy.isEmpty) Policy.emptyPf
                 else decideNewlinesOnlyAfterToken(breakToken)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -97,3 +97,9 @@ case class Split(
   override def toString =
     s"""$modification:${line.value}(cost=$cost, indents=$indentation, $policy)"""
 }
+
+object Split {
+
+  val ignored = Split(NoSplit, 0, ignoreIf = true)(sourcecode.Line(0))
+
+}

--- a/scalafmt-tests/src/test/resources/default/Idempotency.stat
+++ b/scalafmt-tests/src/test/resources/default/Idempotency.stat
@@ -9,12 +9,7 @@ class A {
 >>>
 class A {
   def traced(in: A => Unit, out: B => Unit): Fun[A, B] =
-    (f.mapIn[A] { x =>
-        in(x); x
-      }
-      .mapOut[B] { x =>
-        out(x); x
-      })
+    (f.mapIn[A] { x => in(x); x }.mapOut[B] { x => out(x); x })
 }
 
 <<< akka 1

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -145,11 +145,8 @@ class Sample {
 >>>
 class Sample {
   def mkFunc(flag: Boolean): String => Boolean = {
-    if (flag) { (v =>
-      true)
-    } else { (v =>
-      false)
-    }
+    if (flag) { (v => true) }
+    else { (v => false) }
   }
 }
 <<< #1413

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -132,6 +132,26 @@ if (fullInfo)
     .flatMap(_.toSeq)
     .map(_._1)
     .toSet
+<<< #1409
+class Sample {
+  def mkFunc(flag: Boolean): String => Boolean = {
+    if(flag) {
+      (v => true)
+    } else {
+      (v => false)
+    }
+  }
+}
+>>>
+class Sample {
+  def mkFunc(flag: Boolean): String => Boolean = {
+    if (flag) { (v =>
+      true)
+    } else { (v =>
+      false)
+    }
+  }
+}
 <<< #1413
 if (Keys.useCoursier.value)
       Def.task {

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -37,9 +37,7 @@ def withDedicatedVar: Unit = {
   {
     {
       preloads.foreach { p =>
-        cache.getOrElseUpdate(p, futureStreams.map { r =>
-          r.streams.get(p)
-        })
+        cache.getOrElseUpdate(p, futureStreams.map { r => r.streams.get(p) })
       }
     }
   }
@@ -211,17 +209,23 @@ def test(dataFrame: DataFrame) = {
       .map{case (sum, count) => sum}
   }
 >>>
-Unable to format file due to bug in scalafmt
 def test(dataFrame: DataFrame) = {
-    val zeroAccumulator = Array.fill(1)((0.0, 0))
+  val zeroAccumulator = Array.fill(1)((0.0, 0))
 
-    dataFrame.rdd.aggregate(zeroAccumulator)({(acc, row) => acc.zip(row.toSeq).map{ case (x, y) => {
-      if(true) (1, 2)
-      else (x._1 + 2, x._2 + 1)
-    }}},
-      {(acc1, acc2) => acc1.zip(acc2).map{ case (x, y) => (x._1 + y._1, x._2 + y._2)}})
-      .map{case (sum, count) => sum}
-  }
+  dataFrame.rdd
+    .aggregate(zeroAccumulator)(
+      { (acc, row) =>
+        acc.zip(row.toSeq).map {
+          case (x, y) => {
+            if (true) (1, 2)
+            else (x._1 + 2, x._2 + 1)
+          }
+        }
+      },
+      { (acc1, acc2) => acc1.zip(acc2).map { case (x, y) => (x._1 + y._1, x._2 + y._2) } }
+    )
+    .map { case (sum, count) => sum }
+}
 <<< one-line lambda: make sure infix is handled correctly
 object a {
 val parser = new scopt.OptionParser[ServerConfig]("CreateServer") {
@@ -261,9 +265,7 @@ object a {
     c.copy(commands = c.commands :+ "help")
   } children (
       arg[String]("<command>") optional ()
-        action { (x, c) =>
-          c.copy(commands = c.commands :+ x)
-        }
+        action { (x, c) => c.copy(commands = c.commands :+ x) }
   )
 }
 <<< one-line lambda: make sure multiline string is handled correctly

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -193,3 +193,110 @@ pairList.map(pair => {
 val add = (x: Int) => x + 2
 >>>
 val add = (x: Int) => x + 2
+<<< #965
+style = defaultWithAlign
+maxColumn = 120
+newlines.sometimesBeforeColonInMethodReturnType = false
+align.openParenCallSite = false
+rewrite.rules = [RedundantBraces, RedundantParens]
+===
+def test(dataFrame: DataFrame) = {
+    val zeroAccumulator = Array.fill(1)((0.0, 0))
+
+    dataFrame.rdd.aggregate(zeroAccumulator)({(acc, row) => acc.zip(row.toSeq).map{ case (x, y) => {
+      if(true) (1, 2)
+      else (x._1 + 2, x._2 + 1)
+    }}},
+      {(acc1, acc2) => acc1.zip(acc2).map{ case (x, y) => (x._1 + y._1, x._2 + y._2)}})
+      .map{case (sum, count) => sum}
+  }
+>>>
+Unable to format file due to bug in scalafmt
+def test(dataFrame: DataFrame) = {
+    val zeroAccumulator = Array.fill(1)((0.0, 0))
+
+    dataFrame.rdd.aggregate(zeroAccumulator)({(acc, row) => acc.zip(row.toSeq).map{ case (x, y) => {
+      if(true) (1, 2)
+      else (x._1 + 2, x._2 + 1)
+    }}},
+      {(acc1, acc2) => acc1.zip(acc2).map{ case (x, y) => (x._1 + y._1, x._2 + y._2)}})
+      .map{case (sum, count) => sum}
+  }
+<<< one-line lambda: make sure infix is handled correctly
+object a {
+val parser = new scopt.OptionParser[ServerConfig]("CreateServer") {
+      opt[String]("batch") action { (x, c) =>
+        c.copy(batch = x)
+      } text ("Batch label of the deployment.")
+      opt[String]("engineId") action { (x, c) =>
+        c.copy(engineId = Some(x))
+      } text ("Engine ID.")
+  }
+}
+>>>
+object a {
+  val parser = new scopt.OptionParser[ServerConfig]("CreateServer") {
+    opt[String]("batch") action { (x, c) =>
+      c.copy(batch = x)
+    } text ("Batch label of the deployment.")
+    opt[String]("engineId") action { (x, c) =>
+      c.copy(engineId = Some(x))
+    } text ("Engine ID.")
+  }
+}
+<<< one-line lambda: make sure infix is handled correctly 2
+object a {
+cmd("help").action {
+ (_, c) => c.copy(commands = c.commands :+ "help")
+  } children (
+         arg[String]("<command>") optional ()
+          action { (x, c) =>
+            c.copy(commands = c.commands :+ x)
+          }
+       )
+}
+>>>
+object a {
+  cmd("help").action { (_, c) =>
+    c.copy(commands = c.commands :+ "help")
+  } children (
+      arg[String]("<command>") optional ()
+        action { (x, c) =>
+          c.copy(commands = c.commands :+ x)
+        }
+  )
+}
+<<< one-line lambda: make sure multiline string is handled correctly
+object a {
+val b = c { d => """The quick brown fox jumps over the lazy dog
+     | The quick brown fox jumps over the lazy dog
+     | The quick brown fox jumps over the lazy dog
+     |""".stripMargin }
+}
+>>>
+object a {
+  val b = c { d =>
+    """The quick brown fox jumps over the lazy dog
+     | The quick brown fox jumps over the lazy dog
+     | The quick brown fox jumps over the lazy dog
+     |""".stripMargin
+  }
+}
+<<< one-line lambda: make sure multiline string is handled correctly 2
+assumeStandardLibraryStripMargin = true
+===
+object a {
+val b = c { d => """The quick brown fox jumps over the lazy dog
+      | The quick brown fox jumps over the lazy dog
+      | The quick brown fox jumps over the lazy dog
+      |""".stripMargin }
+}
+>>>
+object a {
+  val b = c { d =>
+    """The quick brown fox jumps over the lazy dog
+      | The quick brown fox jumps over the lazy dog
+      | The quick brown fox jumps over the lazy dog
+      |""".stripMargin
+  }
+}

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -138,9 +138,7 @@ lst.map { x =>
 >>>
 LookupJoin
   .rightSumming(TypedPipe.from(in1))
-  .map { x =>
-    x
-  }
+  .map { x => x }
   .write(TypedTsv[(String, String, String, String)]("output2"))
 <<< scalding discardTestJob
 
@@ -154,13 +152,9 @@ class DiscardTestJob(args: Args) extends Job(args) {
 >>>
 class DiscardTestJob(args: Args) extends Job(args) {
   TextLine(args("in"))
-    .map('words -> 'wsize) { word: String =>
-      word.length
-    }
+    .map('words -> 'wsize) { word: String => word.length }
     .discard('words)
-    .map('* -> 'correct) { te: TupleEntry =>
-      te.getFields.contains('words)
-    }
+    .map('* -> 'correct) { te: TupleEntry => te.getFields.contains('words) }
     .write(Tsv(args("out")))
 }
 <<< scalding typedthrowserrorsjov

--- a/scalafmt-tests/src/test/resources/default/Unindent.stat
+++ b/scalafmt-tests/src/test/resources/default/Unindent.stat
@@ -32,9 +32,7 @@
   {
     assert(
         backoffs.force.toSeq ==
-          (0 until 10 map { i =>
-            (1 << i).seconds
-          }))
+          (0 until 10 map { i => (1 << i).seconds }))
   }
 }
 

--- a/scalafmt-tests/src/test/resources/default/Val.stat
+++ b/scalafmt-tests/src/test/resources/default/Val.stat
@@ -67,9 +67,7 @@ val ps = params map { p =>
      JSMethodParam(p.info, p.asTerm.isParamWithDefault)
    }
 >>>
-val ps = params map { p =>
-  JSMethodParam(p.info, p.asTerm.isParamWithDefault)
-}
+val ps = params map { p => JSMethodParam(p.info, p.asTerm.isParamWithDefault) }
 <<< #269 2
 val wasBOM = if (endianness == AutoEndian) {
   // Read BOM

--- a/scalafmt-tests/src/test/resources/newlines/AlwaysBeforeCurlyBraceLambdaParams.stat
+++ b/scalafmt-tests/src/test/resources/newlines/AlwaysBeforeCurlyBraceLambdaParams.stat
@@ -16,15 +16,13 @@ lst.map { x =>
 }
 >>>
 lst.map {
-  x =>
-    x
+  x => x
 }
 <<< apply to one-liners as well
 lst.map { x => x }
 >>>
 lst.map {
-  x =>
-    x
+  x => x
 }
 <<< but preserve newlines if inserted
 lst.map {
@@ -33,6 +31,5 @@ lst.map {
 }
 >>>
 lst.map {
-  x =>
-    x
+  x => x
 }

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaAlways.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaAlways.stat
@@ -16,10 +16,22 @@ def f = {
   }
 }
 
-<<< Force newline in lambda call
+<<< Force empty line in lambda call with a newline
 def f = {
   something.call { x =>
     g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}
+<<< Force empty line in lambda call without a newline
+def f = {
+  something.call { x =>    g(x)
   }
 }
 >>>

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
@@ -10,9 +10,7 @@ def f = {
 }
 >>>
 def f = {
-  something.call { x =>
-    g(x)
-  }
+  something.call { x => g(x) }
 }
 
 <<< Preseve no-newline in lambda call
@@ -23,9 +21,7 @@ def f = {
 }
 >>>
 def f = {
-  something.call { x =>
-    g(x)
-  }
+  something.call { x => g(x) }
 }
 
 <<< Remove many newlines in lambda call
@@ -39,7 +35,5 @@ def f = {
 }
 >>>
 def f = {
-  something.call { x =>
-    g(x)
-  }
+  something.call { x => g(x) }
 }

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
@@ -16,7 +16,16 @@ def f = {
   }
 }
 
-<<< Preserve no-newline in lambda call
+<<< Preserve no newline in lambda call
+def f = {
+  something.call { x =>    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x => g(x) }
+}
+<<< Preserve no empty line in lambda call
 def f = {
   something.call { x =>
     g(x)

--- a/scalafmt-tests/src/test/resources/optIn/SelectChain.stat
+++ b/scalafmt-tests/src/test/resources/optIn/SelectChain.stat
@@ -11,12 +11,8 @@ includeCurlyBraceInSelectChains = true
 >>>
 def acceptParticipants =
   actions[Lottery]
-    .handleCommand { cmd: AddParticipant =>
-      ParticipantAdded(cmd.name, id)
-    }
-    .handleEvent { evt: ParticipantAdded =>
-      this.addParticipant(evt.name)
-    }
+    .handleCommand { cmd: AddParticipant => ParticipantAdded(cmd.name, id) }
+    .handleEvent { evt: ParticipantAdded => this.addParticipant(evt.name) }
 <<< .value #639
 val x = Def.taskDyn {
     println(1)

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
@@ -14,9 +14,7 @@ lst.map(foo)
 <<< has curly
 lst map { x => y }
 >>>
-lst.map { x =>
-  y
-}
+lst.map { x => y }
 <<< to
 1 to 100
 >>>
@@ -125,9 +123,7 @@ seq should have length 5
   perform(_ + 1)
 }
 >>>
-(1 to total).foreach { _ =>
-  perform(_ + 1)
-}
+(1 to total).foreach { _ => perform(_ + 1) }
 <<< excluded combinators in lhs 4
 seq should have length 5 and true
 >>>

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix3.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix3.stat
@@ -5,9 +5,7 @@ rewrite.rules = [AvoidInfix]
   x
 }
 >>>
-(NotQuoted ~ any.*).map { x =>
-  x
-}
+(NotQuoted ~ any.*).map { x => x }
 <<< settings
 Project("sub", file("sub")) delegateTo (root) settings (check <<= checkTask)
 >>>

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -57,6 +57,7 @@ object a {
 object a {
   def x(i: Int): Int = {
     List.filter { x =>
+      // comment
       x > 1
     }
   }
@@ -65,6 +66,7 @@ object a {
 object a {
   def x(i: Int): Int = {
     List.filter { x =>
+      // comment
       x > 1
     }
   }
@@ -272,8 +274,7 @@ class Test extends AnyWordSpec {
   println
   Post("/", urlEncodedForm) ~> {
     formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) {
-      (firstName, age, sex, vip) ⇒
-        complete(firstName + age + sex + vip)
+      (firstName, age, sex, vip) ⇒ complete(firstName + age + sex + vip)
     }
   } ~> check { responseAs[String] shouldEqual "Mike42Nonefalse" }
 }
@@ -360,11 +361,8 @@ object a {
 }
 >>>
 object a {
-  val select = if (max) { (a: CTuple, b: CTuple) =>
-    (a.compareTo(b) >= 0)
-  } else { (a: CTuple, b: CTuple) =>
-    (a.compareTo(b) <= 0)
-  }
+  val select = if (max) { (a: CTuple, b: CTuple) => (a.compareTo(b) >= 0) }
+  else { (a: CTuple, b: CTuple) => (a.compareTo(b) <= 0) }
 }
 <<< #1633 2.2: function block in a val statement
 object a {
@@ -374,9 +372,7 @@ object a {
 }
 >>>
 object a {
-  val select = { (a: CTuple, b: CTuple) =>
-    (a.compareTo(b) >= 0)
-  }
+  val select = { (a: CTuple, b: CTuple) => (a.compareTo(b) >= 0) }
 }
 <<< #1633 3.1: function block in a val statement
 object a {
@@ -524,9 +520,7 @@ object a {
 }
 >>>
 object a {
-  val b = c { d =>
-    e
-  } // comment1
+  val b = c { d => e } // comment1
   /* comment2 */
   /* comment3 */
 }

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysOwners.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysOwners.stat
@@ -5,6 +5,4 @@ lst.map { x =>
   x + 1
 }
 >>>
-lst.map { x =>
-  x + 1
-}
+lst.map { x => x + 1 }

--- a/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
@@ -120,9 +120,7 @@ ctx.replace(
 ctx.replace(
     additionalImports =
       "" ::
-        foo.map { x =>
-          x + 1
-        }
+        foo.map { x => x + 1 }
 )
 <<< right assoc
 x ::

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -36,9 +36,7 @@ Thing() { implicit ctx => j =>
       ???
 }
 >>>
-Thing() { implicit ctx => j =>
-  ???
-}
+Thing() { implicit ctx => j => ??? }
 <<< curried break before first
 Thing() { implicit ctx => j => kkkkkkkkkk =>
       ???
@@ -57,8 +55,7 @@ Thing() {
   implicit ctx => j =>
     kkkkkkkkkkkkkkkkkkk =>
       llllllllllll =>
-        mmmmmmmmmmmmmmmmmmm =>
-          ???
+        mmmmmmmmmmmmmmmmmmm => ???
 }
 <<< curried with ()
 Thing(implicit ctx => j =>
@@ -82,9 +79,7 @@ Thing() { implicit ctx =>
       ???
 }
 >>>
-Thing() { implicit ctx =>
-  ???
-}
+Thing() { implicit ctx => ??? }
 <<< ( arg =>
 val groupedData = Array(topic1, topic2).flatMap(
         topic =>
@@ -99,9 +94,7 @@ val x: Int => Int =  { y =>
   y + 1
 }
 >>>
-val x: Int => Int = { y =>
-  y + 1
-}
+val x: Int => Int = { y => y + 1 }
 <<< indent
 map(() => {
   x =>
@@ -139,8 +132,7 @@ classTag[K] match {
 call(1) { x =>
 }
 >>>
-call(1) { x =>
-}
+call(1) { x => }
 <<< #1171 comment
 call(1) { x => // nothing
 }

--- a/scalafmt-tests/src/test/resources/unit/Trait.source
+++ b/scalafmt-tests/src/test/resources/unit/Trait.source
@@ -35,9 +35,7 @@ trait Cap extends Util { self =>
     x
   }
 
-  val x: Int => Int = { y =>
-    y + 1
-  }
+  val x: Int => Int = { y => y + 1 }
 }
 <<< #370
 trait SampleTrait extends A with B with C with D with E{


### PR DESCRIPTION
The rule applies only if `newlines.afterCurlyLambda` is either `never`, or `preserve` without a line break, and abides by `newlines.alwaysBeforeCurlyBraceLambdaParams`.

Also, make sure to clarify the other space rule for lambda to break on arrow before breaking on the closing brace, so that it doesn't end up with a lone break at the end.

This is a prerequisite to adding the rewrite rule requested in #1027. Also, fixes #965.

For `alwaysBeforeCurlyBraceLambdaParams = false`:
```
  // new
  a map { x => x }
  // old
  a map { x =>
    x
  }
```
For `alwaysBeforeCurlyBraceLambdaParams = true`:
```
  // new
  a map {
    x => x
  }
  // old
  a map {
    x =>
      x
  }
```

`scala-repos` diffs:
  * forbid multiline toks in single-line block: https://github.com/kitbellew/scala-repos/commit/2daf6cae8c63eeaef01ac32f2461d1a7d6c2540b?w=1
  * allow single-line curly lambdas: https://github.com/kitbellew/scala-repos/commit/2f5c04590797971b908c9908866cb32c91ca9d41?w=1