### PR TITLE
RewriteTrailingCommas: trivial, remove duplicate

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
@@ -36,7 +36,6 @@ case object RewriteTrailingCommas extends Rewrite {
       case t: Ctor.Primary => afterEachArgs(t.paramss)
 
       case t: Term.Apply => afterArgs(t.args)
-      case t: Type.Apply => afterArgs(t.args)
       case t: Pat.Extract => afterArgs(t.args)
       case t: Pat.Tuple => afterArgs(t.args)
       case t: Term.Tuple => afterArgs(t.args)


### PR DESCRIPTION
One of the patterns was present in both isDefnSite and isCallSite (not
sure why, and which of them should keep the pattern is a separate issue)
so it ended up twice in this class. Remove the second.