### PR TITLE
#1627 [04]: Router: ignore line breaks in if-else and bodies

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.classifiers.classifier
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
 
+import org.scalafmt.config.Newlines
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.Decision
 import org.scalafmt.internal.FormatToken
@@ -250,5 +251,12 @@ object TokenOps {
     "// @formatter:on", // IntelliJ
     "// format: on" // scalariform
   )
+
+  def shouldBreak(ft: FormatToken)(implicit style: ScalafmtConfig): Boolean =
+    style.newlines.source match {
+      case Newlines.classic | Newlines.keep => ft.hasBreak
+      case Newlines.fold => false
+      case Newlines.unfold => true
+    }
 
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -165,3 +165,13 @@ object a {
     SizeUtils.calculate(segments, "user")
   } should have message """Cannot resolve column name "user" among (segment_id);"""
 }
+<<< 1.d: if-else, no curlies
+if (a)
+println("bbb") else if (b) b else
+ c
+>>>
+if (a)
+  println("bbb")
+else if (b) b
+else
+  c

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -152,3 +152,17 @@ object a {
     SizeUtils.calculate(segments, "user")
   } should have message """Cannot resolve column name "user" among (segment_id);"""
 }
+<<< 1.d: if-else, no curlies
+if (a)
+println("bbb")
+ else
+  if (b)
+   b else
+ c
+>>>
+if (a)
+  println("bbb")
+else if (b)
+  b
+else
+  c

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -160,9 +160,6 @@ println("bbb")
    b else
  c
 >>>
-if (a)
-  println("bbb")
-else if (b)
-  b
-else
-  c
+if (a) println("bbb")
+else if (b) b
+else c

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -165,3 +165,13 @@ object a {
     SizeUtils.calculate(segments, "user")
   } should have message """Cannot resolve column name "user" among (segment_id);"""
 }
+<<< 1.d: if-else, no curlies
+if (a)
+println("bbb") else if (b) b else
+ c
+>>>
+if (a)
+  println("bbb")
+else if (b) b
+else
+  c

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -178,3 +178,11 @@ object a {
     SizeUtils.calculate(segments, "user")
   } should have message """Cannot resolve column name "user" among (segment_id);"""
 }
+<<< 1.d: if-else, no curlies
+if (a)
+println("bbb") else if (b) b else c
+>>>
+if (a)
+  println("bbb")
+else if (b) b
+else c

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -16,7 +16,8 @@ println("bbb") } else c
 object a {
   if (a) {
     println("bbb")
-  } else c
+  } else
+    c
 }
 <<< 1.3: block, if, non-egyptian curlies
 object a {
@@ -184,5 +185,7 @@ println("bbb") else if (b) b else c
 >>>
 if (a)
   println("bbb")
-else if (b) b
-else c
+else if (b)
+  b
+else
+  c


### PR DESCRIPTION
Modify breaks around control expressions (`if-else`, `for`, `while` etc.) and their bodies.

Helps with #1627.

`scala-repos` diffs:
* `classic` and `keep`: unchanged
* `fold`: https://github.com/kitbellew/scala-repos/commit/50420e514f66910d77ed8a549c56ee212350a329?w=1
* `unfold`: https://github.com/kitbellew/scala-repos/commit/f3e2e427ab5b3b5f2ecf29f4d84679bd0061b1e2?w=1