### PR TITLE
A couple of bugfixes in handling of first arg after "("

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1022,4 +1022,16 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         (newlines == 0, if (newlines >= 2) Newline2x else Newline)
     }
 
+  def getNoSplit(
+      ft: FormatToken,
+      spaceOk: Boolean
+  )(implicit style: ScalafmtConfig): Modification =
+    ft.right match {
+      case c: T.Comment =>
+        val isDetachedSlc = ft.newlinesBetween != 0 && isSingleLineComment(c)
+        if (isDetachedSlc || next(ft).leftHasNewline) null else Space
+      case _ =>
+        Space(style.spaces.inParentheses && spaceOk)
+    }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1034,4 +1034,24 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         Space(style.spaces.inParentheses && spaceOk)
     }
 
+  def getLambdaAtSingleArgCallSite(
+      ft: FormatToken
+  )(implicit style: ScalafmtConfig): Option[Term.Function] =
+    ft.meta.leftOwner match {
+      case Term.Apply(_, List(fun: Term.Function)) => Some(fun)
+      case fun: Term.Function if fun.parent.exists({
+            case Term.ApplyInfix(_, _, _, List(`fun`)) => true
+            case _ => false
+          }) =>
+        Some(fun)
+      case t: Init if style.activeForEdition_2020_01 =>
+        ft.meta.rightOwner.parent.flatMap { rparam =>
+          t.argss.collectFirst {
+            case List(fun: Term.Function) if rparam eq fun.params.head =>
+              fun
+          }
+        }
+      case _ => None
+    }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1045,13 +1045,19 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
           }) =>
         Some(fun)
       case t: Init if style.activeForEdition_2020_01 =>
-        ft.meta.rightOwner.parent.flatMap { rparam =>
-          t.argss.collectFirst {
-            case List(fun: Term.Function) if rparam eq fun.params.head =>
-              fun
-          }
-        }
+        findArgsFor(ft, t.argss).collect { case List(f: Term.Function) => f }
       case _ => None
     }
+
+  def findArgsFor(ft: FormatToken, argss: Seq[Seq[Tree]]): Option[Seq[Tree]] = {
+    // find the arg group starting with given format token
+    val beg = ft.left.start
+    argss
+      .find(_.headOption.exists(_.tokens.head.start >= beg))
+      .filter { x =>
+        val pos = x.head.tokens.head.start
+        pos <= ft.right.end || pos <= matching(ft.left).start
+      }
+  }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -216,7 +216,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             start.newlinesBetween == 0 =>
         rhsOptimalToken(next(start))
       case c: T.Comment
-          if style.activeForEdition_2020_01 && start.newlinesBetween == 0 =>
+          if style.activeForEdition_2020_01 && start.newlinesBetween == 0 &&
+            (!start.left.is[T.LeftParen] || isSingleLineComment(c)) =>
         c
       case _ => start.left
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -988,12 +988,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       style.verticalMultilineAtDefinitionSiteArityThreshold
     )
 
