### PR TITLE
DanglingParentheses: move `exclude` list from VerticalMultiline

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -441,6 +441,25 @@ object a {
 }
 ```
 
+#### `danglingParentheses.exclude`
+
+When the appropriate `danglingParentheses` flag (e.g., `defnSite`) has been set,
+this parameter can be used to limit contexts where dangling is applied
+(currently, `class`, `trait` and `def` are supported).
+
+```scala mdoc:defaults
+danglingParentheses.exclude
+```
+
+```scala mdoc:scalafmt
+continuationIndent.defnSite = 2
+danglingParentheses.defnSite = true
+danglingParentheses.exclude = [def]
+---
+def other(a: String, b: String)(c: String, d: String) = a + b + c
+other(a, b)(c, d)
+```
+
 ### `newlines.alwaysBeforeTopLevelStatements`
 
 ```scala mdoc:defaults
@@ -926,6 +945,29 @@ verticalMultiline.arityThreshold = 2
 verticalMultiline.newlineAfterOpenParen = true
 ---
 def other(a: String, b: String)(c: String, d: String) = a + b + c
+```
+
+### `verticalMultiline.excludeDanglingParens`
+
+> This parameter has been deprecated, please use
+> [danglingParentheses.exclude](#danglingparenthesesexclude). Keep in mind,
+> though, that the new parameter is empty by default while the old one isn't,
+> so to use empty exclude list, one must set the old
+> `verticalMultiline.excludeDanglingParens=[]`.
+
+```scala mdoc:defaults
+verticalMultiline.excludeDanglingParens
+```
+
+```scala mdoc:scalafmt
+continuationIndent.defnSite = 2
+verticalMultiline.excludeDanglingParens = [def]
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = true
+---
+def other(a: String, b: String)(c: String, d: String) = a + b + c
+other(a, b)(c, d)
 ```
 
 ### Vertical multiline with `implicit` parameter lists

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -397,22 +397,19 @@ insert newlines.
 
 While this parameter is not technically under the `newlines` section, it logically belongs there.
 
+#### `danglingParentheses.defnSite`
 ```scala mdoc:defaults
-danglingParentheses
+danglingParentheses.defnSite
 ```
-
 ```scala mdoc:scalafmt
 danglingParentheses.defnSite = true
