### PR TITLE
Router: modify indent of case clauses consistently

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -582,6 +582,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         .isDefined)) 0
     else if (!isNewline &&
       !isSingleLineComment(formatToken.right)) 0
+    else if (style.activeForEdition_2020_03 &&
+      isChildOfCaseClause(owner)) 0
     else 2
   }
 
@@ -743,10 +745,14 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     else style
   }
 
-  def getApplyIndent(leftOwner: Tree, isConfigStyle: Boolean = false): Num = {
-    val style = styleAt(leftOwner)
+  def getApplyIndent(
+      leftOwner: Tree,
+      isConfigStyle: Boolean = false
+  )(implicit style: ScalafmtConfig): Num =
     leftOwner match {
-      case _: Pat if leftOwner.parent.exists(_.is[Case]) =>
+      case _: Pat
+          if !style.activeForEdition_2020_03 &&
+            leftOwner.parent.exists(_.is[Case]) =>
         // The first layer of indentation is provided by the case ensure
         // orpan comments and the case cond is indented correctly.
         Num(0)
@@ -755,7 +761,6 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
         else Num(style.continuationIndent.defnSite)
       case _ => Num(style.continuationIndent.callSite)
     }
-  }
 
   def isBinPack(owner: Tree): Boolean = {
     val style = styleAt(owner)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -609,4 +609,11 @@ object TreeOps {
       }
     }
 
