### PR TITLE
Rewrites: traverse tree once, applying all rules

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
@@ -2,7 +2,7 @@ package org.scalafmt.config
 
 import metaconfig._
 import org.scalafmt.Error.InvalidScalafmtConfiguration
-import org.scalafmt.rewrite.{AvoidInfix, Rewrite}
+import org.scalafmt.rewrite.Rewrite
 
 case class RewriteSettings(
     rules: Seq[Rewrite] = Nil,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -11,7 +11,15 @@ import scala.meta.tokens.Token.{
 }
 import scala.meta._
 
-case object AvoidInfix extends Rewrite {
+object AvoidInfix extends Rewrite {
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    new AvoidInfix
+}
+
+class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
+
+  private val matcher = ctx.style.rewrite.neverInfix.toMatcher
+
   // In a perfect world, we could just use
   // Tree.transform {
   //   case t: Term.ApplyInfix => Term.Apply(Term.Select(t.lhs, t.op), t.args)
@@ -19,88 +27,88 @@ case object AvoidInfix extends Rewrite {
   // and be done with it. However, until transform becomes token aware (see https://github.com/scalameta/scalameta/pull/457)
   // we will do these dangerous rewritings by hand.
 
-  override def rewrite(implicit ctx: RewriteCtx): Unit = {
-    val matcher = ctx.style.rewrite.neverInfix.toMatcher
-    ctx.tree.traverse {
-      case infix @ Term.ApplyInfix(lhs, op, _, args)
-          if matcher.matches(op.value) =>
-        val fstOpToken = op.tokens.head
-        val selectorToBeAdded = Seq(
-          TokenPatch.AddLeft(fstOpToken, ".", keepTok = true)
-        )
+  override def rewrite(tree: Tree): Unit = tree match {
+    case infix @ Term.ApplyInfix(lhs, op, _, args)
+        if matcher.matches(op.value) =>
+      val fstOpToken = op.tokens.head
+      val selectorToBeAdded = Seq(
+        TokenPatch.AddLeft(fstOpToken, ".", keepTok = true)
+      )
 
-        val fstArgsToken = args.headOption.flatMap(_.tokens.headOption)
-        val lastArgsToken = args.lastOption.flatMap(_.tokens.lastOption)
-        val fstIsNotLeftParenAndBrace = fstArgsToken
-          .exists(_.isNot[LeftParen]) && fstArgsToken
-          .exists(_.isNot[LeftBrace])
-        val lastIsNotRightParenAndBrace = lastArgsToken
-          .exists(_.isNot[RightParen]) && lastArgsToken
-          .exists(_.isNot[RightBrace])
-        val isSingleArg = args.size == 1
-        val selectorParensToBeAdded =
-          if (isSingleArg && (fstIsNotLeftParenAndBrace || lastIsNotRightParenAndBrace)) {
-            val selectorParens = for {
-              fstToken <- fstArgsToken
-              lastToken <- lastArgsToken
-            } yield Seq(
-              TokenPatch.AddLeft(fstToken, "(", keepTok = true),
-              TokenPatch.AddRight(lastToken, ")", keepTok = true)
-            )
-            selectorParens.getOrElse(Seq.empty)
-          } else
-            Nil
-
-        def wrapLhsInParens =
-          Seq(
-            TokenPatch.AddLeft(lhs.tokens.head, "(", keepTok = true),
-            TokenPatch.AddRight(lhs.tokens.last, ")", keepTok = true)
+      val fstArgsToken = args.headOption.flatMap(_.tokens.headOption)
+      val lastArgsToken = args.lastOption.flatMap(_.tokens.lastOption)
+      val fstIsNotLeftParenAndBrace = fstArgsToken
+        .exists(_.isNot[LeftParen]) && fstArgsToken
+        .exists(_.isNot[LeftBrace])
+      val lastIsNotRightParenAndBrace = lastArgsToken
+        .exists(_.isNot[RightParen]) && lastArgsToken
+        .exists(_.isNot[RightBrace])
+      val isSingleArg = args.size == 1
+      val selectorParensToBeAdded =
+        if (isSingleArg && (fstIsNotLeftParenAndBrace || lastIsNotRightParenAndBrace)) {
+          val selectorParens = for {
+            fstToken <- fstArgsToken
+            lastToken <- lastArgsToken
+          } yield Seq(
+            TokenPatch.AddLeft(fstToken, "(", keepTok = true),
+            TokenPatch.AddRight(lastToken, ")", keepTok = true)
           )
-        val lhsParensToBeAdded = lhs match {
-          case Term.ApplyInfix(lhs1, op1, _, _)
-              if !matcher.matches(op1.value)
-                && lhs.tokens.head.isNot[LeftParen] =>
-            wrapLhsInParens
-          case Term.Eta(_) => // foo _ compose bar => (foo _).compose(bar)
-            wrapLhsInParens
-          case _ => Nil
-        }
-
-        val toBeRemoved = fstArgsToken.fold(Seq.empty[TokenPatch])(token =>
-          ctx.tokenTraverser
-            .filter(fstOpToken, token)(_.is[LF])
-            .map(TokenPatch.Remove)
-        )
-
-        val hasSingleLineComment = fstArgsToken.exists(token =>
-          ctx.tokenTraverser
-            .filter(fstOpToken, token)(TokenOps.isSingleLineComment)
-            .nonEmpty
-        )
-
-        val infixTokens = infix.tokens
-        val enclosingParens = for {
-          parent <- infix.parent
-          if !parent.is[Term.ApplyInfix]
-          first <- infixTokens.headOption
-          if first.is[LeftParen]
-          last <- infixTokens.lastOption
-          if last.is[RightParen]
-          if ctx.isMatching(first, last)
-        } yield {
-          List(TokenPatch.Remove(first), TokenPatch.Remove(last))
-        }
-
-        if (hasSingleLineComment)
+          selectorParens.getOrElse(Seq.empty)
+        } else
           Nil
-        else
-          ctx.addPatchSet(
-            lhsParensToBeAdded ++
-              selectorToBeAdded ++
-              selectorParensToBeAdded ++
-              toBeRemoved ++
-              enclosingParens.getOrElse(List()): _*
-          )
-    }
+
+      def wrapLhsInParens =
+        Seq(
+          TokenPatch.AddLeft(lhs.tokens.head, "(", keepTok = true),
+          TokenPatch.AddRight(lhs.tokens.last, ")", keepTok = true)
+        )
+      val lhsParensToBeAdded = lhs match {
+        case Term.ApplyInfix(lhs1, op1, _, _)
+            if !matcher.matches(op1.value)
+              && lhs.tokens.head.isNot[LeftParen] =>
+          wrapLhsInParens
+        case Term.Eta(_) => // foo _ compose bar => (foo _).compose(bar)
+          wrapLhsInParens
+        case _ => Nil
+      }
+
+      val toBeRemoved = fstArgsToken.fold(Seq.empty[TokenPatch])(token =>
+        ctx.tokenTraverser
+          .filter(fstOpToken, token)(_.is[LF])
+          .map(TokenPatch.Remove)
+      )
+
+      val hasSingleLineComment = fstArgsToken.exists(token =>
+        ctx.tokenTraverser
+          .filter(fstOpToken, token)(TokenOps.isSingleLineComment)
+          .nonEmpty
+      )
+
+      val infixTokens = infix.tokens
+      val enclosingParens = for {
+        parent <- infix.parent
+        if !parent.is[Term.ApplyInfix]
+        first <- infixTokens.headOption
+        if first.is[LeftParen]
+        last <- infixTokens.lastOption
+        if last.is[RightParen]
+        if ctx.isMatching(first, last)
+      } yield {
+        List(TokenPatch.Remove(first), TokenPatch.Remove(last))
+      }
+
+      if (hasSingleLineComment)
+        Nil
+      else
+        ctx.addPatchSet(
+          lhsParensToBeAdded ++
+            selectorToBeAdded ++
+            selectorParensToBeAdded ++
+            toBeRemoved ++
+            enclosingParens.getOrElse(List()): _*
+        )
+
+    case _ =>
   }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ExpandImportSelectors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ExpandImportSelectors.scala
@@ -3,53 +3,62 @@ package org.scalafmt.rewrite
 import scala.collection.mutable
 import scala.meta._
 
-case object ExpandImportSelectors extends Rewrite {
+object ExpandImportSelectors extends Rewrite {
 
-  override def rewrite(implicit ctx: RewriteCtx): Unit = {
-    ctx.tree.traverse {
-      case q"import ..$imports" =>
-        val groupedPatches = mutable.Map.empty[Token, Group]
-        imports.foreach { `import` =>
-          val parentTokens = `import`.parent.get.tokens
-          val group =
-            groupedPatches.getOrElseUpdate(parentTokens.head, new Group)
-          parentTokens.tail.foreach(x => group.patches += TokenPatch.Remove(x))
-
-          `import`.traverse {
-            case importer @ Importer(path, importees) =>
-              val hasRenamesOrUnimports = importees.exists(importee =>
-                importee.is[Importee.Rename] || importee.is[Importee.Unimport]
-              )
-
-              val hasWildcards = importees.exists(_.is[Importee.Wildcard])
-
-              if (hasWildcards && hasRenamesOrUnimports)
-                group.imports += s"import ${importer.syntax}"
-              else
-                importees.foreach { importee =>
-                  val importString = importee.toString
-                  val replacement =
-                    if (importString.contains("=>"))
-                      s"import $path.{$importString}"
-                    else
-                      s"import $path.$importString"
-                  group.imports += replacement
-                }
-          }
-        }
-
-        groupedPatches.foreach {
-          case (tok, group) =>
-            group.patches +=
-              TokenPatch.AddRight(tok, group.imports.mkString("\n"))
-            ctx.addPatchSet(group.patches.result(): _*)
-        }
-    }
-  }
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    new ExpandImportSelectors
 
   private case class Group(
       patches: mutable.Builder[TokenPatch, Seq[TokenPatch]] = Seq.newBuilder,
       imports: mutable.ArrayBuffer[String] = new mutable.ArrayBuffer
   )
+
+}
+
+class ExpandImportSelectors(implicit ctx: RewriteCtx) extends RewriteSession {
+
+  import ExpandImportSelectors.Group
+
+  override def rewrite(tree: Tree): Unit = tree match {
+    case q"import ..$imports" =>
+      val groupedPatches = mutable.Map.empty[Token, Group]
+      imports.foreach { `import` =>
+        val parentTokens = `import`.parent.get.tokens
+        val group =
+          groupedPatches.getOrElseUpdate(parentTokens.head, new Group)
+        parentTokens.tail.foreach(x => group.patches += TokenPatch.Remove(x))
+
+        `import`.traverse {
+          case importer @ Importer(path, importees) =>
+            val hasRenamesOrUnimports = importees.exists(importee =>
+              importee.is[Importee.Rename] || importee.is[Importee.Unimport]
+            )
+
+            val hasWildcards = importees.exists(_.is[Importee.Wildcard])
+
+            if (hasWildcards && hasRenamesOrUnimports)
+              group.imports += s"import ${importer.syntax}"
+            else
+              importees.foreach { importee =>
+                val importString = importee.toString
+                val replacement =
+                  if (importString.contains("=>"))
+                    s"import $path.{$importString}"
+                  else
+                    s"import $path.$importString"
+                group.imports += replacement
+              }
+        }
+      }
+
+      groupedPatches.foreach {
+        case (tok, group) =>
+          group.patches +=
+            TokenPatch.AddRight(tok, group.imports.mkString("\n"))
+          ctx.addPatchSet(group.patches.result(): _*)
+      }
+
+    case _ =>
+  }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -3,45 +3,51 @@ package org.scalafmt.rewrite
 import scala.meta._
 import scala.meta.tokens.Token.{LeftParen, RightParen}
 
-case object RedundantParens extends Rewrite {
+object RedundantParens extends Rewrite {
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    new RedundantParens
+}
+
+class RedundantParens(implicit ctx: RewriteCtx) extends RewriteSession {
+
+  import ctx.dialect
 
   def isWrappedInParens(tokens: Tokens): Boolean =
     tokens.nonEmpty && tokens.head.is[LeftParen] && tokens.last.is[RightParen]
 
-  override def rewrite(implicit ctx: RewriteCtx): Unit = {
-    import ctx.dialect
-    ctx.tree.traverse {
-      case g: Enumerator.Guard =>
-        val tokens: Tokens = g.cond.tokens
-        if (isWrappedInParens(tokens)) {
-          val openParensCount = tokens.segmentLength(_.is[LeftParen], 0)
-          val closeParensCount =
-            tokens.reverse.segmentLength(_.is[RightParen], 0)
-          val parensToRemoveCount = Math.min(openParensCount, closeParensCount)
-          val leftSegment: Tokens = tokens.slice(0, parensToRemoveCount)
-          val rightSegment: Tokens =
-            tokens.slice(tokens.length - parensToRemoveCount, tokens.length)
-          leftSegment.zip(rightSegment.reverse).foreach {
-            case (left, right) if ctx.isMatching(left, right) =>
-              ctx.addPatchSet(TokenPatch.Remove(left), TokenPatch.Remove(right))
-            case _ =>
-          }
+  override def rewrite(tree: Tree): Unit = tree match {
+    case g: Enumerator.Guard =>
+      val tokens: Tokens = g.cond.tokens
+      if (isWrappedInParens(tokens)) {
+        val openParensCount = tokens.segmentLength(_.is[LeftParen], 0)
+        val closeParensCount =
+          tokens.reverse.segmentLength(_.is[RightParen], 0)
+        val parensToRemoveCount = Math.min(openParensCount, closeParensCount)
+        val leftSegment: Tokens = tokens.slice(0, parensToRemoveCount)
+        val rightSegment: Tokens =
+          tokens.slice(tokens.length - parensToRemoveCount, tokens.length)
+        leftSegment.zip(rightSegment.reverse).foreach {
+          case (left, right) if ctx.isMatching(left, right) =>
+            ctx.addPatchSet(TokenPatch.Remove(left), TokenPatch.Remove(right))
+          case _ =>
         }
+      }
 
-      case t @ Term.Apply(_, List(b: Term.Block))
-          if ctx.style.activeForEdition_2020_01 &&
-            b.tokens.headOption.exists(_.is[Token.LeftBrace]) =>
-        t.tokens.lastOption.filter(_.is[RightParen]).foreach { rparen =>
-          ctx.getMatchingOpt(rparen).foreach { lparen =>
-            implicit val builder = Seq.newBuilder[TokenPatch]
-            builder += TokenPatch.Remove(lparen)
-            builder += TokenPatch.Remove(rparen)
-            ctx.removeLFToAvoidEmptyLine(lparen)
-            ctx.removeLFToAvoidEmptyLine(rparen)
-            ctx.addPatchSet(builder.result(): _*)
-          }
+    case t @ Term.Apply(_, List(b: Term.Block))
+        if ctx.style.activeForEdition_2020_01 &&
+          b.tokens.headOption.exists(_.is[Token.LeftBrace]) =>
+      t.tokens.lastOption.filter(_.is[RightParen]).foreach { rparen =>
+        ctx.getMatchingOpt(rparen).foreach { lparen =>
+          implicit val builder = Seq.newBuilder[TokenPatch]
+          builder += TokenPatch.Remove(lparen)
+          builder += TokenPatch.Remove(rparen)
+          ctx.removeLFToAvoidEmptyLine(lparen)
+          ctx.removeLFToAvoidEmptyLine(rparen)
+          ctx.addPatchSet(builder.result(): _*)
         }
+      }
 
-    }
+    case _ =>
   }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
@@ -6,49 +6,53 @@ import scala.meta.tokens.Token
 
 import org.scalafmt.util.Whitespace
 
-case object RewriteTrailingCommas extends Rewrite {
+object RewriteTrailingCommas extends Rewrite {
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    new RewriteTrailingCommas
+}
+
+class RewriteTrailingCommas(implicit ctx: RewriteCtx) extends RewriteSession {
 
   /* even if this rule is called for 'always', we'll still remove any trailing
    * commas here, to avoid any idempotence problems caused by an extra comma,
    * with a different AST, in a subsequent runs; in FormatWriter, we'll add
    * them back if there is a newline before the closing bracket/paren/brace */
-  override def rewrite(implicit ctx: RewriteCtx): Unit =
-    ctx.tree.traverse {
-      case t: Importer =>
-        t.tokens.lastOption match {
-          case Some(close: Token.RightBrace) => before(close)
-          case _ =>
-        }
+  override def rewrite(tree: Tree): Unit = tree match {
+    case t: Importer =>
+      t.tokens.lastOption match {
+        case Some(close: Token.RightBrace) => before(close)
+        case _ =>
+      }
 
-      case t: Decl.Def => afterTParams(t.tparams); afterEachArgs(t.paramss)
-      case t: Defn.Def => afterTParams(t.tparams); afterEachArgs(t.paramss)
-      case t: Defn.Macro => afterTParams(t.tparams); afterEachArgs(t.paramss)
-      case t: Defn.Class => afterTParams(t.tparams)
-      case t: Defn.Trait => afterTParams(t.tparams)
-      case t: Ctor.Secondary => afterEachArgs(t.paramss)
-      case t: Decl.Type => afterTParams(t.tparams)
-      case t: Defn.Type => afterTParams(t.tparams)
-      case t: Type.Apply => afterArgs(t.args)
-      case t: Type.Param => afterTParams(t.tparams)
-      case t: Type.Tuple => afterArgs(t.args)
-      case t: Term.Function => afterArgs(t.params)
-      case t: Type.Function => afterArgs(t.params)
-      case t: Ctor.Primary => afterEachArgs(t.paramss)
+    case t: Decl.Def => afterTParams(t.tparams); afterEachArgs(t.paramss)
+    case t: Defn.Def => afterTParams(t.tparams); afterEachArgs(t.paramss)
+    case t: Defn.Macro => afterTParams(t.tparams); afterEachArgs(t.paramss)
+    case t: Defn.Class => afterTParams(t.tparams)
+    case t: Defn.Trait => afterTParams(t.tparams)
+    case t: Ctor.Secondary => afterEachArgs(t.paramss)
+    case t: Decl.Type => afterTParams(t.tparams)
+    case t: Defn.Type => afterTParams(t.tparams)
+    case t: Type.Apply => afterArgs(t.args)
+    case t: Type.Param => afterTParams(t.tparams)
+    case t: Type.Tuple => afterArgs(t.args)
+    case t: Term.Function => afterArgs(t.params)
+    case t: Type.Function => afterArgs(t.params)
+    case t: Ctor.Primary => afterEachArgs(t.paramss)
 
-      case t: Term.Apply => afterArgs(t.args)
-      case t: Pat.Extract => afterArgs(t.args)
-      case t: Pat.Tuple => afterArgs(t.args)
-      case t: Term.Tuple => afterArgs(t.args)
-      case t: Term.ApplyType => afterArgs(t.targs)
-      case t: Init => afterEachArgs(t.argss)
+    case t: Term.Apply => afterArgs(t.args)
+    case t: Pat.Extract => afterArgs(t.args)
+    case t: Pat.Tuple => afterArgs(t.args)
+    case t: Term.Tuple => afterArgs(t.args)
+    case t: Term.ApplyType => afterArgs(t.targs)
+    case t: Init => afterEachArgs(t.argss)
 
-      case _ =>
-    }
+    case _ =>
+  }
 
-  private def patch(token: Token)(implicit ctx: RewriteCtx): Unit =
+  private def patch(token: Token): Unit =
     ctx.addPatchSet(TokenPatch.Remove(token))
 
-  private def before(close: Token)(implicit ctx: RewriteCtx): Unit =
+  private def before(close: Token): Unit =
     ctx.tokenTraverser.findBefore(close) {
       case c: Token.Comma => patch(c); Some(false)
       case Whitespace() | _: Token.Comment => None
@@ -57,7 +61,7 @@ case object RewriteTrailingCommas extends Rewrite {
 
   private def forwardBeforeType[A](
       start: Token
-  )(implicit ctx: RewriteCtx, cls: Classifier[Token, A]): Unit = {
+  )(implicit cls: Classifier[Token, A]): Unit = {
     var comma: Token.Comma = null
     ctx.tokenTraverser.findAfter(start) {
       case Whitespace() | _: Token.Comment => None
@@ -66,21 +70,17 @@ case object RewriteTrailingCommas extends Rewrite {
     }
   }
 
-  private def afterTParams(
-      tparams: List[Type.Param]
-  )(implicit ctx: RewriteCtx): Unit =
+  private def afterTParams(tparams: List[Type.Param]): Unit =
     tparams.lastOption.foreach {
       _.tokens.lastOption.foreach(forwardBeforeType[Token.RightBracket])
     }
 
-  private def afterArgs(args: List[Tree])(implicit ctx: RewriteCtx): Unit =
+  private def afterArgs(args: List[Tree]): Unit =
     args.lastOption.foreach {
       _.tokens.lastOption.foreach(forwardBeforeType[Token.RightParen])
     }
 
-  private def afterEachArgs(
-      argss: List[List[Tree]]
-  )(implicit ctx: RewriteCtx): Unit =
+  private def afterEachArgs(argss: List[List[Tree]]): Unit =
     argss.foreach(afterArgs)
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortImports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortImports.scala
@@ -13,36 +13,38 @@ import scala.meta._
   *
   * import a.{b, c}
   */
-sealed trait SortImports extends Rewrite {
+sealed abstract class SortImports(implicit ctx: RewriteCtx)
+    extends RewriteSession {
+
+  import ctx.dialect
 
   /**
     * The sorting scheme to use when sorting the imports
     */
   protected def sorted(str: Seq[String]): IndexedSeq[String]
 
-  override def rewrite(implicit ctx: RewriteCtx): Unit = {
-    import ctx.dialect
-    ctx.tree.traverse {
-      case Import(imports) =>
-        val builder = Seq.newBuilder[TokenPatch]
-        imports.foreach { `import` =>
-          val importees = `import`.importees
-          if (!importees.exists(!_.is[Importee.Name])) {
-            // Do nothing if an importee has for example rename
-            // import a.{d, b => c}
-            // I think we are safe to sort these, just want to convince myself
-            // it's 100% safe first.
-            val sortedImportees = sorted(importees.map(_.tokens.mkString))
-            var i = 0
-            importees.foreach { importee =>
-              builder +=
-                TokenPatch.AddRight(importee.tokens.head, sortedImportees(i))
-              i += 1
-            }
+  override def rewrite(tree: Tree): Unit = tree match {
+    case Import(imports) =>
+      val builder = Seq.newBuilder[TokenPatch]
+      imports.foreach { `import` =>
+        val importees = `import`.importees
+        if (!importees.exists(!_.is[Importee.Name])) {
+          // Do nothing if an importee has for example rename
+          // import a.{d, b => c}
+          // I think we are safe to sort these, just want to convince myself
+          // it's 100% safe first.
+          val sortedImportees = sorted(importees.map(_.tokens.mkString))
+          var i = 0
+          importees.foreach { importee =>
+            builder +=
+              TokenPatch.AddRight(importee.tokens.head, sortedImportees(i))
+            i += 1
           }
         }
-        ctx.addPatchSet(builder.result(): _*)
-    }
+      }
+      ctx.addPatchSet(builder.result(): _*)
+
+    case _ =>
   }
 }
 
@@ -50,26 +52,31 @@ sealed trait SortImports extends Rewrite {
   * Sort imports with symbols at the beginning, followed by lowercase and
   * finally uppercase
   */
-case object SortImports extends SortImports {
+object SortImports extends Rewrite {
 
   // sort contributed by @djspiewak: https://gist.github.com/djspiewak/127776c2b6a9d6cd3c21a228afd4580f
   private val LCase = """([a-z].*)""".r
   private val UCase = """([A-Z].*)""".r
   private val Other = """(.+)""".r
 
-  override def sorted(strs: Seq[String]): IndexedSeq[String] = {
-    // we really want partition, but there is no ternary version of it
-    val (syms, lcs, ucs) = strs.foldLeft(
-      (Vector.empty[String], Vector.empty[String], Vector.empty[String])
-    ) {
-      case ((syms, lcs, ucs), str) =>
-        str match {
-          case LCase(s) => (syms, lcs :+ s, ucs)
-          case UCase(s) => (syms, lcs, ucs :+ s)
-          case Other(s) => (syms :+ s, lcs, ucs)
-        }
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    new Impl
+
+  private class Impl(implicit ctx: RewriteCtx) extends SortImports {
+    override def sorted(strs: Seq[String]): IndexedSeq[String] = {
+      // we really want partition, but there is no ternary version of it
+      val (syms, lcs, ucs) = strs.foldLeft(
+        (Vector.empty[String], Vector.empty[String], Vector.empty[String])
+      ) {
+        case ((syms, lcs, ucs), str) =>
+          str match {
+            case LCase(s) => (syms, lcs :+ s, ucs)
+            case UCase(s) => (syms, lcs, ucs :+ s)
+            case Other(s) => (syms :+ s, lcs, ucs)
+          }
+      }
+      syms.sorted ++ lcs.sorted ++ ucs.sorted
     }
-    syms.sorted ++ lcs.sorted ++ ucs.sorted
   }
 }
 
@@ -78,8 +85,13 @@ case object SortImports extends SortImports {
   *
   * See: http://support.ecisolutions.com/doc-ddms/help/reportsmenu/ascii_sort_order_chart.htm
   */
-case object AsciiSortImports extends SortImports {
+object AsciiSortImports extends Rewrite {
 
-  override def sorted(strs: Seq[String]): IndexedSeq[String] =
-    strs.sorted.toIndexedSeq
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    new Impl
+
+  private class Impl(implicit ctx: RewriteCtx) extends SortImports {
+    override def sorted(strs: Seq[String]): IndexedSeq[String] =
+      strs.sorted.toIndexedSeq
+  }
 }


### PR DESCRIPTION
Also, turn rewrites into sessions with the context instance.