### PR TITLE
#1627 [02]: Router: ignore line breaks for blocks

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -125,6 +125,15 @@ case class Newlines(
       s"newlines: can't use source=${source} and afterCurlyLambda=$afterCurlyLambda"
     )
   }
+
+  @inline
+  def sourceIs(hint: Newlines.SourceHints): Boolean =
+    hint eq source
+
+  @inline
+  def sourceIn(hints: Newlines.SourceHints*): Boolean =
+    hints.contains(source)
+
 }
 
 object Newlines {

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1,3 +1,167 @@
 align = none
 maxColumn = 40
 # newlines.source = classic
+<<< 1.1: block, if-else, line too long
+if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}
+>>>
+if (true) {
+  println(aaaaaaaaaaaaaaaaaaaaaaaaaa)
+}
+<<< 1.2: block, if-else, egyptian curlies
+object a {
+if (a) {
+println("bbb") } else c
+}
+>>>
+object a {
+  if (a) {
+    println("bbb")
+  } else c
+}
+<<< 1.3: block, if, non-egyptian curlies
+object a {
+if (a)
+{
+println("bbb")
+}
+else
+{
+c
+}}
+>>>
+object a {
+  if (a) {
+    println("bbb")
+  } else {
+    c
+  }
+}
+<<< 1.4: block #1043
+object a {
+      if ('0' <= c && c <= '9') { c - '0' }
+      else if ('A' <= c && c <= 'F') {
+       c - 'A' + 10 }
+      else if ('a' <= c && c <= 'f') { c - 'a' + 10 }
+      else {
+       -1  }}
+>>>
+object a {
+  if ('0' <= c && c <= '9') { c - '0' }
+  else if ('A' <= c && c <= 'F') {
+    c - 'A' + 10
+  } else if ('a' <= c && c <= 'f') {
+    c - 'a' + 10
+  } else {
+    -1
+  }
+}
+<<< 1.5: block #1043 with lines joined
+object a {
+      if ('0' <= c && c <= '9') { c - '0' }      else if ('A' <= c && c <= 'F') {
+       c - 'A' + 10 }  else if ('a' <= c && c <= 'f') { c - 'a' + 10 }      else {
+                                                            -1
+}}
+>>>
+object a {
+  if ('0' <= c && c <= '9') { c - '0' }
+  else if ('A' <= c && c <= 'F') {
+    c - 'A' + 10
+  } else if ('a' <= c && c <= 'f') {
+    c - 'a' + 10
+  } else {
+    -1
+  }
+}
+<<< 1.6: block, try-catch, line too long
+object a {
+try { aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa } catch { case b => }
+}
+>>>
+object a {
+  try {
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  } catch { case b => }
+}
+<<< 1.7: block, try-catch, no breaks
+object a {
+try { a } catch { case b => ; case c => } finally { d }
+}
+>>>
+object a {
+  try { a }
+  catch { case b => ; case c => }
+  finally { d }
+}
+<<< 1.8: block, try-catch, with breaks
+object a {
+try {
+ a } catch {
+  case b => ; case c => } finally {
+   d }
+}
+>>>
+object a {
+  try {
+    a
+  } catch {
+    case b => ; case c =>
+  } finally {
+    d
+  }
+}
+<<< 1.9: block, try-catch, with breaks, top-level
+try {
+ a } catch {
+  case b => ; case c => } finally {
+   d }
+>>>
+try {
+  a
+} catch {
+  case b => ; case c =>
+} finally {
+  d
+}
+<<< 1.a: block, class
+object a {
+class a {
+ type b = Int
+}
+}
+>>>
+object a {
+  class a {
+    type b = Int
+  }
+}
+<<< 1.b: block, trait and object
+object a {
+trait b {
+ type c = Int
+}
+object b {
+def apply(c: Int) = { new d(c)
+}
+}}
+>>>
+object a {
+  trait b {
+    type c = Int
+  }
+  object b {
+    def apply(c: Int) = { new d(c) }
+  }
+}
+<<< 1.c: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user")
+    } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message """Cannot resolve column name "user" among (segment_id);"""
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -14,9 +14,8 @@ println("bbb") } else c
 }
 >>>
 object a {
-  if (a) {
-    println("bbb")
-  } else c
+  if (a) { println("bbb") }
+  else c
 }
 <<< 1.3: block, if, non-egyptian curlies
 object a {
@@ -30,11 +29,8 @@ c
 }}
 >>>
 object a {
-  if (a) {
-    println("bbb")
-  } else {
-    c
-  }
+  if (a) { println("bbb") }
+  else { c }
 }
 <<< 1.4: block #1043
 object a {
@@ -51,9 +47,7 @@ object a {
     c - 'A' + 10
   } else if ('a' <= c && c <= 'f') {
     c - 'a' + 10
-  } else {
-    -1
-  }
+  } else { -1 }
 }
 <<< 1.5: block #1043 with lines joined
 object a {
@@ -68,9 +62,7 @@ object a {
     c - 'A' + 10
   } else if ('a' <= c && c <= 'f') {
     c - 'a' + 10
-  } else {
-    -1
-  }
+  } else { -1 }
 }
 <<< 1.6: block, try-catch, line too long
 object a {
@@ -101,13 +93,9 @@ try {
 }
 >>>
 object a {
-  try {
-    a
-  } catch {
-    case b => ; case c =>
-  } finally {
-    d
-  }
+  try { a }
+  catch { case b => ; case c => }
+  finally { d }
 }
 <<< 1.9: block, try-catch, with breaks, top-level
 try {
@@ -117,9 +105,8 @@ try {
 >>>
 try {
   a
-} catch {
-  case b => ; case c =>
-} finally {
+} catch { case b => ; case c => }
+finally {
   d
 }
 <<< 1.a: block, class

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1,3 +1,167 @@
 align = none
 maxColumn = 40
 newlines.source = fold
+<<< 1.1: block, if-else, line too long
+if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}
+>>>
+if (true) {
+  println(aaaaaaaaaaaaaaaaaaaaaaaaaa)
+}
+<<< 1.2: block, if-else, egyptian curlies
+object a {
+if (a) {
+println("bbb") } else c
+}
+>>>
+object a {
+  if (a) {
+    println("bbb")
+  } else c
+}
+<<< 1.3: block, if, non-egyptian curlies
+object a {
+if (a)
+{
+println("bbb")
+}
+else
+{
+c
+}}
+>>>
+object a {
+  if (a) {
+    println("bbb")
+  } else {
+    c
+  }
+}
+<<< 1.4: block #1043
+object a {
+      if ('0' <= c && c <= '9') { c - '0' }
+      else if ('A' <= c && c <= 'F') {
+       c - 'A' + 10 }
+      else if ('a' <= c && c <= 'f') { c - 'a' + 10 }
+      else {
+       -1  }}
+>>>
+object a {
+  if ('0' <= c && c <= '9') { c - '0' }
+  else if ('A' <= c && c <= 'F') {
+    c - 'A' + 10
+  } else if ('a' <= c && c <= 'f') {
+    c - 'a' + 10
+  } else {
+    -1
+  }
+}
+<<< 1.5: block #1043 with lines joined
+object a {
+      if ('0' <= c && c <= '9') { c - '0' }      else if ('A' <= c && c <= 'F') {
+       c - 'A' + 10 }  else if ('a' <= c && c <= 'f') { c - 'a' + 10 }      else {
+                                                            -1
+}}
+>>>
+object a {
+  if ('0' <= c && c <= '9') { c - '0' }
+  else if ('A' <= c && c <= 'F') {
+    c - 'A' + 10
+  } else if ('a' <= c && c <= 'f') {
+    c - 'a' + 10
+  } else {
+    -1
+  }
+}
+<<< 1.6: block, try-catch, line too long
+object a {
+try { aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa } catch { case b => }
+}
+>>>
+object a {
+  try {
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  } catch { case b => }
+}
+<<< 1.7: block, try-catch, no breaks
+object a {
+try { a } catch { case b => ; case c => } finally { d }
+}
+>>>
+object a {
+  try { a }
+  catch { case b => ; case c => }
+  finally { d }
+}
+<<< 1.8: block, try-catch, with breaks
+object a {
+try {
+ a } catch {
+  case b => ; case c => } finally {
+   d }
+}
+>>>
+object a {
+  try {
+    a
+  } catch {
+    case b => ; case c =>
+  } finally {
+    d
+  }
+}
+<<< 1.9: block, try-catch, with breaks, top-level
+try {
+ a } catch {
+  case b => ; case c => } finally {
+   d }
+>>>
+try {
+  a
+} catch {
+  case b => ; case c =>
+} finally {
+  d
+}
+<<< 1.a: block, class
+object a {
+class a {
+ type b = Int
+}
+}
+>>>
+object a {
+  class a {
+    type b = Int
+  }
+}
+<<< 1.b: block, trait and object
+object a {
+trait b {
+ type c = Int
+}
+object b {
+def apply(c: Int) = { new d(c)
+}
+}}
+>>>
+object a {
+  trait b {
+    type c = Int
+  }
+  object b {
+    def apply(c: Int) = { new d(c) }
+  }
+}
+<<< 1.c: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user")
+    } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message """Cannot resolve column name "user" among (segment_id);"""
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1,3 +1,167 @@
 align = none
 maxColumn = 40
 newlines.source = keep
+<<< 1.1: block, if-else, line too long
+if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}
+>>>
+if (true) {
+  println(aaaaaaaaaaaaaaaaaaaaaaaaaa)
+}
+<<< 1.2: block, if-else, egyptian curlies
+object a {
+if (a) {
+println("bbb") } else c
+}
+>>>
+object a {
+  if (a) {
+    println("bbb")
+  } else c
+}
+<<< 1.3: block, if, non-egyptian curlies
+object a {
+if (a)
+{
+println("bbb")
+}
+else
+{
+c
+}}
+>>>
+object a {
+  if (a) {
+    println("bbb")
+  } else {
+    c
+  }
+}
+<<< 1.4: block #1043
+object a {
+      if ('0' <= c && c <= '9') { c - '0' }
+      else if ('A' <= c && c <= 'F') {
+       c - 'A' + 10 }
+      else if ('a' <= c && c <= 'f') { c - 'a' + 10 }
+      else {
+       -1  }}
+>>>
+object a {
+  if ('0' <= c && c <= '9') { c - '0' }
+  else if ('A' <= c && c <= 'F') {
+    c - 'A' + 10
+  } else if ('a' <= c && c <= 'f') {
+    c - 'a' + 10
+  } else {
+    -1
+  }
+}
+<<< 1.5: block #1043 with lines joined
+object a {
+      if ('0' <= c && c <= '9') { c - '0' }      else if ('A' <= c && c <= 'F') {
+       c - 'A' + 10 }  else if ('a' <= c && c <= 'f') { c - 'a' + 10 }      else {
+                                                            -1
+}}
+>>>
+object a {
+  if ('0' <= c && c <= '9') { c - '0' }
+  else if ('A' <= c && c <= 'F') {
+    c - 'A' + 10
+  } else if ('a' <= c && c <= 'f') {
+    c - 'a' + 10
+  } else {
+    -1
+  }
+}
+<<< 1.6: block, try-catch, line too long
+object a {
+try { aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa } catch { case b => }
+}
+>>>
+object a {
+  try {
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  } catch { case b => }
+}
+<<< 1.7: block, try-catch, no breaks
+object a {
+try { a } catch { case b => ; case c => } finally { d }
+}
+>>>
+object a {
+  try { a }
+  catch { case b => ; case c => }
+  finally { d }
+}
+<<< 1.8: block, try-catch, with breaks
+object a {
+try {
+ a } catch {
+  case b => ; case c => } finally {
+   d }
+}
+>>>
+object a {
+  try {
+    a
+  } catch {
+    case b => ; case c =>
+  } finally {
+    d
+  }
+}
+<<< 1.9: block, try-catch, with breaks, top-level
+try {
+ a } catch {
+  case b => ; case c => } finally {
+   d }
+>>>
+try {
+  a
+} catch {
+  case b => ; case c =>
+} finally {
+  d
+}
+<<< 1.a: block, class
+object a {
+class a {
+ type b = Int
+}
+}
+>>>
+object a {
+  class a {
+    type b = Int
+  }
+}
+<<< 1.b: block, trait and object
+object a {
+trait b {
+ type c = Int
+}
+object b {
+def apply(c: Int) = { new d(c)
+}
+}}
+>>>
+object a {
+  trait b {
+    type c = Int
+  }
+  object b {
+    def apply(c: Int) = { new d(c) }
+  }
+}
+<<< 1.c: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user")
+    } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message """Cannot resolve column name "user" among (segment_id);"""
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1,3 +1,167 @@
 align = none
 maxColumn = 40
 newlines.source = unfold
