### PR TITLE
Various minor fixes to logging and tests

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -8,6 +8,8 @@ import scala.meta.tokens.Tokens
 
 import org.scalafmt.internal.FormatToken
 import org.scalafmt.internal.Split
+import org.scalafmt.internal.State
+
 import sourcecode.Text
 
 /**
@@ -20,12 +22,19 @@ object LoggerOps {
   def name2style[T](styles: Text[T]*): Map[String, T] =
     styles.map(x => x.source -> x.value).toMap
 
+  def log(s: State): String = {
+    val policies = s.policy.policies.map(_.toString).mkString(",")
+    s"d=${s.depth} w=${s.cost} i=${s.indentation} col=${s.column}; p=$policies; s=${log(s.split)}"
+  }
   def log(split: Split): String = s"$split"
 
   def log(formatToken: FormatToken): String =
     s"""${log(formatToken.left)}
        |${log(formatToken.between: _*)}
        |${log(formatToken.right)}""".stripMargin
+
+  def log2(formatToken: FormatToken): String =
+    s"${formatToken.left}∙${formatToken.right}"
 
   def escape(raw: String): String = {
     raw

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -2,6 +2,8 @@ package org.scalafmt.util
 
 import java.io.File
 
+import scala.annotation.tailrec
+
 import metaconfig.Configured
 import org.scalafmt.Error.UnknownStyle
 import org.scalafmt.{Debug, Scalafmt}
@@ -99,7 +101,12 @@ trait HasTests extends FormatAssertions {
       )
     }
 
-    var linenum = 2 + split.head.split(sep).length
+    @tailrec
+    def numLines(str: String, cnt: Int = 1, off: Int = 0): Int = {
+      val idx = str.indexOf(sep, off)
+      if (idx < 0) cnt else numLines(str, cnt + 1, idx + sep.length)
+    }
+    var linenum = numLines(split.head, 2)
     split.tail.map { t =>
       val before :: expected :: Nil = t.split(s"$sep>>>$sep", 2).toList
       val extraConfig = before.split(s"$sep===$sep", 2).toList
@@ -120,7 +127,7 @@ trait HasTests extends FormatAssertions {
         moduleOnly || isOnly(name),
         testStyle
       )
-      linenum += t.split(sep).length
+      linenum += numLines(t)
       test
     }
   }


### PR DESCRIPTION
*  HasTests: fix the line number computation
* DiffAssertions: compute diff once, swap comparands
* LoggerOps: log state and a shorter FormatToken