### PR TITLE
BestFirstSearch: check optimal token not to overflow

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -228,7 +228,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   @tailrec
   final def endOfSingleLineBlock(
       start: FormatToken
-  )(implicit style: ScalafmtConfig): FormatToken = {
+  )(implicit style: ScalafmtConfig): Token = {
     lazy val isInfix = style.activeForEdition_2020_03 && isInfixRhs(start)
     val endFound = start.right match {
       case _: T.Comma | _: T.LeftParen | _: T.Semicolon | _: T.RightArrow |
@@ -236,16 +236,16 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         None
       case _: T.RightParen if start.left.is[T.LeftParen] => None
       case c: T.Comment if isSingleLineComment(c) && start.noBreak =>
-        Some(start)
+        Some(c)
       case _ if start.noBreak && isInfix => None
-      case _ => Some(prev(start))
+      case _ => Some(start.left)
     }
 
     endFound match {
       case Some(t) => t
       case None =>
-        if (!tokens.hasNext(start)) start
-        else if (!isInfix && startsNewBlockOnRight(start)) prev(start)
+        if (!tokens.hasNext(start)) start.right
+        else if (!isInfix && startsNewBlockOnRight(start)) start.left
         else endOfSingleLineBlock(next(start))
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -262,17 +262,13 @@ class Router(formatOps: FormatOps) {
         val singleLineSplit =
           if (singleLineDecision == null) Split.ignored
           else {
-            val (expire, optimal) =
-              if (lambdaPolicy != null || style.activeForEdition_2020_03) {
-                val endFT = endOfSingleLineBlock(closeFT)
-                val expire = endFT.right
-                (expire, if (isInfixRhs(endFT)) None else Some(expire))
-              } else (close, Some(close))
+            val useOpt = lambdaPolicy != null || style.activeForEdition_2020_03
+            val expire = if (useOpt) endOfSingleLineBlock(closeFT) else close
             val policy =
               SingleLineBlock(expire, penaliseNewlinesInsideTokens = true)
                 .andThen(singleLineDecision)
             Split(xmlSpace(leftOwner), 0, policy = policy)
-              .withOptimalTokenOpt(optimal, killOnFail = true)
+              .withOptimalToken(expire, killOnFail = true)
           }
 
         Seq(

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -623,8 +623,7 @@ SSLConfig(SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 comment 2
   val config = WSClientConfig(ssl =
     SSLConfig(
         SSLLooseConfig(allowLegacyHelloMessages =
-          None
-        ) /*comment 123 comment 234*/
+          None) /*comment 123 comment 234*/
     )
   ) //comment 345 comment 456
 }

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -449,8 +449,9 @@ object a {
 }
 >>>
 object a {
-  (intercept[IllegalStateException] { t.failingJOptionPigdog }).getMessage should ===(
-      "expected")
+  (intercept[IllegalStateException] {
+    t.failingJOptionPigdog
+  }).getMessage should ===("expected")
 }
 <<< block deep into an infix expression 2
 object a {

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -442,3 +442,24 @@ object a {
   }.getMessage shouldBe s"Invalid feature tag `unknown`, supported tags: " +
     "tags..."
 }
+<<< block deep into an infix expression 1
+object a {
+        (intercept[IllegalStateException] { t.failingJOptionPigdog }).getMessage should ===(
+          "expected")
+}
+>>>
+object a {
+  (intercept[IllegalStateException] { t.failingJOptionPigdog }).getMessage should ===(
+      "expected")
+}
+<<< block deep into an infix expression 2
+object a {
+           server.out1 ~> Flow[SslTlsOutbound]
+            .collect { case SendBytes(x) ⇒ x }
+             .buffer(1, OverflowStrategy.backpressure) ~> netOut.sink
+}
+>>>
+object a {
+  server.out1 ~> Flow[SslTlsOutbound].collect { case SendBytes(x) ⇒ x }
+    .buffer(1, OverflowStrategy.backpressure) ~> netOut.sink
+}

--- a/scalafmt-tests/src/test/resources/default/Idempotency.stat
+++ b/scalafmt-tests/src/test/resources/default/Idempotency.stat
@@ -51,9 +51,9 @@ val bindingFuture = Http().bindAndHandleSync({
       {
         {
           {
-            RawRequestURI(new String(
-                uriBytes,
-                HttpCharsets.aaaaaaaaaa.nioCharset)) :: headers
+            RawRequestURI(
+                new String(uriBytes,
+                           HttpCharsets.aaaaaaaaaa.nioCharset)) :: headers
           }
         }
       }

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -234,8 +234,8 @@ Seq(
   {
     {
       system.actorOf(
-          Props[ThreadNameEcho]
-            .withDispatcher("myapp.balancing-dispatcher")) ! "what's the name?"
+          Props[ThreadNameEcho].withDispatcher(
+              "myapp.balancing-dispatcher")) ! "what's the name?"
     }
   }
 }

--- a/scalafmt-tests/src/test/resources/default/Semicolon.stat
+++ b/scalafmt-tests/src/test/resources/default/Semicolon.stat
@@ -12,7 +12,8 @@
 text.charAt(pos) match {
   case '<' => handle("&lt;"); prev = pos + 1
   case '<' =>
-    handle("&lt;"); prev = pos + 1 // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    handle("&lt;");
+    prev = pos + 1 // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   case '<' =>
     handle("&lt;");
     prev = pos + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
@@ -57,8 +57,9 @@ object a {
 object a {
   def filterPA(pa: BfCFE2ProjectedPaymentAction): Boolean =
     // nb: the ruby code doesn't explicitly filter on charge being nonEmpty, but its absence would trigger an error
-    pa.`type`.nonEmpty && wantedTypes
-      .contains(pa.`type`.get) && pa.charge.nonEmpty
+    pa.`type`.nonEmpty && wantedTypes.contains(
+      pa.`type`.get
+    ) && pa.charge.nonEmpty
 }
 <<< function
 object A {

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -234,8 +234,8 @@ object RTCIceCandidateInit {
   @inline
   def apply(candidate: js.UndefOr[String] = js.undefined,
       sdpMid: js.UndefOr[String] = js.undefined,
-      sdpMLineIndex: js.UndefOr[
-          Double] = js.undefined): RTCIceCandidateInit = {
+      sdpMLineIndex: js.UndefOr[Double] =
+        js.undefined): RTCIceCandidateInit = {
     val result = js.Dynamic.literal()
     candidate.foreach(result.candidate = _)
     sdpMid.foreach(result.sdpMid = _)

--- a/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
@@ -18,7 +18,8 @@ js.Return(!(!({
 <<< force space on infix application arguments
 opt[(Int, Int)]("range") hidden() action {}
 >>>
-opt[(Int, Int)]("range") hidden () action {}
+opt[(Int, Int)](
+    "range") hidden () action {}
 <<< string concatenation
 logger.warning("foooooooooooooo" +
 "baaaaaaaaaaaaaar")

--- a/scalafmt-tests/src/test/resources/unit/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/unit/DefDef.stat
@@ -39,8 +39,8 @@ def identity[T](t: T): T = t
         sym.hasAnnotation(JSBracketCallAnnotation)
 >>>
 def hasExplicitJSEncoding =
-  sym
-    .hasAnnotation(JSNameAnnotation) ||
+  sym.hasAnnotation(
+      JSNameAnnotation) ||
     sym.hasAnnotation(
         JSBracketAccessAnnotation) ||
     sym.hasAnnotation(


### PR DESCRIPTION
Follow the post-optimal states on the same line while we get exactly one active split to use; if the line overflows, don't mark optimal as found. This way, we are more likely to fit within the column limit and select a better solution.

Also, now that BestFirstSearch logic dealing with optimal tokens has been improved, the suboptimal special case handling of infix expressions around blocks is no longer needed.

`scala-repos` diffs:
* BestFirstSearch: check optimal tok not to overflow: https://github.com/kitbellew/scala-repos/commit/fd8b18e8d4638c73724a343b343a9e9c83151c00?w=1
* Router: always use optimal token within infix op: https://github.com/kitbellew/scala-repos/commit/5a8132dc0f796690190079d2b8be6fd5d01398c1?w=1