+<<< 1.1: block, if-else, line too long
+if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}
+>>>
+if (true) {
+  println(aaaaaaaaaaaaaaaaaaaaaaaaaa)
+}
+<<< 1.2: block, if-else, egyptian curlies
+object a {
+if (a) {
+println("bbb") } else c
+}
+>>>
+object a {
+  if (a) {
+    println("bbb")
+  } else c
+}
+<<< 1.3: block, if, non-egyptian curlies
+object a {
+if (a)
+{
+println("bbb")
+}
+else
+{
+c
+}}
+>>>
+object a {
+  if (a) {
+    println("bbb")
+  } else {
+    c
+  }
+}
+<<< 1.4: block #1043
+object a {
+      if ('0' <= c && c <= '9') { c - '0' }
+      else if ('A' <= c && c <= 'F') {
+       c - 'A' + 10 }
+      else if ('a' <= c && c <= 'f') { c - 'a' + 10 }
+      else {
+       -1  }}
+>>>
+object a {
+  if ('0' <= c && c <= '9') { c - '0' }
+  else if ('A' <= c && c <= 'F') {
+    c - 'A' + 10
+  } else if ('a' <= c && c <= 'f') {
+    c - 'a' + 10
+  } else {
+    -1
+  }
+}
+<<< 1.5: block #1043 with lines joined
+object a {
+      if ('0' <= c && c <= '9') { c - '0' }      else if ('A' <= c && c <= 'F') {
+       c - 'A' + 10 }  else if ('a' <= c && c <= 'f') { c - 'a' + 10 }      else {
+                                                            -1
+}}
+>>>
+object a {
+  if ('0' <= c && c <= '9') { c - '0' }
+  else if ('A' <= c && c <= 'F') {
+    c - 'A' + 10
+  } else if ('a' <= c && c <= 'f') {
+    c - 'a' + 10
+  } else {
+    -1
+  }
+}
+<<< 1.6: block, try-catch, line too long
+object a {
+try { aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa } catch { case b => }
+}
+>>>
+object a {
+  try {
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  } catch { case b => }
+}
+<<< 1.7: block, try-catch, no breaks
+object a {
+try { a } catch { case b => ; case c => } finally { d }
+}
+>>>
+object a {
+  try { a }
+  catch { case b => ; case c => }
+  finally { d }
+}
+<<< 1.8: block, try-catch, with breaks
+object a {
+try {
+ a } catch {
+  case b => ; case c => } finally {
+   d }
+}
+>>>
+object a {
+  try {
+    a
+  } catch {
+    case b => ; case c =>
+  } finally {
+    d
+  }
+}
+<<< 1.9: block, try-catch, with breaks, top-level
+try {
+ a } catch {
+  case b => ; case c => } finally {
+   d }
+>>>
+try {
+  a
+} catch {
+  case b => ; case c =>
+} finally {
+  d
+}
+<<< 1.a: block, class
+object a {
+class a {
+ type b = Int
+}
+}
+>>>
+object a {
+  class a {
+    type b = Int
+  }
+}
+<<< 1.b: block, trait and object
+object a {
+trait b {
+ type c = Int
+}
+object b {
+def apply(c: Int) = { new d(c)
+}
+}}
+>>>
+object a {
+  trait b {
+    type c = Int
+  }
+  object b {
+    def apply(c: Int) = { new d(c) }
+  }
+}
+<<< 1.c: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user")
+    } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message """Cannot resolve column name "user" among (segment_id);"""
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -46,8 +46,9 @@ object a {
        -1  }}
 >>>
 object a {
-  if ('0' <= c && c <= '9') { c - '0' }
-  else if ('A' <= c && c <= 'F') {
+  if ('0' <= c && c <= '9') {
+    c - '0'
+  } else if ('A' <= c && c <= 'F') {
     c - 'A' + 10
   } else if ('a' <= c && c <= 'f') {
     c - 'a' + 10
@@ -63,8 +64,9 @@ object a {
 }}
 >>>
 object a {
-  if ('0' <= c && c <= '9') { c - '0' }
-  else if ('A' <= c && c <= 'F') {
+  if ('0' <= c && c <= '9') {
+    c - '0'
+  } else if ('A' <= c && c <= 'F') {
     c - 'A' + 10
   } else if ('a' <= c && c <= 'f') {
     c - 'a' + 10
@@ -80,7 +82,9 @@ try { aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa } catch { case b => }
 object a {
   try {
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  } catch { case b => }
+  } catch {
+    case b =>
+  }
 }
 <<< 1.7: block, try-catch, no breaks
 object a {
@@ -88,9 +92,13 @@ try { a } catch { case b => ; case c => } finally { d }
 }
 >>>
 object a {
-  try { a }
-  catch { case b => ; case c => }
-  finally { d }
+  try {
+    a
+  } catch {
+    case b => ; case c =>
+  } finally {
+    d
+  }
 }
 <<< 1.8: block, try-catch, with breaks
 object a {
@@ -149,7 +157,9 @@ object a {
     type c = Int
   }
   object b {
-    def apply(c: Int) = { new d(c) }
+    def apply(c: Int) = {
+      new d(c)
+    }
   }
 }
 <<< 1.c: block followed by an infix, overflowing if no break


### PR DESCRIPTION
While previously we were trying to keep blocks without line breaks if that's how they were originally input, now we actively attempt to take a multi-line representation and fold it into a single line (fold), or take a single-line representation and unfold it into multiple lines (unfold). In the [keep] case, we'll keep the line break if it was there before.

Fixes #271 #1002 #1043
Helps with #1627

`scala-repos` diffs:
* _classic_: none
* _keep_: https://github.com/kitbellew/scala-repos/commit/51c4d1e3ad2cdbcdce2ba29aea78cb1209d25f94?w=1
* _fold_: https://github.com/kitbellew/scala-repos/commit/242d091577f73a3e3f3e74c29458e76c79145def?w=1
* _unfold_: https://github.com/kitbellew/scala-repos/commit/0a882e3102bf94c134d5d0e07904076ee0cb2add?w=1