### PR TITLE
Trailing commas: add a rewrite rule, remove first

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -8,8 +8,8 @@ import scala.meta.tokens.Token.LF
 
 import org.scalafmt.config.ReaderUtil
 import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.util.Whitespace
-import org.scalafmt.util.{TokenOps, TokenTraverser, TreeOps}
+import org.scalafmt.config.TrailingCommas
+import org.scalafmt.util.{TokenOps, TokenTraverser, TreeOps, Whitespace}
 
 case class RewriteCtx(
     style: ScalafmtConfig,
@@ -112,7 +112,12 @@ object Rewrite {
   }
 
   def apply(input: Input, style: ScalafmtConfig): Input = {
-    val rewrites = style.rewrite.rules
+    val trailingCommaRewrite =
+      if (!style.runner.dialect.allowTrailingCommas ||
+        style.trailingCommas == TrailingCommas.preserve) Seq.empty
+      else Seq(RewriteTrailingCommas)
+
+    val rewrites = style.rewrite.rules ++ trailingCommaRewrite
     if (rewrites.isEmpty) {
       input
     } else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
@@ -1,0 +1,87 @@
+package org.scalafmt.rewrite
+
+import scala.meta._
+import scala.meta.classifiers.Classifier
+import scala.meta.tokens.Token
+
+import org.scalafmt.util.Whitespace
+
+case object RewriteTrailingCommas extends Rewrite {
+
+  /* even if this rule is called for 'always', we'll still remove any trailing
+   * commas here, to avoid any idempotence problems caused by an extra comma,
+   * with a different AST, in a subsequent runs; in FormatWriter, we'll add
+   * them back if there is a newline before the closing bracket/paren/brace */
+  override def rewrite(implicit ctx: RewriteCtx): Unit =
+    ctx.tree.traverse {
+      case t: Importer =>
+        t.tokens.lastOption match {
+          case Some(close: Token.RightBrace) => before(close)
+          case _ =>
+        }
+
+      case t: Decl.Def => afterTParams(t.tparams); afterEachArgs(t.paramss)
+      case t: Defn.Def => afterTParams(t.tparams); afterEachArgs(t.paramss)
+      case t: Defn.Macro => afterTParams(t.tparams); afterEachArgs(t.paramss)
+      case t: Defn.Class => afterTParams(t.tparams)
+      case t: Defn.Trait => afterTParams(t.tparams)
+      case t: Ctor.Secondary => afterEachArgs(t.paramss)
+      case t: Decl.Type => afterTParams(t.tparams)
+      case t: Defn.Type => afterTParams(t.tparams)
+      case t: Type.Apply => afterArgs(t.args)
+      case t: Type.Param => afterTParams(t.tparams)
+      case t: Type.Tuple => afterArgs(t.args)
+      case t: Term.Function => afterArgs(t.params)
+      case t: Type.Function => afterArgs(t.params)
+      case t: Ctor.Primary => afterEachArgs(t.paramss)
+
+      case t: Term.Apply => afterArgs(t.args)
+      case t: Type.Apply => afterArgs(t.args)
+      case t: Pat.Extract => afterArgs(t.args)
+      case t: Pat.Tuple => afterArgs(t.args)
+      case t: Term.Tuple => afterArgs(t.args)
+      case t: Term.ApplyType => afterArgs(t.targs)
+      case t: Init => afterEachArgs(t.argss)
+
+      case _ =>
+    }
+
+  private def patch(token: Token)(implicit ctx: RewriteCtx): Unit =
+    ctx.addPatchSet(TokenPatch.Remove(token))
+
+  private def before(close: Token)(implicit ctx: RewriteCtx): Unit =
+    ctx.tokenTraverser.findBefore(close) {
+      case c: Token.Comma => patch(c); Some(false)
+      case Whitespace() | _: Token.Comment => None
+      case _ => Some(false)
+    }
+
+  private def forwardBeforeType[A](
+      start: Token
+  )(implicit ctx: RewriteCtx, cls: Classifier[Token, A]): Unit = {
+    var comma: Token.Comma = null
+    ctx.tokenTraverser.findAfter(start) {
+      case Whitespace() | _: Token.Comment => None
+      case c: Token.Comma => comma = c; None
+      case t => if (comma != null && cls(t)) patch(comma); Some(false)
+    }
+  }
+
+  private def afterTParams(
+      tparams: List[Type.Param]
+  )(implicit ctx: RewriteCtx): Unit =
+    tparams.lastOption.foreach {
+      _.tokens.lastOption.foreach(forwardBeforeType[Token.RightBracket])
+    }
+
+  private def afterArgs(args: List[Tree])(implicit ctx: RewriteCtx): Unit =
+    args.lastOption.foreach {
+      _.tokens.lastOption.foreach(forwardBeforeType[Token.RightParen])
+    }
+
+  private def afterEachArgs(
+      argss: List[List[Tree]]
+  )(implicit ctx: RewriteCtx): Unit =
+    argss.foreach(afterArgs)
+
+}

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -34,3 +34,71 @@ val t = (
   a,
   b,
 )
+<<< #1667 test various scenarios
+object a {
+  class a[
+   t1,
+   t2 // comment
+  ](a1: Int,
+    a2: Int // comment
+  )(
+    b1: String,
+    b2: String // comment
+  )(implicit
+    c1: SomeType1,
+    c2: SomeType2 // comment
+  ) {
+    def this(
+      a1: Int,
+      a2: Int // comment
+    )(
+      b1: String,
+      b2: String // comment
+    )(implicit
+      c1: SomeType1,
+      c2: SomeType2 // comment
+    ) = this(
+      a1,
+      a2 // comment
+    ) (
+      b1,
+      b2 // comment
+    )
+  }
+}
+>>>
+object a {
+  class a[
+      t1,
+      t2, // comment
+  ](
+      a1: Int,
+      a2: Int, // comment
+  )(
+      b1: String,
+      b2: String, // comment
+  )(
+      implicit
+      c1: SomeType1,
+      c2: SomeType2, // comment
+  ) {
+    def this(
+        a1: Int,
+        a2: Int, // comment
+    )(
+        b1: String,
+        b2: String, // comment
+    )(
+        implicit
+        c1: SomeType1,
+        c2: SomeType2, // comment
+    ) =
+      this(
+        a1,
+        a2, // comment
+      )(
+        b1,
+        b2, // comment
+      )
+  }
+}

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -229,3 +229,100 @@ object Foo {
       dddddddd + eeeeeeee, /* comment */
   )
 }
+<<< #1667
+maxColumn = 80
+optIn.breakChainOnFirstMethodDot = false
+===
+object Foo {
+  def foo(): Unit = {
+    aaaaaaaaaaaaaaa(c, ddddddd).map { zzzzzzzzzz =>
+      val ccccc = zz.bbbbbb(EEEEE.xxx, Schema.String).toOption.flatMap {
+        case c: Seq[String] =>
+          xxxx(c, (v: String) => s"""\\"$v\\"""")(Schema.String).map(s =>
+            Yyyyyyyyyyyyyyyy("SSSSSSS", s),
+          )
+      }
+    }.get
+  }
+}
+>>>
+Idempotency violated
+object Foo {
+  def foo(): Unit = {
+    aaaaaaaaaaaaaaa(c, ddddddd).map { zzzzzzzzzz =>
+      val ccccc = zz.bbbbbb(EEEEE.xxx, Schema.String).toOption.flatMap {
+        case c: Seq[String] =>
+          xxxx(c, (v: String) => s"""\\"$v\\"""")(Schema.String)
+            .map(s => Yyyyyyyyyyyyyyyy("SSSSSSS", s))
+      }
+    }.get
+  }
+}
+<<< #1667 test various scenarios
+object a {
+  class a[
+   t1,
+   t2 // comment
+  ](a1: Int,
+    a2: Int // comment
+  )(
+    b1: String,
+    b2: String // comment
+  )(implicit
+    c1: SomeType1,
+    c2: SomeType2 // comment
+  ) {
+    def this(
+      a1: Int,
+      a2: Int // comment
+    )(
+      b1: String,
+      b2: String // comment
+    )(implicit
+      c1: SomeType1,
+      c2: SomeType2 // comment
+    ) = this(
+      a1,
+      a2 // comment
+    ) (
+      b1,
+      b2 // comment
+    )
+  }
+}
+>>>
+object a {
+  class a[
+      t1,
+      t2, // comment
+  ](
+      a1: Int,
+      a2: Int, // comment
+  )(
+      b1: String,
+      b2: String, // comment
+  )(
+      implicit
+      c1: SomeType1,
+      c2: SomeType2, // comment
+  ) {
+    def this(
+        a1: Int,
+        a2: Int, // comment
+    )(
+        b1: String,
+        b2: String, // comment
+    )(
+        implicit
+        c1: SomeType1,
+        c2: SomeType2, // comment
+    ) =
+      this(
+        a1,
+        a2, // comment
+      )(
+        b1,
+        b2, // comment
+      )
+  }
+}

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -246,14 +246,14 @@ object Foo {
   }
 }
 >>>
-Idempotency violated
 object Foo {
   def foo(): Unit = {
     aaaaaaaaaaaaaaa(c, ddddddd).map { zzzzzzzzzz =>
       val ccccc = zz.bbbbbb(EEEEE.xxx, Schema.String).toOption.flatMap {
         case c: Seq[String] =>
-          xxxx(c, (v: String) => s"""\\"$v\\"""")(Schema.String)
-            .map(s => Yyyyyyyyyyyyyyyy("SSSSSSS", s))
+          xxxx(c, (v: String) => s"""\\"$v\\"""")(Schema.String).map(s =>
+            Yyyyyyyyyyyyyyyy("SSSSSSS", s),
+          )
       }
     }.get
   }

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
@@ -33,3 +33,71 @@ def method(
     abc: String, // abc comment
     d: String // d comment
 ) = ???
+<<< #1667 test various scenarios
+object a {
+  class a[
+   t1,
+   t2, // comment
+  ](a1: Int,
+    a2: Int    , // comment
+  )(
+    b1: String,
+    b2: String , // comment
+  )(implicit
+    c1: SomeType1,
+    c2: SomeType2 , // comment
+  ) {
+    def this(
+      a1: Int,
+      a2: Int, // comment
+    )(
+      b1: String,
+      b2: String, // comment
+    )(implicit
+      c1: SomeType1,
+      c2: SomeType2, // comment
+    ) = this(
+      a1,
+      a2, // comment
+    ) (
+      b1,
+      b2, // comment
+    )
+  }
+}
+>>>
+object a {
+  class a[
+      t1,
+      t2 // comment
+  ](
+      a1: Int,
+      a2: Int // comment
+  )(
+      b1: String,
+      b2: String // comment
+  )(
+      implicit
+      c1: SomeType1,
+      c2: SomeType2 // comment
+  ) {
+    def this(
+        a1: Int,
+        a2: Int // comment
+    )(
+        b1: String,
+        b2: String // comment
+    )(
+        implicit
+        c1: SomeType1,
+        c2: SomeType2 // comment
+    ) =
+      this(
+        a1,
+        a2 // comment
+      )(
+        b1,
+        b2 // comment
+      )
+  }
+}


### PR DESCRIPTION
In order to avoid idempotence issues triggered by modified commas at the final stage of formatting, let's remove them in the beginning to have a clean format, and append as necessary.

This rule is only applied if the TrailingCommas configuration takes one of the mutating settings, i.e. always or never.

Fixes #1667.