### PR TITLE
SBT_OPTS tuning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"
       - run: sbt +tests/test
         env:
-          SBT_OPTS: "-Xms1G -Xmx3G -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheSize=250M -XX:+TieredCompilation -XX:-UseGCOverheadLimit -XX:+CMSClassUnloadingEnabled"
+          SBT_OPTS: "-Xms1G -Xmx3G -XX:ReservedCodeCacheSize=250M -XX:+TieredCompilation -XX:-UseGCOverheadLimit -XX:+CMSClassUnloadingEnabled"
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
openjdk11 tests fails with 

```
java.lang.OutOfMemoryError: Metaspace
[info]   at java.base/java.lang.ClassLoader.defineClass1(Native Method)
[info]   at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
[info]   at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
[info]   at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:550)
[info]   at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:458)
[info]   at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:452)
```