### PR TITLE
RedundantBraces: update method body rewrite rules

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -68,6 +68,9 @@ case object RedundantBraces extends Rewrite {
       case t: Term.Apply if ctx.style.activeForEdition_2019_11 =>
         processApply(t)
 
+      case t: Init if ctx.style.activeForEdition_2020_01 =>
+        processInit(t)
+
       case b: Term.Block =>
         processBlock(b)
 
@@ -75,6 +78,11 @@ case object RedundantBraces extends Rewrite {
         processInterpolation(t)
     }
   }
+
+  private def processInit(
+      tree: Init
+  )(implicit ctx: RewriteCtx): Unit =
+    tree.argss.foreach(processMultiArgApply)
 
   private def processApply(
       tree: Term.Apply

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -224,7 +224,7 @@ case object RedundantBraces extends Rewrite {
         !disqualifiedByUnit
 
       case p: Term.Function
-          if ctx.style.activeForEdition_2019_11 && isBlockFunction(p) =>
+          if ctx.style.activeForEdition_2019_11 && isFunctionWithBraces(p) =>
         settings.methodBodies
 
       case _ =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -263,7 +263,7 @@ case object RedundantBraces extends Rewrite {
         case p: Term.ApplyInfix =>
           stat match {
             case _: Term.ApplyInfix =>
-              val useRight = p.args.lengthCompare(1) == 0 && (p.args.head eq b)
+              val useRight = isSingleElement(p.args, b)
               SyntacticGroupOps.groupNeedsParenthesis(
                 TreeSyntacticGroup(p),
                 TreeSyntacticGroup(stat),

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -105,7 +105,7 @@ case object RedundantBraces extends Rewrite {
     // a(b => { c; d }) change to a { b => c; d }
     case f: Term.Function
         if settings.methodBodies && f.tokens.last.is[Token.RightBrace] &&
-          getTermLineSpan(f) > 0 =>
+          (ctx.style.activeForEdition_2020_01 || getTermLineSpan(f) > 0) =>
       val rbrace = f.tokens.last
       val lbrace = ctx.matchingParens(TokenOps.hash(rbrace))
       // we really wanted the first token of body but Block usually

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -80,7 +80,7 @@ case object RedundantBraces extends Rewrite {
       tree: Term.Apply
   )(implicit ctx: RewriteCtx): Unit = {
     val lastToken = tree.tokens.last
-    if (settings.methodBodies && lastToken.is[Token.RightParen]) {
+    if (lastToken.is[Token.RightParen]) {
       tree.args match {
         case Nil =>
         case List(arg) => processSingleArgApply(arg, lastToken)
@@ -96,7 +96,8 @@ case object RedundantBraces extends Rewrite {
     // single-arg apply of a lambda
     // a(b => { c; d }) change to a { b => c; d }
     case f: Term.Function
-        if f.tokens.last.is[Token.RightBrace] && getTermLineSpan(f) > 0 =>
+        if settings.methodBodies && f.tokens.last.is[Token.RightBrace] &&
+          getTermLineSpan(f) > 0 =>
       val rbrace = f.tokens.last
       val lbrace = ctx.matchingParens(TokenOps.hash(rbrace))
       // we really wanted the first token of body but Block usually
@@ -121,7 +122,7 @@ case object RedundantBraces extends Rewrite {
     // a single-stat lambda with braces can be converted to one without braces,
     // but the reverse conversion isn't always possible
     case fun @ Term.Function(_, body)
-        if fun.tokens.last.is[Token.RightBrace] &&
+        if settings.methodBodies && fun.tokens.last.is[Token.RightBrace] &&
           isSingleStatLineSpanOk(body) =>
       val rbrace = fun.tokens.last
       val lbrace = ctx.matchingParens(TokenOps.hash(rbrace))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -67,6 +67,12 @@ object TreeOps {
       case _ => false
     }
 
+  def isFunctionWithBraces(fun: Term.Function): Boolean =
+    fun.parent match {
+      case Some(b: Term.Block) => isSingleElement(b.stats, fun)
+      case _ => false
+    }
+
   def extractStatementsIfAny(tree: Tree): Seq[Tree] = tree match {
     case b: Term.Block => b.stats
     case b: Term.Function if isBlockFunction(b) => b.body :: Nil

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -59,14 +59,12 @@ object TreeOps {
     ret.result()
   }
 
+  @tailrec
   def isBlockFunction(fun: Term.Function): Boolean =
-    fun.parent.exists {
-      case b: Term.Block =>
-        b.stats.lengthCompare(1) == 0 && b.stats.head.eq(fun)
-      case next: Term.Function =>
-        isBlockFunction(next)
-      case _ =>
-        false
+    fun.parent match {
+      case Some(b: Term.Block) => isSingleElement(b.stats, fun)
+      case Some(next: Term.Function) => isBlockFunction(next)
+      case _ => false
     }
 
   def extractStatementsIfAny(tree: Tree): Seq[Tree] = tree match {
@@ -548,5 +546,8 @@ object TreeOps {
         Some(fun)
       case _ => None
     }
+
+  def isSingleElement(elements: List[Tree], value: Tree): Boolean =
+    elements.lengthCompare(1) == 0 && (value eq elements.head)
 
 }

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -214,15 +214,14 @@ def test(dataFrame: DataFrame) = {
 
   dataFrame.rdd
     .aggregate(zeroAccumulator)(
-      { (acc, row) =>
+      (acc, row) =>
         acc.zip(row.toSeq).map {
           case (x, y) => {
             if (true) (1, 2)
             else (x._1 + 2, x._2 + 1)
           }
-        }
-      },
-      { (acc1, acc2) => acc1.zip(acc2).map { case (x, y) => (x._1 + y._1, x._2 + y._2) } }
+        },
+      (acc1, acc2) => acc1.zip(acc2).map { case (x, y) => (x._1 + y._1, x._2 + y._2) }
     )
     .map { case (sum, count) => sum }
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -126,5 +126,5 @@ object a {
 }
 >>>
 object a {
-  val a = b { c => d => e; f }
+  val a = b { c => d => { e; f } }
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -81,7 +81,7 @@ object a {
 }
 >>>
 object a {
-  val a = b(c => { d; e })
+  val a = b { c => d; e }
 }
 <<< #1237 7 apply single multi-stat with semicolon and newline
 object a {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -120,3 +120,11 @@ object a {
   val a = b { c => { d
    e}}
 }
+<<< look only for immediate braces around lambda
+object a {
+  val a = b { c => d => { e; f } }
+}
+>>>
+object a {
+  val a = b { c => d => e; f }
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -1,13 +1,13 @@
 rewrite.rules = [RedundantBraces]
 rewrite.redundantBraces.methodBodies = true
 rewrite.redundantBraces.maxLines = 1
-<<< #1237 1 ctor is untouched
+<<< #1237 1 ctor is treated as multi-stat
 object a {
-  val a = new b(c => { d })
+  val a = new b(c => { d })(c => {d}, c => { d; e })
 }
 >>>
 object a {
-  val a = new b(c => { d })
+  val a = new b(c => d)(c => d, c => { d; e })
 }
 <<< #1237 2 apply single-stat with comments
 object a {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -548,7 +548,7 @@ object a {
 }
 >>>
 object a {
-  b({ 1 + 2 }, { x => { y; z } })({ x => y }, { x; y })
+  b(1 + 2, x => { y; z })(x => y, { x; y })
 }
 <<< apply 2: single-stat block as an apply arg
 rewrite.redundantBraces.methodBodies = true
@@ -559,5 +559,5 @@ object a {
 }
 >>>
 object a {
-  b({ 1 + 2 }, { x => y; z })({ x => y }, { x; y })
+  b(1 + 2, { x => y; z })(x => y, { x; y })
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -539,3 +539,25 @@ object a {
     e => f
   )
 }
+<<< apply 1: single-stat block as an apply arg
+rewrite.redundantBraces.methodBodies = false
+===
+object a {
+  b({ 1 + 2 },
+    { x => { y; z }})({ x => y }, { x; y })
+}
+>>>
+object a {
+  b({ 1 + 2 }, { x => { y; z } })({ x => y }, { x; y })
+}
+<<< apply 2: single-stat block as an apply arg
+rewrite.redundantBraces.methodBodies = true
+===
+object a {
+  b({ 1 + 2 },
+    { x => { y; z }})({ x => y }, { x; y })
+}
+>>>
+object a {
+  b({ 1 + 2 }, { x => y; z })({ x => y }, { x; y })
+}


### PR DESCRIPTION
Follow-on to #1660.

`scala-repos` diffs:
* RedundantBraces: treat ctor as a multi-arg apply: https://github.com/kitbellew/scala-repos/commit/431b849b502d3210a9bbfdfbe2351f378b9ad6ac?w=1
* RedundantBraces: rewrite single-line lambdas: https://github.com/kitbellew/scala-repos/commit/10b83aea95471cb7adffa5317472a7f10157776d?w=1
* RedundantBraces: remove block around an (argument): https://github.com/kitbellew/scala-repos/commit/cb746698aa3d2f53826f8df721ad9cbf2b2add57?w=1