### PR TITLE
Various cleanup and refactoring changes in BestFirstSearch

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -67,7 +67,7 @@ object Scalafmt {
         val toParse = Rewrite(Input.VirtualFile(filename, unixCode), style)
         val tree = runner.dialect(toParse).parse(runner.parser).get
         val formatOps = new FormatOps(tree, style)
-        runner.eventCallback(CreateFormatOps(formatOps))
+        runner.event(CreateFormatOps(formatOps))
         val formatWriter = new FormatWriter(formatOps)
         val search = new BestFirstSearch(formatOps, range, formatWriter)
         val partial = search.getBestPath

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FormatEvent.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FormatEvent.scala
@@ -2,7 +2,6 @@ package org.scalafmt.config
 
 import org.scalafmt.internal.FormatOps
 import org.scalafmt.internal.FormatToken
-import org.scalafmt.internal.FormatTokens
 import org.scalafmt.internal.Split
 import org.scalafmt.internal.State
 
@@ -16,9 +15,6 @@ object FormatEvent {
   case class VisitToken(formatToken: FormatToken) extends FormatEvent
   case class Explored(n: Int, depth: Int, queueSize: Int) extends FormatEvent
   case class Enqueue(split: Split) extends FormatEvent
-  case class CompleteFormat(
-      totalExplored: Int,
-      finalState: State,
-      tokens: FormatTokens
-  ) extends FormatEvent
+  case class CompleteFormat(totalExplored: Int, finalState: State)
+      extends FormatEvent
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
@@ -16,7 +16,7 @@ import scala.meta.parsers.Parse
   */
 case class ScalafmtRunner(
     debug: Boolean = false,
-    eventCallback: FormatEvent => Unit = _ => (),
+    private val eventCallback: FormatEvent => Unit = null,
     parser: Parse[_ <: Tree] = Parse.parseSource,
     optimizer: ScalafmtOptimizer = ScalafmtOptimizer.default,
     maxStateVisits: Int = 1000000,
@@ -33,6 +33,13 @@ case class ScalafmtRunner(
         toplevelSeparator = ""
       )
     )
+
+  def event(evt: => FormatEvent): Unit =
+    if (null != eventCallback) eventCallback(evt)
+
+  def events(evts: => Iterator[FormatEvent]): Unit =
+    if (null != eventCallback) evts.foreach(eventCallback)
+
 }
 
 object ScalafmtRunner {
@@ -84,7 +91,6 @@ object ScalafmtRunner {
     */
   val default = ScalafmtRunner(
     debug = false,
-    eventCallback = _ => (),
     parser = scala.meta.parsers.Parse.parseSource,
     optimizer = ScalafmtOptimizer.default,
     maxStateVisits = 1000000

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -171,15 +171,13 @@ class BestFirstSearch(
         runner.eventCallback(VisitToken(splitToken))
         visits.put(splitToken, visits(splitToken) + 1)
 
-        def lastWasNewline =
-          curr.split != null && curr.split.modification.isNewline
-        if (dequeueOnNewStatements &&
-          dequeueSpots.contains(hash(splitToken.left)) &&
-          (depth > 0 || !isInsideNoOptZone(splitToken)) &&
-          lastWasNewline) {
-          Q.clear()
-        } else if (emptyQueueSpots(hash(splitToken.left)) && lastWasNewline) {
-          Q.clear()
+        if (curr.split != null && curr.split.modification.isNewline) {
+          val tokenHash = hash(splitToken.left)
+          if (emptyQueueSpots.contains(tokenHash) ||
+            dequeueOnNewStatements &&
+            dequeueSpots.contains(tokenHash) &&
+            (depth > 0 || !isInsideNoOptZone(splitToken)))
+            Q.clear()
         }
 
         if (shouldRecurseOnBlock(curr, stop)) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -125,19 +125,6 @@ class BestFirstSearch(
     }
   }
 
-  def untilNextStatement(state: State, maxDepth: Int): State = {
-    var curr = state
-    while (!hasReachedEof(curr) && {
-        val token = tokens(curr.depth)
-        !statementStarts.contains(hash(token.left)) &&
-        numParents(token.meta.leftOwner) <= maxDepth
-      }) {
-      val tok = tokens(curr.depth)
-      curr = curr.next(styleMap.at(tok), provided(tok), tok)
-    }
-    curr
-  }
-
   /**
     * Runs best first search to find lowest penalty split.
     */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -163,7 +163,7 @@ class BestFirstSearch(
           token.left.syntax.nonEmpty && token.left.start >= stop.start
         }) {
         result = curr
-        Q.dequeueAll
+        Q.clear()
       } else if (shouldEnterState(curr)) {
         val splitToken = tokens(curr.depth)
         val style = styleMap.at(splitToken)
@@ -182,13 +182,12 @@ class BestFirstSearch(
           dequeueSpots.contains(hash(splitToken.left)) &&
           (depth > 0 || !isInsideNoOptZone(splitToken)) &&
           lastWasNewline) {
-          Q.dequeueAll
+          Q.clear()
           if (!isInsideNoOptZone(splitToken) && lastDequeue.policy.isSafe) {
             lastDequeue = curr
           }
-        } else if (emptyQueueSpots(hash(splitToken.left)) &&
-          lastWasNewline) {
-          Q.dequeueAll
+        } else if (emptyQueueSpots(hash(splitToken.left)) && lastWasNewline) {
+          Q.clear()
         }
 
         if (shouldRecurseOnBlock(curr, stop)) {
@@ -201,7 +200,7 @@ class BestFirstSearch(
           }
         } else if (escapeInPathologicalCases &&
           visits(splitToken) > maxVisitsPerToken) {
-          Q.dequeueAll
+          Q.clear()
           best.clear()
           visits.clear()
           runner.eventCallback(CompleteFormat(explored, deepestYet, tokens))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -146,7 +146,7 @@ class BestFirstSearch(
     while (Q.nonEmpty) {
       val curr = Q.dequeue()
       explored += 1
-      runner.eventCallback(Explored(explored, depth, Q.size))
+      runner.event(Explored(explored, depth, Q.size))
       if (explored > runner.maxStateVisits)
         throw SearchStateExploded(
           deepestYet,
@@ -162,7 +162,7 @@ class BestFirstSearch(
         if (curr.depth > deepestYet.depth) {
           deepestYet = curr
         }
-        runner.eventCallback(VisitToken(splitToken))
+        runner.event(VisitToken(splitToken))
         visits(curr.depth) += 1
 
         if (curr.split != null && curr.split.modification.isNewline) {
@@ -182,7 +182,7 @@ class BestFirstSearch(
           visits(curr.depth) > maxVisitsPerToken) {
           Q.clear()
           best.clear()
-          runner.eventCallback(CompleteFormat(explored, deepestYet, tokens))
+          runner.event(CompleteFormat(explored, deepestYet, tokens))
           throw SearchStateExploded(
             deepestYet,
             formatWriter.mkString(deepestYet),
@@ -208,7 +208,7 @@ class BestFirstSearch(
               !best.contains(curr.depth)) {
               best.update(curr.depth, nextState)
             }
-            runner.eventCallback(Enqueue(split))
+            runner.event(Enqueue(split))
             split.optimalAt match {
               case Some(OptimalToken(token, killOnFail))
                   if acceptOptimalAtHints && optimalNotFound &&
@@ -242,7 +242,7 @@ class BestFirstSearch(
   def getBestPath: SearchResult = {
     val state = shortestPath(State.start, tree.tokens.last)
     if (state.depth == tokens.length) {
-      runner.eventCallback(CompleteFormat(explored, state, tokens))
+      runner.event(CompleteFormat(explored, state, tokens))
       SearchResult(state, reachedEOF = true)
     } else {
       val nextSplits = routes(deepestYet.depth)
@@ -261,7 +261,7 @@ class BestFirstSearch(
         logger.debug(s"""Failed to format
                         |$msg""".stripMargin)
       }
-      runner.eventCallback(CompleteFormat(explored, deepestYet, tokens))
+      runner.event(CompleteFormat(explored, deepestYet, tokens))
       SearchResult(deepestYet, reachedEOF = false)
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -182,7 +182,7 @@ class BestFirstSearch(
           visits(curr.depth) > maxVisitsPerToken) {
           Q.clear()
           best.clear()
-          runner.event(CompleteFormat(explored, deepestYet, tokens))
+          runner.event(CompleteFormat(explored, deepestYet))
           throw SearchStateExploded(
             deepestYet,
             formatWriter.mkString(deepestYet),
@@ -242,7 +242,7 @@ class BestFirstSearch(
   def getBestPath: SearchResult = {
     val state = shortestPath(State.start, tree.tokens.last)
     if (state.depth == tokens.length) {
-      runner.event(CompleteFormat(explored, state, tokens))
+      runner.event(CompleteFormat(explored, state))
       SearchResult(state, reachedEOF = true)
     } else {
       val nextSplits = routes(deepestYet.depth)
@@ -261,7 +261,7 @@ class BestFirstSearch(
         logger.debug(s"""Failed to format
                         |$msg""".stripMargin)
       }
-      runner.event(CompleteFormat(explored, deepestYet, tokens))
+      runner.event(CompleteFormat(explored, deepestYet))
       SearchResult(deepestYet, reachedEOF = false)
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -44,7 +44,6 @@ class BestFirstSearch(
   val noOptimizations = noOptimizationZones(tree)
   var explored = 0
   var deepestYet = State.start
-  var deepestYetSafe = State.start
   var statementCount = 0
   val best = mutable.Map.empty[Token, State]
   var pathologicalEscapes = 0
@@ -150,7 +149,6 @@ class BestFirstSearch(
   ): State = {
     val Q = new mutable.PriorityQueue[State]()
     var result = start
-    var lastDequeue = start
     Q += start
     // TODO(olafur) this while loop is waaaaaaaaaaaaay tooo big.
     while (Q.nonEmpty) {
@@ -170,9 +168,6 @@ class BestFirstSearch(
         if (curr.depth > deepestYet.depth) {
           deepestYet = curr
         }
-        if (curr.policy.isSafe && curr.depth > deepestYetSafe.depth) {
-          deepestYetSafe = curr
-        }
         runner.eventCallback(VisitToken(splitToken))
         visits.put(splitToken, visits(splitToken) + 1)
 
@@ -183,9 +178,6 @@ class BestFirstSearch(
           (depth > 0 || !isInsideNoOptZone(splitToken)) &&
           lastWasNewline) {
           Q.clear()
-          if (!isInsideNoOptZone(splitToken) && lastDequeue.policy.isSafe) {
-            lastDequeue = curr
-          }
         } else if (emptyQueueSpots(hash(splitToken.left)) && lastWasNewline) {
           Q.clear()
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -23,7 +23,7 @@ class FormatWriter(formatOps: FormatOps) {
 
   def mkString(state: State): String = {
     val sb = new StringBuilder()
-    val locations = getFormatLocations(tokens.arr, state, debug = false)
+    val locations = getFormatLocations(state, debug = false)
 
     locations.iterate.foreach { entry =>
       val location = entry.curr
@@ -126,10 +126,10 @@ class FormatWriter(formatOps: FormatOps) {
   import org.scalafmt.util.TokenOps._
 
   def getFormatLocations(
-      toks: Array[FormatToken],
       state: State,
       debug: Boolean
   ): FormatLocations = {
+    val toks = formatOps.tokens.arr
     require(toks.length >= state.depth, "splits !=")
     val result = new Array[FormatLocation](state.depth)
     var curState = state

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -13,8 +13,7 @@ import scala.meta.tokens.Token
 case class Policy(
     f: Policy.Pf,
     expire: Int,
-    noDequeue: Boolean = false,
-    isSingleLine: Boolean = false
+    noDequeue: Boolean = false
 )(implicit val line: sourcecode.Line) {
 
   def isEmpty: Boolean = Policy.isEmpty(f)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -6,9 +6,7 @@ import org.scalafmt.util.LoggerOps
 class PolicySummary(val policies: Vector[Policy]) {
   import LoggerOps._
 
-  @inline def noDequeue = policies.exists { x => x.isSingleLine || x.noDequeue }
-
-  @inline def isSafe = !noDequeue
+  @inline def noDequeue = policies.exists(_.noDequeue)
 
   def combine(other: Policy, position: Int): PolicySummary = {
     // TODO(olafur) filter policies by expiration date

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -150,8 +150,7 @@ object TokenOps {
           }
       },
       expire.end,
-      noDequeue = exclude.isEmpty,
-      isSingleLine = true
+      noDequeue = true
     )
   }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/Debug.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/Debug.scala
@@ -27,7 +27,7 @@ object Debug {
   var lastTestExplored = 0
   var explored = 0
   var state = State.start
-  var tokens = Array.empty[FormatToken]
+  def tokens = formatOps.tokens.arr
   var startTime = System.nanoTime()
 
   def newTest(): Unit = {

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -34,10 +34,9 @@ trait HasTests extends FormatAssertions {
       case explored: Explored if explored.n % 10000 == 0 =>
         logger.elem(explored)
       case Enqueue(split) => Debug.enqueued(split)
-      case CompleteFormat(explored, state, tokens) =>
+      case CompleteFormat(explored, state) =>
         Debug.explored += explored
         Debug.state = state
-        Debug.tokens = tokens.arr
       case _ =>
     }
   )

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -175,7 +175,7 @@ trait HasTests extends FormatAssertions {
   ): Array[FormatOutput] = {
     val builder = mutable.ArrayBuilder.make[FormatOutput]
     val locations = new FormatWriter(Debug.formatOps)
-      .getFormatLocations(Debug.tokens, Debug.state, debug = onlyOne)
+      .getFormatLocations(Debug.state, debug = onlyOne)
     locations.iterate.foreach { entry =>
       val token = entry.curr.formatToken
       builder += FormatOutput(


### PR DESCRIPTION
Removes some unused code or unnecessary complexity. Doesn't change formatting.

Precursor to the algorithm fix which addresses a host of "unable to format due to bug in scalafmt" issues, to be submitted after.