-danglingParentheses.callSite = true
-# shortcut to set both
-danglingParentheses = true
+danglingParentheses.callSite = false
 ---
 object a {
   // defnSite
   def method(
     a: Int,
-    b: String
-  ): Boolean
+    b: String): Boolean
 
   // callSite
   method(
@@ -422,17 +419,20 @@ object a {
 }
 ```
 
+#### `danglingParentheses.callSite`
+```scala mdoc:defaults
+danglingParentheses.callSite
+```
 ```scala mdoc:scalafmt
 danglingParentheses.defnSite = false
-danglingParentheses.callSite = false
-# shortcut to set both
-danglingParentheses = false
+danglingParentheses.callSite = true
 ---
 object a {
   // defnSite
   def method(
     a: Int,
-    b: String): Boolean
+    b: String
+  ): Boolean
 
   // callSite
   method(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
@@ -9,26 +9,25 @@ case class DanglingParentheses(
   val decoder: ConfDecoder[DanglingParentheses] =
     generic.deriveDecoder(this).noTypos
 }
+
 object DanglingParentheses {
-  val default = DanglingParentheses(true, true)
+
+  private val shortcutTrue = DanglingParentheses(true, true)
+  private val shortcutFalse = DanglingParentheses(false, false)
+
+  val default = shortcutTrue
+
   implicit lazy val surface: generic.Surface[DanglingParentheses] =
     generic.deriveSurface
 
   implicit val decoder: ConfDecoder[DanglingParentheses] =
     ConfDecoder.instance[DanglingParentheses] {
-      case Conf.Bool(true) => Configured.Ok(DanglingParentheses(true, true))
-      case Conf.Bool(false) => Configured.Ok(DanglingParentheses(false, false))
+      case Conf.Bool(true) => Configured.Ok(shortcutTrue)
+      case Conf.Bool(false) => Configured.Ok(shortcutFalse)
       case els => default.decoder.read(els)
     }
 
   implicit val encoder: ConfEncoder[DanglingParentheses] =
-    ConfEncoder.instance[DanglingParentheses] {
-      case DanglingParentheses(true, true) => Conf.Bool(true)
-      case DanglingParentheses(true, false) =>
-        Conf.Obj("callSite" -> Conf.Bool(true), "defnSite" -> Conf.Bool(false))
-      case DanglingParentheses(false, true) =>
-        Conf.Obj("callSite" -> Conf.Bool(false), "defnSite" -> Conf.Bool(true))
-      case DanglingParentheses(false, false) => Conf.Bool(false)
+    generic.deriveEncoder
 
-    }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
@@ -4,7 +4,8 @@ import metaconfig._
 
 case class DanglingParentheses(
     callSite: Boolean,
-    defnSite: Boolean
+    defnSite: Boolean,
+    exclude: List[DanglingParentheses.Exclude] = Nil
 ) {
   val decoder: ConfDecoder[DanglingParentheses] =
     generic.deriveDecoder(this).noTypos
@@ -29,5 +30,16 @@ object DanglingParentheses {
 
   implicit val encoder: ConfEncoder[DanglingParentheses] =
     generic.deriveEncoder
+
+  sealed abstract class Exclude
+
+  object Exclude {
+    case object `class` extends Exclude
+    case object `trait` extends Exclude
+    case object `def` extends Exclude
+
+    implicit val reader: ConfCodec[Exclude] =
+      ReaderUtil.oneOf[Exclude](`class`, `trait`, `def`)
+  }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -21,9 +21,14 @@ case class VerticalMultiline(
     )
     newlineAfterImplicitKW: Boolean = false,
     newlineAfterOpenParen: Boolean = false,
-    excludeDanglingParens: List[DanglingExclude] = List(
-      DanglingExclude.`class`,
-      DanglingExclude.`trait`
+    @annotation.DeprecatedName(
+      "excludeDanglingParens",
+      "Use danglingParentheses.exclude instead",
+      "2.5.0"
+    )
+    excludeDanglingParens: List[DanglingParentheses.Exclude] = List(
+      DanglingParentheses.Exclude.`class`,
+      DanglingParentheses.Exclude.`trait`
     )
 ) {
   val reader: ConfDecoder[VerticalMultiline] =
@@ -35,15 +40,4 @@ object VerticalMultiline {
     generic.deriveSurface
   implicit lazy val encoder: ConfEncoder[VerticalMultiline] =
     generic.deriveEncoder[VerticalMultiline]
-}
-
-sealed abstract class DanglingExclude
-
-object DanglingExclude {
-  case object `class` extends DanglingExclude
-  case object `trait` extends DanglingExclude
-  case object `def` extends DanglingExclude
-
-  implicit val danglingExcludeReader: ConfCodec[DanglingExclude] =
-    ReaderUtil.oneOf[DanglingExclude](`class`, `trait`, `def`)
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -3,11 +3,7 @@ package org.scalafmt.internal
 import java.{util => ju}
 import scala.collection.JavaConverters._
 import org.scalafmt.Error.UnexpectedTree
-import org.scalafmt.config.{
-  DanglingParentheses,
-  NewlineCurlyLambda,
-  ScalafmtConfig
-}
+import org.scalafmt.config.{NewlineCurlyLambda, ScalafmtConfig}
 import org.scalafmt.internal.ExpiresOn.{Left, Right}
 import org.scalafmt.internal.Length.Num
 import org.scalafmt.internal.Policy.NoPolicy
@@ -904,31 +900,13 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
     val mixedParams = {
       owner match {
-        case cls: meta.Defn.Class =>
+        case cls: Defn.Class =>
           cls.tparams.nonEmpty && cls.ctor.paramss.nonEmpty
         case _ => false
       }
     }
 
-    val isClassLike = owner.is[meta.Ctor.Primary] || owner.is[meta.Defn.Class]
-    val isTrait = owner.is[meta.Defn.Trait]
-    val isDef = owner.is[meta.Defn.Def]
-    val danglingParenthesesExclude =
-      if (style.danglingParentheses.exclude.isEmpty)
-        style.verticalMultiline.excludeDanglingParens
-      else
-        style.danglingParentheses.exclude
-    val excludeClass = danglingParenthesesExclude
-      .contains(DanglingParentheses.Exclude.`class`)
-    val excludeTrait = danglingParenthesesExclude
-      .contains(DanglingParentheses.Exclude.`trait`)
-    val excludeDef = danglingParenthesesExclude
-      .contains(DanglingParentheses.Exclude.`def`)
-
-    val shouldNotDangle =
-      (isClassLike && excludeClass) ||
-        (isTrait && excludeTrait) ||
-        (isDef && excludeDef)
+    val shouldNotDangle = shouldNotDangleAtDefnSite(owner, true)
 
     // Since classes and defs aren't the same (see below), we need to
     // create two (2) OneArgOneLineSplit when dealing with classes. One

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2,8 +2,12 @@ package org.scalafmt.internal
 
 import java.{util => ju}
 import scala.collection.JavaConverters._
-import org.scalafmt.Error.{CaseMissingArrow, UnexpectedTree}
-import org.scalafmt.config.{DanglingExclude, NewlineCurlyLambda, ScalafmtConfig}
+import org.scalafmt.Error.UnexpectedTree
+import org.scalafmt.config.{
+  DanglingParentheses,
+  NewlineCurlyLambda,
+  ScalafmtConfig
+}
 import org.scalafmt.internal.ExpiresOn.{Left, Right}
 import org.scalafmt.internal.Length.Num
 import org.scalafmt.internal.Policy.NoPolicy
@@ -909,12 +913,17 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     val isClassLike = owner.is[meta.Ctor.Primary] || owner.is[meta.Defn.Class]
     val isTrait = owner.is[meta.Defn.Trait]
     val isDef = owner.is[meta.Defn.Def]
-    val excludeClass = style.verticalMultiline.excludeDanglingParens
-      .contains(DanglingExclude.`class`)
-    val excludeTrait = style.verticalMultiline.excludeDanglingParens
-      .contains(DanglingExclude.`trait`)
-    val excludeDef = style.verticalMultiline.excludeDanglingParens
-      .contains(DanglingExclude.`def`)
+    val danglingParenthesesExclude =
+      if (style.danglingParentheses.exclude.isEmpty)
+        style.verticalMultiline.excludeDanglingParens
+      else
+        style.danglingParentheses.exclude
+    val excludeClass = danglingParenthesesExclude
+      .contains(DanglingParentheses.Exclude.`class`)
+    val excludeTrait = danglingParenthesesExclude
+      .contains(DanglingParentheses.Exclude.`trait`)
+    val excludeDef = danglingParenthesesExclude
+      .contains(DanglingParentheses.Exclude.`def`)
 
     val shouldNotDangle =
       (isClassLike && excludeClass) ||

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -775,7 +775,7 @@ class Router(formatOps: FormatOps) {
           expirationToken.is[T.Comment]
         )
         val wouldDangle =
-          if (defnSite) style.danglingParentheses.defnSite
+          if (defnSite) !shouldNotDangleAtDefnSite(leftOwner, false)
           else style.danglingParentheses.callSite
 
         val newlinePolicy: Policy =
@@ -1063,10 +1063,9 @@ class Router(formatOps: FormatOps) {
             }
         }
 
-        def wouldDangle = {
-          val dangleStyle = style.danglingParentheses
-          (dangleStyle.defnSite && leftOwner.parent.exists(isDefnSite)) ||
-          (dangleStyle.callSite && leftOwner.parent.exists(isCallSite))
+        def wouldDangle = leftOwner.parent.exists { lop =>
+          if (isDefnSite(lop)) !shouldNotDangleAtDefnSite(lop, false)
+          else isCallSite(lop) && style.danglingParentheses.callSite
         }
 
         val expire = rhs.tokens.last

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -105,3 +105,166 @@ implicit def pairEncoder[A, B](implicit
   aEncoder: CsvEncoder[A],
   bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]
+<<< #1362 1: single implict, long line
+danglingParentheses = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+===
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String
+) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F]
+  ): F[Resolution] =
+    ???
+}
+>>>
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F]
+  ): F[Resolution] =
+    ???
+}
+<<< #1362 2: single implicit, short line
+maxColumn = 40
+danglingParentheses = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+===
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String
+) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F]
+  ): F[Resolution] =
+    ???
+}
+>>>
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F]
+  ): F[Resolution] =
+    ???
+}
+<<< #1362 3: multiple implicits, short line
+maxColumn = 30
+danglingParentheses = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+===
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String
+) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F],
+    G: Monad[G]
+  ): F[Resolution] =
+    ???
+}
+>>>
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F],
+    G: Monad[G]
+  ): F[Resolution] =
+    ???
+}
+<<< #1362 4: multiple implicits, long line
+maxColumn = 60
+danglingParentheses = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+===
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String
+) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F],
+    G: Monad[G]
+  ): F[Resolution] =
+    ???
+}
+>>>
+case class Foo(
+  a: Int,
+  b: Boolean,
+  c: String,
+  d: String,
+  e: String,
+  f: String,
+  g: String) {
+  def run[F[_]](
+    a: Int,
+    b: Int = 0
+  )(implicit
+    F: Monad[F],
+    G: Monad[G]
+  ): F[Resolution] =
+    ???
+}

