### PR TITLE
Documentation: describe a few important parameters

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -393,6 +393,54 @@ insert newlines.
 > You might be interested in the [Vertical Multiline](#vertical-multiline)
 > section.
 
+### `danglingParentheses`
+
+While this parameter is not technically under the `newlines` section, it logically belongs there.
+
+```scala mdoc:defaults
+danglingParentheses
+```
+
+```scala mdoc:scalafmt
+danglingParentheses.defnSite = true
+danglingParentheses.callSite = true
+# shortcut to set both
+danglingParentheses = true
+---
+object a {
+  // defnSite
+  def method(
+    a: Int,
+    b: String
+  ): Boolean
+
+  // callSite
+  method(
+    a,
+    b
+  )
+}
+```
+
+```scala mdoc:scalafmt
+danglingParentheses.defnSite = false
+danglingParentheses.callSite = false
+# shortcut to set both
+danglingParentheses = false
+---
+object a {
+  // defnSite
+  def method(
+    a: Int,
+    b: String): Boolean
+
+  // callSite
+  method(
+    a,
+    b)
+}
+```
+
 ### `newlines.alwaysBeforeTopLevelStatements`
 
 ```scala mdoc:defaults
@@ -520,6 +568,7 @@ Configuration options and default values:
 
 - `rewrite.redundantBraces.maxLines = 100`
 - `rewrite.redundantBraces.includeUnitMethods = true`
+- `rewrite.redundantBraces.methodBodies = true`
 - `rewrite.redundantBraces.stringInterpolation = true`
 - `rewrite.redundantBraces.generalExpressions = false` (disabled by default due
   to #1147)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,6 +109,10 @@ editors in their respective parts of the
 
 ## sbt
 
+NB: keep in mind that versions of `scalafmt-core` and `sbt-scalafmt` are released
+independently and don't have to align. The version of `scalafmt-core` is defined
+in the `.scalafmt.conf` configuration file and downloaded dynamically.
+
 ```scala
 // In project/plugins.sbt. Note, does not support sbt 0.13, only sbt 1.x.
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Edition.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Edition.scala
@@ -1,24 +1,33 @@
 package org.scalafmt.config
 
+import java.time.YearMonth
+
 import metaconfig.{Conf, ConfDecoder, ConfEncoder, Configured}
 
-case class Edition(year: Int, month: Int)
+class Edition(val ym: YearMonth) extends AnyVal with Ordered[Edition] {
+  override def toString: String = ym.toString
+  override def compare(o: Edition): Int = ym.compareTo(o.ym)
+}
 
 object Edition {
-  val Latest = Edition(Int.MaxValue, Int.MaxValue)
-  implicit val ordering: Ordering[Edition] =
-    Ordering.by[Edition, (Int, Int)](e => e.year -> e.month)
+
+  val Latest = Edition(9999, 12)
+
+  def apply(year: Int, month: Int): Edition =
+    new Edition(YearMonth.of(year, month))
+  def apply(str: String): Edition =
+    new Edition(YearMonth.parse(str))
+
   lazy val format = "(\\d{4})-(\\d{1,2})".r
 
   implicit val decoder: ConfDecoder[Edition] =
     ConfDecoder.instanceExpect("'$year-$month', for example '2019-08'") {
       case Conf.Str(format(year, month)) =>
-        Configured.ok(Edition(year.toInt, month.toInt))
+        try Configured.ok(Edition(year.toInt, month.toInt))
+        catch { case e: Exception => Configured.error(e.getMessage) }
       case Conf.Str("latest") => Configured.ok(Latest)
     }
 
   implicit val encoder: ConfEncoder[Edition] =
-    ConfEncoder.instance(edition =>
-      Conf.Str(f"${edition.year}%d-${edition.month}%02d")
-    )
+    ConfEncoder.instance(edition => Conf.Str(edition.ym.toString))
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -192,8 +192,7 @@ case class ScalafmtConfig(
   )
 
   // Edition-specific settings below
-  def activeFor(edition: Edition): Boolean =
-    Edition.ordering.gteq(this.edition, edition)
+  def activeFor(edition: Edition): Boolean = this.edition >= edition
 
   // Edition 2019-11
   val activeForEdition_2019_11: Boolean = activeFor(Edition(2019, 11))

--- a/scalafmt-tests/src/test/scala/org/scalafmt/EditionTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/EditionTest.scala
@@ -6,7 +6,7 @@ import org.scalafmt.config.Edition
 import org.scalafmt.util.DiffAssertions
 
 class EditionTest extends AnyFunSuite with DiffAssertions {
-  def check(original: String, expected: Edition): Unit = {
+  def check(original: String, expected: Edition, expectedStr: String): Unit = {
     test(original) {
       val conf = Conf.Str(original)
       val obtained = Edition.decoder.read(conf).get
@@ -14,6 +14,12 @@ class EditionTest extends AnyFunSuite with DiffAssertions {
         Edition.encoder.write(obtained).toString(),
         Edition.encoder.write(expected).toString()
       )
+      assertNoDiff(expected.toString, expectedStr)
+    }
+  }
+  def checkActiveFor(less: String, more: String): Unit = {
+    test(s"$less <= $more") {
+      assert(Edition(less) <= Edition(more))
     }
   }
   def checkError(original: String, expectedError: String): Unit = {
@@ -26,9 +32,9 @@ class EditionTest extends AnyFunSuite with DiffAssertions {
       }
     }
   }
-  check("2019-09", Edition(2019, 9))
-  check("2019-9", Edition(2019, 9))
-  check("2019-10", Edition(2019, 10))
+  check("2019-09", Edition(2019, 9), "2019-09")
+  check("2019-9", Edition(2019, 9), "2019-09")
+  check("2019-10", Edition(2019, 10), "2019-10")
   checkError(
     "2019-invalid",
     """|Type mismatch;
@@ -36,4 +42,7 @@ class EditionTest extends AnyFunSuite with DiffAssertions {
        |  expected : '$year-$month', for example '2019-08'
        |""".stripMargin.trim
   )
+  checkActiveFor("2019-09", "2019-09")
+  checkActiveFor("2019-09", "2019-10")
+  checkActiveFor("2019-08", "2019-09")
 }


### PR DESCRIPTION
Fixes #1659. Fixes #1482. Helps with #1523.

Additionally, implement the `Edition.toString` method so that the automatic documentation which lists all possible options displays this value in a more user-friendly way. Also, implement edition using `java.time.YearMonth`.