### PR TITLE
Tests: determine test's location, provide to Intellij

### DIFF
--- a/scalafmt-tests/src/main/scala/org/scalafmt/util/DiffAssertions.scala
+++ b/scalafmt-tests/src/main/scala/org/scalafmt/util/DiffAssertions.scala
@@ -26,7 +26,17 @@ trait DiffAssertions extends AnyFunSuiteLike {
           Some(title + "\n" + error2message(obtained, expected)),
         None: Option[Throwable],
         pos
-      )
+      ) {
+    /* fool Intellij, prepend a stack trace element pointing to the test case
+     * to allow clicking to the file location; the trick is to show just the
+     * short file name under failedCodeFileName, and put the slightly longer
+     * version in pos.fileName as a hint in case of multiple matches. */
+    // see https://github.com/JetBrains/intellij-scala/blob/ce13d312447ff67404f9359a0543d1bf78c7430a/scala/scala-impl/src/org/jetbrains/plugins/scala/testingSupport/util/scalatest/ScalaTestFailureLocationFilter.java#L76
+    override def failedCodeFileName = Some(new File(pos.fileName).getName)
+    override lazy val failedCodeStackDepth = 0
+    override lazy val getStackTrace =
+      new StackTraceElement(pos.fileName, "", "", 0) +: super.getStackTrace
+  }
 
   def error2message(obtained: String, expected: String): String = {
     val sb = new StringBuilder

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/CanRunTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/CanRunTests.scala
@@ -1,5 +1,6 @@
 package org.scalafmt.util
 
+import org.scalactic.source.Position
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalafmt.Debug
 
@@ -8,6 +9,8 @@ import scala.meta.parsers.{Parse, ParseException}
 
 trait CanRunTests extends AnyFunSuite with HasTests {
   def runTest(run: (DiffTest, Parse[_ <: Tree]) => Unit)(t: DiffTest): Unit = {
+    implicit val loc: Position = t.loc
+    val filename = loc.filePathname
     val paddedName = f"${t.fullName}%-70s|"
 
     if (ignore(t)) {
@@ -17,7 +20,7 @@ trait CanRunTests extends AnyFunSuite with HasTests {
     } else {
       test(paddedName) {
         Debug.newTest()
-        filename2parse(t.filename) match {
+        filename2parse(filename) match {
           case Some(parse) =>
             try {
               run.apply(t, parse)
@@ -28,7 +31,7 @@ trait CanRunTests extends AnyFunSuite with HasTests {
                     parseException2Message(e, t.original)
                 )
             }
-          case None => fail(s"Found no parse for filename ${t.filename}")
+          case None => fail(s"Found no parse for filename $filename")
         }
       }
     }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/DiffTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/DiffTest.scala
@@ -1,16 +1,16 @@
 package org.scalafmt.util
 
+import org.scalactic.source.Position
 import org.scalafmt.config.ScalafmtConfig
 
 case class DiffTest(
-    spec: String,
     name: String,
-    filename: String,
+    loc: Position,
     original: String,
     expected: String,
     skip: Boolean,
     only: Boolean,
     style: ScalafmtConfig
 ) {
-  val fullName = s"$spec: $name"
+  val fullName = s"${loc.fileName}:${loc.lineNumber}: $name"
 }


### PR DESCRIPTION
While this approach will not make the test case itself clickable, any failures (which Intellij's runner will mark with `ScalaTestFailureLocation` and then parse to provide a clickable `... at (<link>)`) will have a link which will open the test file on the right line.