### PR TITLE
Release Drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> The release drafter service has been discontinued in favor of a custom GitHub action that we haven’t setup in the Scalafmt repo (example https://github.com/scalameta/metals-languageclient/blob/master/.github/workflows/release-drafter.yml).

https://github.com/scalameta/scalafmt/issues/1711#issuecomment-586673599