### PR TITLE
ScalafmtConfig: rename parameters when loading

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -502,6 +502,34 @@ else {
 }
 ```
 
+### `newlines.beforeImplicitKW`
+
+```scala mdoc:defaults
+newlines.beforeImplicitKW
+```
+
+```scala mdoc:scalafmt
+maxColumn = 60
+verticalMultiline.atDefnSite = true
+newlines.beforeImplicitKW = true
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
+### `newlines.afterImplicitKW`
+
+```scala mdoc:defaults
+newlines.afterImplicitKW
+```
+
+```scala mdoc:scalafmt
+maxColumn = 60
+verticalMultiline.atDefnSite = true
+newlines.afterImplicitKW = true
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
 ## Rewrite Rules
 
 To enable a rewrite rule, add it to the config like this
@@ -709,20 +737,6 @@ verticalMultiline.arityThreshold = 2
 verticalMultiline.newlineAfterOpenParen = true
 ---
 def other(a: String, b: String)(c: String, d: String) = a + b + c
-```
-
-### `verticalMultiline.newlineBeforeImplicitKW`
-
-```scala mdoc:defaults
-verticalMultiline.newlineBeforeImplicitKW
-```
-
-```scala mdoc:scalafmt
-maxColumn = 60
-verticalMultiline.atDefnSite = true
-verticalMultiline.newlineBeforeImplicitKW = true
----
-def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
 
 ## Disabling Formatting

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
@@ -70,7 +70,14 @@ object Config {
       ScalafmtConfig.configReader(default).read(next)
     }
 
-  private val renamedParameters = Map.empty[String, String]
+  private val renamedParameters = Map(
+    "verticalMultilineAtDefinitionSite" -> "verticalMultiline.atDefnSite",
+    "verticalMultilineAtDefinitionSiteArityThreshold" -> "verticalMultiline.arityThreshold",
+    "newlines.afterImplicitKWInVerticalMultiline" -> "newlines.afterImplicitKW",
+    "newlines.beforeImplicitKWInVerticalMultiline" -> "newlines.beforeImplicitKW",
+    "verticalMultiline.newlineBeforeImplicitKW" -> "newlines.beforeImplicitKW",
+    "verticalMultiline.newlineAfterImplicitKW" -> "newlines.afterImplicitKW"
+  )
 
   def confRename(conf: Conf, srcToDst: Map[String, String]): Configured[Conf] =
     conf match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -104,10 +104,8 @@ case class Newlines(
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
-    @deprecated("Use VerticalMultiline.newlineAfterImplicitKW instead")
-    afterImplicitKWInVerticalMultiline: Boolean = false,
-    @deprecated("Use VerticalMultiline.newlineBeforeImplicitKW instead")
-    beforeImplicitKWInVerticalMultiline: Boolean = false,
+    afterImplicitKW: Boolean = false,
+    beforeImplicitKW: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
     avoidAfterYield: Boolean = true

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -151,10 +151,6 @@ case class ScalafmtConfig(
     danglingParentheses: DanglingParentheses = DanglingParentheses(true, true),
     poorMansTrailingCommasInConfigStyle: Boolean = false,
     trailingCommas: TrailingCommas = TrailingCommas.never,
-    @deprecated("Use VerticalMultiline.atDefnSite instead", "1.6.0")
-    verticalMultilineAtDefinitionSite: Boolean = false,
-    @deprecated("Use VerticalMultiline.arityThreshold instead", "1.6.0")
-    verticalMultilineAtDefinitionSiteArityThreshold: Int = 100,
     verticalMultiline: VerticalMultiline = VerticalMultiline(),
     verticalAlignMultilineOperators: Boolean = false,
     onTestFailure: String = "",

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -8,8 +8,6 @@ import metaconfig._
 case class VerticalMultiline(
     atDefnSite: Boolean = false,
     arityThreshold: Int = 100,
-    newlineBeforeImplicitKW: Boolean = false,
-    newlineAfterImplicitKW: Boolean = false,
     newlineAfterOpenParen: Boolean = false,
     excludeDanglingParens: List[DanglingExclude] = List(
       DanglingExclude.`class`,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -955,10 +955,6 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
         val isImplicitArgList = right.is[T.KwImplicit]
 
-        val newlineBeforeImplicitEnabled =
-          style.verticalMultiline.newlineBeforeImplicitKW ||
-            style.newlines.beforeImplicitKWInVerticalMultiline
-
         val mixedParamsWithCtorModifier =
           mixedParams && prevT.meta.leftOwner.is[CtorModifier]
 
@@ -966,7 +962,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         val isDefinition = ownerCheck(owners(close2))
 
         val shouldAddNewline =
-          (isImplicitArgList && newlineBeforeImplicitEnabled) ||
+          (isImplicitArgList && style.newlines.beforeImplicitKW) ||
             (style.verticalMultiline.newlineAfterOpenParen && !isImplicitArgList && isDefinition) ||
             mixedParamsWithCtorModifier
 
@@ -977,7 +973,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             .withIndent(indentParam, close2, Right)
         )
       case Decision(t @ FormatToken(T.KwImplicit(), _, _), _)
-          if (style.verticalMultiline.newlineAfterImplicitKW || style.newlines.afterImplicitKWInVerticalMultiline) =>
+          if style.newlines.afterImplicitKW =>
         Seq(Split(Newline, 0))
     }
 
@@ -1002,14 +998,9 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case _ => 0
     }
 
-    def belowArityThreshold = maxArity < math.min(
-      style.verticalMultiline.arityThreshold,
-      style.verticalMultilineAtDefinitionSiteArityThreshold
-    )
-
     Seq(
       Split(Space(style.spaces.inParentheses), 0)
-        .onlyIf(isBracket || belowArityThreshold)
+        .onlyIf(isBracket || maxArity < style.verticalMultiline.arityThreshold)
         .withPolicy(SingleLineBlock(singleLineExpire)),
       Split(Newline, 1) // Otherwise split vertically
         .withIndent(firstIndent, close, Right)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -537,7 +537,7 @@ class Router(formatOps: FormatOps) {
       // Parameter opening for one parameter group. This format works
       // on the WHOLE defnSite (via policies)
       case ft @ FormatToken((T.LeftParen() | T.LeftBracket()), _, _)
-          if (style.verticalMultiline.atDefnSite || style.verticalMultilineAtDefinitionSite) &&
+          if style.verticalMultiline.atDefnSite &&
             isDefnSiteWithParams(leftOwner) =>
         verticalMultiline(leftOwner, ft)(style)
 


### PR DESCRIPTION
This way, we don't need to maintain multiple parameters in different places.

Also, rename vertical multiline params. We'll reuse them to bring consistency with non-vertical-multiline paths.

Will be used in #1696, and to fix #1362.