--- a/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
@@ -115,7 +115,6 @@ def getListing(
 def getListing(a: String, b: String, c: String, d: String)(implicit
     e: String,
     g: String,
-    f: String
-): Future[String] = {
+    f: String): Future[String] = {
   a + b + c + d + e + g + f
 }

--- a/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
@@ -78,3 +78,44 @@ def getListing(
     f: String): Future[String] = {
   a + b + c + d + e + g + f
 }
+<<< with many implicits (non-vm)
+verticalMultiline.atDefnSite = false
+danglingParentheses = true
+===
+def getListing(
+  a: String,
+  b: String,
+  c: String,
+  d: String)(implicit e: String, g: String, f: String
+): Future[String] = {
+  a + b + c + d + e + g + f
+}
+>>>
+def getListing(a: String, b: String, c: String, d: String)(implicit
+    e: String,
+    g: String,
+    f: String
+): Future[String] = {
+  a + b + c + d + e + g + f
+}
+<<< with many implicits (non-vm, with exclude)
+verticalMultiline.atDefnSite = false
+danglingParentheses = true
+danglingParentheses.exclude = [def]
+===
+def getListing(
+  a: String,
+  b: String,
+  c: String,
+  d: String)(implicit e: String, g: String, f: String
+): Future[String] = {
+  a + b + c + d + e + g + f
+}
+>>>
+def getListing(a: String, b: String, c: String, d: String)(implicit
+    e: String,
+    g: String,
+    f: String
+): Future[String] = {
+  a + b + c + d + e + g + f
+}


### PR DESCRIPTION
With the default of empty, this doesn't change any existing formatting. However, just like with `VerticalMultiline`, it will allow users to reduce effect of `danglingParenthese.defnSite = true`.