### PR TITLE
Minor improvements to split, decision and policy logic

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -8,24 +8,26 @@ package org.scalafmt.internal
 case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
   import org.scalafmt.util.TokenOps._
 
-  def noNewlines: Decision =
-    Decision(formatToken, splits.filterNot(_.modification.isNewline))
+  def noNewlines: Seq[Split] =
+    splits.filterNot(_.modification.isNewline)
 
-  def onlyNewlinesWithFallback(default: => Split): Decision = {
+  def onlyNewlinesWithFallback(default: => Split): Seq[Split] = {
     val filtered = onlyNewlineSplits
-    Decision(formatToken, if (filtered.nonEmpty) filtered else Seq(default))
+    if (filtered.nonEmpty) filtered else Seq(default)
   }
 
-  def forceNewline: Decision =
+  def forceNewline: Seq[Split] =
     if (isAttachedSingleLineComment(formatToken))
-      this
+      splits
     else
       onlyNewlinesWithoutFallback
 
-  def onlyNewlinesWithoutFallback: Decision =
-    Decision(formatToken, onlyNewlineSplits)
+  def onlyNewlinesWithoutFallback: Seq[Split] =
+    onlyNewlineSplits
 
   private def onlyNewlineSplits: Seq[Split] =
     splits.filter(_.modification.isNewline)
+
+  def withSplits(splits: Seq[Split]): Decision = copy(splits = splits)
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -761,7 +761,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
   def delayedBreakPolicy(
       leftCheck: Option[Token => Boolean]
-  )(onBreakPolicy: Policy): Policy = {
+  )(onBreakPolicy: Policy)(implicit line: sourcecode.Line): Policy = {
     object OnBreakDecision {
       def unapply(d: Decision): Option[Seq[Split]] =
         if (leftCheck.exists(!_(d.formatToken.left))) None

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -1,23 +1,17 @@
 package org.scalafmt.internal
 
 sealed abstract class Modification {
-
-  def isNewline: Boolean = this match {
-    case _: NewlineT => true
-    case Provided(code) if code.headOption == Some('\n') => true
-    case _ => false
-  }
-
-  def newlines: Int = this match {
-    case n: NewlineT => if (n.isDouble) 2 else 1
-    case Provided(code) => code.count(_ == '\n')
-    case _ => 0
-  }
+  val newlines: Int
+  @inline final def isNewline: Boolean = newlines != 0
 }
 
-case class Provided(code: String) extends Modification
+case class Provided(code: String) extends Modification {
+  override lazy val newlines: Int = code.count(_ == '\n')
+}
 
-case object NoSplit extends Modification
+case object NoSplit extends Modification {
+  override val newlines: Int = 0
+}
 
 /**
   * A split representing a newline.
@@ -40,6 +34,7 @@ case class NewlineT(
     val indent = if (noIndent) "NoIndent" else ""
     double + indent + "Newline"
   }
+  override val newlines: Int = if (isDouble) 2 else 1
 }
 
 object Newline extends NewlineT {
@@ -53,5 +48,6 @@ object NoIndentNewline extends NewlineT(noIndent = true)
 object Newline2xNoIndent extends NewlineT(isDouble = true, noIndent = true)
 
 object Space extends Modification {
+  override val newlines: Int = 0
   override def toString = "Space"
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -34,12 +34,12 @@ case class Policy(
     other.fold(this)(orElse)
 
   def andThen(other: Policy): Policy =
-    if (isEmpty) other else andThen(other.f)
+    if (isEmpty) other else andThen(other.f, other.expire)
 
   /** Similar to PartialFunction.andThen, except applies second pf even if the
     * first pf is not defined at argument.
     */
-  def andThen(otherF: Policy.Pf): Policy = {
+  def andThen(otherF: Policy.Pf, minExpire: Int = 0): Policy = {
     if (Policy.isEmpty(otherF)) this
     else if (isEmpty) copy(f = otherF)
     else {
@@ -51,7 +51,7 @@ case class Policy(
             (x: Decision) => x.splits
           )
       }
-      copy(f = newPf)
+      copy(f = newPf, expire = math.max(minExpire, expire))
     }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -2,8 +2,6 @@ package org.scalafmt.internal
 
 import scala.meta.tokens.Token
 
-import org.scalafmt.Error.NoopDefaultPolicyApplied
-
 /**
   * The decision made by [[Router]].
   *
@@ -49,8 +47,8 @@ case class Policy(
       val newPf: Policy.Pf = {
         case x =>
           otherF.applyOrElse(
-            f.applyOrElse(x, identity[Decision]),
-            identity[Decision]
+            f.andThen(x.withSplits _).applyOrElse(x, identity[Decision]),
+            (x: Decision) => x.splits
           )
       }
       copy(f = newPf)
@@ -62,7 +60,7 @@ case class Policy(
 
 object Policy {
 
-  type Pf = PartialFunction[Decision, Decision]
+  type Pf = PartialFunction[Decision, Seq[Split]]
 
   val emptyPf: Pf = PartialFunction.empty
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -595,8 +595,8 @@ class Router(formatOps: FormatOps) {
         val indent = getApplyIndent(leftOwner, isConfigStyle = true)
         val close = matching(open)
         val newlineBeforeClose: Policy.Pf = {
-          case Decision(t @ FormatToken(_, `close`, _), splits) =>
-            Decision(t, Seq(Split(Newline, 0)))
+          case Decision(FormatToken(_, `close`, _), _) =>
+            Seq(Split(Newline, 0))
         }
         val extraIndent: Length =
           if (style.poorMansTrailingCommasInConfigStyle) Num(2)
@@ -1148,7 +1148,7 @@ class Router(formatOps: FormatOps) {
                 if (style.optIn.breaksInsideChains && t.newlinesBetween == 0)
                   NoSplit
                 else Newline
-              Decision(t, Seq(Split(mod, 1)))
+              Seq(Split(mod, 1))
           },
           expire.end
         )
@@ -1395,11 +1395,10 @@ class Router(formatOps: FormatOps) {
       case FormatToken(open @ T.LeftParen(), right, _) =>
         val owner = owners(open)
         val isConfig = opensConfigStyle(formatToken)
-        val isSuperfluous = isSuperfluousParenthesis(open, owner)
         val close = matching(open)
         val breakOnClose = Policy({
-          case Decision(t @ FormatToken(_, `close`, _), s) =>
-            Decision(t, Seq(Split(Newline, 0)))
+          case Decision(FormatToken(_, `close`, _), _) =>
+            Seq(Split(Newline, 0))
         }, close.end)
         val indent: Length = right match {
           case T.KwIf() => StateColumn

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -77,9 +77,14 @@ case class Split(
     newPolicy.fold(this)(withPolicy)
 
   def orElsePolicy(newPolicy: Policy): Split =
-    if (NoPolicy == newPolicy) this
-    else if (NoPolicy == policy) copy(policy = newPolicy)
+    if (newPolicy.isEmpty) this
+    else if (policy.isEmpty) copy(policy = newPolicy)
     else copy(policy = policy.orElse(newPolicy))
+
+  def andThenPolicy(newPolicy: Policy): Split =
+    if (newPolicy.isEmpty) this
+    else if (policy.isEmpty) copy(policy = newPolicy)
+    else copy(policy = policy.andThen(newPolicy))
 
   def withPenalty(penalty: Int): Split =
     copy(cost = cost + penalty, penalty = true)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -150,7 +150,7 @@ object TokenOps {
               exclude.forall(!_.contains(tok.left.start)) &&
               (disallowSingleLineComments || !isSingleLineComment(tok.left)) =>
           if (penaliseNewlinesInsideTokens && tok.leftHasNewline) {
-            Decision(tok, Seq.empty[Split])
+            Seq.empty
           } else {
             d.noNewlines
           }


### PR DESCRIPTION
* Policy: return just the splits in the partial func
  * the point of a policy is to narrow down the set of splits, there's no need to duplicate the logic of building up an object which contains the input format token and can then be fed into another policy
* Policy: make sure to extend expire in andThen
  * combining two policies would occasionally fail since the expiration point of the second one was ignored
* Modification: optimize/cache newlines computation
  * minor performance