### PR TITLE
FormatWriter: {} => (): don't rewrite some lambdas

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -174,8 +174,9 @@ class FormatWriter(formatOps: FormatOps) {
             case b: Term.Block if TreeOps.getBlockSingleStat(b).exists {
                   /* guard for statements requiring a wrapper block
                    * "foo { x => y; z }" can't become "foo(x => y; z)" */
-                  case Term.Function(_, body) =>
-                    TreeOps.getTermSingleStat(body).isDefined
+                  case f: Term.Function =>
+                    TreeOps.getTermSingleStat(f.body).isDefined &&
+                      !RedundantBraces.needParensAroundParams(f)
                   case _ => true
                 } =>
               b.parent match {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -136,20 +136,18 @@ override def run(args: List[String]): IO[ExitCode] =
       program
     }
 >>>
-test does not parse
 override def run(args: List[String]): IO[ExitCode] =
   Slf4jLogger
     .create[IO]
-    .flatMap(implicit logger: Logger[IO] => program)
+    .flatMap { implicit logger: Logger[IO] => program }
 <<< #1707 2: don't rewrite to parens if typed lambda param
 def a(b: B): C[D] =
     C[String].contramap[D] { i: D =>
       b.format(i)
     }
 >>>
-test does not parse
-def a(formatter: DateTimeFormatter): b[Instant] =
-  C[String].contramap[D](i: D => b.format(i))
+def a(b: B): C[D] =
+  C[String].contramap[D] { i: D => b.format(i) }
 <<< #1707 3: rewrite to parens if typed lambda param with parens
 def a(b: B): C[D] =
     C[String].contramap[D] { (i: D) =>
@@ -172,6 +170,4 @@ danglingParentheses = false
 val a = b[IO](
 { c: Int => if (d) e else f }, g)
 >>>
-test does not parse
-val a = b[IO](
- c: Int => if (d) e else f , g)
+val a = b[IO]({ c: Int => if (d) e else f }, g)

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -128,3 +128,50 @@ object a {
 object a {
   val a = b(c => d => { e; f })
 }
+<<< #1707 1: don't rewrite to parens if typed lambda param
+override def run(args: List[String]): IO[ExitCode] =
+  Slf4jLogger
+    .create[IO]
+    .flatMap { implicit logger: Logger[IO] =>
+      program
+    }
+>>>
+test does not parse
+override def run(args: List[String]): IO[ExitCode] =
+  Slf4jLogger
+    .create[IO]
+    .flatMap(implicit logger: Logger[IO] => program)
+<<< #1707 2: don't rewrite to parens if typed lambda param
+def a(b: B): C[D] =
+    C[String].contramap[D] { i: D =>
+      b.format(i)
+    }
+>>>
+test does not parse
+def a(formatter: DateTimeFormatter): b[Instant] =
+  C[String].contramap[D](i: D => b.format(i))
+<<< #1707 3: rewrite to parens if typed lambda param with parens
+def a(b: B): C[D] =
+    C[String].contramap[D] { (i: D) =>
+      b.format(i)
+    }
+>>>
+def a(b: B): C[D] =
+  C[String].contramap[D]((i: D) => b.format(i))
+<<< #1707 4: rewrite to parens if multiple params
+def a(b: B): C[D] =
+    C[String].contramap[D] { (i: D, j: Int) =>
+      b.format(i)
+    }
+>>>
+def a(b: B): C[D] =
+  C[String].contramap[D]((i: D, j: Int) => b.format(i))
+<<< #1708
+danglingParentheses = false
+===
+val a = b[IO](
+{ c: Int => if (d) e else f }, g)
+>>>
+test does not parse
+val a = b[IO](
+ c: Int => if (d) e else f , g)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/CanRunTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/CanRunTests.scala
@@ -27,7 +27,7 @@ trait CanRunTests extends AnyFunSuite with HasTests {
             } catch {
               case e: ParseException =>
                 fail(
-                  "test does not parse" +
+                  "test does not parse\n" +
                     parseException2Message(e, t.original)
                 )
             }


### PR DESCRIPTION
We can't rewrite a lambda unless it has parens around parameters or one simple parameter without a type.

Fixes #1707.
Fixes #1708.