### PR TITLE
BestFirstSearch: don't give up too soon

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -69,8 +69,7 @@ object Scalafmt {
         val formatOps = new FormatOps(tree, style)
         runner.event(CreateFormatOps(formatOps))
         val formatWriter = new FormatWriter(formatOps)
-        val search = new BestFirstSearch(formatOps, range, formatWriter)
-        val partial = search.getBestPath
+        val partial = BestFirstSearch(formatOps, range, formatWriter)
         val formattedString = formatWriter.mkString(partial.state)
         val correctedFormattedString =
           if ((style.lineEndings == preserve && isWindows) ||

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -18,7 +18,7 @@ import org.scalafmt.util.TreeOps
 /**
   * Implements best first search to find optimal formatting.
   */
-class BestFirstSearch(
+private class BestFirstSearch private (
     val formatOps: FormatOps,
     range: Set[Range],
     formatWriter: FormatWriter
@@ -180,8 +180,6 @@ class BestFirstSearch(
             .foreach(Q.enqueue(_))
         else if (escapeInPathologicalCases &&
           visits(curr.depth) > maxVisitsPerToken) {
-          Q.clear()
-          best.clear()
           runner.event(CompleteFormat(explored, deepestYet))
           throw SearchStateExploded(
             deepestYet,
@@ -268,3 +266,14 @@ class BestFirstSearch(
 }
 
 case class SearchResult(state: State, reachedEOF: Boolean)
+
+object BestFirstSearch {
+
+  def apply(
+      formatOps: FormatOps,
+      range: Set[Range],
+      formatWriter: FormatWriter
+  ): SearchResult =
+    new BestFirstSearch(formatOps, range, formatWriter).getBestPath
+
+}

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -386,3 +386,40 @@ testAsync("Resource.make is equivalent to a partially applied bracket") { implic
     }
   }
 }
+<<< #448
+object Foo {
+  code.collect {
+    case d: Defn.Def if (d match {
+      case _ => false
+
+
+    }) &&
+      d=>
+  }
+}
+>>>
+Unable to format file due to bug in scalafmt
+<<< #1485
+style = IntelliJ
+maxColumn = 120
+===
+class A {
+  def foo: B =
+    a.b() { c =>
+        val d = c.add(
+          D[E](
+            1, {
+              case conditionNameShouldLongEnough =>
+                foo1(objectNameShouldLongEnough, objectNameShouldLongEnough)
+                0
+              case conditionNameShouldLongEnough =>
+                foo1(objectNameShouldLongEnough, objectNameShouldLongEnough)
+                1
+            }
+          )
+        )
+      }
+      .f("f")
+}
+>>>
+Unable to format file due to bug in scalafmt

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -398,7 +398,16 @@ object Foo {
   }
 }
 >>>
-Unable to format file due to bug in scalafmt
+object Foo {
+  code.collect {
+    case d: Defn.Def
+        if (d match {
+          case _ => false
+
+        }) &&
+          d =>
+  }
+}
 <<< #1485
 style = IntelliJ
 maxColumn = 120
@@ -422,4 +431,17 @@ class A {
       .f("f")
 }
 >>>
-Unable to format file due to bug in scalafmt
+class A {
+  def foo: B =
+    a.b() { c =>
+        val d = c.add(D[E](1, {
+          case conditionNameShouldLongEnough =>
+            foo1(objectNameShouldLongEnough, objectNameShouldLongEnough)
+            0
+          case conditionNameShouldLongEnough =>
+            foo1(objectNameShouldLongEnough, objectNameShouldLongEnough)
+            1
+        }))
+      }
+      .f("f")
+}

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
@@ -56,4 +56,18 @@ class Bar {
   }
 }
 >>>
-Unable to format file due to bug in scalafmt
+class Bar {
+  def foo(request: Request): RpcResult[Response] = {
+    repository
+      .flatMap { campaigns =>
+        request match {
+          case Nil => connection.pure(Right(toResponse(campaigns, Map.empty)))
+          case _ =>
+            getProfileEmails(request.securityContext, profileIds).to[ConnectionIO].map {
+              profileEmails => Right(toResponse(campaigns, profileEmails))
+            }
+        }
+      }
+      .transact(managerTransactor)
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
@@ -37,3 +37,23 @@ def f = {
 def f = {
   something.call { x => g(x) }
 }
+<<< #1717
+maxColumn = 100
+===
+class Bar {
+  def foo(request: Request): RpcResult[Response] = {
+    repository
+      .flatMap { campaigns =>
+        request match {
+          case Nil => connection.pure(Right(toResponse(campaigns, Map.empty)))
+          case _ =>
+            getProfileEmails(request.securityContext, profileIds).to[ConnectionIO].map {
+              profileEmails =>
+                Right(toResponse(campaigns, profileEmails))
+            }
+        }
+      }.transact(managerTransactor)
+  }
+}
+>>>
+Unable to format file due to bug in scalafmt

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -714,7 +714,23 @@ object A {
   }
 }
 >>>
-Unable to format file due to bug in scalafmt
+object A {
+  def foo() = {
+    x.map(
+      _.y(
+        abcd,
+        { case ((abcdefghij, aswbasdfaw), asfda) => aswdf }, {
+          case (abcdefghij, sadfasdass) =>
+            (
+              asdfa.sadvfs(abcdefghij).get,
+              asdfasdfasfdasda.asdfas(asdfasdaas).get
+            )
+        },
+        foo
+      )
+    )
+  }
+}
 <<< #1599 2: modified, with partial func inside block
 object A {
   def foo() = {
@@ -727,7 +743,25 @@ object A {
   }
 }
 >>>
-Unable to format file due to bug in scalafmt
+object A {
+  def foo() = {
+    x.map(
+      _.y(
+        abcd,
+        { { case ((abcdefghij, aswbasdfaw), asfda) => aswdf } }, {
+          {
+            case (abcdefghij, sadfasdass) =>
+              (
+                asdfa.sadvfs(abcdefghij).get,
+                asdfasdfasfdasda.asdfas(asdfasdaas).get
+              )
+          }
+        },
+        foo
+      )
+    )
+  }
+}
 <<< #1599 3: modified, with lambda
 object A {
   def foo() = {
@@ -740,4 +774,20 @@ object A {
   }
 }
 >>>
-Unable to format file due to bug in scalafmt
+object A {
+  def foo() = {
+    x.map(
+      _.y(
+        abcd,
+        { case_abcdefghij_aswbasdfaw_asfda => aswdf }, {
+          case_abcdefghij_sadfasdass =>
+            (
+              asdfa.sadvfs(abcdefghij).get,
+              asdfasdfasfdasda.asdfas(asdfasdaas).get
+            )
+        },
+        foo
+      )
+    )
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -702,3 +702,42 @@ object a {
         _ => e
       )
 }
+<<< #1599 1: original, with partial func
+object A {
+  def foo() = {
+    x.map(_.y(
+      abcd,
+      { case ((abcdefghij, aswbasdfaw), asfda) => aswdf},
+      { case (abcdefghij, sadfasdass) => (asdfa.sadvfs(abcdefghij).get, asdfasdfasfdasda.asdfas(asdfasdaas).get) },
+      foo
+    ))
+  }
+}
+>>>
+Unable to format file due to bug in scalafmt
+<<< #1599 2: modified, with partial func inside block
+object A {
+  def foo() = {
+    x.map(_.y(
+      abcd,
+      {{ case ((abcdefghij, aswbasdfaw), asfda) => aswdf}},
+      {{ case (abcdefghij, sadfasdass) => (asdfa.sadvfs(abcdefghij).get, asdfasdfasfdasda.asdfas(asdfasdaas).get) }},
+      foo
+    ))
+  }
+}
+>>>
+Unable to format file due to bug in scalafmt
+<<< #1599 3: modified, with lambda
+object A {
+  def foo() = {
+    x.map(_.y(
+      abcd,
+      { case_abcdefghij_aswbasdfaw_asfda => aswdf},
+      { case_abcdefghij_sadfasdass => (asdfa.sadvfs(abcdefghij).get, asdfasdfasfdasda.asdfas(asdfasdaas).get) },
+      foo
+    ))
+  }
+}
+>>>
+Unable to format file due to bug in scalafmt

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -28,4 +28,14 @@ object Test {
 
 }
 >>>
-Unable to format file due to bug in scalafmt
+object Test {
+
+  def create(
+    somethingInfo: foo.T = Something("my-something", Some("test-something"), "something",
+      Some(Format("something", "something")), Some(something.Something("something",
+          "something", "something", "something")))
+  ): Unit = {
+    w(foo)
+  }
+
+}

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -14,3 +14,18 @@ def format_![T <: Tree](
 )(implicit ev: Parse[T],
   ev2: EC
 ): String
+<<< #1462
+maxColumn = 91
+===
+object Test {
+
+  def create(
+    somethingInfo: foo.T = Something("my-something", Some("test-something"), "something", Some(Format("something", "something")),
+      Some(something.Something("something", "something", "something", "something")))
+  ): Unit = {
+    w(foo)
+  }
+
+}
+>>>
+Unable to format file due to bug in scalafmt


### PR DESCRIPTION
Currently, the algorithm would clear the search priority queue when the top candidate points to a new statement. Sometimes this leads to losing a viable path and the dreaded "Unable to format due to bug" error.

Rather than clearing the queue, let's maintain several generations of priority queues and create a new generation on a new statement, thus continuing to process subsequent states just like the old algorithm did but with the previously discarded states available as backup.

Apply this modification to top-level invocations only, so that nested calls will still terminate early; thus the backup candidates are really processed at the very end of the existing logic.

Fixes #448. Fixes #1462. Fixes #1485. Fixes #1599. Fixes #1717.

NB: `scala-repos` diffs, looks like they contain files previously unformatted by `scalafmt`: https://github.com/kitbellew/scala-repos/commit/0876f01369b34584e5efa04cdc29b88a93ff1a1d?w=1