### PR TITLE
Trailing commas bugfix: can't have trailing comma in `preserve` without a break

### DIFF
--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
@@ -32,3 +32,38 @@ def method(
     a: String,
     b: String
 )
+<<< should remove trailing comma when folding
+def a(b: Int,
+ c: Int,
+)
+>>>
+Formatter output does not parse:
+def a(b: Int, c: Int, )
+<<< should remove trailing comma when folding, with comment
+maxColumn = 40
+danglingParentheses = false
+===
+def a(b: Int, c: Int,
+ /* comment */ )
+>>>
+Formatter output does not parse:
+def a(b: Int, c: Int, /* comment */ )
+<<< should remove trailing comma when folding, with spaces
+spaces.inParentheses = true
+===
+def a(b: Int,
+ c: Int,
+)
+>>>
+Formatter output does not parse:
+def a( b: Int, c: Int, )
+<<< should remove trailing comma when folding, with spaces and comment
+spaces.inParentheses = true
+maxColumn = 40
+danglingParentheses = false
+===
+def a(b: Int, c: Int,
+ /* comment */ )
+>>>
+Formatter output does not parse:
+def a( b: Int, c: Int, /* comment */ )

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
@@ -37,8 +37,7 @@ def a(b: Int,
  c: Int,
 )
 >>>
-Formatter output does not parse:
-def a(b: Int, c: Int, )
+def a(b: Int, c: Int)
 <<< should remove trailing comma when folding, with comment
 maxColumn = 40
 danglingParentheses = false
@@ -46,8 +45,7 @@ danglingParentheses = false
 def a(b: Int, c: Int,
  /* comment */ )
 >>>
-Formatter output does not parse:
-def a(b: Int, c: Int, /* comment */ )
+def a(b: Int, c: Int /* comment */ )
 <<< should remove trailing comma when folding, with spaces
 spaces.inParentheses = true
 ===
@@ -55,8 +53,7 @@ def a(b: Int,
  c: Int,
 )
 >>>
-Formatter output does not parse:
-def a( b: Int, c: Int, )
+def a( b: Int, c: Int )
 <<< should remove trailing comma when folding, with spaces and comment
 spaces.inParentheses = true
 maxColumn = 40
@@ -65,5 +62,4 @@ danglingParentheses = false
 def a(b: Int, c: Int,
  /* comment */ )
 >>>
-Formatter output does not parse:
-def a( b: Int, c: Int, /* comment */ )
+def a( b: Int, c: Int /* comment */ )


### PR DESCRIPTION
Follow-on to #1669 