### PR TITLE
RedundantBraces: add parensForOneLineApply flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -523,6 +523,9 @@ Configuration options and default values:
 - `rewrite.redundantBraces.stringInterpolation = true`
 - `rewrite.redundantBraces.generalExpressions = false` (disabled by default due
   to #1147)
+- `rewrite.redundantBraces.parensForOneLineApply`
+  - by default, `true` in edition 2020-01
+  - turns `foo { bar => baz }` into `foo(bar => baz)`
 
 ### `RedundantParens`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RedundantBracesSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RedundantBracesSettings.scala
@@ -7,6 +7,7 @@ case class RedundantBracesSettings(
     includeUnitMethods: Boolean = true,
     maxLines: Int = 100,
     stringInterpolation: Boolean = false,
+    parensForOneLineApply: Option[Boolean] = None,
     // Re-enable generalExpressions once
     // https://github.com/scalameta/scalafmt/issues/1147 is fixed
     generalExpressions: Boolean = false

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -146,7 +146,8 @@ class FormatWriter(formatOps: FormatOps) {
       }
     }
 
-    if (initStyle.activeForEdition_2020_01 &&
+    if (initStyle.rewrite.redundantBraces.parensForOneLineApply
+        .getOrElse(initStyle.activeForEdition_2020_01) &&
       initStyle.rewrite.rules.contains(RedundantBraces))
       replaceRedundantBraces(result)
 


### PR DESCRIPTION
By default, it's enabled in edition 2020-01, just as before, but can be
disabled if necessary, as has been requested by several users.