### PR TITLE
#1627 [01]: ScalafmtConfig: flag to ignore input line breaks

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1,0 +1,3 @@
+align = none
+maxColumn = 40
+# newlines.source = classic

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1,0 +1,3 @@
+align = none
+maxColumn = 40
+newlines.source = fold

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1,0 +1,3 @@
+align = none
+maxColumn = 40
+newlines.source = keep

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1,0 +1,3 @@
+align = none
+maxColumn = 40
+newlines.source = unfold


### PR DESCRIPTION
The flag can be:

* _classic_ (unspecified): consistent with the current mixed behaviour
* _keep_: will try to preserve existing line breaks
* _fold_: removes some line breaks, for a more compact look
* _unfold_: inserts line breaks as appropriate, expanding

Also, add empty test suites for each value of this new flag. We will be adding test cases and the code using the flag in the next commits.

Towards #1627.