-    val singleLineModification =
-      if (style.spaces.inParentheses) Space
-      else NoSplit
-
     Seq(
-      Split(singleLineModification, 0)
+      Split(Space(style.spaces.inParentheses), 0)
         .onlyIf(isBracket || belowArityThreshold)
         .withPolicy(SingleLineBlock(singleLineExpire)),
       Split(Newline, 1) // Otherwise split vertically

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -1,5 +1,6 @@
 package org.scalafmt.internal
 
+import scala.meta.Tree
 import scala.meta.tokens.Token
 
 import org.scalafmt.util.TokenOps._
@@ -43,7 +44,9 @@ object FormatToken {
     */
   case class Meta(
       between: Array[Token],
-      idx: Int
+      idx: Int,
+      leftOwner: Tree,
+      rightOwner: Tree
   )
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -50,4 +50,6 @@ object Newline2xNoIndent extends NewlineT(isDouble = true, noIndent = true)
 object Space extends Modification {
   override val newlines: Int = 0
   override def toString = "Space"
+
+  def apply(flag: Boolean): Modification = if (flag) Space else NoSplit
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -139,7 +139,7 @@ class Router(formatOps: FormatOps) {
         }
 
         Seq(
-          Split(if (style.spaces.inImportCurlyBraces) Space else NoSplit, 0)
+          Split(Space(style.spaces.inImportCurlyBraces), 0)
             .withPolicy(policy),
           Split(Newline, 1)
             .onlyIf(style.importSelectors != ImportSelectors.singleLine)
@@ -158,8 +158,7 @@ class Router(formatOps: FormatOps) {
         val isInterpolate = rightOwner.is[Term.Interpolate]
         Seq(
           Split(
-            if (style.spaces.inImportCurlyBraces && !isInterpolate) Space
-            else NoSplit,
+            Space(style.spaces.inImportCurlyBraces && !isInterpolate),
             0
           )
         )
@@ -881,7 +880,7 @@ class Router(formatOps: FormatOps) {
         val expire = lastToken(defDefReturnType(rightOwner).get)
         val penalizeNewlines =
           penalizeAllNewlines(expire, Constants.BracketPenalty)
-        val sameLineSplit = if (endsWithSymbolIdent(left)) Space else NoSplit
+        val sameLineSplit = Space(endsWithSymbolIdent(left))
         Seq(
           Split(sameLineSplit, 0).withPolicy(penalizeNewlines),
           // Spark style guide allows this:
@@ -1023,9 +1022,9 @@ class Router(formatOps: FormatOps) {
             val contextOption = style.spaces.beforeContextBoundColon
             val summaryTypeBoundsCount =
               tp.tbounds.lo.size + tp.tbounds.hi.size + tp.cbounds.size
-            if (contextOption.isIfMultipleBounds && summaryTypeBoundsCount > 1 || contextOption.isAlways)
-              Space
-            else NoSplit
+            val useSpace = contextOption.isAlways ||
+              contextOption.isIfMultipleBounds && summaryTypeBoundsCount > 1
+            Space(useSpace)
 
           case _ =>
             left match {
@@ -1192,7 +1191,7 @@ class Router(formatOps: FormatOps) {
             case _ => false
           } =>
         Seq(
-          Split(if (isSymbolicIdent(right)) Space else NoSplit, 0)
+          Split(Space(isSymbolicIdent(right)), 0)
         )
       // Annotations, see #183 for discussion on this.
       case FormatToken(_, bind @ T.At(), _) if rightOwner.is[Pat.Bind] =>
@@ -1569,12 +1568,11 @@ class Router(formatOps: FormatOps) {
         )
       case FormatToken(left, T.Hash(), _) =>
         Seq(
-          Split(if (endsWithSymbolIdent(left)) Space else NoSplit, 0)
+          Split(Space(endsWithSymbolIdent(left)), 0)
         )
       case FormatToken(T.Hash(), ident: T.Ident, _) =>
-        val mod = if (TokenOps.isSymbolicIdent(ident)) Space else NoSplit
         Seq(
-          Split(mod, 0)
+          Split(Space(isSymbolicIdent(ident)), 0)
         )
       case FormatToken(T.Dot(), T.Ident(_) | T.KwThis() | T.KwSuper(), _) =>
         Seq(
@@ -1586,9 +1584,7 @@ class Router(formatOps: FormatOps) {
         )
       case FormatToken(_, T.RightParen(), _) =>
         val mod =
-          if (style.spaces.inParentheses &&
-            isDefnOrCallSite(rightOwner)) Space
-          else NoSplit
+          Space(style.spaces.inParentheses && isDefnOrCallSite(rightOwner))
         Seq(
           Split(mod, 0)
         )
@@ -1622,7 +1618,7 @@ class Router(formatOps: FormatOps) {
           Split(NoSplit, 0)
         )
       case FormatToken(T.RightArrow(), _, _) if leftOwner.is[Type.ByName] =>
-        val mod = if (!style.spaces.inByNameTypes) NoSplit else Space
+        val mod = Space(style.spaces.inByNameTypes)
         Seq(
           Split(mod, 0)
         )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -768,8 +768,7 @@ class Router(formatOps: FormatOps) {
         val oneArgOneLine = OneArgOneLineSplit(formatToken)
 
         val newlineMod: Modification =
-          if (right.is[T.Comment] && newlines == 0)
-            Space
+          if (newlines == 0 && isSingleLineComment(right)) Space
           else if (right.is[T.LeftBrace]) NoSplit
           else Newline
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -18,7 +18,6 @@ case class OptimalToken(token: Token, killOnFail: Boolean = false)
   * @param cost How good is this output? Lower is better.
   * @param indents Does this add indentation?
   * @param policy How does this split affect other later splits?
-  * @param penalty Does this split overflow the column limit?
   * @param line For debugging, to retrace from which case in [[Router]]
   *             this split originates.
   *
@@ -29,7 +28,6 @@ case class Split(
     ignoreIf: Boolean = false,
     indents: Vector[Indent[Length]] = Vector.empty[Indent[Length]],
     policy: Policy = NoPolicy,
-    penalty: Boolean = false,
     optimalAt: Option[OptimalToken] = None
 )(implicit val line: sourcecode.Line) {
   import TokenOps._
@@ -67,13 +65,13 @@ case class Split(
 
   def withOptimalToken(token: Token, killOnFail: Boolean = false): Split = {
     require(optimalAt.isEmpty)
-    copy(optimalAt = Some(OptimalToken(token, killOnFail)), penalty = true)
+    copy(optimalAt = Some(OptimalToken(token, killOnFail)))
   }
 
   def withPolicy(newPolicy: Policy): Split = {
     if (policy != NoPolicy)
       throw new UnsupportedOperationException("Can't have two policies yet.")
-    copy(policy = newPolicy, penalty = true)
+    copy(policy = newPolicy)
   }
 
   def withPolicy(newPolicy: Option[Policy]): Split =
@@ -90,7 +88,7 @@ case class Split(
     else copy(policy = policy.andThen(newPolicy))
 
   def withPenalty(penalty: Int): Split =
-    copy(cost = cost + penalty, penalty = true)
+    copy(cost = cost + penalty)
 
   def withIndent(length: Length, expire: Token, expiresOn: ExpiresOn): Split =
     length match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -76,8 +76,7 @@ object TokenOps {
     between.lastOption.exists(_.is[LF])
 
   def rhsIsCommentedOut(formatToken: FormatToken): Boolean =
-    formatToken.right.is[Comment] &&
-      formatToken.right.syntax.startsWith("//") &&
+    isSingleLineComment(formatToken.right) &&
       endsWithNoIndent(formatToken.between)
 
   val booleanOperators = Set("&&", "||")
@@ -156,8 +155,11 @@ object TokenOps {
     )
   }
 
+  def isSingleLineComment(c: Token.Comment): Boolean =
+    c.syntax.startsWith("//")
+
   def isSingleLineComment(token: Token): Boolean = token match {
-    case c: Comment => c.syntax.startsWith("//")
+    case c: Comment => isSingleLineComment(c)
     case _ => false
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -114,9 +114,7 @@ object TokenOps {
 
   def identModification(ident: Ident): Modification = {
     val lastCharacter = ident.syntax.last
-    if (Character.isLetterOrDigit(lastCharacter) || lastCharacter == '`')
-      NoSplit
-    else Space
+    Space(!Character.isLetterOrDigit(lastCharacter) && lastCharacter != '`')
   }
 
   def isOpenApply(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -555,26 +555,6 @@ object TreeOps {
       case _ => None
     }
 
-  def getLambdaAtSingleArgCallSite(
-      ft: FormatToken
-  )(implicit style: ScalafmtConfig): Option[Term.Function] =
-    ft.meta.leftOwner match {
-      case Term.Apply(_, List(fun: Term.Function)) => Some(fun)
-      case fun: Term.Function if fun.parent.exists({
-            case Term.ApplyInfix(_, _, _, List(`fun`)) => true
-            case _ => false
-          }) =>
-        Some(fun)
-      case t: Init if style.activeForEdition_2020_01 =>
-        ft.meta.rightOwner.parent.flatMap { rparam =>
-          t.argss.collectFirst {
-            case List(fun: Term.Function) if rparam eq fun.params.head =>
-              fun
-          }
-        }
-      case _ => None
-    }
-
   def isSingleElement(elements: List[Tree], value: Tree): Boolean =
     elements.lengthCompare(1) == 0 && (value eq elements.head)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -389,10 +389,8 @@ object TreeOps {
 
   val splitApplyIntoLhsAndArgsLifted = splitApplyIntoLhsAndArgs.lift
 
-  def getApplyArgs(
-      formatToken: FormatToken,
-      leftOwner: Tree
-  ): (Tree, Seq[Tree]) = {
+  def getApplyArgs(formatToken: FormatToken): (Tree, Seq[Tree]) = {
+    val leftOwner = formatToken.meta.leftOwner
     leftOwner match {
       case t: Defn.Def if formatToken.left.is[LeftBracket] =>
         t.name -> t.tparams
@@ -558,10 +556,9 @@ object TreeOps {
     }
 
   def getLambdaAtSingleArgCallSite(
-      ltree: Tree,
-      rtree: Tree
+      ft: FormatToken
   )(implicit style: ScalafmtConfig): Option[Term.Function] =
-    ltree match {
+    ft.meta.leftOwner match {
       case Term.Apply(_, List(fun: Term.Function)) => Some(fun)
       case fun: Term.Function if fun.parent.exists({
             case Term.ApplyInfix(_, _, _, List(`fun`)) => true
@@ -569,7 +566,7 @@ object TreeOps {
           }) =>
         Some(fun)
       case t: Init if style.activeForEdition_2020_01 =>
-        rtree.parent.flatMap { rparam =>
+        ft.meta.rightOwner.parent.flatMap { rparam =>
           t.argss.collectFirst {
             case List(fun: Term.Function) if rparam eq fun.params.head =>
               fun

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -165,11 +165,11 @@ val ret = new mutable.MapBuilder[TokenHash, Tree, Map[TokenHash, Tree]](
       {
         Seq(
             Split(
-                  // This split needs to have an optimalAt field.
-                  Space,
-                  0,
-                  ignoreIf = !spaceCouldBeOk,
-                  optimalAt = Some(expire_______________a))
+                // This split needs to have an optimalAt field.
+                Space,
+                0,
+                ignoreIf = !spaceCouldBeOk,
+                optimalAt = Some(expire_______________a))
               .withPolicy(SingleLineBlockAAAA(expire))
         )
       }
@@ -204,14 +204,14 @@ val result = new scala.collection.mutable.SetBuilder[Token, Set[Token]](Set.empt
     })
 >>>
 writeRead(
-          // Use list because Array has a shitty toString
-          { (b: List[Byte], os) =>
-            os.writePosVarInt(b.size); os.writeBytes(b.toArray)
-          }, { is =>
-            val bytes = new Array[Byte](is.readPosVarInt)
-            is.readFully(bytes)
-            bytes.toList
-          })
+    // Use list because Array has a shitty toString
+    { (b: List[Byte], os) =>
+      os.writePosVarInt(b.size); os.writeBytes(b.toArray)
+    }, { is =>
+      val bytes = new Array[Byte](is.readPosVarInt)
+      is.readFully(bytes)
+      bytes.toList
+    })
 <<< resolution copier
 class ResolutionCopier(x: Int) {
 
@@ -658,9 +658,9 @@ maxColumn = 28
 val a = b(  /* comment */ arg1,
    arg2)
 >>>
-Idempotency violated
 val a = b(
-/* comment */ arg1, arg2)
+    /* comment */ arg1,
+    arg2)
 <<< comment in first arg, newline
 maxColumn = 28
 ===
@@ -668,7 +668,8 @@ val a = b(
   /* comment */ arg1,    arg2)
 >>>
 val a = b(
-/* comment */ arg1, arg2)
+    /* comment */ arg1,
+    arg2)
 <<< init with multiple curried parameters and comment, long
 align = none
 ===

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -652,3 +652,35 @@ SSLConfig(SSLLooseConfig(None)/*comment 123 comment 234*/)) //comment 345 commen
       SSLConfig(SSLLooseConfig(None) /*comment 123 comment 234*/ )
   ) //comment 345 comment 456
 }
+<<< comment in first arg, no newline
+maxColumn = 28
+===
+val a = b(  /* comment */ arg1,
+   arg2)
+>>>
+Idempotency violated
+val a = b(
+/* comment */ arg1, arg2)
+<<< comment in first arg, newline
+maxColumn = 28
+===
+val a = b(
+  /* comment */ arg1,    arg2)
+>>>
+val a = b(
+/* comment */ arg1, arg2)
+<<< init with multiple curried parameters and comment, long
+align = none
+===
+val a = new b(/*c1*/c => d)(/*c2*/e => f, g => h)
+>>>
+val a = new b( /*c1*/ c => d)( /*c2*/ e => f, g => h)
+<<< init with multiple curried parameters and comment, short
+align = none
+maxColumn = 30
+===
+val a = new b(/*c1*/c => dddddddd)(/*c2*/e => f, g => h)
+>>>
+val a = new b(
+    /*c1*/ c => dddddddd
+)( /*c2*/ e => f, g => h)

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -682,6 +682,7 @@ maxColumn = 30
 ===
 val a = new b(/*c1*/c => dddddddd)(/*c2*/e => f, g => h)
 >>>
-val a = new b(
-    /*c1*/ c => dddddddd
-)( /*c2*/ e => f, g => h)
+val a = new b( /*c1*/ c =>
+  dddddddd)(
+    /*c2*/ e => f,
+    g => h)

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -102,3 +102,13 @@ object a {
       )
   }
 }
+<<< #1703
+object Foo {
+  def foo(): Unit = ()
+
+  def run(): Thread = {
+    new Thread( /*c1*/ )(() => foo())
+  }
+}
+>>>
+java.util.NoSuchElementException: head of empty list

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -111,4 +111,11 @@ object Foo {
   }
 }
 >>>
-java.util.NoSuchElementException: head of empty list
+object Foo {
+  def foo(): Unit = ()
+
+  def run(): Thread = {
+    new Thread( /*c1*/ )(() =>
+      foo())
+  }
+}

--- a/scalafmt-tests/src/test/resources/unit/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/unit/DefDef.stat
@@ -121,3 +121,39 @@ def heyImCool = {
   val c = b.foobar
 
 }
+<<< multiple bracket and paren groups with comments 1
+  implicit def xorBifunctor: Bitraverse[Xor] =
+    new Bitraverse[Xor] {
+      def bitraverse[G[_], A, B, C, D](/*c1*/fab: Xor[A, B])(/*c2*/
+          f: A => G[C],
+          g: B => G[D])(implicit G: Applicative[G]): G[Xor[C, D]] =
+        fab match {
+          case Xor.Left(a)  => G.map(f(a))(Xor.left)
+          case Xor.Right(b) => G.map(g(b))(Xor.right)
+        }
+}
+>>>
+Idempotency violated
+implicit def xorBifunctor
+    : Bitraverse[Xor] =
+  new Bitraverse[Xor] {
+    def bitraverse[G[_], A, B, C, D]( /*c1*/ fab: Xor[A, B])(
+        /*c2*/
+        f: A => G[C],
+        g: B => G[D])(
+        implicit G: Applicative[G])
+        : G[Xor[C, D]] =
+      fab match {
+        case Xor.Left(a) =>
+          G.map(f(a))(Xor.left)
+        case Xor.Right(b) =>
+          G.map(g(b))(Xor.right)
+      }
+  }
+<<< multiple bracket and paren groups with comments 2
+val a = new a[b, c](/*c1*/d => e)(/*c2*/f => g, h => i)(/*c3*/j => k)
+>>>
+val a = new a[b, c]( /*c1*/ d => e)(
+    /*c2*/ f => g,
+    h => i
+)( /*c3*/ j => k)

--- a/scalafmt-tests/src/test/resources/unit/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/unit/DefDef.stat
@@ -133,11 +133,11 @@ def heyImCool = {
         }
 }
 >>>
-Idempotency violated
 implicit def xorBifunctor
     : Bitraverse[Xor] =
   new Bitraverse[Xor] {
-    def bitraverse[G[_], A, B, C, D]( /*c1*/ fab: Xor[A, B])(
+    def bitraverse[G[_], A, B, C, D](
+        /*c1*/ fab: Xor[A, B])(
         /*c2*/
         f: A => G[C],
         g: B => G[D])(
@@ -155,5 +155,4 @@ val a = new a[b, c](/*c1*/d => e)(/*c2*/f => g, h => i)(/*c3*/j => k)
 >>>
 val a = new a[b, c]( /*c1*/ d => e)(
     /*c2*/ f => g,
-    h => i
-)( /*c3*/ j => k)
+    h => i)( /*c3*/ j => k)


### PR DESCRIPTION
Fixes #1703 

`scala-repos` diffs:
* Router bugfix: split, indent comments consistently https://github.com/kitbellew/scala-repos/commit/93a939860e153783b1e3e6d79005d0ef2381a386
* TreeOps bugfix: find Init param group correctly https://github.com/kitbellew/scala-repos/commit/68cb5977aadcfc68466ebfff49e4e81e966f4987?w=1
* Router bugfix: consistently allow break on "(/**/" https://github.com/kitbellew/scala-repos/commit/3fd4a1a7241282b43aed2615b5383bc0f4588511?w=1