### PR TITLE
BestFirstSearch: if failed without a solution, retry without optimization

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -47,7 +47,7 @@ private class BestFirstSearch private (
   var deepestYet = State.start
   val best = mutable.Map.empty[Int, State]
   val visits = new Array[Int](tokens.length)
-  val keepSlowStates = !pruneSlowStates
+  var keepSlowStates = !pruneSlowStates
 
   type StateHash = Long
 
@@ -247,7 +247,16 @@ private class BestFirstSearch private (
   }
 
   def getBestPath: SearchResult = {
-    val state = shortestPath(State.start, tree.tokens.last)
+    val state = {
+      def run = shortestPath(State.start, tree.tokens.last)
+      val state = run
+      if (null != state) state
+      else {
+        best.clear()
+        keepSlowStates = true
+        run
+      }
+    }
     if (null != state) {
       runner.event(CompleteFormat(explored, state))
       SearchResult(state, reachedEOF = true)

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -487,19 +487,28 @@ object x {
 type iovec = CStruct2[Ptr[Byte], // iov_base
                         CSize] // iov_len
 >>>
-Unable to format file due to bug in scalafmt
+type iovec = CStruct2[
+  Ptr[Byte], // iov_base
+  CSize
+] // iov_len
 <<< #1720 with val
 val iovec = CStruct2[Ptr[Byte], // iov_base
                         CSize](a) // iov_len
 >>>
-Unable to format file due to bug in scalafmt
+val iovec = CStruct2[
+  Ptr[Byte], // iov_base
+  CSize
+](a) // iov_len
 <<< #1720 no align
 align = none
 ===
 type iovec = CStruct2[Ptr[Byte], // iov_base
                         CSize] // iov_len
 >>>
-Unable to format file due to bug in scalafmt
+type iovec = CStruct2[
+  Ptr[Byte], // iov_base
+  CSize
+] // iov_len
 <<< #1720 second SL comment
 type iovec = CStruct2[Ptr[Byte],
                         CSize] // iov_len
@@ -509,7 +518,10 @@ type iovec = CStruct2[Ptr[Byte], CSize] // iov_len
 type iovec = CStruct2[Ptr[Byte], // iov_base
                         CSize]
 >>>
-Unable to format file due to bug in scalafmt
+type iovec = CStruct2[
+  Ptr[Byte], // iov_base
+  CSize
+]
 <<< #1720 nested multi-arg type with two SL comments
 type iovec = CStruct2[Ptr[Byte, // iov_base
                         CSize]] // iov_len
@@ -529,7 +541,10 @@ type iovec = CStruct2[
 type iovec = CStruct2[Ptr[Byte], /* iov_base */
                         CSize]
 >>>
-Unable to format file due to bug in scalafmt
+type iovec = CStruct2[
+  Ptr[Byte], /* iov_base */
+  CSize
+]
 <<< #1720 first inline comment with apply
 val iovec = CStruct2(Ptr(Byte), /* iov_base */
                         CSize)

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -483,3 +483,58 @@ object x {
   // comment
   println("foo") // comment
 }
+<<< #1720 original, two SL comments
+type iovec = CStruct2[Ptr[Byte], // iov_base
+                        CSize] // iov_len
+>>>
+Unable to format file due to bug in scalafmt
+<<< #1720 with val
+val iovec = CStruct2[Ptr[Byte], // iov_base
+                        CSize](a) // iov_len
+>>>
+Unable to format file due to bug in scalafmt
+<<< #1720 no align
+align = none
+===
+type iovec = CStruct2[Ptr[Byte], // iov_base
+                        CSize] // iov_len
+>>>
+Unable to format file due to bug in scalafmt
+<<< #1720 second SL comment
+type iovec = CStruct2[Ptr[Byte],
+                        CSize] // iov_len
+>>>
+type iovec = CStruct2[Ptr[Byte], CSize] // iov_len
+<<< #1720 first SL comment
+type iovec = CStruct2[Ptr[Byte], // iov_base
+                        CSize]
+>>>
+Unable to format file due to bug in scalafmt
+<<< #1720 nested multi-arg type with two SL comments
+type iovec = CStruct2[Ptr[Byte, // iov_base
+                        CSize]] // iov_len
+>>>
+type iovec = CStruct2[Ptr[
+  Byte, // iov_base
+  CSize
+]] // iov_len
+<<< #1720 one arg with SL comment
+type iovec = CStruct2[Ptr[Byte] // iov_base
+                        ]
+>>>
+type iovec = CStruct2[
+  Ptr[Byte] // iov_base
+]
+<<< #1720 first inline comment
+type iovec = CStruct2[Ptr[Byte], /* iov_base */
+                        CSize]
+>>>
+Unable to format file due to bug in scalafmt
+<<< #1720 first inline comment with apply
+val iovec = CStruct2(Ptr(Byte), /* iov_base */
+                        CSize)
+>>>
+val iovec = CStruct2(
+  Ptr(Byte), /* iov_base */
+  CSize
+)


### PR DESCRIPTION
Fixes #1720.

`scala-repos` diffs consists of one file only which couldn't be formatted previously: https://github.com/kitbellew/scala-repos/commit/3d4fb7b212874069deaf7c73eaf0b0e1d8810ec2?w=1