### PR TITLE
TreeOps: structure the details of defns or calls

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -671,7 +671,7 @@ class Router(formatOps: FormatOps) {
         val open = formatToken.left
         val close = matching(open)
         val indent = getApplyIndent(leftOwner)
-        val (lhs, args) = getApplyArgs(formatToken)
+        val (_, args) = getApplyArgs(formatToken)
         val optimal = leftOwner.tokens.find(_.is[T.Comma]).orElse(Some(close))
         val isBracket = open.is[T.LeftBracket]
         // TODO(olafur) DRY. Same logic as in default.
@@ -1153,11 +1153,13 @@ class Router(formatOps: FormatOps) {
             // many arguments on the same line can be hard to read. By not
             // putting a newline before the dot, we force the argument list
             // to break into multiple lines.
-            splitApplyIntoLhsAndArgsLifted(tokens(tok, 2).meta.rightOwner)
-              .map {
-                case (_, lst) => Math.max(0, lst.length - 1)
-              }
-              .getOrElse(0)
+            splitCallIntoParts.lift(tokens(tok, 2).meta.rightOwner) match {
+              case Some((_, util.Left(args))) =>
+                Math.max(0, args.length - 1)
+              case Some((_, util.Right(argss))) =>
+                Math.max(0, argss.map(_.length).sum - 1)
+              case _ => 0
+            }
           } else 0
         Seq(
           Split(NoSplit, 0, ignoreIf = ignoreNoSplit)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -732,9 +732,10 @@ class Router(formatOps: FormatOps) {
 
         val indent = getApplyIndent(leftOwner)
 
+        // XXX: sometimes we have zero args, so multipleArgs != !singleArgument
         val singleArgument = args.length == 1
         val multipleArgs = args.length > 1
-        val tooManyArguments = args.length > 100
+        val notTooManyArgs = multipleArgs && args.length <= 100
 
         def insideBraces(t: FormatToken): Boolean =
           excludeRanges.exists(_.contains(t.left.start))
@@ -852,7 +853,7 @@ class Router(formatOps: FormatOps) {
             .withIndent(indent, close, Right),
           Split(noSplitMod, (2 + lhsPenalty) * bracketCoef)
             .withPolicy(oneArgOneLine)
-            .onlyIf(!singleArgument && !tooManyArguments && align)
+            .onlyIf(notTooManyArgs && align)
             .onlyIf(noSplitMod != null)
             .withOptimalToken(expirationToken)
             .withIndent(StateColumn, close, Right),

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -8,7 +8,6 @@ import scala.meta.Ctor
 import scala.meta.Decl
 import scala.meta.Defn
 import scala.meta.Enumerator
-import scala.meta.Importer
 import scala.meta.Init
 import scala.meta.Mod
 import scala.meta.Pat
@@ -26,15 +25,11 @@ import scala.meta.tokens.Tokens
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 import org.scalafmt.Error
-import org.scalafmt.Error.UnexpectedTree
-import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.internal.FormatToken
 
 /**
   * Stateless helper functions on [[scala.meta.Tree]].
   */
 object TreeOps {
-  import LoggerOps._
   import TokenOps._
 
   @tailrec
@@ -388,22 +383,6 @@ object TreeOps {
   }
 
   val splitApplyIntoLhsAndArgsLifted = splitApplyIntoLhsAndArgs.lift
-
-  def getApplyArgs(formatToken: FormatToken): (Tree, Seq[Tree]) = {
-    val leftOwner = formatToken.meta.leftOwner
-    leftOwner match {
-      case t: Defn.Def if formatToken.left.is[LeftBracket] =>
-        t.name -> t.tparams
-      // TODO(olafur) missing Defn.Def with `(` case.
-      case _ =>
-        splitApplyIntoLhsAndArgsLifted(leftOwner).getOrElse {
-          logger.debug(s"""Unknown tree
-                          |${log(leftOwner.parent.get)}
-                          |${isDefnSite(leftOwner)}""".stripMargin)
-          throw UnexpectedTree[Term.Apply](leftOwner)
-        }
-    }
-  }
 
   def isChainApplyParent(parent: Tree, child: Tree): Boolean =
     splitApplyIntoLhsAndArgsLifted(parent).exists(_._1 == child)

--- a/scalafmt-tests/src/test/resources/default/Trait.stat
+++ b/scalafmt-tests/src/test/resources/default/Trait.stat
@@ -101,3 +101,15 @@ abstract class Quantity[A <: Quantity[A]]
     with Ordered[A] { self: A ⇒
   println(1)
 }
+<<< trait with multiple complex type params
+align = none
+===
+ trait CounterLike[
+    K, V, +M <: scala.collection.mutable.Map[K, V], +This <: Counter[K, V]]
+     extends TensorLike[K, V, This]
+     with Serializable { }
+>>>
+trait CounterLike[
+    K, V, +M <: scala.collection.mutable.Map[K, V], +This <: Counter[K, V]]
+    extends TensorLike[K, V, This]
+    with Serializable {}


### PR DESCRIPTION
Prepare for a number of fixes which require a better understanding of a definition.

Also, we can vastly simplify the RewriteTrailingCommas logic immediately, and will be able to improve the FormatOps.getApplyArgs logic later, allowing us to tuck implicit in multi-arg calls or apply trailing commas to calls with a given arity.

No changes to tests or `scala-repos`.