### PR TITLE
Router bugfix: extend line break past infix for any block

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -202,8 +202,9 @@ private class BestFirstSearch private (
           var optimalNotFound = true
           actualSplit.foreach { split =>
             val nextState = curr.next(style, split, splitToken)
-            if (!keepSlowStates && depth == 0 && split.modification.isNewline &&
-              !best.contains(curr.depth)) {
+            val updateBest = !keepSlowStates && depth == 0 &&
+              split.modification.isNewline && !best.contains(curr.depth)
+            if (updateBest) {
               best.update(curr.depth, nextState)
             }
             runner.event(Enqueue(split))
@@ -223,12 +224,15 @@ private class BestFirstSearch private (
                   // TODO(olafur) DRY. This solution can still be optimal.
 //                  logger.elem(split, splitToken)
                   Q.enqueue(nextState)
-                } // else kill branch
+                } else { // else kill branch
+                  if (updateBest) best.remove(curr.depth)
+                }
               case _
                   if optimalNotFound &&
                     nextState.cost - curr.cost <= maxCost =>
                 Q.enqueue(nextState)
               case _ => // Kill branch.
+                if (updateBest) best.remove(curr.depth)
             }
           }
         }

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -396,7 +396,9 @@ object a {
 }
 >>>
 object a {
-  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should have message """Cannot resolve column name "user" among (segment_id);"""
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message """Cannot resolve column name "user" among (segment_id);"""
 }
 <<< block followed by infix 2
 object a {

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -389,3 +389,54 @@ dddddddd + eeeeeeee /* comment */ })
     dddddddd + eeeeeeee /* comment */
   })
 }
+<<< block followed by infix 1
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user")
+    } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< block followed by infix 2
+object a {
+      opt[String]("env") action { (x, c) =>
+        c.copy(env = Some(x))
+      } text ("Comma-separated list of environmental variables (in 'FOO=BAR' " +
+         "format) to pass to the Spark execution environment.")
+}
+>>>
+object a {
+  opt[String]("env") action { (x, c) =>
+    c.copy(env = Some(x))
+  } text ("Comma-separated list of environmental variables (in 'FOO=BAR' " +
+    "format) to pass to the Spark execution environment.")
+}
+<<< infix followed by block, and then another statement (endOfSingleLineBlock)
+object a {
+      (1 to demand3.toInt) foreach { _ ⇒ pSub.sendNext(input.next()) }
+      ((demand1 + demand2 + 1).toInt to (demand1 + demand2 + demand3).toInt) foreach {
+        n ⇒ c.expectNext(n)
+      }
+}
+>>>
+object a {
+  (1 to demand3.toInt) foreach { _ ⇒ pSub.sendNext(input.next()) }
+  ((demand1 + demand2 + 1).toInt to (demand1 + demand2 + demand3).toInt) foreach {
+    n ⇒ c.expectNext(n)
+  }
+}
+<<< block followed by infix 3 (BestFirstSearch shouldn't give up)
+object a {
+    intercept[MappingException] {
+      ExpressionJsonSerializer.deserialize[Token](unknownJson)
+    }.getMessage shouldBe s"Invalid feature tag `unknown`, supported tags: " +
+      "tags..."
+}
+>>>
+object a {
+  intercept[MappingException] {
+    ExpressionJsonSerializer.deserialize[Token](unknownJson)
+  }.getMessage shouldBe s"Invalid feature tag `unknown`, supported tags: " +
+    "tags..."
+}

--- a/scalafmt-tests/src/test/resources/default/Val.stat
+++ b/scalafmt-tests/src/test/resources/default/Val.stat
@@ -203,9 +203,7 @@ val myRoute = path("") {
         readFromFile(fileName)
       }
 >>>
-val vfile = options.jar map { jar =>
-  readFromJar(jar, fileName)
-} getOrElse {
+val vfile = options.jar map { jar => readFromJar(jar, fileName) } getOrElse {
   readFromFile(fileName)
 }
 <<< vfile 2
@@ -217,9 +215,7 @@ val vfile = options.jar map { jar =>
       }
 >>>
 val vfile =
-  options.jar map { jar =>
-    readFromJar(jar, fileName)
-  } getOrElse {
+  options.jar map { jar => readFromJar(jar, fileName) } getOrElse {
     readFromFile(fileName)
   }
 <<< #590

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
@@ -57,7 +57,8 @@ object a {
 object a {
   def filterPA(pa: BfCFE2ProjectedPaymentAction): Boolean =
     // nb: the ruby code doesn't explicitly filter on charge being nonEmpty, but its absence would trigger an error
-    pa.`type`.nonEmpty && wantedTypes.contains(pa.`type`.get) && pa.charge.nonEmpty
+    pa.`type`.nonEmpty && wantedTypes
+      .contains(pa.`type`.get) && pa.charge.nonEmpty
 }
 <<< function
 object A {

--- a/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
@@ -130,9 +130,7 @@ x ::
   z
 >>>
 x ::
-  y.map { x =>
-    x + 1
-  } ::
+  y.map { x => x + 1 } ::
   z
 <<< simple expr
 x ::


### PR DESCRIPTION
This approach is better than applying a higher cost to blocks abutting an infix. Fixes a number of line-too-long problems and also avoid line breaks when they are not necessary.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/787fbfa747792b9cf56034bee8f41e3909ac3362?w=1