### PR TITLE
RedundantBraces: use () for {} one-line lambdas

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -259,23 +259,11 @@ case object RedundantBraces extends Rewrite {
   private def isSingleStatLineSpanOk(
       b: Term
   )(implicit ctx: RewriteCtx): Boolean =
-    b match {
-      case b: Term.Block => getSingleStatIfLineSpanOk(b).isDefined
-      case _ => getTermLineSpan(b) <= settings.maxLines
-    }
+    getTermSingleStat(b).exists(getTermLineSpan(_) <= settings.maxLines)
 
   private def getSingleStatIfLineSpanOk(
       b: Term.Block
   )(implicit ctx: RewriteCtx): Option[Stat] =
-    if (b.stats.lengthCompare(1) != 0) None
-    else {
-      val s = b.stats.head
-      val spanOk = (s.pos.endLine - s.pos.startLine) <= settings.maxLines
-      if (spanOk) Some(s) else None
-    }
-
-  private def getTermLineSpan(b: Term)(implicit ctx: RewriteCtx): Int =
-    if (b.tokens.isEmpty) 0
-    else b.tokens.last.pos.endLine - b.tokens.head.pos.startLine
+    getBlockSingleStat(b).filter(getTermLineSpan(_) <= settings.maxLines)
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -13,6 +13,7 @@ import scala.meta.Mod
 import scala.meta.Pat
 import scala.meta.Pkg
 import scala.meta.Source
+import scala.meta.Stat
 import scala.meta.Template
 import scala.meta.Term
 import scala.meta.Tree
@@ -555,5 +556,20 @@ object TreeOps {
 
   def isSingleElement(elements: List[Tree], value: Tree): Boolean =
     elements.lengthCompare(1) == 0 && (value eq elements.head)
+
+  def getBlockSingleStat(b: Term.Block): Option[Stat] =
+    if (b.stats.lengthCompare(1) != 0) None else Some(b.stats.head)
+
+  def getTermSingleStat(t: Term): Option[Tree] = t match {
+    case b: Term.Block => getBlockSingleStat(b)
+    case _ => Some(t)
+  }
+
+  def getTermLineSpan(b: Tree): Int =
+    if (b.tokens.isEmpty) 0
+    else {
+      val pos = b.pos
+      pos.endLine - pos.startLine
+    }
 
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -126,5 +126,5 @@ object a {
 }
 >>>
 object a {
-  val a = b { c => d => { e; f } }
+  val a = b(c => d => { e; f })
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -239,6 +239,175 @@ object a {
     4
   }
 }
+<<< #1027 1.1: braces to parens yes: single-stat
+object a {
+  b.c { d =>
+   e }
+}
+>>>
+object a {
+  b.c { d => e }
+}
+<<< #1027 1.2: braces to parens no: multi-stat
+object a {
+  b.c { d =>
+   e; f }
+}
+>>>
+object a {
+  b.c { d => e; f }
+}
+<<< #1027 1.3: braces to parens no: multi-stat block
+object a {
+  b.c { d => {
+   e; f }}
+}
+>>>
+object a {
+  b.c { d => e; f }
+}
+<<< #1027 1.4: braces to parens no: empty body
+object a {
+  b.c { d => }
+}
+>>>
+object a {
+  b.c { d => }
+}
+<<< #1027 1.5: braces to parens yes: multi-param list
+object a {
+  b.c(d) { e => f }
+}
+>>>
+object a {
+  b.c(d) { e => f }
+}
+<<< #1027 1.6: braces to parens yes: func of func
+object a {
+  b.c(d) { implicit e => f => g }
+}
+>>>
+object a {
+  b.c(d) { implicit e => f => g }
+}
+<<< #1027 1.7: braces to parens yes: func of infix
+object a {
+  b.c(d) { implicit e => f shouldBe g }
+}
+>>>
+object a {
+  b.c(d) { implicit e => f shouldBe g }
+}
+<<< #1027 1.8: braces to parens yes: multiple brace single-arg param-lists
+object a {
+  b.c(d) { e } { implicit f => g }
+}
+>>>
+object a {
+  b.c(d) { e } { implicit f => g }
+}
+<<< #1027 1.9: braces to parens yes: func of multi-stat func
+object a {
+  b.c { d => e => { f; g } }
+}
+>>>
+object a {
+  b.c { d => e => { f; g } }
+}
+<<< #1027 2.1: parens to braces no
+object a {
+  b.c (d =>
+    e
+     + f)
+}
+>>>
+object a {
+  b.c(d =>
+    e
+      + f
+  )
+}
+<<< #1027 2.2: parens to braces no
+object a {
+  b.c ({d =>    e     + f})
+}
+>>>
+object a {
+  b.c({ d => e + f })
+}
+<<< #1027 3.1: with align
+align = more
+===
+object a {
+  val b = c(d => {e}) // comment1
+  val bb = cc(dd => {ee}) // comment2
+}
+>>>
+object a {
+  val b  = c { d => e }    // comment1
+  val bb = cc { dd => ee } // comment2
+}
+<<< #1027 3.2: with align
+align = more
+===
+object a {
+  val b = c(d => {e}) // comment1
+  val bb = cc(dd => ee) // comment2
+}
+>>>
+object a {
+  val b  = c { d => e } // comment1
+  val bb = cc(dd => ee) // comment2
+}
+<<< #1027 3.3: with align
+align = more
+===
+object a {
+  val b = c(d => {e})(d => {e}) // comment1
+  val bb = cc(dd => {ee})(dd => {ee}) // comment2
+}
+>>>
+object a {
+  val b  = c { d => e } { d => e }      // comment1
+  val bb = cc { dd => ee } { dd => ee } // comment2
+}
+<<< #1027 3.4: with align
+align = more
+===
+object a {
+  val b = c(d => {e})(d => {e}) // comment1
+  val bb = cc(dd => ee)(dd => ee) // comment2
+}
+>>>
+object a {
+  val b  = c { d => e } { d => e } // comment1
+  val bb = cc(dd => ee)(dd => ee)  // comment2
+}
+<<< #1027 3.5: with align
+align = more
+===
+object a {
+  val b = c(d => e)(d => e) // comment1
+  val bb = cc(dd => {ee})(dd => {ee(ff =>{gg})}) // comment2
+}
+>>>
+object a {
+  val b  = c(d => e)(d => e)                         // comment1
+  val bb = cc { dd => ee } { dd => ee { ff => gg } } // comment2
+}
+<<< #1027 3.6: with align, no redundant braces
+rewrite.rules = []
+align = more
+===
+object a {
+  val b  = c(d => e)(d => e) // comment1
+  val bb = cc(dd => {ee})(dd => {ee}) // comment2
+}
+>>>
+object a {
+  val b  = c(d => e)(d => e)              // comment1
+  val bb = cc(dd => { ee })(dd => { ee }) // comment2
+}
 <<< #1631
 class Test extends AnyWordSpec {
   "SUT" when {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -246,7 +246,7 @@ object a {
 }
 >>>
 object a {
-  b.c { d => e }
+  b.c(d => e)
 }
 <<< #1027 1.2: braces to parens no: multi-stat
 object a {
@@ -280,7 +280,7 @@ object a {
 }
 >>>
 object a {
-  b.c(d) { e => f }
+  b.c(d)(e => f)
 }
 <<< #1027 1.6: braces to parens yes: func of func
 object a {
@@ -288,7 +288,7 @@ object a {
 }
 >>>
 object a {
-  b.c(d) { implicit e => f => g }
+  b.c(d)(implicit e => f => g)
 }
 <<< #1027 1.7: braces to parens yes: func of infix
 object a {
@@ -296,7 +296,7 @@ object a {
 }
 >>>
 object a {
-  b.c(d) { implicit e => f shouldBe g }
+  b.c(d)(implicit e => f shouldBe g)
 }
 <<< #1027 1.8: braces to parens yes: multiple brace single-arg param-lists
 object a {
@@ -304,7 +304,7 @@ object a {
 }
 >>>
 object a {
-  b.c(d) { e } { implicit f => g }
+  b.c(d)(e)(implicit f => g)
 }
 <<< #1027 1.9: braces to parens yes: func of multi-stat func
 object a {
@@ -312,7 +312,7 @@ object a {
 }
 >>>
 object a {
-  b.c { d => e => { f; g } }
+  b.c(d => e => { f; g })
 }
 <<< #1027 2.1: parens to braces no
 object a {
@@ -344,8 +344,8 @@ object a {
 }
 >>>
 object a {
-  val b  = c { d => e }    // comment1
-  val bb = cc { dd => ee } // comment2
+  val b  = c(d => e)    // comment1
+  val bb = cc(dd => ee) // comment2
 }
 <<< #1027 3.2: with align
 align = more
@@ -356,7 +356,7 @@ object a {
 }
 >>>
 object a {
-  val b  = c { d => e } // comment1
+  val b  = c(d => e)    // comment1
   val bb = cc(dd => ee) // comment2
 }
 <<< #1027 3.3: with align
@@ -368,8 +368,8 @@ object a {
 }
 >>>
 object a {
-  val b  = c { d => e } { d => e }      // comment1
-  val bb = cc { dd => ee } { dd => ee } // comment2
+  val b  = c(d => e)(d => e)      // comment1
+  val bb = cc(dd => ee)(dd => ee) // comment2
 }
 <<< #1027 3.4: with align
 align = more
@@ -380,8 +380,8 @@ object a {
 }
 >>>
 object a {
-  val b  = c { d => e } { d => e } // comment1
-  val bb = cc(dd => ee)(dd => ee)  // comment2
+  val b  = c(d => e)(d => e)      // comment1
+  val bb = cc(dd => ee)(dd => ee) // comment2
 }
 <<< #1027 3.5: with align
 align = more
@@ -392,8 +392,8 @@ object a {
 }
 >>>
 object a {
-  val b  = c(d => e)(d => e)                         // comment1
-  val bb = cc { dd => ee } { dd => ee { ff => gg } } // comment2
+  val b  = c(d => e)(d => e)                // comment1
+  val bb = cc(dd => ee)(dd => ee(ff => gg)) // comment2
 }
 <<< #1027 3.6: with align, no redundant braces
 rewrite.rules = []
@@ -445,7 +445,7 @@ class Test extends AnyWordSpec {
     formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) {
       (firstName, age, sex, vip) ⇒ complete(firstName + age + sex + vip)
     }
-  } ~> check { responseAs[String] shouldEqual "Mike42Nonefalse" }
+  } ~> check(responseAs[String] shouldEqual "Mike42Nonefalse")
 }
 <<< #1633 1.2: func with placeholder and select
 object a {
@@ -557,7 +557,7 @@ object a {
 }
 >>>
 object a {
-  b getOrElse { c.d { e } }
+  b getOrElse { c.d(e) }
 }
 <<< #1633 3.3: function block in a val statement
 object a {
@@ -689,7 +689,7 @@ object a {
 }
 >>>
 object a {
-  val b = c { d => e } // comment1
+  val b = c(d => e) // comment1
   /* comment2 */
   /* comment3 */
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
@@ -37,11 +37,11 @@ object a {
       iv: Option[String]
   ): dim.MerchantDna =
     dim.MerchantDna(
-      primaryRecurPeriod = subsDna.flatMap { _.primary },
-      weekly = subsDna.map { _.weekly }.getOrElse(false),
-      monthly = subsDna.map { _.monthly }.getOrElse(false),
-      quarterly = subsDna.map { _.quarterly }.getOrElse(false),
-      annual = subsDna.map { _.annual }.getOrElse(false),
+      primaryRecurPeriod = subsDna.flatMap(_.primary),
+      weekly = subsDna.map(_.weekly).getOrElse(false),
+      monthly = subsDna.map(_.monthly).getOrElse(false),
+      quarterly = subsDna.map(_.quarterly).getOrElse(false),
+      annual = subsDna.map(_.annual).getOrElse(false),
       platformConnectUsage = cu,
       industryVertical = iv
     )


### PR DESCRIPTION
Output a single-line { a => b } as (a => b), as mentioned in #1027.

`scala-repos` diff: https://github.com/kitbellew/scala-repos/commit/1ba9dbff2ae0c1f977191b64725d3c6f9e180fd4?w=1

NB: We can't easily do the opposite, formatting multi-line paren lambdas using braces, it can sometimes lead to incorrect code:
```
  a(x =>
    1
    + 2)
```
is the same as
```
  a { x =>
    1 +
    2
  }
```
but not
```
a { x =>
  1
  +2
}
```