### PR TITLE
"// format: off" enabled for comments, literals, etc.

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -73,7 +73,7 @@ class FormatWriter(formatOps: FormatOps) {
           sb.append(rewrittenToken)
       }
 
-      entry.formatWhitespace(sb)
+      entry.formatWhitespace(sb, state.prev.formatOff)
     }
 
     sb.toString()
@@ -320,7 +320,7 @@ class FormatWriter(formatOps: FormatOps) {
         }
       }
 
-      def formatWhitespace(sb: StringBuilder): Unit = {
+      def formatWhitespace(sb: StringBuilder, formatOff: Boolean): Unit = {
 
         import org.scalafmt.config.TrailingCommas
 
@@ -369,7 +369,12 @@ class FormatWriter(formatOps: FormatOps) {
 
         @inline def ws(offset: Int): Unit = sb.append(getWhitespace(offset))
 
-        if (!runner.dialect.allowTrailingCommas || tok.left.is[T.Comment])
+        val noExtraOffset =
+          !runner.dialect.allowTrailingCommas ||
+            tok.left.is[T.Comment] ||
+            formatOff
+
+        if (noExtraOffset)
           ws(0)
         else
           initStyle.trailingCommas match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -73,6 +73,9 @@ class FormatWriter(formatOps: FormatOps) {
 
       entry.formatWhitespace(sb)
 
+      // formatting flag switches at the end of iteration because of
+      // `formatToken.left` rendering. `FormatToken(x, // format: on)` will have
+      // formatOff = false, but x still should not be formatted
       formatOff = state.formatOff
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -2,7 +2,6 @@ package org.scalafmt.internal
 
 import java.util.regex.Pattern
 
-import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.rewrite.RedundantBraces
 import org.scalafmt.util.TokenOps.TokenHash
 import org.scalafmt.util.TreeOps
@@ -28,12 +27,14 @@ class FormatWriter(formatOps: FormatOps) {
     val sb = new StringBuilder()
     val locations = getFormatLocations(state, debug = false)
 
+    var formatOff = false
     locations.iterate.foreach { entry =>
       val location = entry.curr
       val state = location.state
       val formatToken = location.formatToken
 
       formatToken.left match {
+        case token if formatOff => sb.append(token.syntax)
         case c: T.Comment =>
           sb.append(formatComment(c, state.indentation))
         case token @ T.Interpolation.Part(_) =>
@@ -71,6 +72,8 @@ class FormatWriter(formatOps: FormatOps) {
       }
 
       entry.formatWhitespace(sb)
+
+      formatOff = state.formatOff
     }
 
     sb.toString()

--- a/scalafmt-tests/src/test/resources/unit/FormatOff.stat
+++ b/scalafmt-tests/src/test/resources/unit/FormatOff.stat
@@ -54,3 +54,21 @@ object A {
 // format: off
 0x123l
 // format: on
+<<< don't add extra trailing commas
+trailingCommas=always
+===
+// format: off
+f(
+    a,
+    b,
+    c
+)
+// format: on
+>>>
+// format: off
+f(
+    a,
+    b,
+    c
+)
+// format: on

--- a/scalafmt-tests/src/test/resources/unit/FormatOff.stat
+++ b/scalafmt-tests/src/test/resources/unit/FormatOff.stat
@@ -72,3 +72,11 @@ f(
     c
 )
 // format: on
+<<< should not delete multiple spaces
+// format: off
+val x    =  "ads"
+// format: on
+>>>
+// format: off
+val x    =  "ads"
+// format: on

--- a/scalafmt-tests/src/test/resources/unit/FormatOff.stat
+++ b/scalafmt-tests/src/test/resources/unit/FormatOff.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+maxColumn = 40
 <<< identity matrix
     object A   {
   // format: OFF
@@ -32,3 +32,25 @@ object A {
                              0, 0, 1)
                              function("I don't care about formatting at all")
              }
+<<< should work on comments
+// format: off
+/*
+   *
+*/
+// format: on
+42
+>>>
+// format: off
+/*
+   *
+*/
+// format: on
+42
+<<< should work on longs
+// format: off
+0x123l
+// format: on
+>>>
+// format: off
+0x123l
+// format: on


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalafmt/issues/1424