### PR TITLE
VerticalMultiline: check config style

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -986,7 +986,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       if (isBracket) close // If we can fit the type params, make it so
       else lastParen // If we can fit all in one block, make it so
 
-    val maxArity = valueParamsOwner match {
+    def maxArity = valueParamsOwner match {
       case d: Decl.Def if d.paramss.nonEmpty => d.paramss.map(_.size).max
       case d: Defn.Def if d.paramss.nonEmpty => d.paramss.map(_.size).max
       case m: Defn.Macro if m.paramss.nonEmpty => m.paramss.map(_.size).max
@@ -995,12 +995,16 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case _ => 0
     }
 
+    def configStyle =
+      style.optIn.configStyleArguments &&
+        style.activeForEdition_2020_03 && ft.newlinesBetween != 0
+
     def belowArityThreshold =
       maxArity < style.verticalMultiline.arityThreshold
 
     Seq(
       Split(Space(style.spaces.inParentheses), 0)
-        .onlyIf(isBracket || belowArityThreshold)
+        .onlyIf(isBracket || !configStyle && belowArityThreshold)
         .withPolicy(SingleLineBlock(singleLineExpire)),
       Split(Newline, 1) // Otherwise split vertically
         .withIndent(firstIndent, close, Right)

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -268,3 +268,24 @@ case class Foo(
   ): F[Resolution] =
     ???
 }
+<<< #1539 1: config style, no dangling
+optIn.configStyleArguments = true
+danglingParentheses = false
+===
+class Abc(
+  x: Int,
+  b: Int
+)
+>>>
+class Abc(x: Int, b: Int)
+<<< #1539 2: config style, dangling
+optIn.configStyleArguments = true
+danglingParentheses = true
+verticalMultiline.excludeDanglingParens = []
+===
+class Abc(
+  x: Int,
+  b: Int
+)
+>>>
+class Abc(x: Int, b: Int)

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -277,7 +277,9 @@ class Abc(
   b: Int
 )
 >>>
-class Abc(x: Int, b: Int)
+class Abc(
+  x: Int,
+  b: Int)
 <<< #1539 2: config style, dangling
 optIn.configStyleArguments = true
 danglingParentheses = true
@@ -288,4 +290,7 @@ class Abc(
   b: Int
 )
 >>>
-class Abc(x: Int, b: Int)
+class Abc(
+  x: Int,
+  b: Int
+)

--- a/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
@@ -4,6 +4,8 @@ verticalMultiline = {
 }
 
 <<< not modify single line
+optIn.configStyleArguments = false
+===
 def getListing(
   a: String,
   b: String,

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -21,6 +21,8 @@ def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
 def format_![T <: Tree](code: String)(f: A => B)(implicit ev: Parse[T]): String
 
 <<< small multi-line functions should fit in one line
+optIn.configStyleArguments = false
+===
 def format_![T <: Tree](
     code: String)(
     f: A => B)


### PR DESCRIPTION
If `optin.configStyleArguments` is set, incorporate the setting into the vertical multiline logic.

For the purposes of this integration, we'll assume that config style means there's a line break after the opening parenthesis (without requiring dangling, or a line break before the closing one), and `optIn.configStyleArguments` is set.

Fixes #1539.