### PR TITLE
Documentation improvements

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -746,7 +746,7 @@ rewrite.rules = [AsciiSortImports]
 import foo.{~>, `symbol`, bar, Random}
 ```
 
-### Trailing commas
+## Trailing commas
 
 > See [SIP](https://docs.scala-lang.org/sips/trailing-commas.html)
 
@@ -1127,6 +1127,28 @@ optIn.breakChainOnFirstMethodDot = true
 foo
   .map(_ + 1) // preserve existing newlines
   .filter(_ > 2)
+```
+
+### `rewriteTokens`
+Map of tokens to rewrite. For example, Map("⇒" -> "=>") will rewrite unicode arrows to regular ascii arrows.
+
+```scala mdoc:defaults
+rewriteTokens
+```
+
+```scala mdoc:scalafmt
+rewriteTokens = {
+  "⇒": "=>"
+  "→": "->"
+  "←": "<-"
+}
+---
+val tuple = "a" → 1
+val lambda = (x: Int) ⇒ x + 1
+for {
+  a ← Option(1)
+  b ← Option(2)
+} yield a + b
 ```
 
 ## Other

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -746,7 +746,7 @@ rewrite.rules = [AsciiSortImports]
 import foo.{~>, `symbol`, bar, Random}
 ```
 
-## Trailing commas
+### Trailing commas
 
 > See [SIP](https://docs.scala-lang.org/sips/trailing-commas.html)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,12 +115,18 @@ in the `.scalafmt.conf` configuration file and downloaded dynamically.
 
 ```scala
 // In project/plugins.sbt. Note, does not support sbt 0.13, only sbt 1.x.
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
-// or
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1") // before 1.6.0-RC4
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.2") // "2.3.2" is just sbt plugin version
 ```
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.scalameta/sbt-scalafmt/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.scalameta/sbt-scalafmt)
+
+To configure the scalafmt version add the following line into `.scalafmt.conf`:
+
+```
+version = @STABLE_VERSION@
+```
+
+The latest version will be used by default.
 
 ### Task keys
 


### PR DESCRIPTION
Attempt to clarify sbt integration versioning by `.scalafmt.conf` example near to plugin installation section.

Also `rewriteTokens`: incredibly useful config still not presented on the site.

Grammar check, please :)

Related to https://github.com/scalameta/scalafmt/issues/1523