### PR TITLE
Split: switch ignoreIf to tag, allows more control

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -196,6 +196,7 @@ private class BestFirstSearch private (
             curr.policy
               .execute(Decision(splitToken, splits))
               .splits
+              .filter(_.isActive)
               .sortBy(_.cost)
           }
           var optimalNotFound = true

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -946,9 +946,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             (style.verticalMultiline.newlineAfterOpenParen && !isImplicitArgList && isDefinition) ||
             mixedParamsWithCtorModifier
 
-        val mod =
-          if (shouldAddNewline) Newline
-          else NoSplit
+        val mod = NoSplit.orNL(!shouldAddNewline)
 
         Seq(
           Split(mod, 0)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -11,6 +11,7 @@ case class Provided(code: String) extends Modification {
 
 case object NoSplit extends Modification {
   override val newlines: Int = 0
+  def orNL(flag: Boolean): Modification = if (flag) this else Newline
 }
 
 /**
@@ -51,5 +52,6 @@ object Space extends Modification {
   override val newlines: Int = 0
   override def toString = "Space"
 
-  def apply(flag: Boolean): Modification = if (flag) Space else NoSplit
+  def apply(flag: Boolean): Modification = if (flag) this else NoSplit
+  def orNL(flag: Boolean): Modification = if (flag) this else Newline
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -289,7 +289,7 @@ class Router(formatOps: FormatOps) {
               style.newlines.alwaysBeforeCurlyBraceLambdaParams ||
                 isSelfAnnotation || lambdaPolicy == null
             )
-            .withOptimalToken(lambdaArrow)
+            .withOptimalTokenOpt(lambdaArrow)
             .withIndent(lambdaIndent, close, Right)
             .withPolicy(lambdaPolicy),
           Split(nl, 1)
@@ -577,7 +577,7 @@ class Router(formatOps: FormatOps) {
             .onlyIf(noSplitMod != null)
             .withOptimalToken(lambdaToken),
           Split(Newline, newlinePenalty)
-            .withPolicy(newlinePolicy)
+            .withPolicyOpt(newlinePolicy)
             .withIndent(style.continuationIndent.callSite, close, Right)
         )
       }
@@ -687,7 +687,7 @@ class Router(formatOps: FormatOps) {
             .andThen(unindent)
         Seq(
           Split(NoSplit, 0)
-            .withOptimalToken(optimal)
+            .withOptimalTokenOpt(optimal)
             .withPolicy(noSplitPolicy)
             .withIndent(indent, close, Left),
           Split(Newline, 2)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -1,0 +1,25 @@
+package org.scalafmt.internal
+
+sealed abstract class SplitTag {
+
+  def activateOnly(splits: Seq[Split]): Seq[Split]
+
+}
+
+object SplitTag {
+
+  abstract class Base extends SplitTag {
+    override final def activateOnly(splits: Seq[Split]): Seq[Split] = splits
+  }
+
+  abstract class Custom extends SplitTag {
+    override final def activateOnly(splits: Seq[Split]): Seq[Split] =
+      splits.flatMap { s =>
+        if (s.isTaggedFor(this)) Some(s.copy(tag = SplitTag.Active)) else None
+      }
+  }
+
+  case object Active extends Base
+  case object Ignored extends Base
+
+}


### PR DESCRIPTION
Rather than enabling a split using a simple boolean flag, let's allow a split to be enabled in some cases. This will allow us to set up some splits which will not be used unless some policy in a specific context decided to use them (for instance, splits for ", {" that would be triggered only if `OneArgPerLine` policy is used). See #1722, will be used in that PR.

Also, make a few minor cosmetic changes.