### PR TITLE
Router: handle implicit in non-vertical-multiline

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -502,6 +502,68 @@ else {
 }
 ```
 
+### Newlines around `implicit` parameter list modifier
+
+#### Before
+
+> If set, forces newline before `implicit`. Otherwise, newline
+> can still be added if the keyword would overflow the line.
+
+```scala mdoc:defaults
+newlines.beforeImplicitParamListModifier
+```
+```scala mdoc:scalafmt
+maxColumn = 60
+newlines.beforeImplicitParamListModifier = true
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
+#### After
+
+> If set, forces newline after `implicit`. Otherwise, newline can
+> still be added unless `before` is true, or the entire implicit
+> parameter list fits on a line, or config style is false.
+
+```scala mdoc:defaults
+newlines.afterImplicitParamListModifier
+```
+```scala mdoc:scalafmt
+maxColumn = 60
+newlines.afterImplicitParamListModifier = true
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
+#### Both before and after
+```scala mdoc:scalafmt
+maxColumn = 60
+newlines.afterImplicitParamListModifier = true
+newlines.beforeImplicitParamListModifier = true
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
+#### Neither before nor after
+```scala mdoc:scalafmt
+maxColumn = 60
+newlines.afterImplicitParamListModifier = false
+newlines.beforeImplicitParamListModifier = false
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
+#### With `optIn.configStyleArguments`
+```scala mdoc:scalafmt
+maxColumn = 60
+optIn.configStyleArguments = true
+newlines.afterImplicitParamListModifier = true
+---
+def format(code: String, age: Int)(
+   implicit ev: Parser, c: Context
+): String
+```
+
 ## Rewrite Rules
 
 To enable a rewrite rule, add it to the config like this
@@ -711,16 +773,35 @@ verticalMultiline.newlineAfterOpenParen = true
 def other(a: String, b: String)(c: String, d: String) = a + b + c
 ```
 
-### `verticalMultiline.newlineBeforeImplicitKW`
+### Vertical multiline with `implicit` parameter lists
 
