### PR TITLE
FormatOps: in one-arg-per-line, handle lbrace case

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -389,10 +389,14 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case Decision(t @ FormatToken(_: T.Comma, right, _), splits)
           if owner == t.meta.leftOwner &&
             // TODO(olafur) what the right { decides to be single line?
-            !right.is[T.LeftBrace] &&
             // If comment is bound to comma, see unit/Comment.
             (!right.is[T.Comment] || t.newlinesBetween != 0) =>
-        splits.filter(_.modification.isNewline)
+        if (!right.is[T.LeftBrace])
+          splits.filter(_.modification.isNewline)
+        else if (!style.activeForEdition_2020_03)
+          splits
+        else
+          SplitTag.OneArgPerLine.activateOnly(splits)
     }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -601,13 +601,7 @@ class Router(formatOps: FormatOps) {
         val isForcedBinPack = styleMap.forcedBinPack.contains(leftOwner)
         val policy =
           if (isForcedBinPack) Policy(close)(newlineBeforeClose)
-          else {
-            val oneArgOneLine = OneArgOneLineSplit(
-              formatToken,
-              noTrailingCommas = style.poorMansTrailingCommasInConfigStyle
-            )
-            oneArgOneLine.copy(f = oneArgOneLine.f.orElse(newlineBeforeClose))
-          }
+          else OneArgOneLineSplit(formatToken).orElse(newlineBeforeClose)
         Seq(
           Split(Newline, 0, policy = policy)
             .withIndent(indent, close, Right)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -22,4 +22,6 @@ object SplitTag {
   case object Active extends Base
   case object Ignored extends Base
 
+  case object OneArgPerLine extends Custom
+
 }

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -207,7 +207,8 @@ writeRead(
     // Use list because Array has a shitty toString
     { (b: List[Byte], os) =>
       os.writePosVarInt(b.size); os.writeBytes(b.toArray)
-    }, { is =>
+    },
+    { is =>
       val bytes = new Array[Byte](is.readPosVarInt)
       is.readFully(bytes)
       bytes.toList

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -680,3 +680,62 @@ object a {
           }),
         _ => e)
 }
+<<< multiple block arguments 1
+object a {
+ b(
+        { _ + _ }, { _ - _ }, { _ * _ },
+         { _ * _ }, {
+          _ / _
+        }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+}
+>>>
+object a {
+  b({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
+    _ / _
+  }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+}
+<<< multiple block arguments 2
+@expand
+@expand.valify
+implicit def v_s_Op[
+    @expand.args(Int, Double, Float, Long) T,
+    @expand.args(
+      OpAdd,
+      OpSub,
+      OpMulScalar,
+      OpMulMatrix,
+      OpDiv,
+      OpSet,
+      OpMod,
+      OpPow
+    ) Op <: OpType
+](
+    implicit @expand.sequence[Op]({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
+     _ / _ }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+    op: Op.Impl2[T, T, T],
+    @expand.sequence[T](0, 0.0, 0.0f, 0L)
+    zero: T
+): BinaryRegistry[Vector[T], T, Op.type, Vector[T]] = null
+>>>
+@expand
+@expand.valify
+implicit def v_s_Op[
+    @expand.args(Int, Double, Float, Long) T,
+    @expand.args(
+      OpAdd,
+      OpSub,
+      OpMulScalar,
+      OpMulMatrix,
+      OpDiv,
+      OpSet,
+      OpMod,
+      OpPow
+    ) Op <: OpType
+](
+    implicit @expand.sequence[Op]({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
+      _ / _
+    }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+    op: Op.Impl2[T, T, T],
+    @expand.sequence[T](0, 0.0, 0.0f, 0L)
+    zero: T
+): BinaryRegistry[Vector[T], T, Op.type, Vector[T]] = null

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -791,3 +791,62 @@ object A {
     )
   }
 }
+<<< multiple block arguments 1
+object a {
+ b(
+        { _ + _ }, { _ - _ }, { _ * _ },
+         { _ * _ }, {
+          _ / _
+        }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+}
+>>>
+object a {
+  b({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
+    _ / _
+  }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+}
+<<< multiple block arguments 2
+@expand
+@expand.valify
+implicit def v_s_Op[
+    @expand.args(Int, Double, Float, Long) T,
+    @expand.args(
+      OpAdd,
+      OpSub,
+      OpMulScalar,
+      OpMulMatrix,
+      OpDiv,
+      OpSet,
+      OpMod,
+      OpPow
+    ) Op <: OpType
+](
+    implicit @expand.sequence[Op]({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
+     _ / _ }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+    op: Op.Impl2[T, T, T],
+    @expand.sequence[T](0, 0.0, 0.0f, 0L)
+    zero: T
+): BinaryRegistry[Vector[T], T, Op.type, Vector[T]] = null
+>>>
+@expand
+@expand.valify
+implicit def v_s_Op[
+    @expand.args(Int, Double, Float, Long) T,
+    @expand.args(
+      OpAdd,
+      OpSub,
+      OpMulScalar,
+      OpMulMatrix,
+      OpDiv,
+      OpSet,
+      OpMod,
+      OpPow
+    ) Op <: OpType
+](
+    implicit @expand.sequence[Op]({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
+      _ / _
+    }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+    op: Op.Impl2[T, T, T],
+    @expand.sequence[T](0, 0.0, 0.0f, 0L)
+    zero: T
+): BinaryRegistry[Vector[T], T, Op.type, Vector[T]] = null

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -719,7 +719,8 @@ object A {
     x.map(
       _.y(
         abcd,
-        { case ((abcdefghij, aswbasdfaw), asfda) => aswdf }, {
+        { case ((abcdefghij, aswbasdfaw), asfda) => aswdf },
+        {
           case (abcdefghij, sadfasdass) =>
             (
               asdfa.sadvfs(abcdefghij).get,
@@ -748,7 +749,8 @@ object A {
     x.map(
       _.y(
         abcd,
-        { { case ((abcdefghij, aswbasdfaw), asfda) => aswdf } }, {
+        { { case ((abcdefghij, aswbasdfaw), asfda) => aswdf } },
+        {
           {
             case (abcdefghij, sadfasdass) =>
               (
@@ -779,12 +781,12 @@ object A {
     x.map(
       _.y(
         abcd,
-        { case_abcdefghij_aswbasdfaw_asfda => aswdf }, {
-          case_abcdefghij_sadfasdass =>
-            (
-              asdfa.sadvfs(abcdefghij).get,
-              asdfasdfasfdasda.asdfas(asdfasdaas).get
-            )
+        { case_abcdefghij_aswbasdfaw_asfda => aswdf },
+        { case_abcdefghij_sadfasdass =>
+          (
+            asdfa.sadvfs(abcdefghij).get,
+            asdfasdfasfdasda.asdfas(asdfasdaas).get
+          )
         },
         foo
       )


### PR DESCRIPTION
The `scalafmt` error described in #1599 turns out to be mainly due to the rule which formats multiple method arguments one per line. Router would attempt to format `, {` combination as a newline followed by the entire block on a single line, or a space without additional rules instead.

Two problems with this approach:
* because of some aspect of `BestFirstSearch` algorithm that I don't yet fully understand, having these two possible splits led to the search reaching a dead end before it attempted the space split 
  * the expectation was that having additional splits could only lead to a *search state exploded* error, not this)
  * removing the newline split (leaving the space split only) solved the problem
* also, in cases when the space split was chosen, the result wasn't guaranteed to have one argument per line

Instead:
* force a newline for regular or partial functions
* for all other blocks, modify the space rule to force breaks after `{` and before `}`.

Fixes #1599.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/e2042d04c44c988e50189ff1575e0f68fbeef445?w=1