### PR TITLE
FormatWriter: don't rewrite {} => () in assignment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -177,6 +177,7 @@ class FormatWriter(formatOps: FormatOps) {
                   case f: Term.Function =>
                     TreeOps.getTermSingleStat(f.body).isDefined &&
                       !RedundantBraces.needParensAroundParams(f)
+                  case _: Term.Assign => false // disallowed in 2.13
                   case _ => true
                 } =>
               b.parent match {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -171,3 +171,13 @@ val a = b[IO](
 { c: Int => if (d) e else f }, g)
 >>>
 val a = b[IO]({ c: Int => if (d) e else f }, g)
+<<< #1708 with an assignment block
+F.runAsync(stream.compile.toVector) {
+           case Right(bs) => IO { bytes = bs }
+           case Left(t) => IO.raiseError(t)
+         }
+>>>
+F.runAsync(stream.compile.toVector) {
+  case Right(bs) => IO { bytes = bs }
+  case Left(t)   => IO.raiseError(t)
+}


### PR DESCRIPTION
This case has apparently been deprecated in 2.13. Hopefully, not too many additional special cases remain.

Fixes #1708.