### PR TITLE
Router: handle if with/without braces consistently

### DIFF
--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -47,33 +47,34 @@ val createAsStat = if (semantics.asInstanceOfs == Unchecked) {
       }
 >>>
 val createAsStat = if (semantics.asInstanceOfs == Unchecked) {
-  js.Skip()
-} else {
-  envFieldDef(
-      "as",
-      className,
-      js.Function(List(objParam),
-                  js.Return(className match {
-                    case Definitions.ObjectClass => obj
-                    case _ =>
-                      val throwError = {
-                        genCallHelper("throwClassCastException",
-                                      obj,
-                                      js.StringLiteral(displayName))
-                      }
-                      if (className == RuntimeNothingClass) {
-                        // Always throw for .asInstanceOf[Nothing], even for null
-                        throwError
-                      } else {
-                        js.If(js.Apply(envField("is", className), List(obj)) ||
-                                (obj === js.Null()), {
-                                obj
-                              }, {
-                                throwError
-                              })
-                      }
-                  })))
-}
+    js.Skip()
+  } else {
+    envFieldDef(
+        "as",
+        className,
+        js.Function(
+            List(objParam),
+            js.Return(className match {
+              case Definitions.ObjectClass => obj
+              case _ =>
+                val throwError = {
+                  genCallHelper("throwClassCastException",
+                                obj,
+                                js.StringLiteral(displayName))
+                }
+                if (className == RuntimeNothingClass) {
+                  // Always throw for .asInstanceOf[Nothing], even for null
+                  throwError
+                } else {
+                  js.If(js.Apply(envField("is", className), List(obj)) ||
+                          (obj === js.Null()), {
+                          obj
+                        }, {
+                          throwError
+                        })
+                }
+            })))
+  }
 <<< processOptions
   def processOptions(): Unit = {
       if (option.startsWith("relSourceMap:")) {

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -173,3 +173,113 @@ else
         CustomHttp.okhttpClient.value
     )
   }
+<<< #1747 1: one line with else
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) } else { None }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) }
+  else { None }
+}
+<<< #1747 2: one line without else
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+}
+<<< #1747 3: split on then with else
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  else
+    None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+    else
+      None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+}
+<<< #1747 4: split on else
+object a {
+  val ok1 = if (a > 10) Some(a) else
+    None
+  val ok2 = if (a > 10) { Some(a) } else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+    else
+      None
+  val ok2 = if (a > 10) { Some(a) }
+  else {
+    None
+  }
+}
+<<< #1747 5: split on then without else
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  val ok2 = if (a > 10) {
+    Some(a) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+  val ok2 = if (a > 10) {
+    Some(a)
+  }
+}
+<<< #1747 6: split on if
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) } else { None }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else { None }
+}
+<<< #1747 7: split on if without else
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+}

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -182,7 +182,7 @@ object a {
 object a {
   val ok1 = if (a > 10) Some(a) else None
   val ok2 = if (a > 10) { Some(a) }
-  else { None }
+    else { None }
 }
 <<< #1747 2: one line without else
 object a {
@@ -208,16 +208,15 @@ object a {
 }
 >>>
 object a {
-  val ok1 =
-    if (a > 10)
+  val ok1 = if (a > 10)
       Some(a)
     else
       None
   val ok2 = if (a > 10) {
-    Some(a)
-  } else {
-    None
-  }
+      Some(a)
+    } else {
+      None
+    }
 }
 <<< #1747 4: split on else
 object a {
@@ -229,14 +228,13 @@ object a {
 }
 >>>
 object a {
-  val ok1 =
-    if (a > 10) Some(a)
+  val ok1 = if (a > 10) Some(a)
     else
       None
   val ok2 = if (a > 10) { Some(a) }
-  else {
-    None
-  }
+    else {
+      None
+    }
 }
 <<< #1747 5: split on then without else
 object a {
@@ -247,9 +245,8 @@ object a {
 }
 >>>
 object a {
-  val ok1 =
-    if (a > 10)
-      Some(a)
+  val ok1 = if (a > 10)
+    Some(a)
   val ok2 = if (a > 10) {
     Some(a)
   }

--- a/scalafmt-tests/src/test/resources/default/Val.stat
+++ b/scalafmt-tests/src/test/resources/default/Val.stat
@@ -85,19 +85,19 @@ val wasBOM = if (endianness == AutoEndian) {
 } else false
 >>>
 val wasBOM = if (endianness == AutoEndian) {
-  // Read BOM
-  if (b1 == 0xfe && b2 == 0xff) {
-    endianness = BigEndian
-    true
-  } else if (b1 == 0xff && b2 == 0xfe) {
-    endianness = LittleEndian
-    true
-  } else {
-    // Not a valid BOM: default to BigEndian and start reading
-    endianness = BigEndian
-    false
-  }
-} else false
+    // Read BOM
+    if (b1 == 0xfe && b2 == 0xff) {
+      endianness = BigEndian
+      true
+    } else if (b1 == 0xff && b2 == 0xfe) {
+      endianness = LittleEndian
+      true
+    } else {
+      // Not a valid BOM: default to BigEndian and start reading
+      endianness = BigEndian
+      false
+    }
+  } else false
 <<< #269 3
  val route =
         scheme("https") { completeOk } ~
@@ -141,9 +141,9 @@ val predefinedType = if (clazz.getTypeParameters.length == 1) {
         ScDesignatorType(clazz)
 >>>
 val predefinedType = if (clazz.getTypeParameters.length == 1) {
-  ScParameterizedType(ScDesignatorType(clazz), undefines)
-} else
-  ScDesignatorType(clazz)
+    ScParameterizedType(ScDesignatorType(clazz), undefines)
+  } else
+    ScDesignatorType(clazz)
 <<< myRoute
   val myRoute =
     path("") {

--- a/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
@@ -22,8 +22,7 @@ forAll(table)((reqProto, headReq, reqCH, resProto, resCH, resCD, renCH, close) â
     response = HttpResponse(
       200,
       headers = resCH.toList,
-      entity =
-        if (resCD)
+      entity = if (resCD)
           HttpEntity.CloseDelimited(
             ContentTypes.`text/plain(UTF-8)`,
             Source.single(ByteString("ENTITY"))

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -531,7 +531,7 @@ object a {
 >>>
 object a {
   val select = if (max) { (a: CTuple, b: CTuple) => (a.compareTo(b) >= 0) }
-  else { (a: CTuple, b: CTuple) => (a.compareTo(b) <= 0) }
+    else { (a: CTuple, b: CTuple) => (a.compareTo(b) <= 0) }
 }
 <<< #1633 2.2: function block in a val statement
 object a {

--- a/scalafmt-tests/src/test/resources/unit/If.stat
+++ b/scalafmt-tests/src/test/resources/unit/If.stat
@@ -27,8 +27,8 @@ if (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
 val newColumn = if(split == Newline) newIndent
                 else column + split.length
 >>>
-val newColumn =
-  if (split == Newline) newIndent
+val newColumn = if (split == Newline)
+    newIndent
   else column + split.length
 <<< Egyptian curlies
 if (optimalAt.contains(tok.left)) {


### PR DESCRIPTION
To do that, allow space only if 'else' is empty or the entire expression fits on the line.

Fixes #1747.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/3670a380d2efa282b8432c8f1ab45ca49efa2991?w=1

p.s. old diffs: https://github.com/kitbellew/scala-repos/commit/dc650f97f6666e1120da601e2c98ad2233d86c96?w=1