### PR TITLE
#1627 [03]: Router: newlines.source=unfold for semicolons

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -389,11 +389,15 @@ class Router(formatOps: FormatOps) {
       // New statement
       case tok @ FormatToken(T.Semicolon(), right, between)
           if startsStatement(tok) && newlines == 0 =>
-        val expire = statementStarts(hash(right)).tokens.last
+        val spaceSplit =
+          if (style.newlines.sourceIs(Newlines.unfold)) Split.ignored
+          else {
+            val expire = statementStarts(hash(right)).tokens.last
+            Split(Space, 0, policy = SingleLineBlock(expire))
+              .withOptimalToken(expire)
+          }
         Seq(
-          Split(Space, 0)
-            .withOptimalToken(expire)
-            .withPolicy(SingleLineBlock(expire)),
+          spaceSplit,
           // For some reason, this newline cannot cost 1.
           Split(NewlineT(shouldGet2xNewlines(tok)), 0)
         )

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -95,7 +95,8 @@ object a {
   try {
     a
   } catch {
-    case b => ; case c =>
+    case b => ;
+    case c =>
   } finally {
     d
   }
@@ -112,7 +113,8 @@ object a {
   try {
     a
   } catch {
-    case b => ; case c =>
+    case b => ;
+    case c =>
   } finally {
     d
   }
@@ -126,7 +128,8 @@ try {
 try {
   a
 } catch {
-  case b => ; case c =>
+  case b => ;
+  case c =>
 } finally {
   d
 }


### PR DESCRIPTION
For semicolons, we can `unfold` by adding a line break. In the `fold` case, we can try to remove a line break but that doesn't really look that good, plus semicolons shouldn't generally be used anyway.

`scala-repos` diffs:
* _unfold_: https://github.com/kitbellew/scala-repos/commit/2ffa7f60a0aaf4443ceb5af8d407112d827af87d?w=1
* others: unchanged

Helps with #1627