### PR TITLE
Scalafmt is supported by format-all for emacs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,9 +76,11 @@ in Vim and NeoVim. For more details, refer to the
 
 You can use the [Metals](#metals) language server to format code with Scalafmt
 in Emacs. For more details, refer to the [Metals
-documentation](https://scalameta.org/metals/docs/editors/emacs.html). Alternatively
-it is supported by the
-[format-all](https://github.com/lassik/emacs-format-all-the-code) extension.
+documentation](https://scalameta.org/metals/docs/editors/emacs.html).
+
+The externally maintained
+[format-all](https://github.com/lassik/emacs-format-all-the-code) extension to
+Emacs also supports scalafmt as one of its formatters.
 
 ## Sublime Text
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,8 +75,10 @@ in Vim and NeoVim. For more details, refer to the
 ## Emacs
 
 You can use the [Metals](#metals) language server to format code with Scalafmt
-in Emacs. For more details, refer to the
-[Metals documentation](https://scalameta.org/metals/docs/editors/emacs.html).
+in Emacs. For more details, refer to the [Metals
+documentation](https://scalameta.org/metals/docs/editors/emacs.html). Alternatively
+it is supported by the
+[format-all](https://github.com/lassik/emacs-format-all-the-code) extension.
 
 ## Sublime Text
 


### PR DESCRIPTION
A common formatting extension supporting a wide varity of languages.