-```scala mdoc:defaults
-verticalMultiline.newlineBeforeImplicitKW
-```
+> Also see the general section on
+> [implicit parameter lists](#newlines-around-implicit-parameter-list-modifier).
 
+#### Before only
 ```scala mdoc:scalafmt
 maxColumn = 60
 verticalMultiline.atDefnSite = true
-verticalMultiline.newlineBeforeImplicitKW = true
+newlines.beforeImplicitParamListModifier = true
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
+#### After only
+```scala mdoc:scalafmt
+maxColumn = 60
+verticalMultiline.atDefnSite = true
+newlines.afterImplicitParamListModifier = true
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
+#### Before and after
+```scala mdoc:scalafmt
+maxColumn = 60
+verticalMultiline.atDefnSite = true
+newlines.beforeImplicitParamListModifier = true
+newlines.afterImplicitParamListModifier = true
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -104,6 +104,8 @@ case class Newlines(
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
+    afterImplicitParamListModifier: Boolean = false,
+    beforeImplicitParamListModifier: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
     avoidAfterYield: Boolean = true

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -104,10 +104,6 @@ case class Newlines(
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
-    @deprecated("Use VerticalMultiline.newlineAfterImplicitKW instead")
-    afterImplicitKWInVerticalMultiline: Boolean = false,
-    @deprecated("Use VerticalMultiline.newlineBeforeImplicitKW instead")
-    beforeImplicitKWInVerticalMultiline: Boolean = false,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
     avoidAfterYield: Boolean = true

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -151,10 +151,6 @@ case class ScalafmtConfig(
     danglingParentheses: DanglingParentheses = DanglingParentheses(true, true),
     poorMansTrailingCommasInConfigStyle: Boolean = false,
     trailingCommas: TrailingCommas = TrailingCommas.never,
-    @deprecated("Use VerticalMultiline.atDefnSite instead", "1.6.0")
-    verticalMultilineAtDefinitionSite: Boolean = false,
-    @deprecated("Use VerticalMultiline.arityThreshold instead", "1.6.0")
-    verticalMultilineAtDefinitionSiteArityThreshold: Int = 100,
     verticalMultiline: VerticalMultiline = VerticalMultiline(),
     verticalAlignMultilineOperators: Boolean = false,
     onTestFailure: String = "",

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -8,7 +8,17 @@ import metaconfig._
 case class VerticalMultiline(
     atDefnSite: Boolean = false,
     arityThreshold: Int = 100,
+    @annotation.DeprecatedName(
+      "newlineBeforeImplicitKW",
+      "Use newlines.beforeImplicitParamListModifier instead",
+      "2.5.0"
+    )
     newlineBeforeImplicitKW: Boolean = false,
+    @annotation.DeprecatedName(
+      "newlineAfterImplicitKW",
+      "Use newlines.afterImplicitParamListModifier instead",
+      "2.5.0"
+    )
     newlineAfterImplicitKW: Boolean = false,
     newlineAfterOpenParen: Boolean = false,
     excludeDanglingParens: List[DanglingExclude] = List(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -956,8 +956,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         val isImplicitArgList = right.is[T.KwImplicit]
 
         val newlineBeforeImplicitEnabled =
-          style.verticalMultiline.newlineBeforeImplicitKW ||
-            style.newlines.beforeImplicitKWInVerticalMultiline
+          style.verticalMultiline.newlineBeforeImplicitKW
 
         val mixedParamsWithCtorModifier =
           mixedParams && prevT.meta.leftOwner.is[CtorModifier]
@@ -977,7 +976,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             .withIndent(indentParam, close2, Right)
         )
       case Decision(t @ FormatToken(T.KwImplicit(), _, _), _)
-          if (style.verticalMultiline.newlineAfterImplicitKW || style.newlines.afterImplicitKWInVerticalMultiline) =>
+          if style.verticalMultiline.newlineAfterImplicitKW =>
         Seq(Split(Newline, 0))
     }
 
@@ -1002,10 +1001,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case _ => 0
     }
 
-    def belowArityThreshold = maxArity < math.min(
-      style.verticalMultiline.arityThreshold,
-      style.verticalMultilineAtDefinitionSiteArityThreshold
-    )
+    def belowArityThreshold =
+      maxArity < style.verticalMultiline.arityThreshold
 
     Seq(
       Split(Space(style.spaces.inParentheses), 0)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -957,6 +957,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
         val shouldAddNewline = {
           if (right.is[T.KwImplicit])
+            style.newlines.beforeImplicitParamListModifier ||
             style.verticalMultiline.newlineBeforeImplicitKW
           else
             style.verticalMultiline.newlineAfterOpenParen && isDefinition
@@ -967,7 +968,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
             .withIndent(indentParam, close2, Right)
         )
       case Decision(t @ FormatToken(T.KwImplicit(), _, _), _)
-          if style.verticalMultiline.newlineAfterImplicitKW =>
+          if style.newlines.afterImplicitParamListModifier ||
+            style.verticalMultiline.newlineAfterImplicitKW =>
         Seq(Split(Newline, 0))
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1146,4 +1146,10 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     paramsOpt.filter(!_.exists(TreeOps.hasExplicitImplicit))
   }
 
+  def opensImplicitParamList(ft: FormatToken, args: Seq[Tree]): Boolean =
+    ft.right.is[T.KwImplicit] && args.forall {
+      case t: Term.Param => !hasExplicitImplicit(t)
+      case _ => true
+    }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1400,43 +1400,6 @@ class Router(formatOps: FormatOps) {
           if isApplyInfix(op, rightOwner) =>
         val InfixApplication(_, op, args) = rightOwner.parent.get
         infixSplit(rightOwner, op, args, formatToken)
-      case opt
-          if style.optIn.annotationNewlines &&
-            optionalNewlines(hash(opt.right)) =>
-        Seq(Split(newlines2Modification(newlines), 0))
-      // Pat
-      case tok @ FormatToken(T.Ident("|"), _, _)
-          if leftOwner.is[Pat.Alternative] =>
-        Seq(
-          Split(Space, 0),
-          Split(Newline, 1)
-        )
-      case FormatToken(
-          T.Ident(_) | Literal() | T.Interpolation.End() | T.Xml.End(),
-          T.Ident(_) | Literal() | T.Xml.Start(),
-          _
-          ) =>
-        Seq(
-          Split(Space, 0)
-        )
-
-      // Case
-      case FormatToken(_, T.KwMatch(), _) =>
-        Seq(
-          Split(Space, 0)
-        )
-
-      // Protected []
-      case tok @ FormatToken(_, T.LeftBracket(), _)
-          if isModPrivateProtected(leftOwner) =>
-        Seq(
-          Split(NoSplit, 0)
-        )
-      case tok @ FormatToken(T.LeftBracket(), _, _)
-          if isModPrivateProtected(leftOwner) =>
-        Seq(
-          Split(NoSplit, 0)
-        )
 
       // Case
       case tok @ FormatToken(cs @ T.KwCase(), _, _) if leftOwner.is[Case] =>
@@ -1484,6 +1447,45 @@ class Router(formatOps: FormatOps) {
         Seq(Split(Newline, 0))
       case FormatToken(c: T.Comment, _, _) =>
         Seq(Split(newlines2Modification(newlines), 0))
+
+      case opt
+          if style.optIn.annotationNewlines &&
+            optionalNewlines(hash(opt.right)) =>
+        Seq(Split(newlines2Modification(newlines), 0))
+
+      // Pat
+      case tok @ FormatToken(T.Ident("|"), _, _)
+          if leftOwner.is[Pat.Alternative] =>
+        Seq(
+          Split(Space, 0),
+          Split(Newline, 1)
+        )
+      case FormatToken(
+          T.Ident(_) | Literal() | T.Interpolation.End() | T.Xml.End(),
+          T.Ident(_) | Literal() | T.Xml.Start(),
+          _
+          ) =>
+        Seq(
+          Split(Space, 0)
+        )
+
+      // Case
+      case FormatToken(_, T.KwMatch(), _) =>
+        Seq(
+          Split(Space, 0)
+        )
+
+      // Protected []
+      case tok @ FormatToken(_, T.LeftBracket(), _)
+          if isModPrivateProtected(leftOwner) =>
+        Seq(
+          Split(NoSplit, 0)
+        )
+      case tok @ FormatToken(T.LeftBracket(), _, _)
+          if isModPrivateProtected(leftOwner) =>
+        Seq(
+          Split(NoSplit, 0)
+        )
 
       // Term.ForYield
       case tok @ FormatToken(_, arrow @ T.KwIf(), _)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -583,24 +583,20 @@ class Router(formatOps: FormatOps) {
       }
 
       case FormatToken(T.LeftParen() | T.LeftBracket(), right, between)
-          if style.optIn.configStyleArguments &&
-            (isDefnSite(leftOwner) || isCallSite(leftOwner)) &&
+          if style.optIn.configStyleArguments && isDefnOrCallSite(leftOwner) &&
             (opensConfigStyle(formatToken) || {
               forceConfigStyle(leftOwner) && !styleMap.forcedBinPack(leftOwner)
             }) =>
         val open = formatToken.left
         val indent = getApplyIndent(leftOwner, isConfigStyle = true)
         val close = matching(open)
-        val newlineBeforeClose: Policy.Pf = {
-          case Decision(FormatToken(_, `close`, _), _) =>
-            Seq(Split(Newline, 0))
-        }
+        val newlineBeforeClose = newlinesOnlyBeforeClosePolicy(close)
         val extraIndent: Length =
           if (style.poorMansTrailingCommasInConfigStyle) Num(2)
           else Num(0)
         val isForcedBinPack = styleMap.forcedBinPack.contains(leftOwner)
         val policy =
-          if (isForcedBinPack) Policy(close)(newlineBeforeClose)
+          if (isForcedBinPack) newlineBeforeClose
           else OneArgOneLineSplit(formatToken).orElse(newlineBeforeClose)
         Seq(
           Split(Newline, 0, policy = policy)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -752,8 +752,6 @@ class Router(formatOps: FormatOps) {
           baseSingleLinePolicy
         }
 
-        val oneArgOneLine = OneArgOneLineSplit(formatToken)
-
         val newlineMod: Modification = NoSplit.orNL(right.is[T.LeftBrace])
 
         val defnSite = isDefnSite(leftOwner)
@@ -823,6 +821,8 @@ class Router(formatOps: FormatOps) {
             singleLine(3)
           else
             singleLine(10)
+        val oneArgOneLine =
+          newlinePolicy.andThen(OneArgOneLineSplit(formatToken))
         Seq(
           Split(noSplitMod, 0, policy = noSplitPolicy)
             .onlyIf(noSplitMod != null)
@@ -840,7 +840,7 @@ class Router(formatOps: FormatOps) {
             .withOptimalToken(expirationToken)
             .withIndent(StateColumn, close, Right),
           Split(Newline, (3 + nestedPenalty) * bracketCoef)
-            .withPolicy(newlinePolicy.andThen(oneArgOneLine))
+            .withPolicy(oneArgOneLine)
             .onlyIf(!singleArgument && !alignTuple)
             .withIndent(indent, close, Right)
         ) ++ splitsForAssign.getOrElse(Seq.empty)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -537,7 +537,7 @@ class Router(formatOps: FormatOps) {
       // Parameter opening for one parameter group. This format works
       // on the WHOLE defnSite (via policies)
       case ft @ FormatToken((T.LeftParen() | T.LeftBracket()), _, _)
-          if (style.verticalMultiline.atDefnSite || style.verticalMultilineAtDefinitionSite) &&
+          if style.verticalMultiline.atDefnSite &&
             isDefnSiteWithParams(leftOwner) =>
         verticalMultiline(leftOwner, ft)(style)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -583,4 +583,7 @@ object TreeOps {
   def isExplicitImplicit(m: Mod): Boolean =
     m.tokens.nonEmpty && m.is[Mod.Implicit]
 
+  def hasExplicitImplicit(param: Term.Param): Boolean =
+    param.mods.exists(isExplicitImplicit)
+
 }

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -718,6 +718,6 @@ align = none
       : SerializedSuspendableExecutionContext =
      new SerializedSuspendableExecutionContext(throughput)
 >>>
-def apply(throughput: Int)(implicit context: ExecutionContext)
-    : SerializedSuspendableExecutionContext =
+def apply(throughput: Int)(implicit
+    context: ExecutionContext): SerializedSuspendableExecutionContext =
   new SerializedSuspendableExecutionContext(throughput)

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -711,3 +711,13 @@ object ThreadPoolConfigDispatcherBuilder {
       : Option[(ThreadPoolConfigDispatcherBuilder) => ThreadPoolConfigDispatcherBuilder] =
     opt map fun
 }
+<<< implicit with single argument
+align = none
+===
+  def apply(throughput: Int)(implicit context: ExecutionContext)
+      : SerializedSuspendableExecutionContext =
+     new SerializedSuspendableExecutionContext(throughput)
+>>>
+def apply(throughput: Int)(implicit context: ExecutionContext)
+    : SerializedSuspendableExecutionContext =
+  new SerializedSuspendableExecutionContext(throughput)

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -158,3 +158,174 @@ final class TypedArrayBufferOps[ // scalastyle:ignore
     extends AnyVal {
   ???
 }
+<<< #1362 1: single implict, long line
+danglingParentheses = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+===
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String
+) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F]
+  ): F[Resolution] =
+    ???
+}
+>>>
+case class Foo(
+    a: Int,
+    b: Boolean,
+    c: String,
+    d: String,
+    e: String,
+    f: String,
+    g: String
+) {
+  def run[F[_]](
+      a: Int,
+      b: Int = 0
+  )(
+      implicit
+      F: Monad[F]
+  ): F[Resolution] =
+    ???
+}
+<<< #1362 2: single implicit, short line
+maxColumn = 40
+danglingParentheses = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+===
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String
+) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F]
+  ): F[Resolution] =
+    ???
+}
+>>>
+case class Foo(
+    a: Int,
+    b: Boolean,
+    c: String,
+    d: String,
+    e: String,
+    f: String,
+    g: String
+) {
+  def run[F[_]](
+      a: Int,
+      b: Int = 0
+  )(
+      implicit
+      F: Monad[F]
+  ): F[Resolution] =
+    ???
+}
+<<< #1362 3: multiple implicits, short line
+maxColumn = 30
+danglingParentheses = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+===
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String
+) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F],
+    G: Monad[G]
+  ): F[Resolution] =
+    ???
+}
+>>>
+case class Foo(
+    a: Int,
+    b: Boolean,
+    c: String,
+    d: String,
+    e: String,
+    f: String,
+    g: String
+) {
+  def run[F[_]](
+      a: Int,
+      b: Int = 0
+  )(
+      implicit
+      F: Monad[F],
+      G: Monad[G]
+  ): F[Resolution] =
+    ???
+}
+<<< #1362 4: multiple implicits, long line
+maxColumn = 60
+danglingParentheses = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+===
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String
+) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F],
+    G: Monad[G]
+  ): F[Resolution] =
+    ???
+}
+>>>
+case class Foo(
+    a: Int,
+    b: Boolean,
+    c: String,
+    d: String,
+    e: String,
+    f: String,
+    g: String
+) {
+  def run[F[_]](
+      a: Int,
+      b: Int = 0
+  )(
+      implicit
+      F: Monad[F],
+      G: Monad[G]
+  ): F[Resolution] =
+    ???
+}

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -193,8 +193,7 @@ case class Foo(
   def run[F[_]](
       a: Int,
       b: Int = 0
-  )(
-      implicit
+  )(implicit
       F: Monad[F]
   ): F[Resolution] =
     ???
@@ -235,8 +234,7 @@ case class Foo(
   def run[F[_]](
       a: Int,
       b: Int = 0
-  )(
-      implicit
+  )(implicit
       F: Monad[F]
   ): F[Resolution] =
     ???
@@ -278,8 +276,7 @@ case class Foo(
   def run[F[_]](
       a: Int,
       b: Int = 0
-  )(
-      implicit
+  )(implicit
       F: Monad[F],
       G: Monad[G]
   ): F[Resolution] =
@@ -322,8 +319,7 @@ case class Foo(
   def run[F[_]](
       a: Int,
       b: Int = 0
-  )(
-      implicit
+  )(implicit
       F: Monad[F],
       G: Monad[G]
   ): F[Resolution] =

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -33,7 +33,8 @@ private def withNewLocalDefs(bindings: List[Binding])(
   def joinFull[E1 >: E, E2, U2, D[_], O1, U1, O2](q2: Query[E2, _, D])(implicit ol1: OptionLift[E1, O1], sh1: Shape[FlatShapeLevel, O1, U1, _], ol2: OptionLift[E2, O2], sh2: Shape[FlatShapeLevel, O2, U2, _])
 >>>
 def joinFull[E1 >: E, E2, U2, D[_], O1, U1, O2](q2: Query[E2, _, D])(
-    implicit ol1: OptionLift[E1, O1],
+    implicit
+    ol1: OptionLift[E1, O1],
     sh1: Shape[FlatShapeLevel, O1, U1, _],
     ol2: OptionLift[E2, O2],
     sh2: Shape[FlatShapeLevel, O2, U2, _])
@@ -45,16 +46,16 @@ def zipWith[E2, U2, F, G, T, D[_]](q2: Query[E2, U2, D], f: (E, E2) => F)(
 <<< slick groupBy
   def groupBy[K, T, G, P](f: E => K)(implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G], vshape: Shape[_ <: FlatShapeLevel, E, _, P]): Query[(G, Query[P, U, Seq]), (T, Query[P, U, Seq]), C]
 >>>
-def groupBy[K, T, G, P](f: E => K)(
-    implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G],
-    vshape: Shape[_ <: FlatShapeLevel, E, _, P])
+def groupBy[K, T, G, P](f: E => K)(implicit
+                                   kshape: Shape[_ <: FlatShapeLevel, K, T, G],
+                                   vshape: Shape[_ <: FlatShapeLevel, E, _, P])
     : Query[(G, Query[P, U, Seq]), (T, Query[P, U, Seq]), C]
 <<< slick groupBy 2
   def groupBy[K, T, G, P](f: E => K)(implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G], vshape: Shape[_ <: FlatShapeLevel, E, _, P]): Query[(G, Query[P, U, Seq]), (T, Query[P, U, Seq]), CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC, (T, Query[P, U, Seq]), (T, Query[P, U, Seq])]
 >>>
-def groupBy[K, T, G, P](f: E => K)(
-    implicit kshape: Shape[_ <: FlatShapeLevel, K, T, G],
-    vshape: Shape[_ <: FlatShapeLevel, E, _, P])
+def groupBy[K, T, G, P](f: E => K)(implicit
+                                   kshape: Shape[_ <: FlatShapeLevel, K, T, G],
+                                   vshape: Shape[_ <: FlatShapeLevel, E, _, P])
     : Query[(G, Query[P, U, Seq]),
             (T, Query[P, U, Seq]),
             CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC,

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -103,7 +103,8 @@ private def extractRhino(e: js.Dynamic): js.Array[String] = {
     .jsReplace("""^\s+at\s+""".re("gm"), "") // remove 'at' and indentation
     .jsReplace("""^(.+?)(?: \((.+)\))?$""".re("gm"), "$2@$1")
     .jsReplace("""\r\n?""".re("gm"),
-               "\n") // Rhino has platform-dependent EOL's
+               "\n"
+    ) // Rhino has platform-dependent EOL's
     .jsSplit("\n")
 }
 <<< select is cheaper

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -738,8 +738,8 @@ implicit def v_s_Op[
       OpMod,
       OpPow
     ) Op <: OpType
-](
-    implicit @expand.sequence[Op](
+](implicit
+    @expand.sequence[Op](
       { _ + _ },
       { _ - _ },
       { _ * _ },

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -852,8 +852,8 @@ implicit def v_s_Op[
       OpMod,
       OpPow
     ) Op <: OpType
-](
-    implicit @expand.sequence[Op](
+](implicit
+    @expand.sequence[Op](
       { _ + _ },
       { _ - _ },
       { _ * _ },

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
@@ -1,4 +1,4 @@
-maxColumn = 200 #to not disturb the output too much
+maxColumn = 100 #to not disturb the output too much
 rewrite {
   rules = [SortModifiers]
   sortModifiers {

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148.stat
@@ -16,8 +16,7 @@ class X(private final val x: Int)(
     val i1: Int
 )
 >>>
-class X(private final val x: Int)(
-    implicit
+class X(private final val x: Int)(implicit
     val i1: Int
 )
 <<< 1148 — implicit val with only private
@@ -27,8 +26,7 @@ class X(private final val x: Int)(
     private[this] var i2: String
 )
 >>>
-class X(private final val x: Int)(
-    implicit
+class X(private final val x: Int)(implicit
     private[this] val i1: Int,
     private[this] var i2: String
 )
@@ -39,21 +37,14 @@ class X(private final val x: Int)(
     private[this] final var i2: String
 )
 >>>
-class X(private final val x: Int)(
-    implicit
+class X(private final val x: Int)(implicit
     private[this] final val i1: Int,
     private[this] final var i2: String
 )
 <<< 1148 — implicit val with duplicate implicit mod
-class X(private final val x: Int)(
-    implicit val i1: Int,
-    implicit var i2: Int
-)
+class X(private final val x: Int)(implicit val i1: Int, implicit var i2: Int)
 >>>
-class X(private final val x: Int)(
-    implicit val i1: Int,
-    implicit var i2: Int
-)
+class X(private final val x: Int)(implicit val i1: Int, implicit var i2: Int)
 <<< 1148 — implicit val with duplicate implicit, final, private mod — slight inconsistency
 class X(private final val x: Int)(
     implicit final private val i1: Int,

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148_implicit_first_in_order.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148_implicit_first_in_order.stat
@@ -1,4 +1,4 @@
-maxColumn = 200 #to not disturb the output too much
+maxColumn = 100 #to not disturb the output too much
 rewrite {
   rules = [SortModifiers]
   sortModifiers {

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148_implicit_first_in_order.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_bug_1148_implicit_first_in_order.stat
@@ -16,8 +16,7 @@ class X(final private val x: Int)(
     val i1: Int
 )
 >>>
-class X(final private val x: Int)(
-    implicit
+class X(final private val x: Int)(implicit
     val i1: Int
 )
 <<< 1148 — implicit val with only private
@@ -27,8 +26,7 @@ class X(private final val x: Int)(
     private[this] var i2: String
 )
 >>>
-class X(final private val x: Int)(
-    implicit
+class X(final private val x: Int)(implicit
     private[this] val i1: Int,
     private[this] var i2: String
 )
@@ -39,8 +37,7 @@ class X(private final val x: Int)(
     private[this] final var i2: String
 )
 >>>
-class X(final private val x: Int)(
-    implicit
+class X(final private val x: Int)(implicit
     final private[this] val i1: Int,
     final private[this] var i2: String
 )

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -77,8 +77,7 @@ object a {
   )(
       b1: String,
       b2: String, // comment
-  )(
-      implicit
+  )(implicit
       c1: SomeType1,
       c2: SomeType2, // comment
   ) {
@@ -88,8 +87,7 @@ object a {
     )(
         b1: String,
         b2: String, // comment
-    )(
-        implicit
+    )(implicit
         c1: SomeType1,
         c2: SomeType2, // comment
     ) =

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -301,8 +301,7 @@ object a {
   )(
       b1: String,
       b2: String, // comment
-  )(
-      implicit
+  )(implicit
       c1: SomeType1,
       c2: SomeType2, // comment
   ) {
@@ -312,8 +311,7 @@ object a {
     )(
         b1: String,
         b2: String, // comment
-    )(
-        implicit
+    )(implicit
         c1: SomeType1,
         c2: SomeType2, // comment
     ) =

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysVerticalMultilineAtDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysVerticalMultilineAtDefnSite.stat
@@ -1,7 +1,6 @@
 maxColumn = 30
 trailingCommas = always
-verticalMultilineAtDefinitionSite = true
-
+verticalMultiline.atDefnSite = true
 <<< shouldn't put comma in empty parentheses
 case class Test()(a1: Int, a2: Int, a3: Int, a4: Int, a5: Int)
 >>>

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
@@ -76,8 +76,7 @@ object a {
   )(
       b1: String,
       b2: String // comment
-  )(
-      implicit
+  )(implicit
       c1: SomeType1,
       c2: SomeType2 // comment
   ) {
@@ -87,8 +86,7 @@ object a {
     )(
         b1: String,
         b2: String // comment
-    )(
-        implicit
+    )(implicit
         c1: SomeType1,
         c2: SomeType2 // comment
     ) =

--- a/scalafmt-tests/src/test/resources/unit/TermApply.stat
+++ b/scalafmt-tests/src/test/resources/unit/TermApply.stat
@@ -113,9 +113,8 @@ Seq(
 )
 >>>
 Seq(
-    Split(
-        Space,
-        0
+    Split(Space,
+          0
     ), // End files with trailing newline
     Split(Newline, 1)
 )

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -1,8 +1,6 @@
 maxColumn = 80
-verticalMultiline = {
-    atDefnSite = true
-    newlineAfterImplicitKW = true
-}
+newlines.afterImplicitParamListModifier = true
+verticalMultiline.atDefnSite = true
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 0
 

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -21,8 +21,8 @@ verticalMultiline.atDefnSite = false
 ===
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
 >>>
-def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(
-  implicit ev: Parse[T],
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit
+  ev: Parse[T],
   ev2: EC
 ): String
 <<< should add a newline after implicit keyword in class definitions
@@ -88,7 +88,8 @@ implicit def pairEncoder[A, B](
 ): CsvEncoder[(A, B)]
 >>>
 implicit def pairEncoder[A, B](
-  implicit aEncoder: CsvEncoder[A],
+  implicit
+  aEncoder: CsvEncoder[A],
   bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]
 <<< should work without explicit parameter groups (non-vm, before=F)
@@ -100,7 +101,7 @@ implicit def pairEncoder[A, B](
     bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]
 >>>
-implicit def pairEncoder[A, B](
-  implicit aEncoder: CsvEncoder[A],
+implicit def pairEncoder[A, B](implicit
+  aEncoder: CsvEncoder[A],
   bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -16,7 +16,15 @@ def format_![T <: Tree](
   ev: Parse[T],
   ev2: EC
 ): String
-
+<<< should add a newline after implicit keyword in function definitions (non-vm)
+verticalMultiline.atDefnSite = false
+===
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
+>>>
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(
+  implicit ev: Parse[T],
+  ev2: EC
+): String
 <<< should add a newline after implicit keyword in class definitions
 final class UserProfile(name: String, age: Int, address: Address, profession: Profession, school: School)(
   implicit ctx: Context, ec: Executor)
@@ -68,5 +76,31 @@ implicit def pairEncoder[A, B](
 implicit def pairEncoder[A, B](
   implicit
   aEncoder: CsvEncoder[A],
+  bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]
+<<< should work without explicit parameter groups (non-vm, before=T)
+verticalMultiline.atDefnSite = false
+newlines.beforeImplicitParamListModifier = true
+===
+implicit def pairEncoder[A, B](
+    implicit aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]
+>>>
+implicit def pairEncoder[A, B](
+  implicit aEncoder: CsvEncoder[A],
+  bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]
+<<< should work without explicit parameter groups (non-vm, before=F)
+verticalMultiline.atDefnSite = false
+newlines.beforeImplicitParamListModifier = false
+===
+implicit def pairEncoder[A, B](
+    implicit aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]
+>>>
+implicit def pairEncoder[A, B](
+  implicit aEncoder: CsvEncoder[A],
   bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -25,7 +25,8 @@ verticalMultiline.atDefnSite = false
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
 >>>
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(
-  implicit ev: Parse[T],
+  implicit
+  ev: Parse[T],
   ev2: EC
 ): String
 <<< should add a newline after implicit keyword in class definitions
@@ -91,6 +92,7 @@ implicit def pairEncoder[A, B](implicit aEncoder: CsvEncoder[A],
 ): CsvEncoder[(A, B)]
 >>>
 implicit def pairEncoder[A, B](
-  implicit aEncoder: CsvEncoder[A],
+  implicit
+  aEncoder: CsvEncoder[A],
   bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -1,9 +1,7 @@
 maxColumn = 80
-verticalMultiline = {
-    atDefnSite = true
-    newlineAfterImplicitKW = true
-    newlineBeforeImplicitKW = true
-}
+newlines.beforeImplicitParamListModifier = true
+newlines.afterImplicitParamListModifier = true
+verticalMultiline.atDefnSite = true
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 0
 

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -19,6 +19,15 @@ def format_![T <: Tree](
   ev2: EC
 ): String
 
+<<< should add a newline after implicit keyword in function definitions (non-vm)
+verticalMultiline.atDefnSite = false
+===
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
+>>>
+def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(
+  implicit ev: Parse[T],
+  ev2: EC
+): String
 <<< should add a newline after implicit keyword in class definitions
 final class UserProfile(name: String, age: Int, address: Address, profession: Profession, school: School)(
   implicit ctx: Context, ec: Executor)
@@ -72,5 +81,16 @@ implicit def pairEncoder[A, B](implicit aEncoder: CsvEncoder[A],
 implicit def pairEncoder[A, B](
   implicit
   aEncoder: CsvEncoder[A],
+  bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]
+<<< should work without explicit parameter groups (non-vm)
+verticalMultiline.atDefnSite = false
+===
+implicit def pairEncoder[A, B](implicit aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+): CsvEncoder[(A, B)]
+>>>
+implicit def pairEncoder[A, B](
+  implicit aEncoder: CsvEncoder[A],
   bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]


### PR DESCRIPTION
This will format "implicit" on the same line as the opening paren, if possible. It will also break after the "implicit" unless all parameters fit on one line.

Fixes #1362.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/eea2e89051a744b4c13c6e844aaf54ebaa12d64b?w=1