### PR TITLE
FormatOps: find the exact param group for each "("

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1068,7 +1068,10 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case _ => None
     }
 
-  def findArgsFor(ft: FormatToken, argss: Seq[Seq[Tree]]): Option[Seq[Tree]] = {
+  def findArgsFor[A <: Tree](
+      ft: FormatToken,
+      argss: Seq[Seq[A]]
+  ): Option[Seq[A]] = {
     // find the arg group starting with given format token
     val beg = ft.left.start
     argss
@@ -1101,9 +1104,12 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       else tokens(nextNonComment(maybeArrow), 1)
     }(x => prevNonComment(tokens(x, -1)))
 
-  def getApplyArgs(formatToken: FormatToken): (Tree, Seq[Tree]) = {
+  def getApplyArgs(
+      formatToken: FormatToken
+  )(implicit style: ScalafmtConfig): (Tree, Seq[Tree]) = {
     def getArgs(argss: Seq[Seq[Tree]]): Seq[Tree] =
-      argss.flatten
+      if (!style.activeForEdition_2020_03) argss.flatten
+      else findArgsFor(formatToken, argss).getOrElse(Seq.empty)
     formatToken.meta.leftOwner match {
       case t @ SplitDefnIntoParts(_, name, tparams, paramss) =>
         if (formatToken.left.is[T.LeftParen])

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -706,9 +706,8 @@ val a = new b( /*c1*/ c =>
  }
 >>>
 object ThreadPoolConfigDispatcherBuilder {
-  def conf_?[T](opt: Option[T])(
-      fun: (
-          T) => ThreadPoolConfigDispatcherBuilder => ThreadPoolConfigDispatcherBuilder)
+  def conf_?[T](opt: Option[T])(fun: (
+      T) => ThreadPoolConfigDispatcherBuilder => ThreadPoolConfigDispatcherBuilder)
       : Option[(ThreadPoolConfigDispatcherBuilder) => ThreadPoolConfigDispatcherBuilder] =
     opt map fun
 }

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -695,3 +695,20 @@ val a = new b( /*c1*/ c =>
   dddddddd)(
     /*c2*/ e => f,
     g => h)
+<<< def with multiple curried single parameters
+ object ThreadPoolConfigDispatcherBuilder {
+  def conf_?[T](opt: Option[T])(
+      fun: (
+          T) => ThreadPoolConfigDispatcherBuilder => ThreadPoolConfigDispatcherBuilder)
+       : Option[
+         (ThreadPoolConfigDispatcherBuilder) => ThreadPoolConfigDispatcherBuilder] =
+     opt map fun
+ }
+>>>
+object ThreadPoolConfigDispatcherBuilder {
+  def conf_?[T](opt: Option[T])(
+      fun: (
+          T) => ThreadPoolConfigDispatcherBuilder => ThreadPoolConfigDispatcherBuilder)
+      : Option[(ThreadPoolConfigDispatcherBuilder) => ThreadPoolConfigDispatcherBuilder] =
+    opt map fun
+}


### PR DESCRIPTION
Rather than returning the concatenation of all parameter groups, return the specific one.

With that, we can now definitively determine the number of arguments in the specific parameter group, rather than the total number across all groups as we did before. That is, in
```
      def f(a: Int)(b: String, c: Boolean): Unit
```
we used to return 3 in getApplyArgs for both `(`, but would now return 1 and 2, respectively.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/68a90df4556bfa220ac81d57b301e1aecad35ed2?w=1