### PR TITLE
Router: for multiple args, all or one on a line

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -707,22 +707,24 @@ class Router(formatOps: FormatOps) {
         // parens furthest to the right.
         val lhsPenalty = treeDepth(lhs)
 
+        // XXX: sometimes we have zero args, so multipleArgs != !singleArgument
+        val singleArgument = args.length == 1
+        val multipleArgs = args.length > 1
+        val notTooManyArgs = multipleArgs && args.length <= 100
+
         val isBracket = open.is[T.LeftBracket]
         val bracketCoef = if (isBracket) Constants.BracketPenalty else 1
 
         val nestedPenalty = nestedApplies(leftOwner) + lhsPenalty
         val exclude =
           if (isBracket) insideBlock(tok, close, _.is[T.LeftBracket])
+          else if (style.activeForEdition_2020_03 && multipleArgs)
+            Set.empty[Token]
           else
             insideBlock(tok, close, x => x.is[T.LeftBrace])
         val excludeRanges = exclude.map(parensRange)
 
         val indent = getApplyIndent(leftOwner)
-
-        // XXX: sometimes we have zero args, so multipleArgs != !singleArgument
-        val singleArgument = args.length == 1
-        val multipleArgs = args.length > 1
-        val notTooManyArgs = multipleArgs && args.length <= 100
 
         def insideBraces(t: FormatToken): Boolean =
           excludeRanges.exists(_.contains(t.left.start))

--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -49,28 +49,30 @@ val createAsStat = if (semantics.asInstanceOfs == Unchecked) {
 val createAsStat = if (semantics.asInstanceOfs == Unchecked) {
   js.Skip()
 } else {
-  envFieldDef("as",
-              className,
-              js.Function(List(objParam), js.Return(className match {
-                case Definitions.ObjectClass => obj
-                case _ =>
-                  val throwError = {
-                    genCallHelper("throwClassCastException",
-                                  obj,
-                                  js.StringLiteral(displayName))
-                  }
-                  if (className == RuntimeNothingClass) {
-                    // Always throw for .asInstanceOf[Nothing], even for null
-                    throwError
-                  } else {
-                    js.If(js.Apply(envField("is", className), List(obj)) ||
-                            (obj === js.Null()), {
-                            obj
-                          }, {
-                            throwError
-                          })
-                  }
-              })))
+  envFieldDef(
+      "as",
+      className,
+      js.Function(List(objParam),
+                  js.Return(className match {
+                    case Definitions.ObjectClass => obj
+                    case _ =>
+                      val throwError = {
+                        genCallHelper("throwClassCastException",
+                                      obj,
+                                      js.StringLiteral(displayName))
+                      }
+                      if (className == RuntimeNothingClass) {
+                        // Always throw for .asInstanceOf[Nothing], even for null
+                        throwError
+                      } else {
+                        js.If(js.Apply(envField("is", className), List(obj)) ||
+                                (obj === js.Null()), {
+                                obj
+                              }, {
+                                throwError
+                              })
+                      }
+                  })))
 }
 <<< processOptions
   def processOptions(): Unit = {
@@ -202,52 +204,54 @@ options.testFilter match {
             callStatement
           })(jstpe.AnyType)
 >>>
-callStatement = js.If(genIsInstanceOf(callTrg, rtClass.tpe), {
-  if (implMethodSym.owner == ObjectClass) {
-    // If the method is defined on Object, we can call it normally.
-    genApplyMethod(callTrg, implMethodSym, arguments)
-  } else {
-    if (rtClass == StringClass) {
-      val (rtModuleClass, methodIdent) = encodeRTStringMethodSym(implMethodSym)
-      val retTpe = implMethodSym.tpe.resultType
-      val castCallTrg = fromAny(callTrg, StringClass.toTypeConstructor)
-      val rawApply = genApplyMethod(genLoadModule(rtModuleClass),
-                                    methodIdent,
-                                    castCallTrg :: arguments,
-                                    toIRType(retTpe))
-      // Box the result of the implementing method if required
-      if (isPrimitiveValueType(retTpe))
-        makePrimitiveBox(rawApply, retTpe)
-      else
-        rawApply
-    } else {
-      val reflBoxClassPatched = {
-
-        def isIntOrLongKind(kind: TypeKind) = kind match {
-          case _: INT | LONG => true
-          case _ => false
-        }
-        if (rtClass == BoxedDoubleClass &&
-            toTypeKind(implMethodSym.tpe.resultType) == DoubleKind &&
-            isIntOrLongKind(toTypeKind(sym.tpe.resultType))) {
-          // This must be an Int, and not a Double
-          IntegerReflectiveCallClass
+callStatement = js.If(
+    genIsInstanceOf(callTrg, rtClass.tpe), {
+      if (implMethodSym.owner == ObjectClass) {
+        // If the method is defined on Object, we can call it normally.
+        genApplyMethod(callTrg, implMethodSym, arguments)
+      } else {
+        if (rtClass == StringClass) {
+          val (rtModuleClass, methodIdent) =
+            encodeRTStringMethodSym(implMethodSym)
+          val retTpe = implMethodSym.tpe.resultType
+          val castCallTrg = fromAny(callTrg, StringClass.toTypeConstructor)
+          val rawApply = genApplyMethod(genLoadModule(rtModuleClass),
+                                        methodIdent,
+                                        castCallTrg :: arguments,
+                                        toIRType(retTpe))
+          // Box the result of the implementing method if required
+          if (isPrimitiveValueType(retTpe))
+            makePrimitiveBox(rawApply, retTpe)
+          else
+            rawApply
         } else {
-          reflBoxClass
+          val reflBoxClassPatched = {
+
+            def isIntOrLongKind(kind: TypeKind) = kind match {
+              case _: INT | LONG => true
+              case _ => false
+            }
+            if (rtClass == BoxedDoubleClass &&
+                toTypeKind(implMethodSym.tpe.resultType) == DoubleKind &&
+                isIntOrLongKind(toTypeKind(sym.tpe.resultType))) {
+              // This must be an Int, and not a Double
+              IntegerReflectiveCallClass
+            } else {
+              reflBoxClass
+            }
+          }
+          val castCallTrg =
+            fromAny(callTrg,
+                    reflBoxClassPatched.primaryConstructor.tpe.params.head.tpe)
+          val reflBox = genNew(reflBoxClassPatched,
+                               reflBoxClassPatched.primaryConstructor,
+                               List(castCallTrg))
+          genApplyMethod(reflBox, proxyIdent, arguments, jstpe.AnyType)
         }
       }
-      val castCallTrg =
-        fromAny(callTrg,
-                reflBoxClassPatched.primaryConstructor.tpe.params.head.tpe)
-      val reflBox = genNew(reflBoxClassPatched,
-                           reflBoxClassPatched.primaryConstructor,
-                           List(castCallTrg))
-      genApplyMethod(reflBox, proxyIdent, arguments, jstpe.AnyType)
-    }
-  }
-}, { // else
-  callStatement
-})(jstpe.AnyType)
+    }, { // else
+      callStatement
+    })(jstpe.AnyType)
 <<< Infinite recursion?
         val ctorParamDefs = usedCtorParams map { p =>
           // in the apply method's context
@@ -373,30 +377,43 @@ val createIsArrayOfStat = {
   envFieldDef(
       "isArrayOf",
       className,
-      js.Function(List(objParam, depthParam), className match {
-        case Definitions.ObjectClass =>
-          val dataVarDef = genLet(Ident("data"), mutable = false, {
-            obj && (obj DOT "$classData")
-          })
-          val data = dataVarDef.ref
-          js.Block(dataVarDef, js.If(!data, {
-            js.Return(js.BooleanLiteral(false))
-          }, {
-            val arrayDepthVarDef =
-              genLet(Ident("arrayDepth"), mutable = false, {
-                (data DOT "arrayDepth") || js.IntLiteral(0)
-              })
-            val arrayDepth = arrayDepthVarDef.ref
-            js.Block(arrayDepthVarDef, js.Return {
-              // Array[A] </: Array[Array[A]]
-              !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) &&
-              (// Array[Array[A]] <: Array[Object]
-              js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
-              // Array[Int] </: Array[Object]
-              !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive"))
-            })
+      js.Function(
+          List(objParam, depthParam),
+          className match {
+            case Definitions.ObjectClass =>
+              val dataVarDef = genLet(Ident("data"),
+                                      mutable = false, {
+                                        obj && (obj DOT "$classData")
+                                      })
+              val data = dataVarDef.ref
+              js.Block(dataVarDef,
+                       js.If(!data, {
+                               js.Return(js.BooleanLiteral(false))
+                             }, {
+                               val arrayDepthVarDef =
+                                 genLet(Ident("arrayDepth"),
+                                        mutable = false, {
+                                          (data DOT "arrayDepth") || js
+                                            .IntLiteral(0)
+                                        })
+                               val arrayDepth = arrayDepthVarDef.ref
+                               js.Block(arrayDepthVarDef,
+                                        js.Return {
+                                          // Array[A] </: Array[Array[A]]
+                                          !js.BinaryOp(JSBinaryOp.<,
+                                                       arrayDepth,
+                                                       depth) &&
+                                          (// Array[Array[A]] <: Array[Object]
+                                          js.BinaryOp(JSBinaryOp.>,
+                                                      arrayDepth,
+                                                      depth) ||
+                                          // Array[Int] </: Array[Object]
+                                          !genIdentBracketSelect(
+                                              data DOT "arrayBase",
+                                              "isPrimitive"))
+                                        })
+                             }))
           }))
-      }))
 }
 <<< js.Return
                 js.Block(
@@ -412,15 +429,16 @@ val createIsArrayOfStat = {
                   })
 
 >>>
-js.Block(arrayDepthVarDef, js.Return {
-  // Array[A] </: Array[Array[A]]
-  !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) && (
-      // Array[Array[A]] <: Array[Object]
-      js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
-      // Array[Int] </: Array[Object]
-      !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive")
-  )
-})
+js.Block(arrayDepthVarDef,
+         js.Return {
+           // Array[A] </: Array[Array[A]]
+           !js.BinaryOp(JSBinaryOp.<, arrayDepth, depth) && (
+               // Array[Array[A]] <: Array[Object]
+               js.BinaryOp(JSBinaryOp.>, arrayDepth, depth) ||
+               // Array[Int] </: Array[Object]
+               !genIdentBracketSelect(data DOT "arrayBase", "isPrimitive")
+           )
+         })
 <<< Js.Function
 js.Function(List(objParam, depthParam), js.Return {
                     js.If(

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -29,10 +29,12 @@ List(Split(Space,
            0,
            policy = SingleLineBlock(close),
            ignoreIf = blockSize > style.maxColumn),
-     Split(nl, 1, policy = {
-       case Decision(t @ FormatToken(_, `close`, _), s) =>
-         Decision(t, List(Split(Newline, 0)))
-     }))
+     Split(nl,
+           1,
+           policy = {
+             case Decision(t @ FormatToken(_, `close`, _), s) =>
+               Decision(t, List(Split(Newline, 0)))
+           }))
 <<< Massive (good API) 3
 Split(Space, 0).withPolicy {
     // Following case:
@@ -70,17 +72,19 @@ Split(Space, 0, policy = {
       Decision(t, splits.map(_.withModification(Newline2x)))
 })
 >>>
-Split(Space, 0, policy = {
-  // Following case:
-  // package foo // this is cool
-  //
-  // object a
-  case Decision(t @ FormatToken(`lastRef`, _: Comment, between), splits)
-      if !between.exists(_.isInstanceOf[`\n`]) =>
-    Decision(t, splits.map(_.withModification(Space)))
-  case Decision(t @ FormatToken(`lastRef`, _, _), splits) =>
-    Decision(t, splits.map(_.withModification(Newline2x)))
-})
+Split(Space,
+      0,
+      policy = {
+        // Following case:
+        // package foo // this is cool
+        //
+        // object a
+        case Decision(t @ FormatToken(`lastRef`, _: Comment, between), splits)
+            if !between.exists(_.isInstanceOf[`\n`]) =>
+          Decision(t, splits.map(_.withModification(Space)))
+        case Decision(t @ FormatToken(`lastRef`, _, _), splits) =>
+          Decision(t, splits.map(_.withModification(Newline2x)))
+      })
 <<< Looong
 Seq(
   Split(modification, 0, policy = singleLine)
@@ -135,9 +139,10 @@ Seq(
     Split(Space, 0).withPolicy(SingleLineBlock(lastToken)),
     Split(Space, 1)
       .withPolicy(Policy({
-        case Decision(t @ FormatToken(`arrow`, _, _), s) =>
-          Decision(t, s.filter(_.modification.isNewline))
-      }, expire = lastToken.end))
+                           case Decision(t @ FormatToken(`arrow`, _, _), s) =>
+                             Decision(t, s.filter(_.modification.isNewline))
+                         },
+                         expire = lastToken.end))
       .withIndent(2, lastToken, Left) // case body indented by 2.
       .withIndent(2, arrow, Left) // cond body indented by 4.
 )
@@ -312,9 +317,10 @@ implicit class IterableW[+A](it: JSIterable[A]) {
             data => data)
 >>>
 foo.fold(err => {
-  logger.warn(s"Malformed request: $err\n${req.body}")
-  BadRequest(jsonError(JsError toJson err)).fuccess
-}, data => data)
+           logger.warn(s"Malformed request: $err\n${req.body}")
+           BadRequest(jsonError(JsError toJson err)).fuccess
+         },
+         data => data)
 <<< quirk in 0.2.4-RC1, #233
 {{{{{
           compileInputs in (It, compile) <<= (compileInputs in (It, compile)) dependsOn
@@ -345,13 +351,15 @@ foo.fold(err => {
 >>>
 Seq(
     Split(Space, 0),
-    Split(Newline, 1).withPolicy(Policy({
-      // Force template to be multiline.
-      case d @ Decision(FormatToken(open: `{`, right, _), splits)
-          if !right.isInstanceOf[`}`] && // corner case, body is {}
-            childOf(template, owners(open)) =>
-        d.copy(splits = splits.filter(_.modification.isNewline))
-    }, expire.end))
+    Split(Newline, 1).withPolicy(
+        Policy({
+                 // Force template to be multiline.
+                 case d @ Decision(FormatToken(open: `{`, right, _), splits)
+                     if !right.isInstanceOf[`}`] && // corner case, body is {}
+                       childOf(template, owners(open)) =>
+                   d.copy(splits = splits.filter(_.modification.isNewline))
+               },
+               expire.end))
 )
 <<< #310
 CreditCard(customerId = customerId,

--- a/scalafmt-tests/src/test/resources/default/Case.stat
+++ b/scalafmt-tests/src/test/resources/default/Case.stat
@@ -31,15 +31,16 @@ List(Split(Space, 0).withPolicy {
 >>>
 List(Split(Space, 0).withPolicy {
   case Decision(t, s) if tok.right.end <= lastToken.end =>
-    Decision(t, s.map {
-      case nl if nl.modification.isNewline =>
-        val result =
-          if (t.right.isInstanceOf[`if`] &&
-              owners(t.right) == owner) nl
-          else nl.withPenalty(1)
-        result.withPolicy(breakOnArrow)
-      case x => x
-    })
+    Decision(t,
+             s.map {
+               case nl if nl.modification.isNewline =>
+                 val result =
+                   if (t.right.isInstanceOf[`if`] &&
+                       owners(t.right) == owner) nl
+                   else nl.withPenalty(1)
+                 result.withPolicy(breakOnArrow)
+               case x => x
+             })
 })
 <<< chain of || and &&
 x match {

--- a/scalafmt-tests/src/test/resources/default/Idempotency.stat
+++ b/scalafmt-tests/src/test/resources/default/Idempotency.stat
@@ -24,15 +24,19 @@ val bindingFuture = Http().bindAndHandleSync({
 {
   {
     {
-      val bindingFuture = Http().bindAndHandleSync({
-        case HttpRequest(_, _, headers, _, _) ⇒
-          val upgrade =
-            headers.collectFirst { case u: UpgradeToWebSocket ⇒ u }.get
-          upgrade.handleMessages(
-              Flow.fromSinkAndSource(Sink.ignore,
-                                     Source.fromPublisher(source)),
-              None)
-      }, interface = "localhost", port = 0)
+      val bindingFuture = Http().bindAndHandleSync(
+          {
+            case HttpRequest(_, _, headers, _, _) ⇒
+              val upgrade = headers.collectFirst {
+                case u: UpgradeToWebSocket ⇒ u
+              }.get
+              upgrade.handleMessages(
+                  Flow.fromSinkAndSource(Sink.ignore,
+                                         Source.fromPublisher(source)),
+                  None)
+          },
+          interface = "localhost",
+          port = 0)
     }
   }
 }

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -55,17 +55,18 @@ def withDedicatedVar: Unit = {
       end withValue res.value
     })
 >>>
-(excty, { focus: Focus =>
-  val enter = symopt.map { sym =>
-    val cast = focus withOp Op.As(excty, exc.value)
-    curEnv.enter(sym, cast.value)
-    cast
-  }.getOrElse(focus)
-  val begin = enter withOp Nrt.call(Nrt.begin_catch, excwrap.value)
-  val res = genExpr(body, begin)
-  val end = res withOp Nrt.call(Nrt.end_catch)
-  end withValue res.value
-})
+(excty,
+ { focus: Focus =>
+   val enter = symopt.map { sym =>
+     val cast = focus withOp Op.As(excty, exc.value)
+     curEnv.enter(sym, cast.value)
+     cast
+   }.getOrElse(focus)
+   val begin = enter withOp Nrt.call(Nrt.begin_catch, excwrap.value)
+   val res = genExpr(body, begin)
+   val end = res withOp Nrt.call(Nrt.end_catch)
+   end withValue res.value
+ })
 <<< SKIP intellij bug
 class ScProjectionType private () {
   def isAliasTypeInner = {
@@ -434,14 +435,19 @@ class A {
 class A {
   def foo: B =
     a.b() { c =>
-        val d = c.add(D[E](1, {
-          case conditionNameShouldLongEnough =>
-            foo1(objectNameShouldLongEnough, objectNameShouldLongEnough)
-            0
-          case conditionNameShouldLongEnough =>
-            foo1(objectNameShouldLongEnough, objectNameShouldLongEnough)
-            1
-        }))
+        val d = c.add(
+          D[E](
+            1,
+            {
+              case conditionNameShouldLongEnough =>
+                foo1(objectNameShouldLongEnough, objectNameShouldLongEnough)
+                0
+              case conditionNameShouldLongEnough =>
+                foo1(objectNameShouldLongEnough, objectNameShouldLongEnough)
+                1
+            }
+          )
+        )
       }
       .f("f")
 }

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -247,11 +247,14 @@ SparkEnv.get.blockManager.getOrElseUpdate(blockId, storageLevel, elementClassTag
 }
 >>>
 object a {
-  SparkEnv.get.blockManager
-    .getOrElseUpdate(blockId, storageLevel, elementClassTag, () => {
-      readCachedBlock = false
-      computeOrReadCheckpoint(partition, context)
-    })
+  SparkEnv.get.blockManager.getOrElseUpdate(
+      blockId,
+      storageLevel,
+      elementClassTag,
+      () => {
+        readCachedBlock = false
+        computeOrReadCheckpoint(partition, context)
+      })
 }
 <<< #599
 {{

--- a/scalafmt-tests/src/test/resources/default/Unindent.stat
+++ b/scalafmt-tests/src/test/resources/default/Unindent.stat
@@ -93,10 +93,12 @@
 {
   {
     def bindingInfoWithFields(style: BindingStyle) =
-      logger.trace("Looking for fields with style %s".format(style), (for {
-        field <- fields;
-        bindingInfo <- field.binding if bindingInfo.bindingStyle == style
-      } yield (bindingInfo, field)).toList)
+      logger.trace(
+          "Looking for fields with style %s".format(style),
+          (for {
+            field <- fields;
+            bindingInfo <- field.binding if bindingInfo.bindingStyle == style
+          } yield (bindingInfo, field)).toList)
   }
 }
 <<< indent too low
@@ -136,11 +138,12 @@
    case name => CPathField(name)
  }) :: acc)
 >>>
-parse0(tail, (head match {
-  case "[*]" => CPathArray
-  case IndexPattern(index) => CPathIndex(index.toInt)
-  case name => CPathField(name)
-}) :: acc)
+parse0(tail,
+       (head match {
+         case "[*]" => CPathArray
+         case IndexPattern(index) => CPathIndex(index.toInt)
+         case name => CPathField(name)
+       }) :: acc)
 <<< #394 this sucks but so does your tuple
 {{
     (ref.copy(selector = (prefix \ ref.selector)),
@@ -155,13 +158,14 @@ parse0(tail, (head match {
 >>>
 {
   {
-    (ref.copy(selector = (prefix \ ref.selector)), (ref.ctype match {
-      case CString => ArrayStrColumn.empty(sliceSize)
-      case CBoolean => ArrayBoolColumn.empty()
-      case CArrayType(elemType) =>
-        ArrayHomogeneousArrayColumn.empty(sliceSize)(elemType)
-      case CUndefined => sys.error("CUndefined cannot be serialized")
-    }))
+    (ref.copy(selector = (prefix \ ref.selector)),
+     (ref.ctype match {
+       case CString => ArrayStrColumn.empty(sliceSize)
+       case CBoolean => ArrayBoolColumn.empty()
+       case CArrayType(elemType) =>
+         ArrayHomogeneousArrayColumn.empty(sliceSize)(elemType)
+       case CUndefined => sys.error("CUndefined cannot be serialized")
+     }))
   }
 }
 <<< #394 just use variable, it's fine
@@ -197,11 +201,12 @@ val second =
         case _ => 2
       }))
 >>>
-assertEquals(1, ((NoContext: Any) match {
-  case that: AnyRef if this eq that => 0
-  case NoContext => 1
-  case _ => 2
-}))
+assertEquals(1,
+             ((NoContext: Any) match {
+               case that: AnyRef if this eq that => 0
+               case NoContext => 1
+               case _ => 2
+             }))
 <<< #394 4
 {{{{
         b sort {

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -690,9 +690,16 @@ object a {
 }
 >>>
 object a {
-  b({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
-    _ / _
-  }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+  b(
+    { _ + _ },
+    { _ - _ },
+    { _ * _ },
+    { _ * _ }, {
+      _ / _
+    },
+    { (a, b) => b },
+    { _ % _ },
+    { _ pow _ })
 }
 <<< multiple block arguments 2
 @expand
@@ -732,9 +739,16 @@ implicit def v_s_Op[
       OpPow
     ) Op <: OpType
 ](
-    implicit @expand.sequence[Op]({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
-      _ / _
-    }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+    implicit @expand.sequence[Op](
+      { _ + _ },
+      { _ - _ },
+      { _ * _ },
+      { _ * _ }, {
+        _ / _
+      },
+      { (a, b) => b },
+      { _ % _ },
+      { _ pow _ })
     op: Op.Impl2[T, T, T],
     @expand.sequence[T](0, 0.0, 0.0f, 0L)
     zero: T

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -803,9 +803,17 @@ object a {
 }
 >>>
 object a {
-  b({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
-    _ / _
-  }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+  b(
+    { _ + _ },
+    { _ - _ },
+    { _ * _ },
+    { _ * _ }, {
+      _ / _
+    },
+    { (a, b) => b },
+    { _ % _ },
+    { _ pow _ }
+  )
 }
 <<< multiple block arguments 2
 @expand
@@ -845,9 +853,17 @@ implicit def v_s_Op[
       OpPow
     ) Op <: OpType
 ](
-    implicit @expand.sequence[Op]({ _ + _ }, { _ - _ }, { _ * _ }, { _ * _ }, {
-      _ / _
-    }, { (a, b) => b }, { _ % _ }, { _ pow _ })
+    implicit @expand.sequence[Op](
+      { _ + _ },
+      { _ - _ },
+      { _ * _ },
+      { _ * _ }, {
+        _ / _
+      },
+      { (a, b) => b },
+      { _ % _ },
+      { _ pow _ }
+    )
     op: Op.Impl2[T, T, T],
     @expand.sequence[T](0, 0.0, 0.0f, 0L)
     zero: T

--- a/scalafmt-tests/src/test/resources/unit/Advanced.source
+++ b/scalafmt-tests/src/test/resources/unit/Advanced.source
@@ -23,10 +23,10 @@
 }
 >>>
 @foobar("annot", {
-  val x = 2
-  val y = 2 // y=2
-  x + y
-})
+          val x = 2
+          val y = 2 // y=2
+          x + y
+        })
 object a extends b with c {
 
   def foo[T: Int#Double#Triple,

--- a/scalafmt-tests/src/test/resources/unit/TermApply.stat
+++ b/scalafmt-tests/src/test/resources/unit/TermApply.stat
@@ -65,9 +65,13 @@ function(a, b, c, {
     case Foo("a", 1) => Foo("b", 2)
   })
 >>>
-function(a, b, c, {
-  case Foo("a", 1) => Foo("b", 2)
-})
+function(
+    a,
+    b,
+    c,
+    {
+      case Foo("a", 1) => Foo("b", 2)
+    })
 <<< MUST NOT use automatic formatting 1 alexandru/scala-best-practices
 val dp = new DispatchPlan(Set(filteredAssets), start =
   startDate, end = endDate, product, scheduleMap, availabilityMap,


### PR DESCRIPTION
Otherwise, because of the logic ignoring blocks within any argument, we
end up with an unintended bin-pack behaviour.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/96f7a0446bc95af3fe3a886afd4d01d5eb4c17ca?w=1