### PR TITLE
Resource folder path resolution from classloader

### DIFF
--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -41,8 +41,7 @@ trait HasTests extends FormatAssertions {
     }
   )
   lazy val debugResults = mutable.ArrayBuilder.make[Result]
-  val testDir =
-    "scalafmt-tests/src/test/resources".replace("/", File.separator)
+  val testDir = new File(getClass.getClassLoader.getResource("").toURI).getAbsolutePath
 
   def tests: Seq[DiffTest]
 


### PR DESCRIPTION
I think it's more reliable way to get resources. Should fix issue https://github.com/scalameta/scalafmt/pull/1681#issuecomment-583871622