### PR TITLE
RedundantParens: rewrite single-arg apply of block

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
@@ -1,6 +1,6 @@
 package org.scalafmt.rewrite
 
-import org.scalafmt.util.{TokenOps, Whitespace}
+import org.scalafmt.util.Whitespace
 
 import scala.meta.tokens.Tokens
 import scala.meta._
@@ -35,7 +35,7 @@ case object PreferCurlyFors extends Rewrite {
         case Whitespace() => None
         case _ => Some(false)
       }
-      rightParen <- ctx.matchingParens.get(TokenOps.hash(leftParen))
+      rightParen <- ctx.getMatchingOpt(leftParen)
     } yield (leftParen, rightParen)
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -9,7 +9,6 @@ import scala.meta.tokens.Token.LF
 import scala.meta.tokens.Token.LeftBrace
 import scala.meta.tokens.Token.RightBrace
 
-import org.scalafmt.util.TokenOps
 import org.scalafmt.util.TreeOps._
 import org.scalafmt.util.Whitespace
 
@@ -107,11 +106,11 @@ case object RedundantBraces extends Rewrite {
         if settings.methodBodies && f.tokens.last.is[Token.RightBrace] &&
           (ctx.style.activeForEdition_2020_01 || getTermLineSpan(f) > 0) =>
       val rbrace = f.tokens.last
-      val lbrace = ctx.matchingParens(TokenOps.hash(rbrace))
+      val lbrace = ctx.getMatching(rbrace)
       // we really wanted the first token of body but Block usually
       // points to the next non-whitespace token after opening brace
       if (lbrace.start <= f.body.tokens.head.start) {
-        val lparen = ctx.matchingParens(TokenOps.hash(rparen))
+        val lparen = ctx.getMatching(rparen)
         implicit val builder = Seq.newBuilder[TokenPatch]
         builder += TokenPatch.Replace(lparen, lbrace.text)
         builder += TokenPatch.Remove(lbrace)
@@ -133,7 +132,7 @@ case object RedundantBraces extends Rewrite {
         if settings.methodBodies && fun.tokens.last.is[Token.RightBrace] &&
           isSingleStatLineSpanOk(body) =>
       val rbrace = fun.tokens.last
-      val lbrace = ctx.matchingParens(TokenOps.hash(rbrace))
+      val lbrace = ctx.getMatching(rbrace)
       if (lbrace.start <= body.tokens.head.start) {
         implicit val builder = Seq.newBuilder[TokenPatch]
         builder += TokenPatch.Remove(lbrace)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -27,6 +27,21 @@ case object RedundantParens extends Rewrite {
             case _ =>
           }
         }
+
+      case t @ Term.Apply(_, List(b: Term.Block))
+          if ctx.style.activeForEdition_2020_01 &&
+            b.tokens.headOption.exists(_.is[Token.LeftBrace]) =>
+        t.tokens.lastOption.filter(_.is[RightParen]).foreach { rparen =>
+          ctx.getMatchingOpt(rparen).foreach { lparen =>
+            implicit val builder = Seq.newBuilder[TokenPatch]
+            builder += TokenPatch.Remove(lparen)
+            builder += TokenPatch.Remove(rparen)
+            ctx.removeLFToAvoidEmptyLine(lparen)
+            ctx.removeLFToAvoidEmptyLine(rparen)
+            ctx.addPatchSet(builder.result(): _*)
+          }
+        }
+
     }
   }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -20,8 +20,14 @@ case class RewriteCtx(
   val tokenTraverser = new TokenTraverser(tokens)
   val matchingParens = TreeOps.getMatchingParentheses(tokens)
 
-  def isMatching(a: Token, b: Token) =
-    matchingParens.get(TokenOps.hash(a)).contains(b)
+  @inline def getMatching(a: Token): Token =
+    matchingParens(TokenOps.hash(a))
+
+  @inline def getMatchingOpt(a: Token): Option[Token] =
+    matchingParens.get(TokenOps.hash(a))
+
+  @inline def isMatching(a: Token, b: Token) =
+    getMatchingOpt(a).contains(b)
 
   def applyPatches: String =
     tokens.toIterator

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -112,7 +112,7 @@ object a {
 }
 >>>
 object a {
-  a({ b => c })
+  a { b => c }
 }
 <<< single-arg apply of a block 2
 object a {
@@ -120,7 +120,7 @@ object a {
 }
 >>>
 object a {
-  a({ b; c })
+  a { b; c }
 }
 <<< single-arg apply of a block 3
 object a {
@@ -131,7 +131,5 @@ object a {
 }
 >>>
 object a {
-  (
-    a { b; c }
-  )
+  a { b; c }
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -106,3 +106,32 @@ object a {
 object a {
   b match { case _ if ((a) || (a)) => b }
 }
+<<< single-arg apply of a block 1
+object a {
+  a({ b => c })
+}
+>>>
+object a {
+  a({ b => c })
+}
+<<< single-arg apply of a block 2
+object a {
+  a({ b; c })
+}
+>>>
+object a {
+  a({ b; c })
+}
+<<< single-arg apply of a block 3
+object a {
+  (
+  a
+   { b; c }
+   )
+}
+>>>
+object a {
+  (
+    a { b; c }
+  )
+}


### PR DESCRIPTION
Fixes #1321.

Rewrites `a({ b })` and `(a { b })` as `a { b }` (both are considered a single-arg `Apply` of a `Block`).

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/90e2f8b23ea114c5e15f0c7e8b9b1b2833f58121?w=1