### PR TITLE
Router: treat single-arg lambda of init like apply

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -551,8 +551,8 @@ class Router(formatOps: FormatOps) {
       case FormatToken(T.LeftParen(), _, _)
           if style.optIn.configStyleArguments &&
             !style.newlinesBeforeSingleArgParenLambdaParams &&
-            getLambdaAtSingleArgCallSite(leftOwner).isDefined => {
-        val lambda = getLambdaAtSingleArgCallSite(leftOwner).get
+            getLambdaAtSingleArgCallSite(leftOwner, rightOwner).isDefined => {
+        val lambda = getLambdaAtSingleArgCallSite(leftOwner, rightOwner).get
         val lambdaLeft: Option[Token] =
           matchingOpt(functionExpire(lambda)._1).filter(_.is[T.LeftBrace])
 

--- a/scalafmt-tests/src/test/resources/default/Super.stat
+++ b/scalafmt-tests/src/test/resources/default/Super.stat
@@ -7,10 +7,9 @@ foo.super.x()
       @enableIf(c => !c.compilerSettings.exists(_.matches("""^-Xplugin:.*scalajs-compiler_[0-9\.\-]*\.jar$""")))
       def javafxTyper[A]: PropertyTyper[A] = macro Macros.javafxTyper[A]
 >>>
-@enableIf(
-    c =>
-      !c.compilerSettings.exists(
-          _.matches("""^-Xplugin:.*scalajs-compiler_[0-9\.\-]*\.jar$""")))
+@enableIf(c =>
+  !c.compilerSettings.exists(
+      _.matches("""^-Xplugin:.*scalajs-compiler_[0-9\.\-]*\.jar$""")))
 def javafxTyper[A]: PropertyTyper[A] = macro Macros.javafxTyper[A]
 <<< #671
 def this(a: Int) = {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -629,3 +629,54 @@ val f = {
         e
       })
 }
+<<< init: keep single-arg-ctor lambda param on first line 1
+object a {
+  class b extends c(
+  _ => d({
+    e
+    f
+    }))
+}
+>>>
+object a {
+  class b
+      extends c(_ =>
+        d({
+          e
+          f
+        }))
+}
+<<< init: keep single-arg-ctor lambda param on first line 2
+object a {
+  class b extends c( _ => d({
+    e
+    f
+    }))
+}
+>>>
+object a {
+  class b
+      extends c(_ =>
+        d({
+          e
+          f
+        }))
+}
+<<< init: ignore multi-arg-ctor lambda param 3
+object a {
+  class b extends c( _ => d({
+    e
+    f
+    }), _ => e)
+}
+>>>
+object a {
+  class b
+      extends c(
+        _ =>
+          d({
+            e
+            f
+          }),
+        _ => e)
+}

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -648,3 +648,59 @@ val f = {
         e
       })
 }
+<<< init: keep single-arg-ctor lambda param on first line 1
+object a {
+  class b extends c(
+  _ => d({
+    e
+    f
+    }))
+}
+>>>
+object a {
+  class b
+      extends c(
+        _ =>
+          d({
+            e
+            f
+          })
+      )
+}
+<<< init: keep single-arg-ctor lambda param on first line 2
+object a {
+  class b extends c( _ => d({
+    e
+    f
+    }))
+}
+>>>
+object a {
+  class b
+      extends c(
+        _ =>
+          d({
+            e
+            f
+          })
+      )
+}
+<<< init: ignore multi-arg-ctor lambda param 3
+object a {
+  class b extends c( _ => d({
+    e
+    f
+    }), _ => e)
+}
+>>>
+object a {
+  class b
+      extends c(
+        _ =>
+          d({
+            e
+            f
+          }),
+        _ => e
+      )
+}

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -659,12 +659,11 @@ object a {
 >>>
 object a {
   class b
-      extends c(
-        _ =>
-          d({
-            e
-            f
-          })
+      extends c(_ =>
+        d({
+          e
+          f
+        })
       )
 }
 <<< init: keep single-arg-ctor lambda param on first line 2
@@ -677,12 +676,11 @@ object a {
 >>>
 object a {
   class b
-      extends c(
-        _ =>
-          d({
-            e
-            f
-          })
+      extends c(_ =>
+        d({
+          e
+          f
+        })
       )
 }
 <<< init: ignore multi-arg-ctor lambda param 3


### PR DESCRIPTION
Just like #1551, we need to format ctor/init consistently.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/e5a3562989d7f02f4c348a0b730cc74ca9a1dfa4?w=1