+  def isChildOfCaseClause(tree: Tree): Boolean =
+    findTreeWithParent(tree) {
+      case t: Case => Some(tree ne t.body)
+      case _: Pat => None
+      case _ => Some(false)
+    }.isDefined
+
 }

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -288,8 +288,8 @@ object ExternForwarder {
 >>>
 1 match {
   case accountIdStr :: userIdStr :: connectorIdStr :: timestampStr :: eventClassStr :: contactIdStr
-        :: contactPointIdStr :: contactPointValue :: remoteContactId :: to :: subject :: remoteId
-        :: remoteGroupId :: timeZoneStr :: rest
+      :: contactPointIdStr :: contactPointValue :: remoteContactId :: to :: subject :: remoteId
+      :: remoteGroupId :: timeZoneStr :: rest
       if "some lengthy condition is not empty".nonEmpty =>
 }
 <<< unfortunate side-effect of #740

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -283,13 +283,14 @@ object ExternForwarder {
 1 match {
  case accountIdStr :: userIdStr :: connectorIdStr :: timestampStr :: eventClassStr :: contactIdStr
         :: contactPointIdStr :: contactPointValue :: remoteContactId :: to :: subject :: remoteId
-        :: remoteGroupId :: timeZoneStr :: rest =>
+        :: remoteGroupId :: timeZoneStr :: rest if "some lengthy condition is not empty".nonEmpty =>
 }
 >>>
 1 match {
   case accountIdStr :: userIdStr :: connectorIdStr :: timestampStr :: eventClassStr :: contactIdStr
         :: contactPointIdStr :: contactPointValue :: remoteContactId :: to :: subject :: remoteId
-        :: remoteGroupId :: timeZoneStr :: rest =>
+        :: remoteGroupId :: timeZoneStr :: rest
+      if "some lengthy condition is not empty".nonEmpty =>
 }
 <<< unfortunate side-effect of #740
 { lazy val propertyName =

--- a/scalafmt-tests/src/test/resources/default/Case.case
+++ b/scalafmt-tests/src/test/resources/default/Case.case
@@ -108,6 +108,7 @@ case FormatToken(_: `(` | _: `[`, _, between)
                 _: InvocationTargetException | _: NullPointerException |
                 _: ClassNotFoundException
                 ) =>
+                 qux
 >>>
 case e @ (
         _: NoSuchMethodException | _: SecurityException |
@@ -115,3 +116,85 @@ case e @ (
         _: InvocationTargetException | _: NullPointerException |
         _: ClassNotFoundException
     ) =>
+  qux
+<<< gimme space with config style, with guard
+      case e @ (
+      _: NoSuchMethodException | _: SecurityException |
+                _: IllegalAccessException | _: IllegalArgumentException |
+                _: InvocationTargetException | _: NullPointerException |
+                _: ClassNotFoundException
+                ) /* c1 */ if /* c2 */ foo(
+                 bar,
+                 baz
+                 ) =>
+                 qux
+>>>
+case e @ (
+        _: NoSuchMethodException | _: SecurityException |
+        _: IllegalAccessException | _: IllegalArgumentException |
+        _: InvocationTargetException | _: NullPointerException |
+        _: ClassNotFoundException
+    ) /* c1 */
+    if /* c2 */ foo(
+        bar,
+        baz
+    ) =>
+  qux
+<<< gimme space with config style, with infix
+      case e @ (
+      _: NoSuchMethodException | _: SecurityException |
+                _: IllegalAccessException | _: IllegalArgumentException |
+                _: InvocationTargetException | _: NullPointerException |
+                _: ClassNotFoundException
+                ) infix foo(
+                 bar,
+                 baz
+                 ) =>
+                 qux
+>>>
+case e @ (
+        _: NoSuchMethodException | _: SecurityException |
+        _: IllegalAccessException | _: IllegalArgumentException |
+        _: InvocationTargetException | _: NullPointerException |
+        _: ClassNotFoundException
+    ) infix foo(
+        bar,
+        baz
+    ) =>
+  qux
+<<< gimme space with config style, with infix and nest
+      case e @ (
+      _: NoSuchMethodException | _: SecurityException |
+                _: IllegalAccessException | _: IllegalArgumentException |
+                _: InvocationTargetException | _: NullPointerException |
+                _: ClassNotFoundException
+                )
+                infix (
+                foo(
+                 bar,
+                 baz
+                 )
+                 anotherInfix foo(
+                        bar,
+                        baz
+                    )
+                ) =>
+                 qux
+>>>
+case e @ (
+        _: NoSuchMethodException | _: SecurityException |
+        _: IllegalAccessException | _: IllegalArgumentException |
+        _: InvocationTargetException | _: NullPointerException |
+        _: ClassNotFoundException
+    )
+      infix (
+          foo(
+              bar,
+              baz
+          )
+            anotherInfix foo(
+                bar,
+                baz
+            )
+      ) =>
+  qux

--- a/scalafmt-tests/src/test/resources/default/Case.case
+++ b/scalafmt-tests/src/test/resources/default/Case.case
@@ -187,14 +187,14 @@ case e @ (
         _: InvocationTargetException | _: NullPointerException |
         _: ClassNotFoundException
     )
-      infix (
-          foo(
-              bar,
-              baz
-          )
-            anotherInfix foo(
-                bar,
-                baz
-            )
-      ) =>
+    infix (
+        foo(
+            bar,
+            baz
+        )
+        anotherInfix foo(
+            bar,
+            baz
+        )
+    ) =>
   qux

--- a/scalafmt-tests/src/test/resources/default/Case.stat
+++ b/scalafmt-tests/src/test/resources/default/Case.stat
@@ -132,8 +132,8 @@ x match {
 >>>
 x match {
   case Foo(
-      a,
-      b
+          a,
+          b
       ) =>
     ???
 }

--- a/scalafmt-tests/src/test/resources/default/Case.stat
+++ b/scalafmt-tests/src/test/resources/default/Case.stat
@@ -121,3 +121,78 @@ object a {
     } // comment
   }
 }
+<<< #1244 1.1: one multiline pattern
+x match {
+  case Foo(
+      a,
+      b
+      ) =>
+        ???
+}
+>>>
+x match {
+  case Foo(
+      a,
+      b
+      ) =>
+    ???
+}
+<<< #1244 1.2: two multiline patterns with infix and multiline guard
+x match {
+  case
+    Foo(
+      a,
+      b
+  ) infix Bar(
+   c, d
+   ) if bar(
+       a,
+       b
+       ) =>
+    ???
+}
+>>>
+x match {
+  case Foo(
+          a,
+          b
+      ) infix Bar(
+          c,
+          d
+      )
+      if bar(
+          a,
+          b
+      ) =>
+    ???
+}
+<<< #1244 1.3: one single-line pattern and one multiline pattern with infix and guard
+x match {
+  case
+    a@ Foo infix Bar(
+   c, d
+   ) if baz(
+       a,
+       b
+       ) =>
+    if (qux(
+     x,
+     y
+   )) 0 else 1
+}
+>>>
+x match {
+  case a @ Foo infix Bar(
+          c,
+          d
+      )
+      if baz(
+          a,
+          b
+      ) =>
+    if (qux(
+            x,
+            y
+        )) 0
+    else 1
+}

--- a/scalafmt-tests/src/test/resources/newdefault/CaseNoAlign.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/CaseNoAlign.stat
@@ -1,0 +1,576 @@
+style = default
+maxColumn = 80
+align = none
+<<< Route partial function
+val Route: PartialFunction[Decision, Decision] = {
+  case FormatToken(_: Ident | _: `this` | _: `_ ` | _: `(`, _: `.` | _: `#`, _) =>
+  List(
+    NoSplit0
+  )
+}
+>>>
+val Route: PartialFunction[Decision, Decision] = {
+  case FormatToken(
+      _: Ident | _: `this` | _: `_ ` | _: `(`,
+      _: `.` | _: `#`,
+      _
+      ) =>
+    List(
+      NoSplit0
+    )
+}
+<<< What idiot wrote this code
+List(Split(Space, 0).withPolicy {
+            case Decision(t, s) if tok.right.end <= lastToken.end =>
+              Decision(t, s.map {
+                    case nl if nl.modification.isNewline =>
+                      val result =
+                        if (t.right.isInstanceOf[`if`] &&
+                            owners(t.right) == owner) nl
+                        else nl.withPenalty(1)
+                      result.withPolicy(breakOnArrow)
+                    case x => x
+                  })
+            })
+>>>
+List(Split(Space, 0).withPolicy {
+  case Decision(t, s) if tok.right.end <= lastToken.end =>
+    Decision(
+      t,
+      s.map {
+        case nl if nl.modification.isNewline =>
+          val result =
+            if (t.right.isInstanceOf[`if`] &&
+              owners(t.right) == owner) nl
+            else nl.withPenalty(1)
+          result.withPolicy(breakOnArrow)
+        case x => x
+      }
+    )
+})
+<<< chain of || and &&
+x match {
+  case tok if // TODO(olafur) DRY.
+      (leftOwner.isInstanceOf[Term.Interpolate] &&
+        rightOwner.isInstanceOf[Term.Interpolate]) ||
+      (leftOwner.isInstanceOf[Pat.Interpolate] &&
+        rightOwner.isInstanceOf[Pat.Interpolate]) =>
+    Seq(Split(NoSplit, 0))
+}
+>>>
+x match {
+  case tok
+      if // TODO(olafur) DRY.
+      (leftOwner.isInstanceOf[Term.Interpolate] &&
+        rightOwner.isInstanceOf[Term.Interpolate]) ||
+        (leftOwner.isInstanceOf[Pat.Interpolate] &&
+          rightOwner.isInstanceOf[Pat.Interpolate]) =>
+    Seq(Split(NoSplit, 0))
+}
+<<< PrepJSInterop
+x match {
+      case cldef if true =>
+        enterOwner(OwnerKind.EnumImpl) { super.transform(cldef) }
+
+      // Catch Scala Enumerations to transform calls to scala.Enumeration.Value
+      case i => x
+}
+>>>
+x match {
+  case cldef if true =>
+    enterOwner(OwnerKind.EnumImpl) { super.transform(cldef) }
+
+  // Catch Scala Enumerations to transform calls to scala.Enumeration.Value
+  case i => x
+}
+<<< spark case dequeueAll bug
+{
+  def testZipPartitions4(rdd: RDD[Int]): Unit = {
+    rdd.zipPartitions(rdd, rdd, rdd) { case (it1, it2, it3, it4) => return; it1 }.count()
+  }
+}
+>>>
+{
+  def testZipPartitions4(rdd: RDD[Int]): Unit = {
+    rdd
+      .zipPartitions(rdd, rdd, rdd) { case (it1, it2, it3, it4) => return; it1 }
+      .count()
+  }
+}
+<<< #1244 1.1: one multiline pattern
+x match {
+  case Foo(
+      a,
+      b
+      ) =>
+        ???
+}
+>>>
+x match {
+  case Foo(
+      a,
+      b
+      ) =>
+    ???
+}
+<<< #1244 1.2: one multiline pattern, no cfg style
+x match {
+  case Foo(
+      a,
+      b) =>
+        ???
+}
+>>>
+x match {
+  case Foo(a, b) =>
+    ???
+}
+<<< #1244 1.3: two multiline patterns with infix and multiline guard
+x match {
+  case
+    Foo(
+      a,
+      b
+  ) infix Bar(
+   c, d
+   ) if bar(
+       a,
+       b
+       ) =>
+    ???
+}
+>>>
+x match {
+  case Foo(
+        a,
+        b
+      ) infix Bar(
+        c,
+        d
+      )
+      if bar(
+        a,
+        b
+      ) =>
+    ???
+}
+<<< #1244 1.4: two multiline patterns with infix and multiline guard, no cfg style
+x match {
+  case
+    Foo(
+      a,
+      b  ) infix Bar(
+   c, d
+   ) if bar(
+       a,
+       b       ) =>
+    ???
+}
+>>>
+x match {
+  case Foo(a, b) infix Bar(
+        c,
+        d
+      ) if bar(a, b) =>
+    ???
+}
+<<< #1244 1.5: one single-line pattern and one multiline pattern with infix and guard
+{
+        if (
+        x +
+        y) 0 else 1
+
+    if (qux(
+     x,
+     y
+   )) 0 else 1
+
+x match {
+  case
+    a@ Foo infix Bar(
+   c, d
+   ) if baz(
+       a,
+       b
+       ) =>
+        if (
+        x +
+        y) 0 else 1
+    if (qux(
+     x,
+     y
+   )) 0 else 1
+}}
+>>>
+{
+  if (x +
+      y) 0
+  else 1
+
+  if (qux(
+      x,
+      y
+    )) 0
+  else 1
+
+  x match {
+    case a @ Foo infix Bar(
+          c,
+          d
+        )
+        if baz(
+          a,
+          b
+        ) =>
+      if (x +
+          y) 0
+      else 1
+      if (qux(
+          x,
+          y
+        )) 0
+      else 1
+  }
+}
+<<< #1244 1.6: one single-line pattern and one multiline pattern with infix and guard, no cfg style
+{
+        if (
+        x +
+        y) 0 else 1
+
+    if (qux(
+     x,
+     y
+   )) 0 else 1
+
+x match {
+  case
+    a@ Foo infix Bar(
+   c, d   ) if baz(
+       a,
+       b       ) =>
+        if (
+        x +        y) 0 else 1
+    if (qux(
+     x,
+     y   )
+     ) 0 else 1
+}}
+>>>
+{
+  if (x +
+      y) 0
+  else 1
+
+  if (qux(
+      x,
+      y
+    )) 0
+  else 1
+
+  x match {
+    case a @ Foo infix Bar(c, d) if baz(a, b) =>
+      if (x + y) 0 else 1
+      if (qux(x, y)) 0 else 1
+  }
+}
+<<< #1244 1.7: one multiline pattern and one single-line pattern with infix
+x match {
+  case
+    Foo(
+      a,
+      b
+  ) infix Bar
+   =>
+    ???
+}
+>>>
+x match {
+  case Foo(
+        a,
+        b
+      ) infix Bar =>
+    ???
+}
+<<< #1244 1.8: one multiline pattern and one single-line pattern with infix and multiline guard
+x match {
+  case
+    Foo(
+      a,
+      b
+  ) infix Bar if bar(
+       a,
+       b
+       ) =>
+    ???
+}
+>>>
+x match {
+  case Foo(
+        a,
+        b
+      ) infix Bar
+      if bar(
+        a,
+        b
+      ) =>
+    ???
+}
+<<< #1244 1.9: one multiline pattern and one single-line pattern with infix and single-line guard
+x match {
+  case
+    Foo(
+    a,
+      b
+      ) infix Bar if bar(       a,
+       b       ) =>
+    ???
+}
+>>>
+x match {
+  case Foo(
+        a,
+        b
+      ) infix Bar if bar(a, b) =>
+    ???
+}
+<<< #1244 2.1: long patterns: two single-line with infix and guard
+x match {
+  case
+    VeryLongFirstPatExtractCall(      firstParameter,
+      secondParameter
+      )
+       infix QuiteLongSecondPat if VeryLongAdditionalCheck(       a,
+       b       ) =>
+    ???
+}
+>>>
+x match {
+  case VeryLongFirstPatExtractCall(firstParameter, secondParameter)
+        infix QuiteLongSecondPat if VeryLongAdditionalCheck(a, b) =>
+    ???
+}
+<<< #1244 2.2: long patterns: multi-line and single-line with infix and guard
+x match {
+  case
+    VeryLongFirstPatExtractCall(
+          firstParameter,
+      secondParameter
+      )
+   infix QuiteLongSecondPat if VeryLongAdditionalCheck(
+              firstParameter,
+       secondParameter       ) =>
+    ???
+}
+>>>
+x match {
+  case VeryLongFirstPatExtractCall(
+        firstParameter,
+        secondParameter
+      )
+        infix QuiteLongSecondPat
+      if VeryLongAdditionalCheck(firstParameter, secondParameter) =>
+    ???
+}
+<<< #1244 2.3: long patterns: two multi-line with infix and guard
+x match {
+  case
+    VeryLongFirstPatExtractCall(
+          firstParameter,
+      secondParameter
+      )
+   infix QuiteLongSecondPat(
+   aaa, bbb
+   ) if VeryLongAdditionalCheck(
+              firstParameter,
+       secondParameter       ) =>
+    ???
+}
+>>>
+x match {
+  case VeryLongFirstPatExtractCall(
+        firstParameter,
+        secondParameter
+      )
+        infix QuiteLongSecondPat(
+          aaa,
+          bbb
+        ) if VeryLongAdditionalCheck(firstParameter, secondParameter) =>
+    ???
+}
+<<< #1244 2.4: long patterns: two multi-line with infix and select guard
+x match {
+  case
+    VeryLongFirstPatExtractCall(
+          firstParameter,
+      secondParameter
+      )
+   infix QuiteLongSecondPat(
+   aaa, bbb
+   ) if VeryLongAdditionalCheckObject
+   .checkMethod(firstParameter, secondParameter) =>    ???
+}
+>>>
+x match {
+  case VeryLongFirstPatExtractCall(
+        firstParameter,
+        secondParameter
+      )
+        infix QuiteLongSecondPat(
+          aaa,
+          bbb
+        )
+      if VeryLongAdditionalCheckObject
+        .checkMethod(firstParameter, secondParameter) =>
+    ???
+}
+<<< #1244 3.1 splitting on | and not on infix (infix short)
+x match {
+  case _: T.LeftBrace | _: T.RightBrace | _: T.LeftParen | a :: b :: c :: Nil | _: T.RightParen   |_: T.LeftBracket | _: T.RightBracket  if true =>
+    ???
+}
+>>>
+x match {
+  case _: T.LeftBrace | _: T.RightBrace | _: T.LeftParen | a :: b :: c :: Nil |
+      _: T.RightParen | _: T.LeftBracket | _: T.RightBracket if true =>
+    ???
+}
+<<< #1244 3.2 splitting on | and not on infix (infix long)
+x match {
+  case _: T.LeftBrace | _: T.RightBrace | _: T.LeftParen | a :: b :: c :: d :: Nil | _: T.RightParen   | _: T.LeftBracket | _: T.RightBracket  if true =>
+    ???
+}
+>>>
+x match {
+  case _: T.LeftBrace | _: T.RightBrace | _: T.LeftParen |
+      a :: b :: c :: d :: Nil | _: T.RightParen | _: T.LeftBracket |
+      _: T.RightBracket if true =>
+    ???
+}
+<<< #1244 4.1
+object a {
+          expectMsgPF() {
+            case SymbolSearchResults(
+                List(
+                  TypeSearchResult(
+                    "scala.util.Random",
+                    "Random",
+                    DeclaredAs.Class,
+                    Some(_)),
+                  TypeSearchResult(
+                    "scala.util.Random$",
+                    "Random$",
+                    DeclaredAs.Class,
+                    Some(_)))) =>
+            case SymbolSearchResults(
+                List(
+                  TypeSearchResult(
+                    "java.util.Random",
+                    "Random",
+                    DeclaredAs.Class,
+                    Some(_)),
+                  TypeSearchResult(
+                    "scala.util.Random",
+                    "Random",
+                    DeclaredAs.Class,
+                    Some(_)))) =>
+            // this is a pretty ropey test at the best of times
+          }
+          }
+>>>
+object a {
+  expectMsgPF() {
+    case SymbolSearchResults(
+        List(
+          TypeSearchResult(
+            "scala.util.Random",
+            "Random",
+            DeclaredAs.Class,
+            Some(_)
+          ),
+          TypeSearchResult(
+            "scala.util.Random$",
+            "Random$",
+            DeclaredAs.Class,
+            Some(_)
+          )
+        )
+        ) =>
+    case SymbolSearchResults(
+        List(
+          TypeSearchResult(
+            "java.util.Random",
+            "Random",
+            DeclaredAs.Class,
+            Some(_)
+          ),
+          TypeSearchResult(
+            "scala.util.Random",
+            "Random",
+            DeclaredAs.Class,
+            Some(_)
+          )
+        )
+        ) =>
+    // this is a pretty ropey test at the best of times
+  }
+}
+<<< #1244 4.2
+object a {
+  private def typecheckAll(): Unit = {
+    try {
+      task.parse()
+      task.analyze()
+      log.info(
+        "Parsed and analyzed: " + (System.currentTimeMillis() - t) + "ms")
+    } catch {
+      case e @ (_: Abort | _: ArrayIndexOutOfBoundsException |
+          _: AssertionError) =>
+        log.error("Javac error: " + e.getMessage())
+      case (_: Abort | _: ArrayIndexOutOfBoundsException |_: Throwable |
+          _: AssertionError) =>
+        log.error("Javac error: " + e.getMessage())
+    }
+  }
+}
+>>>
+object a {
+  private def typecheckAll(): Unit = {
+    try {
+      task.parse()
+      task.analyze()
+      log.info(
+        "Parsed and analyzed: " + (System.currentTimeMillis() - t) + "ms"
+      )
+    } catch {
+      case e @ (_: Abort | _: ArrayIndexOutOfBoundsException |
+          _: AssertionError) =>
+        log.error("Javac error: " + e.getMessage())
+      case (_: Abort | _: ArrayIndexOutOfBoundsException | _: Throwable |
+          _: AssertionError) =>
+        log.error("Javac error: " + e.getMessage())
+    }
+  }
+}
+<<< #1244 5.1: nested block in body, verify correct indentation
+object a {
+  b match {
+    case c => {}
+     d
+     case e => {
+      f
+     }
+     g
+  }
+}
+>>>
+object a {
+  b match {
+    case c => {}
+      d
+    case e => {
+        f
+      }
+      g
+  }
+}

--- a/scalafmt-tests/src/test/resources/newdefault/CaseNoAlign.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/CaseNoAlign.stat
@@ -11,9 +11,9 @@ val Route: PartialFunction[Decision, Decision] = {
 >>>
 val Route: PartialFunction[Decision, Decision] = {
   case FormatToken(
-      _: Ident | _: `this` | _: `_ ` | _: `(`,
-      _: `.` | _: `#`,
-      _
+        _: Ident | _: `this` | _: `_ ` | _: `(`,
+        _: `.` | _: `#`,
+        _
       ) =>
     List(
       NoSplit0
@@ -108,8 +108,8 @@ x match {
 >>>
 x match {
   case Foo(
-      a,
-      b
+        a,
+        b
       ) =>
     ???
 }
@@ -347,7 +347,7 @@ x match {
 >>>
 x match {
   case VeryLongFirstPatExtractCall(firstParameter, secondParameter)
-        infix QuiteLongSecondPat if VeryLongAdditionalCheck(a, b) =>
+      infix QuiteLongSecondPat if VeryLongAdditionalCheck(a, b) =>
     ???
 }
 <<< #1244 2.2: long patterns: multi-line and single-line with infix and guard
@@ -368,7 +368,7 @@ x match {
         firstParameter,
         secondParameter
       )
-        infix QuiteLongSecondPat
+      infix QuiteLongSecondPat
       if VeryLongAdditionalCheck(firstParameter, secondParameter) =>
     ???
 }
@@ -392,10 +392,10 @@ x match {
         firstParameter,
         secondParameter
       )
-        infix QuiteLongSecondPat(
-          aaa,
-          bbb
-        ) if VeryLongAdditionalCheck(firstParameter, secondParameter) =>
+      infix QuiteLongSecondPat(
+        aaa,
+        bbb
+      ) if VeryLongAdditionalCheck(firstParameter, secondParameter) =>
     ???
 }
 <<< #1244 2.4: long patterns: two multi-line with infix and select guard
@@ -416,10 +416,10 @@ x match {
         firstParameter,
         secondParameter
       )
-        infix QuiteLongSecondPat(
-          aaa,
-          bbb
-        )
+      infix QuiteLongSecondPat(
+        aaa,
+        bbb
+      )
       if VeryLongAdditionalCheckObject
         .checkMethod(firstParameter, secondParameter) =>
     ???
@@ -481,36 +481,36 @@ object a {
 object a {
   expectMsgPF() {
     case SymbolSearchResults(
-        List(
-          TypeSearchResult(
-            "scala.util.Random",
-            "Random",
-            DeclaredAs.Class,
-            Some(_)
-          ),
-          TypeSearchResult(
-            "scala.util.Random$",
-            "Random$",
-            DeclaredAs.Class,
-            Some(_)
+          List(
+            TypeSearchResult(
+              "scala.util.Random",
+              "Random",
+              DeclaredAs.Class,
+              Some(_)
+            ),
+            TypeSearchResult(
+              "scala.util.Random$",
+              "Random$",
+              DeclaredAs.Class,
+              Some(_)
+            )
           )
-        )
         ) =>
     case SymbolSearchResults(
-        List(
-          TypeSearchResult(
-            "java.util.Random",
-            "Random",
-            DeclaredAs.Class,
-            Some(_)
-          ),
-          TypeSearchResult(
-            "scala.util.Random",
-            "Random",
-            DeclaredAs.Class,
-            Some(_)
+          List(
+            TypeSearchResult(
+              "java.util.Random",
+              "Random",
+              DeclaredAs.Class,
+              Some(_)
+            ),
+            TypeSearchResult(
+              "scala.util.Random",
+              "Random",
+              DeclaredAs.Class,
+              Some(_)
+            )
           )
-        )
         ) =>
     // this is a pretty ropey test at the best of times
   }

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -182,8 +182,8 @@ lst.map { case (
 >>>
 lst.map {
   case (
-      value1,
-      value2,
+        value1,
+        value2,
       ) =>
     value1
 }

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleDanglingParens.stat
@@ -182,8 +182,8 @@ lst.map { case (
 >>>
 lst.map {
   case (
-      value1,
-      value2,
+        value1,
+        value2,
       ) =>
     value1
 }

--- a/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
@@ -168,8 +168,8 @@ case x :: x
 >>>
 1 match {
   case x :: x
-        :: y :: y
-        :: z :: z =>
+      :: y :: y
+      :: z :: z =>
 }
 <<< type.apply start line
 type x = (X

--- a/scalafmt-tests/src/test/resources/unit/Case.case
+++ b/scalafmt-tests/src/test/resources/unit/Case.case
@@ -69,8 +69,8 @@ case x: Foo[_] => 1
 case Foooooooooooooooo(aaaaaaaaaaaaaaaa, bbbbbbbbbbbb) =>
 >>>
 case Foooooooooooooooo(
-    aaaaaaaaaaaaaaaa,
-    bbbbbbbbbbbb) =>
+        aaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbb) =>
 <<< #512
 case q"""...${ stats: Seq[Stat] } """ =>
   s"${foo}"


### PR DESCRIPTION
Fixes #1244. `scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/2877c2cc11ac8f6678023498766614669dfefa44

The existing logic was suppressing case pattern indentation which led to incorrect formatting relative to the end of the pattern.

Specifically, here's a problematic pattern:
```
    case pattern(
        argument // indent 1: explicitly suppressed
        ) // closing: clause indentation
          infix another( // indent 2: increased to distinguish from "if"
            ...
          ) if somethingLong
          .methodCalledBySomethingLong =>
      body
```

First, we need to restore indent 1. Second, we need to address indent 2 and there are several options:

* we choose NOT to keep it different from `if`, as `if` can be easily determined as the last line at that level of indentation; that way, we don't add extra indentation for infix, closing parens etc., so it looks like this:
```
    case pattern(
          argument // indent 1: added
        )
        infix another( // indent 2: removed
          ...
        ) if somethingLong
          .methodCalledBySomethingLong =>
      body
```
* if we wanted to keep it different from the `if` guard, we would then have to increase indentation of closing paren, to align with indent 2, which in turn means increasing indent 1, which leads to a bit too much indentation; also, since `if` is frequently tucked after the closing paren on the previous line but could be split, it might lead to an odd formatting like this (and doesn't really emphasize `if` anyway, unless we require a line break before `if`):
```
    case pattern(
            argument // indent 1: added twice
          ) // extra indent
          infix another( // indent 2: unchanged
            ...
          ) if somethingLong
          .methodCalledBySomethingLong =>
      body
```
* finally, an option that was being discussed in the ticket looks a bit like this:
```
    case pattern(
      argument
    )
    infix another(
      ...
    ) if somethingLong
          .methodCalledBySomethingLong =>
      body
```
which is still quite hard to read, as it doesn't really emphasize the `case` keyword, which is an even harder problem when there's no body and another case clause right after:
```
    case pattern1(
      argument
    )
    infix another(
      ...
    ) if guard =>
    case pattern2(
      argument
    )
    infix another(
      ...
    ) if guard =>
```