### PR TITLE
ScalafmtConfig bugfix: read align tokens as seq, not set

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -58,7 +58,7 @@ import metaconfig.generic.Surface
 case class Align(
     openParenCallSite: Boolean = false,
     openParenDefnSite: Boolean = false,
-    tokens: Set[AlignToken] = Set(AlignToken.caseArrow),
+    tokens: Seq[AlignToken] = Seq(AlignToken.caseArrow),
     arrowEnumeratorGenerator: Boolean = false,
     ifWhileOpenParen: Boolean = true,
     tokenCategory: Map[String, String] = Map(),
@@ -74,7 +74,7 @@ case class Align(
     )
 ) {
   implicit val reader: ConfDecoder[Align] = generic.deriveDecoder(this).noTypos
-  implicit val alignReader: ConfDecoder[Set[AlignToken]] =
+  implicit val alignReader: ConfDecoder[Seq[AlignToken]] =
     ScalafmtConfig.alignTokenReader(tokens)
 }
 
@@ -84,7 +84,7 @@ object Align {
   val none: Align = Align(
     openParenCallSite = false,
     openParenDefnSite = false,
-    tokens = Set.empty,
+    tokens = Seq.empty,
     ifWhileOpenParen = false,
     tokenCategory = Map.empty,
     treeCategory = Map.empty

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
@@ -29,7 +29,7 @@ object AlignToken {
       case els => fallbackAlign.reader.read(els)
     }
 
-  val default = Set(
+  val default = Seq(
     caseArrow,
     AlignToken("extends", "Defn.(Class|Trait|Object)"),
     AlignToken("//", ".*"),

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -9,8 +9,6 @@ import metaconfig.Configured._
 import org.scalafmt.util.LoggerOps
 import org.scalafmt.util.ValidationOps
 
-import Edition.ordering._
-
 /** Configuration options for scalafmt.
   *
   * @param version The version of scalafmt to use for this project. Currently not used,
@@ -266,7 +264,7 @@ object ScalafmtConfig {
     docstrings = Docstrings.JavaDoc,
     align = default.align.copy(
       arrowEnumeratorGenerator = false,
-      tokens = Set(AlignToken.caseArrow),
+      tokens = Seq(AlignToken.caseArrow),
       ifWhileOpenParen = false
     )
   )
@@ -304,7 +302,7 @@ object ScalafmtConfig {
     includeCurlyBraceInSelectChains = false,
     danglingParentheses = DanglingParentheses(false, false),
     align = default.align.copy(
-      tokens = Set.empty,
+      tokens = Seq.empty,
       openParenCallSite = true,
       openParenDefnSite = true
     ),
@@ -371,10 +369,10 @@ object ScalafmtConfig {
       case els => base.read(els)
     }
   def alignTokenReader(
-      initTokens: Set[AlignToken]
-  ): ConfDecoder[Set[AlignToken]] = {
-    val baseReader = ConfDecoder[Set[AlignToken]]
-    ConfDecoder.instance[Set[AlignToken]] {
+      initTokens: Seq[AlignToken]
+  ): ConfDecoder[Seq[AlignToken]] = {
+    val baseReader = ConfDecoder[Seq[AlignToken]]
+    ConfDecoder.instance[Seq[AlignToken]] {
       case Conf.Obj(("add", conf) :: Nil) =>
         baseReader.read(conf).map(initTokens ++ _)
       case Align.Builtin(a) => Ok(a.tokens)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -2,7 +2,6 @@ package org.scalafmt.util
 
 import scala.meta._
 
-import org.scalafmt.config.ScalafmtRunner
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.FormatOps
 import org.scalatest.funsuite.AnyFunSuite
@@ -28,6 +27,33 @@ class StyleMapTest extends AnyFunSuite {
         .maxColumn == 100
     )
     assert(m.styleMap.at(m.tokens.last).maxColumn == 110)
+  }
+
+  test("align.tokens.add") {
+    val code =
+      """object a {
+        |  // scalafmt: { align.tokens.add = ["="] }
+        |  println(1)
+        |}
+      """.stripMargin.parse[Source].get
+    val formatOps = new FormatOps(code, ScalafmtConfig.defaultWithAlign)
+    val headToken = formatOps.tokens.head
+    val printlnToken = formatOps.tokens.find(_.left.syntax == "println").get
+
+    val defaultEquals = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type))"
+    val overrideEquals = ".*"
+
+    val headConfig = formatOps.styleMap.at(headToken)
+    val printlnConfig = formatOps.styleMap.at(printlnToken)
+    val newFormatOps = new FormatOps(code, printlnConfig)
+
+    val newHeadConfig = newFormatOps.styleMap.at(headToken)
+    assert(headConfig.alignMap("=").regex == defaultEquals)
+    assert(newHeadConfig.alignMap("=").regex == overrideEquals)
+
+    val newPrintlnConfig = newFormatOps.styleMap.at(printlnToken)
+    assert(printlnConfig.alignMap("=").regex == overrideEquals)
+    assert(newPrintlnConfig.alignMap("=").regex == defaultEquals) // this is wrong
   }
 
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -53,7 +53,7 @@ class StyleMapTest extends AnyFunSuite {
 
     val newPrintlnConfig = newFormatOps.styleMap.at(printlnToken)
     assert(printlnConfig.alignMap("=").regex == overrideEquals)
-    assert(newPrintlnConfig.alignMap("=").regex == defaultEquals) // this is wrong
+    assert(newPrintlnConfig.alignMap("=").regex == overrideEquals)
   }
 
 }


### PR DESCRIPTION
That way, we'll preserve ordering and the mapping.
Fixes #1309.