### PR TITLE
Self formatting with 2.4.0-RC2

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=2.3.2
+version=2.4.0-RC2
 project.git = true
 project.excludeFilters = [
   scalafmt-benchmarks/src/resources,

--- a/scalafmt-benchmarks/src/main/scala-2.12/benchmarks/MacroBenchmark.scala
+++ b/scalafmt-benchmarks/src/main/scala-2.12/benchmarks/MacroBenchmark.scala
@@ -38,9 +38,7 @@ abstract class MacroBenchmark(parallel: Boolean, maxFiles: Int)
             url = Corpus.fastparse.url.replace("olafurpg", "scalameta")
           )
         )
-        .filter { f =>
-          f.projectUrl.contains("scala-js")
-        }
+        .filter { f => f.projectUrl.contains("scala-js") }
         .take(maxFiles)
         .map(_.read)
         .toBuffer
@@ -56,16 +54,12 @@ abstract class MacroBenchmark(parallel: Boolean, maxFiles: Int)
 
   @Benchmark
   def scalafmt(): Unit = {
-    files.foreach { file =>
-      Try(Scalafmt.formatCode(file))
-    }
+    files.foreach { file => Try(Scalafmt.formatCode(file)) }
   }
 
   @Benchmark
   def scalafmt_rewrite(): Unit = {
-    files.foreach { file =>
-      Try(formatRewrite(file))
-    }
+    files.foreach { file => Try(formatRewrite(file)) }
   }
 
 }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -51,7 +51,8 @@ object CliOptions {
       writeMode = newMode,
       config = style,
       common = parsed.common.copy(
-        out = guardPrintStream(parsed.quiet && !parsed.stdIn)(parsed.common.out),
+        out =
+          guardPrintStream(parsed.quiet && !parsed.stdIn)(parsed.common.out),
         info = guardPrintStream(parsed.quiet || parsed.list)(auxOut),
         debug = guardPrintStream(parsed.quiet)(
           if (parsed.debug) auxOut else init.common.debug

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -72,8 +72,6 @@ trait ScalafmtRunner {
         options.gitOps.status.filter(canFormat)
     }
     val excludeRegexp = options.excludeFilterRegexp
-    files.filter { f =>
-      excludeRegexp.findFirstIn(f.path).isEmpty
-    }
+    files.filter { f => excludeRegexp.findFirstIn(f.path).isEmpty }
   }
 }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/TermDisplay.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/TermDisplay.scala
@@ -341,9 +341,7 @@ object TermDisplay {
             doneQueue.clear()
 
             val dw = downloads.toVector
-              .map { url =>
-                url -> infos.get(url)
-              }
+              .map { url => url -> infos.get(url) }
               .sortBy { case (_, info) => -info.fraction.sum }
 
             (q, dw)
@@ -397,9 +395,7 @@ object TermDisplay {
         case Some(Message.Update) =>
           val downloads0 = downloads.synchronized {
             downloads.toVector
-              .map { url =>
-                url -> infos.get(url)
-              }
+              .map { url => url -> infos.get(url) }
               .sortBy { case (_, info) => -info.fraction.sum }
           }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -38,9 +38,7 @@ class BestFirstSearch(
   val routes: Array[Seq[Split]] = {
     val router = new Router(formatOps)
     val result = Array.newBuilder[Seq[Split]]
-    tokens.foreach { t =>
-      result += router.getSplitsMemo(t)
-    }
+    tokens.foreach { t => result += router.getSplitsMemo(t) }
     result.result()
   }
   val noOptimizations = noOptimizationZones(tree)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -831,9 +831,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             if app.args.length >= runner.optimizer.forceConfigStyleMinArgCount &&
               distance(left, matching(left)) > maxDistance =>
           forces += app
-          app.args.foreach { arg =>
-            clearQueues += hash(arg.tokens.head)
-          }
+          app.args.foreach { arg => clearQueues += hash(arg.tokens.head) }
         case _ =>
       }
       (forces.result(), clearQueues.result())
@@ -1003,7 +1001,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case _ => 0
     }
 
-    val aboveArityThreshold = (maxArity >= style.verticalMultiline.arityThreshold) || (maxArity >= style.verticalMultilineAtDefinitionSiteArityThreshold)
+    val aboveArityThreshold =
+      (maxArity >= style.verticalMultiline.arityThreshold) || (maxArity >= style.verticalMultilineAtDefinitionSiteArityThreshold)
 
     val singleLineModification =
       if (style.spaces.inParentheses) Space

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -6,9 +6,7 @@ import org.scalafmt.util.LoggerOps
 class PolicySummary(val policies: Vector[Policy]) {
   import LoggerOps._
 
-  @inline def noDequeue = policies.exists { x =>
-    x.isSingleLine || x.noDequeue
-  }
+  @inline def noDequeue = policies.exists { x => x.isSingleLine || x.noDequeue }
 
   @inline def isSafe = !noDequeue
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -121,7 +121,8 @@ class Router(formatOps: FormatOps) {
       case FormatToken(open @ T.LeftBrace(), _, _)
           if parents(leftOwner).exists(_.is[Import]) =>
         val close = matching(open)
-        val disallowSingleLineComments = style.importSelectors != ImportSelectors.singleLine
+        val disallowSingleLineComments =
+          style.importSelectors != ImportSelectors.singleLine
         val policy = SingleLineBlock(
           close,
           disallowSingleLineComments = disallowSingleLineComments
@@ -378,7 +379,11 @@ class Router(formatOps: FormatOps) {
             )
           case _ =>
             Seq(
-              Split(Space, 0, ignoreIf = newlines != 0), // Gets killed by `case` policy.
+              Split(
+                Space,
+                0,
+                ignoreIf = newlines != 0
+              ), // Gets killed by `case` policy.
               Split(
                 NewlineT(isDouble = false, noIndent = rhsIsCommentedOut(tok)),
                 1
@@ -1034,7 +1039,8 @@ class Router(formatOps: FormatOps) {
         val mod: Modification = rightOwner match {
           case tp: Type.Param =>
             val contextOption = style.spaces.beforeContextBoundColon
-            val summaryTypeBoundsCount = tp.tbounds.lo.size + tp.tbounds.hi.size + tp.cbounds.size
+            val summaryTypeBoundsCount =
+              tp.tbounds.lo.size + tp.tbounds.hi.size + tp.cbounds.size
             if (contextOption.isIfMultipleBounds && summaryTypeBoundsCount > 1 || contextOption.isAlways)
               Space
             else NoSplit
@@ -1162,7 +1168,8 @@ class Router(formatOps: FormatOps) {
         val newlinePolicy = breakOnEveryDot
           .andThen(penalizeNewlinesInApply.f)
           .copy(expire = expire.end)
-        val ignoreNoSplit = style.optIn.breakChainOnFirstMethodDot && newlines > 0
+        val ignoreNoSplit =
+          style.optIn.breakChainOnFirstMethodDot && newlines > 0
         val chainLengthPenalty =
           if (style.newlines.penalizeSingleSelectMultiArgList &&
             chain.length < 2) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -80,7 +80,9 @@ final case class State(
         }) {
         split // fits inside column
       } else {
-        split.withPenalty(Constants.ExceedColumnPenalty + columnOnCurrentLine) // overflow
+        split.withPenalty(
+          Constants.ExceedColumnPenalty + columnOnCurrentLine
+        ) // overflow
       }
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -40,7 +40,9 @@ class StyleMap(
             case Configured.Ok(style) =>
               empty = false
               curr = style
-            case Configured.NotOk(e) => // TODO(olafur) report error via callback
+            case Configured.NotOk(
+                e
+                ) => // TODO(olafur) report error via callback
               logger.elem(e)
           }
         case open @ LeftParen()

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -108,9 +108,7 @@ object TreeOps {
 
     def addAll(trees: Seq[Tree]): Unit = {
       trees.foreach { t =>
-        t.tokens.headOption.foreach { tok =>
-          ret += hash(tok) -> t
-        }
+        t.tokens.headOption.foreach { tok => ret += hash(tok) -> t }
       }
     }
 
@@ -206,9 +204,7 @@ object TreeOps {
     workList.add(tree)
     while (!workList.isEmpty) {
       val x = workList.poll()
-      x.tokens.foreach { tok =>
-        result.put(hash(tok), x)
-      }
+      x.tokens.foreach { tok => result.put(hash(tok), x) }
       workList.addAll(x.children.asJava)
     }
     result.asScala

--- a/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/tests/DynamicSuite.scala
@@ -219,9 +219,7 @@ class DynamicSuite extends FunSuite {
     check()
   }
 
-  check("missing-version") { f =>
-    f.assertMissingVersion()
-  }
+  check("missing-version") { f => f.assertMissingVersion() }
 
   check("ignore-version") { f =>
     f.ignoreVersion()

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -73,12 +73,8 @@ abstract class AbstractCliTest extends FunSuite {
       input: AbsoluteFile,
       expected: String,
       cmds: Seq[Array[String]],
-      assertExit: ExitCode => Unit = { exit =>
-        assert(exit.isOk, exit)
-      },
-      assertOut: String => Unit = { out =>
-        println(out)
-      }
+      assertExit: ExitCode => Unit = { exit => assert(exit.isOk, exit) },
+      assertOut: String => Unit = { out => println(out) }
   ): Unit = {
     cmds.foreach { args =>
       val out = new ByteArrayOutputStream()
@@ -553,9 +549,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
             s"""{version="$version",style=IntelliJ}"""
           )
         ),
-        assertExit = { exit =>
-          assert(exit.is(ExitCode.ParseError))
-        },
+        assertExit = { exit => assert(exit.is(ExitCode.ParseError)) },
         assertOut = out => {
           assert(
             out.contains(
@@ -589,9 +583,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
         string2dir(input),
         input,
         Seq(Array("--test")),
-        assertExit = { exit =>
-          assert(exit.is(ExitCode.TestError))
-        },
+        assertExit = { exit => assert(exit.is(ExitCode.TestError)) },
         assertOut = out => {
           assert(
             out.contains(
@@ -616,9 +608,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
         string2dir(input),
         input,
         Seq(Array("--test", "--config-str", s"""{version="$version"}""")),
-        assertExit = { exit =>
-          assert(exit.isOk)
-        },
+        assertExit = { exit => assert(exit.isOk) },
         assertOut = out => {
           println(s"succeed: $out")
           assert(
@@ -645,9 +635,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
         string2dir(input),
         input,
         Seq(Array("--test")),
-        assertExit = { exit =>
-          assert(exit == ExitCode.ParseError)
-        },
+        assertExit = { exit => assert(exit == ExitCode.ParseError) },
         assertOut = out => {
           assert(
             out.contains(
@@ -672,9 +660,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
         string2dir(input),
         input,
         Seq(Array.empty),
-        assertExit = { exit =>
-          assert(exit == ExitCode.UnexpectedError)
-        },
+        assertExit = { exit => assert(exit == ExitCode.UnexpectedError) },
         assertOut = out => {
           assert(
             out.contains(
@@ -715,9 +701,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
             "--test"
           )
         ),
-        assertExit = { exit =>
-          assert(exit.is(ExitCode.TestError))
-        },
+        assertExit = { exit => assert(exit.is(ExitCode.TestError)) },
         assertOut = out => {
           assert(
             out.contains(expected) &&
@@ -748,9 +732,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
         dir,
         input,
         Seq(Array("--list")),
-        assertExit = { exit =>
-          assert(exit.is(ExitCode.TestError))
-        },
+        assertExit = { exit => assert(exit.is(ExitCode.TestError)) },
         assertOut = out => {
           assert(
             out.contains("bar.scala") &&
@@ -776,11 +758,11 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
       string2dir(input),
       input,
       Seq(
-        Array("--debug") // debug options is needed to output running scalafmt version
+        Array(
+          "--debug"
+        ) // debug options is needed to output running scalafmt version
       ),
-      assertExit = { exit =>
-        assert(exit.isOk, exit)
-      },
+      assertExit = { exit => assert(exit.isOk, exit) },
       assertOut = out => {
         assert(out.contains(Versions.version))
       }
@@ -801,11 +783,11 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
       string2dir(input),
       input,
       Seq(
-        Array("--debug") // debug options is needed to output running scalafmt version
+        Array(
+          "--debug"
+        ) // debug options is needed to output running scalafmt version
       ),
-      assertExit = { exit =>
-        assert(exit.isOk, exit)
-      },
+      assertExit = { exit => assert(exit.isOk, exit) },
       assertOut = out => {
         assert(out.contains(Versions.version))
       }


### PR DESCRIPTION
Just applied last RC to source code

Is it missing from release notes that «Format single-line curly lambdas using parens» works only with `RedundantBraces` rule?