### PR TITLE
#1627 [05]: Router: ignore line breaks in def/val assignments

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1608,7 +1608,7 @@ class Router(formatOps: FormatOps) {
       implicit style: ScalafmtConfig
   ): Seq[Split] = {
     val expire = body.tokens.last
-    def exclude = getExcludeIf(
+    def excludeOld = getExcludeIf(
       expire, {
         case T.RightBrace() => true
         case close @ T.RightParen()
@@ -1623,6 +1623,11 @@ class Router(formatOps: FormatOps) {
         case _ => false
       }
     )
+    def exclude =
+      if (style.activeForEdition_2020_03
+        && style.newlines.alwaysBeforeMultilineDef)
+        Set.empty[Range]
+      else excludeOld
     if (ft.right.is[T.LeftBrace])
       // The block will take care of indenting by 2.
       Seq(Split(Space, 0))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -393,8 +393,7 @@ class Router(formatOps: FormatOps) {
           if (style.newlines.sourceIs(Newlines.unfold)) Split.ignored
           else {
             val expire = statementStarts(hash(right)).tokens.last
-            Split(Space, 0, policy = SingleLineBlock(expire))
-              .withOptimalToken(expire)
+            Split(Space, 0).withSingleLine(expire)
           }
         Seq(
           spaceSplit,
@@ -428,8 +427,7 @@ class Router(formatOps: FormatOps) {
             // This split needs to have an optimalAt field.
             Split(Space, 0)
               .onlyIf(spaceCouldBeOk)
-              .withOptimalToken(expire)
-              .withPolicy(SingleLineBlock(expire)),
+              .withSingleLine(expire),
             // For some reason, this newline cannot cost 1.
             Split(newline, 0)
           )
@@ -489,9 +487,7 @@ class Router(formatOps: FormatOps) {
             d.onlyNewlinesWithoutFallback
         }
         Seq(
-          Split(Space, 0)
-            .withOptimalToken(expire, killOnFail = true)
-            .withPolicy(SingleLineBlock(expire)),
+          Split(Space, 0).withSingleLine(expire, killOnFail = true),
           Split(Space, 1).withPolicy(forceNewlineBeforeExtends)
         )
       // DefDef
@@ -538,9 +534,9 @@ class Router(formatOps: FormatOps) {
         val noSplitMod = getNoSplit(formatToken, true)
         val newlinePenalty = 3 + nestedApplies(leftOwner)
         Seq(
-          Split(noSplitMod, 0, policy = SingleLineBlock(close))
+          Split(noSplitMod, 0)
             .onlyIf(noSplitMod != null)
-            .withOptimalToken(close),
+            .withSingleLine(close),
           Split(noSplitMod, 0, policy = spacePolicy)
             .onlyIf(noSplitMod != null)
             .withOptimalToken(lambdaToken),
@@ -786,11 +782,9 @@ class Router(formatOps: FormatOps) {
                   .withPolicy(newlinePolicy)
                   .withIndent(indent, close, Right),
                 Split(NoSplit, noSplitCost)
-                  .withOptimalToken(breakToken)
-                  .withPolicy(
-                    newlinePolicy
-                      .andThen(newlineAfterAssignDecision)
-                      .andThen(SingleLineBlock(breakToken))
+                  .withSingleLine(breakToken)
+                  .andThenPolicy(
+                    newlinePolicy.andThen(newlineAfterAssignDecision)
                   )
               )
             }
@@ -887,8 +881,7 @@ class Router(formatOps: FormatOps) {
                   newlinesOnlyBeforeClosePolicy(close)
                     .orElse(decideNewlinesOnlyAfterToken(breakAfter))
                 Seq(
-                  Split(Newline, 0, policy = SingleLineBlock(close))
-                    .withOptimalToken(close, killOnFail = true),
+                  Split(Newline, 0).withSingleLine(close, killOnFail = true),
                   Split(Space, 1, policy = multiLine)
                 )
             }).map(_.onlyFor(SplitTag.OneArgPerLine))
@@ -898,8 +891,7 @@ class Router(formatOps: FormatOps) {
             .onlyIf(oneArgPerLineSplits.isEmpty)
             .onlyIf(newlines != 0)
             .onlyIf(open.pos.endLine == close.pos.startLine)
-            .withOptimalToken(close, killOnFail = true)
-            .withPolicy(SingleLineBlock(close))
+            .withSingleLine(close, killOnFail = true)
         ) ++ oneArgPerLineSplits
       case FormatToken(_, _: T.LeftBrace, _) =>
         Seq(Split(Space, 0))
@@ -1216,9 +1208,7 @@ class Router(formatOps: FormatOps) {
                 d.onlyNewlinesWithFallback(Split(Newline, 0))
             }
         Seq(
-          Split(Space, 0)
-            .withOptimalToken(expire, killOnFail = true)
-            .withPolicy(SingleLineBlock(expire)),
+          Split(Space, 0).withSingleLine(expire, killOnFail = true),
           Split(Space, 1).withPolicy(breakOnlyBeforeElse)
         )
       case FormatToken(close: T.RightParen, right, _) if (leftOwner match {
@@ -1330,9 +1320,7 @@ class Router(formatOps: FormatOps) {
 
         Seq(
           // Either everything fits in one line or break on =>
-          Split(Space, 0)
-            .withOptimalToken(expire, killOnFail = true)
-            .withPolicy(SingleLineBlock(expire)),
+          Split(Space, 0).withSingleLine(expire, killOnFail = true),
           Split(Space, 1)
             .withPolicy(
               Policy(expire) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -95,6 +95,19 @@ case class Split(
     if (isIgnored) this else copy(policy = newPolicy)
   }
 
+  def withSingleLine(
+      expire: Token,
+      killOnFail: Boolean = false
+  )(implicit line: sourcecode.Line): Split =
+    withSingleLineAndOptimal(expire, expire, killOnFail)
+
+  def withSingleLineAndOptimal(
+      expire: Token,
+      optimal: Token,
+      killOnFail: Boolean = false
+  )(implicit line: sourcecode.Line): Split =
+    withOptimalToken(optimal, killOnFail).withPolicy(SingleLineBlock(expire))
+
   def withPolicyOpt(newPolicy: => Option[Policy]): Split =
     if (isIgnored) this else newPolicy.fold(this)(withPolicy(_))
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -616,4 +616,12 @@ object TreeOps {
       case _ => Some(false)
     }.isDefined
 
+  @tailrec
+  def getEndOfFirstCall(tree: Tree): Token =
+    tree match {
+      case t: Term.Select => getEndOfFirstCall(t.qual)
+      case SplitCallIntoParts(fun, _) if fun ne tree => getEndOfFirstCall(fun)
+      case _ => tree.tokens.last
+    }
+
 }

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -182,6 +182,8 @@ object a {
   final val OVERLOADED    = 1L << 33 // symbol
 }
 <<< tricky regex #138
+newlines.alwaysBeforeMultilineDef = false
+===
 def f[A](x: A)(f: A => Int) = f(x) match {
   case 1 => true
   case 222 => false
@@ -191,6 +193,17 @@ def f[A](x: A)(f: A => Int) = f(x) match {
   case 1   => true
   case 222 => false
 }
+<<< tricky regex #138 2
+def f[A](x: A)(f: A => Int) = f(x) match {
+  case 1 => true
+  case 222 => false
+}
+>>>
+def f[A](x: A)(f: A => Int) =
+  f(x) match {
+    case 1   => true
+    case 222 => false
+  }
 <<< conflicting number of columns
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % "test",
@@ -296,6 +309,8 @@ for {
   aaa = List(1)
 } yield 1
 <<< don't jump scope #152
+newlines.alwaysBeforeMultilineDef = false
+===
 object Cleaver {
    def apply[R, A, B](): Cleaver[R, A, B] = new Cleaver[R, A, B] {
     def split(x: R): A -> B               = (l(x), r(x))
@@ -308,6 +323,21 @@ object Cleaver {
     def split(x: R): A -> B = (l(x), r(x))
     def join(x: A -> B): R  = f(x._1, x._2)
   }
+}
+<<< don't jump scope #152 2
+object Cleaver {
+   def apply[R, A, B](): Cleaver[R, A, B] = new Cleaver[R, A, B] {
+    def split(x: R): A -> B               = (l(x), r(x))
+    def join(x: A -> B): R                = f(x._1, x._2)
+   }
+ }
+>>>
+object Cleaver {
+  def apply[R, A, B](): Cleaver[R, A, B] =
+    new Cleaver[R, A, B] {
+      def split(x: R): A -> B = (l(x), r(x))
+      def join(x: A -> B): R  = f(x._1, x._2)
+    }
 }
 <<< only align single-line statements
 {

--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -110,14 +110,15 @@ def processOptions(): Unit = {
 
 )
 >>>
-private def scalaJSStageSettings = Seq(
-    usesScalaJSLinkerTag in key := {
-      Tags
-    },
-    // Prevent this linker from being used concurrently
-    concurrentRestrictions in Global +=
-      Tags.limit((usesScalaJSLinkerTag in key).value, 1)
-)
+private def scalaJSStageSettings =
+  Seq(
+      usesScalaJSLinkerTag in key := {
+        Tags
+      },
+      // Prevent this linker from being used concurrently
+      concurrentRestrictions in Global +=
+        Tags.limit((usesScalaJSLinkerTag in key).value, 1)
+  )
 <<< testFilter
   val testFilter: String => Boolean = {
     options.testFilter match {
@@ -227,10 +228,11 @@ callStatement = js.If(
         } else {
           val reflBoxClassPatched = {
 
-            def isIntOrLongKind(kind: TypeKind) = kind match {
-              case _: INT | LONG => true
-              case _ => false
-            }
+            def isIntOrLongKind(kind: TypeKind) =
+              kind match {
+                case _: INT | LONG => true
+                case _ => false
+              }
             if (rtClass == BoxedDoubleClass &&
                 toTypeKind(implMethodSym.tpe.resultType) == DoubleKind &&
                 isIntOrLongKind(toTypeKind(sym.tpe.resultType))) {

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -516,13 +516,14 @@ def startSharding(system: ActorSystem, mediator: ActorRef, shardCount: Int): Uni
 >>>
 def startSharding(system: ActorSystem,
                   mediator: ActorRef,
-                  shardCount: Int): Unit = ClusterSharding(system).start(
-    className[Flow],
-    props(mediator),
-    ClusterShardingSettings(system),
-    { case (name: String, payload) => (name, payload) },
-    { case (name: String, _) => (name.hashCode % shardCount).toString }
-)
+                  shardCount: Int): Unit =
+  ClusterSharding(system).start(
+      className[Flow],
+      props(mediator),
+      ClusterShardingSettings(system),
+      { case (name: String, payload) => (name, payload) },
+      { case (name: String, _) => (name.hashCode % shardCount).toString }
+  )
 <<< spray shit
 {{{
       get {

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -267,17 +267,18 @@ if (other == null) {
     }
 >>>
 object ExternForwarder {
-  def unapply(tree: Tree): Option[Symbol] = tree match {
-    case DefDef()
-        if isExternModule(from.symbol)
-          && params.length == args.length
-          && params.zip(args).forall {
-            case _ => false
-          } =>
-      Some(sel.symbol)
-    case _ =>
-      None
-  }
+  def unapply(tree: Tree): Option[Symbol] =
+    tree match {
+      case DefDef()
+          if isExternModule(from.symbol)
+            && params.length == args.length
+            && params.zip(args).forall {
+              case _ => false
+            } =>
+        Some(sel.symbol)
+      case _ =>
+        None
+    }
 }
 <<< #408
 1 match {

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -152,11 +152,12 @@ def viewMethod: Gen[ViewClass.Op] = oneOf(
   chooseRange ^^ lop(r => s"slice $r"  -> (_ slice r))
 )
 >>>
-def viewMethod: Gen[ViewClass.Op] = oneOf(
-    lowHalf ^^ lop(n => s"drop $n" -> (_ drop n)),
-    highHalf ^^ lop(n => s"take $n" -> (_ take n)),
-    chooseRange ^^ lop(r => s"slice $r" -> (_ slice r))
-)
+def viewMethod: Gen[ViewClass.Op] =
+  oneOf(
+      lowHalf ^^ lop(n => s"drop $n" -> (_ drop n)),
+      highHalf ^^ lop(n => s"take $n" -> (_ take n)),
+      chooseRange ^^ lop(r => s"slice $r" -> (_ slice r))
+  )
 <<< typelevel/cats
   implicit def validatedInstances[E](implicit E: Semigroup[E]): Traverse[Validated[E, ?]] with ApplicativeError[Validated[E, ?], E] = 2
 >>>

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -115,12 +115,13 @@ def foo(x: Int) = x match {
     (y: Int) => -y
   }
 >>>
-def foo(x: Int) = x match {
-  case 1 =>
-    (y: Int) => y
-  case _ =>
-    (y: Int) => -y
-}
+def foo(x: Int) =
+  x match {
+    case 1 =>
+      (y: Int) => y
+    case _ =>
+      (y: Int) => -y
+  }
 <<< SKIP y u break line? Answer: Because optimizer.recurseOnBlocks
 {
   def foo =

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
@@ -49,10 +49,11 @@ package a {
         3
       }
 
-      def e = a match {
-        case 1 => true
-        case 2 => false
-      }
+      def e =
+        a match {
+          case 1 => true
+          case 2 => false
+        }
     }
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -175,3 +175,350 @@ if (a)
 else if (b) b
 else
   c
+<<< 2.1: def one-line body
+def a = b
+>>>
+def a = b
+<<< 2.2: def one-line block body
+object a {
+def a = { b; c }
+}
+>>>
+object a {
+  def a = { b; c }
+}
+<<< 2.3: def one-line block body with a break
+object a {
+def a =
+ { b; c }
+}
+>>>
+object a {
+  def a = { b; c }
+}
+<<< 2.4: def multiline-line block body with a break
+object a {
+def a =
+ {
+  b;c }}
+>>>
+object a {
+  def a = {
+    b; c
+  }
+}
+<<< 2.5: def multiline-line block body with a break
+object a {
+def a = {
+  b;c }
+}
+>>>
+object a {
+  def a = {
+    b; c
+  }
+}
+<<< 2.6 #1747: one line with else
+maxColumn = 55
+===
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) } else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) } else { None }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) }
+  else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+  else { None }
+}
+<<< 2.7 #1747: one line without else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+}
+<<< 2.8 #1747: split on then with else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  else
+    None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+     Some(aaaa)
+  }
+  else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+    else
+      None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  } else {
+    None
+  }
+}
+<<< 2.9 #1747: split on else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10) Some(a) else
+    None
+  val ok2 = if (a > 10) { Some(a) } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) } else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+    else
+      None
+  val ok2 = if (a > 10) { Some(a) }
+  else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+  else {
+    None
+  }
+}
+<<< 2.10 #1747: split on then without else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  val ok2 = if (a > 10) {
+    Some(a) }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+  val ok2 = if (a > 10) {
+    Some(a)
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  }
+}
+<<< 2.11 #1747: split on if
+maxColumn = 60
+===
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) } else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) } else { None }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+    else { None }
+}
+<<< 2.12 #1747: split on if without else
+maxColumn = 60
+===
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+  val ok3 =
+   if (aaaa > 10000) { Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+}
+<<< 2.13 val with for/yield
+maxColumn = 80
+===
+val attributes =
+ for (_ ← 1 to count)
+ yield {
+  val tag = d.readUnsignedShort()
+  val length = d.readInt()
+  if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
+  if (tag != s) {
+    skip(d, length)
+    None
+  } else {
+    val name = d.readUnsignedShort()
+    Some(c(name))
+  }
+}
+>>>
+val attributes =
+  for (_ ← 1 to count)
+    yield {
+      val tag = d.readUnsignedShort()
+      val length = d.readInt()
+      if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
+      if (tag != s) {
+        skip(d, length)
+        None
+      } else {
+        val name = d.readUnsignedShort()
+        Some(c(name))
+      }
+    }
+<<< 2.14 val with short for/yield
+maxColumn = 80
+===
+val attributes =
+ for (i ← 1 to count)
+ yield i
+>>>
+val attributes =
+  for (i ← 1 to count)
+    yield i
+<<< 2.15 val with literal apply
+object a {
+   val a =
+    b(
+      0x1F, // ID1
+       0x8B, // ID2
+       8, // CM = Deflate
+       0, // FLG
+       0, // MTIME 1
+       0, // MTIME 2
+       0, // MTIME 3
+       0, // MTIME 4
+       0, // XFL
+       0 // OS
+    )
+ }
+>>>
+object a {
+  val a =
+    b(
+      0x1F, // ID1
+      0x8B, // ID2
+      8, // CM = Deflate
+      0, // FLG
+      0, // MTIME 1
+      0, // MTIME 2
+      0, // MTIME 3
+      0, // MTIME 4
+      0, // XFL
+      0 // OS
+    )
+}
+<<< 2.16 val with apply and comment
+danglingParentheses = false
+===
+val a =
+  Set(
+    "b" // ...
+  )
+>>>
+val a =
+  Set(
+    "b" // ...
+  )
+<<< 2.17 val with apply-apply-select
+val aaaaa = bbbbb.asss(as).ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+>>>
+val aaaaa = bbbbb
+  .asss(as)
+  .ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+<<< 2.18 val with apply-apply
+val aaaaa = (getSomeLongerFunction(c))(as)
+>>>
+val aaaaa =
+  (getSomeLongerFunction(c))(as)
+<<< 2.19 val with apply-select-select
+val aaaaa = bbbbb.asss.ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+>>>
+val aaaaa = bbbbb.asss.ccccc(
+  ddddd,
+  eeeee,
+  fffff
+) // comment
+<<< 2.20 val with apply-select-select
+val nested =
+  promiseIntercept(new Actor {
+    def receive = {
+      case _ ⇒
+    }
+  })(result)
+>>>
+val nested =
+  promiseIntercept(new Actor {
+    def receive = {
+      case _ ⇒
+    }
+  })(result)
+<<< 2.21 val with apply type
+  val deployment = system
+    .asInstanceOf[ActorSystemImpl]
+    .provider
+    .deployer
+    .lookup(service.split("/").drop(1))
+>>>
+val deployment = system
+  .asInstanceOf[ActorSystemImpl]
+  .provider
+  .deployer
+  .lookup(service.split("/").drop(1))

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -163,3 +163,321 @@ println("bbb")
 if (a) println("bbb")
 else if (b) b
 else c
+<<< 2.1: def one-line body
+def a = b
+>>>
+def a = b
+<<< 2.2: def one-line block body
+object a {
+def a = { b; c }
+}
+>>>
+object a {
+  def a = { b; c }
+}
+<<< 2.3: def one-line block body with a break
+object a {
+def a =
+ { b; c }
+}
+>>>
+object a {
+  def a = { b; c }
+}
+<<< 2.4: def multiline-line block body with a break
+object a {
+def a =
+ {
+  b;c }}
+>>>
+object a {
+  def a = { b; c }
+}
+<<< 2.5: def multiline-line block body with a break
+object a {
+def a = {
+  b;c }
+}
+>>>
+object a {
+  def a = { b; c }
+}
+<<< 2.6 #1747: one line with else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) } else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) } else { None }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) }
+  else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+  else { None }
+}
+<<< 2.7 #1747: one line without else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+}
+<<< 2.8 #1747: split on then with else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  else
+    None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+     Some(aaaa)
+  }
+  else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) }
+  else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+  else { None }
+}
+<<< 2.9 #1747: split on else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10) Some(a) else
+    None
+  val ok2 = if (a > 10) { Some(a) } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) } else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) }
+  else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+  else { None }
+}
+<<< 2.10 #1747: split on then without else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  val ok2 = if (a > 10) {
+    Some(a) }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+}
+<<< 2.11 #1747: split on if
+maxColumn = 60
+===
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) } else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) } else { None }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+    else { None }
+}
+<<< 2.12 #1747: split on if without else
+maxColumn = 60
+===
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+  val ok3 =
+   if (aaaa > 10000) { Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+}
+<<< 2.13 val with for/yield
+maxColumn = 80
+===
+val attributes =
+ for (_ ← 1 to count)
+ yield {
+  val tag = d.readUnsignedShort()
+  val length = d.readInt()
+  if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
+  if (tag != s) {
+    skip(d, length)
+    None
+  } else {
+    val name = d.readUnsignedShort()
+    Some(c(name))
+  }
+}
+>>>
+val attributes =
+  for (_ ← 1 to count) yield {
+    val tag = d.readUnsignedShort()
+    val length = d.readInt()
+    if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
+    if (tag != s) {
+      skip(d, length)
+      None
+    } else {
+      val name = d.readUnsignedShort()
+      Some(c(name))
+    }
+  }
+<<< 2.14 val with short for/yield
+maxColumn = 80
+===
+val attributes =
+ for (i ← 1 to count)
+ yield i
+>>>
+val attributes =
+  for (i ← 1 to count) yield i
+<<< 2.15 val with literal apply
+object a {
+   val a =
+    b(
+      0x1F, // ID1
+       0x8B, // ID2
+       8, // CM = Deflate
+       0, // FLG
+       0, // MTIME 1
+       0, // MTIME 2
+       0, // MTIME 3
+       0, // MTIME 4
+       0, // XFL
+       0 // OS
+    )
+ }
+>>>
+object a {
+  val a =
+    b(
+      0x1F, // ID1
+      0x8B, // ID2
+      8, // CM = Deflate
+      0, // FLG
+      0, // MTIME 1
+      0, // MTIME 2
+      0, // MTIME 3
+      0, // MTIME 4
+      0, // XFL
+      0 // OS
+    )
+}
+<<< 2.16 val with apply and comment
+danglingParentheses = false
+===
+val a = Set(
+  "b" // ...
+)
+>>>
+val a = Set(
+  "b" // ...
+)
+<<< 2.17 val with apply-apply-select
+val aaaaa = bbbbb.asss(as).ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+>>>
+val aaaaa = bbbbb
+  .asss(as)
+  .ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+<<< 2.18 val with apply-apply
+val aaaaa = (getSomeLongerFunction(c))(as)
+>>>
+val aaaaa =
+  (getSomeLongerFunction(c))(as)
+<<< 2.19 val with apply-select-select
+val aaaaa = bbbbb.asss.ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+>>>
+val aaaaa = bbbbb.asss.ccccc(
+  ddddd,
+  eeeee,
+  fffff
+) // comment
+<<< 2.20 val with apply-select-select
+val nested =
+  promiseIntercept(new Actor {
+    def receive = {
+      case _ ⇒
+    }
+  })(result)
+>>>
+val nested =
+  promiseIntercept(new Actor {
+    def receive = {
+      case _ ⇒
+    }
+  })(result)
+<<< 2.21 val with apply type
+  val deployment =
+   system
+    .asInstanceOf[ActorSystemImpl]
+    .provider
+    .deployer
+    .lookup(service.split("/").drop(1))
+>>>
+val deployment =
+  system
+    .asInstanceOf[ActorSystemImpl]
+    .provider
+    .deployer
+    .lookup(service.split("/").drop(1))

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -213,10 +213,12 @@ object a {
 >>>
 object a {
   val ok1 = if (a > 10) Some(a) else None
-  val ok2 = if (a > 10) { Some(a) }
-  else { None }
-  val ok3 = if (aaaa > 10000) { Some(aaaa) }
-  else { None }
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+    else { None }
 }
 <<< 2.7 #1747: one line without else
 maxColumn = 60
@@ -255,10 +257,12 @@ object a {
 >>>
 object a {
   val ok1 = if (a > 10) Some(a) else None
-  val ok2 = if (a > 10) { Some(a) }
-  else { None }
-  val ok3 = if (aaaa > 10000) { Some(aaaa) }
-  else { None }
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+    else { None }
 }
 <<< 2.9 #1747: split on else
 maxColumn = 60
@@ -276,10 +280,12 @@ object a {
 >>>
 object a {
   val ok1 = if (a > 10) Some(a) else None
-  val ok2 = if (a > 10) { Some(a) }
-  else { None }
-  val ok3 = if (aaaa > 10000) { Some(aaaa) }
-  else { None }
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+    else { None }
 }
 <<< 2.10 #1747: split on then without else
 maxColumn = 60
@@ -311,8 +317,7 @@ object a {
 }
 >>>
 object a {
-  val ok1 =
-    if (a > 10) Some(a) else None
+  val ok1 = if (a > 10) Some(a) else None
   val ok2 =
     if (a > 10) { Some(a) }
     else { None }
@@ -333,12 +338,9 @@ object a {
 }
 >>>
 object a {
-  val ok1 =
-    if (a > 10) Some(a)
-  val ok2 =
-    if (a > 10) { Some(a) }
-  val ok3 =
-    if (aaaa > 10000) { Some(aaaa) }
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
 }
 <<< 2.13 val with for/yield
 maxColumn = 80
@@ -358,19 +360,18 @@ val attributes =
   }
 }
 >>>
-val attributes =
-  for (_ ← 1 to count) yield {
-    val tag = d.readUnsignedShort()
-    val length = d.readInt()
-    if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
-    if (tag != s) {
-      skip(d, length)
-      None
-    } else {
-      val name = d.readUnsignedShort()
-      Some(c(name))
-    }
+val attributes = for (_ ← 1 to count) yield {
+  val tag = d.readUnsignedShort()
+  val length = d.readInt()
+  if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
+  if (tag != s) {
+    skip(d, length)
+    None
+  } else {
+    val name = d.readUnsignedShort()
+    Some(c(name))
   }
+}
 <<< 2.14 val with short for/yield
 maxColumn = 80
 ===
@@ -378,8 +379,7 @@ val attributes =
  for (i ← 1 to count)
  yield i
 >>>
-val attributes =
-  for (i ← 1 to count) yield i
+val attributes = for (i ← 1 to count) yield i
 <<< 2.15 val with literal apply
 object a {
    val a =
@@ -398,19 +398,18 @@ object a {
  }
 >>>
 object a {
-  val a =
-    b(
-      0x1F, // ID1
-      0x8B, // ID2
-      8, // CM = Deflate
-      0, // FLG
-      0, // MTIME 1
-      0, // MTIME 2
-      0, // MTIME 3
-      0, // MTIME 4
-      0, // XFL
-      0 // OS
-    )
+  val a = b(
+    0x1F, // ID1
+    0x8B, // ID2
+    8, // CM = Deflate
+    0, // FLG
+    0, // MTIME 1
+    0, // MTIME 2
+    0, // MTIME 3
+    0, // MTIME 4
+    0, // XFL
+    0 // OS
+  )
 }
 <<< 2.16 val with apply and comment
 danglingParentheses = false
@@ -439,8 +438,9 @@ val aaaaa = bbbbb
 <<< 2.18 val with apply-apply
 val aaaaa = (getSomeLongerFunction(c))(as)
 >>>
-val aaaaa =
-  (getSomeLongerFunction(c))(as)
+val aaaaa = (getSomeLongerFunction(c))(
+  as
+)
 <<< 2.19 val with apply-select-select
 val aaaaa = bbbbb.asss.ccccc(
     ddddd,
@@ -461,12 +461,13 @@ val nested =
     }
   })(result)
 >>>
-val nested =
-  promiseIntercept(new Actor {
+val nested = promiseIntercept(
+  new Actor {
     def receive = {
       case _ ⇒
     }
-  })(result)
+  }
+)(result)
 <<< 2.21 val with apply type
   val deployment =
    system
@@ -475,9 +476,8 @@ val nested =
     .deployer
     .lookup(service.split("/").drop(1))
 >>>
-val deployment =
-  system
-    .asInstanceOf[ActorSystemImpl]
-    .provider
-    .deployer
-    .lookup(service.split("/").drop(1))
+val deployment = system
+  .asInstanceOf[ActorSystemImpl]
+  .provider
+  .deployer
+  .lookup(service.split("/").drop(1))

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -175,3 +175,349 @@ if (a)
 else if (b) b
 else
   c
+<<< 2.1: def one-line body
+def a = b
+>>>
+def a = b
+<<< 2.2: def one-line block body
+object a {
+def a = { b; c }
+}
+>>>
+object a {
+  def a = { b; c }
+}
+<<< 2.3: def one-line block body with a break
+object a {
+def a =
+ { b; c }
+}
+>>>
+object a {
+  def a = { b; c }
+}
+<<< 2.4: def multiline-line block body with a break
+object a {
+def a =
+ {
+  b;c }}
+>>>
+object a {
+  def a = {
+    b; c
+  }
+}
+<<< 2.5: def multiline-line block body with a break
+object a {
+def a = {
+  b;c }
+}
+>>>
+object a {
+  def a = {
+    b; c
+  }
+}
+<<< 2.6 #1747: one line with else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) } else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) } else { None }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) }
+  else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+  else { None }
+}
+<<< 2.7 #1747: one line without else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+}
+<<< 2.8 #1747: split on then with else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  else
+    None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+     Some(aaaa)
+  }
+  else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+    else
+      None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  } else {
+    None
+  }
+}
+<<< 2.9 #1747: split on else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10) Some(a) else
+    None
+  val ok2 = if (a > 10) { Some(a) } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) } else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+    else
+      None
+  val ok2 = if (a > 10) { Some(a) }
+  else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+  else {
+    None
+  }
+}
+<<< 2.10 #1747: split on then without else
+maxColumn = 60
+===
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  val ok2 = if (a > 10) {
+    Some(a) }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+  val ok2 = if (a > 10) {
+    Some(a)
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  }
+}
+<<< 2.11 #1747: split on if
+maxColumn = 60
+===
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) } else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) } else { None }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+    else { None }
+}
+<<< 2.12 #1747: split on if without else
+maxColumn = 60
+===
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+  val ok3 =
+   if (aaaa > 10000) { Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+}
+<<< 2.13 val with for/yield
+maxColumn = 80
+===
+val attributes =
+ for (_ ← 1 to count)
+ yield {
+  val tag = d.readUnsignedShort()
+  val length = d.readInt()
+  if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
+  if (tag != s) {
+    skip(d, length)
+    None
+  } else {
+    val name = d.readUnsignedShort()
+    Some(c(name))
+  }
+}
+>>>
+val attributes =
+  for (_ ← 1 to count)
+    yield {
+      val tag = d.readUnsignedShort()
+      val length = d.readInt()
+      if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
+      if (tag != s) {
+        skip(d, length)
+        None
+      } else {
+        val name = d.readUnsignedShort()
+        Some(c(name))
+      }
+    }
+<<< 2.14 val with short for/yield
+maxColumn = 80
+===
+val attributes = for (i ← 1 to count)
+ yield i
+>>>
+val attributes =
+  for (i ← 1 to count)
+    yield i
+<<< 2.15 val with literal apply
+object a {
+   val a =
+    b(
+      0x1F, // ID1
+       0x8B, // ID2
+       8, // CM = Deflate
+       0, // FLG
+       0, // MTIME 1
+       0, // MTIME 2
+       0, // MTIME 3
+       0, // MTIME 4
+       0, // XFL
+       0 // OS
+    )
+ }
+>>>
+object a {
+  val a =
+    b(
+      0x1F, // ID1
+      0x8B, // ID2
+      8, // CM = Deflate
+      0, // FLG
+      0, // MTIME 1
+      0, // MTIME 2
+      0, // MTIME 3
+      0, // MTIME 4
+      0, // XFL
+      0 // OS
+    )
+}
+<<< 2.16 val with apply and comment
+danglingParentheses = false
+===
+val a =
+  Set(
+    "b" // ...
+  )
+>>>
+val a =
+  Set(
+    "b" // ...
+  )
+<<< 2.17 val with apply-apply-select
+val aaaaa = bbbbb.asss(as).ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+>>>
+val aaaaa = bbbbb
+  .asss(as)
+  .ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+<<< 2.18 val with apply-apply
+val aaaaa = (getSomeLongerFunction(c))(as)
+>>>
+val aaaaa =
+  (getSomeLongerFunction(c))(as)
+<<< 2.19 val with apply-select-select
+val aaaaa = bbbbb.asss.ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+>>>
+val aaaaa = bbbbb.asss.ccccc(
+  ddddd,
+  eeeee,
+  fffff
+) // comment
+<<< 2.20 val with apply-select-select
+val nested =
+  promiseIntercept(new Actor {
+    def receive = {
+      case _ ⇒
+    }
+  })(result)
+>>>
+val nested =
+  promiseIntercept(new Actor {
+    def receive = {
+      case _ ⇒
+    }
+  })(result)
+<<< 2.21 val with apply type
+  val deployment = system
+    .asInstanceOf[ActorSystemImpl]
+    .provider
+    .deployer
+    .lookup(service.split("/").drop(1))
+>>>
+val deployment = system
+  .asInstanceOf[ActorSystemImpl]
+  .provider
+  .deployer
+  .lookup(service.split("/").drop(1))

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -189,3 +189,382 @@ else if (b)
   b
 else
   c
+<<< 2.1: def one-line body
+def a = b
+>>>
+def a = b
+<<< 2.2: def one-line block body
+object a {
+def a = { b; c }
+}
+>>>
+object a {
+  def a = {
+    b;
+    c
+  }
+}
+<<< 2.3: def one-line block body with a break
+object a {
+def a =
+ { b; c }
+}
+>>>
+object a {
+  def a = {
+    b;
+    c
+  }
+}
+<<< 2.4: def multiline-line block body with a break
+object a {
+def a =
+ {
+  b;c }}
+>>>
+object a {
+  def a = {
+    b;
+    c
+  }
+}
+<<< 2.5: def multiline-line block body with a break
+object a {
+def a = {
+  b;c }
+}
+>>>
+object a {
+  def a = {
+    b;
+    c
+  }
+}
+<<< 2.6 #1747: one line with else
+maxColumn = 55
+===
+object a {
+  val ok1 = if (a > 10) Some(a) else None
+  val ok2 = if (a > 10) { Some(a) } else { None }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) } else { None }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+    else
+      None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  } else {
+    None
+  }
+}
+<<< 2.7 #1747: one line without else
+maxColumn = 40
+===
+object a {
+  val ok1 = if (a > 10) Some(a)
+  val ok2 = if (a > 10) { Some(a) }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+  val ok2 = if (a > 10) {
+    Some(a)
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  }
+}
+<<< 2.8 #1747: split on then with else
+maxColumn = 55
+===
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  else
+    None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+     Some(aaaa)
+  }
+  else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+    else
+      None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  } else {
+    None
+  }
+}
+<<< 2.9 #1747: split on else
+maxColumn = 55
+===
+object a {
+  val ok1 = if (a > 10) Some(a) else
+    None
+  val ok2 = if (a > 10) { Some(a) } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) { Some(aaaa) } else {
+    None
+  }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+    else
+      None
+  val ok2 = if (a > 10) {
+    Some(a)
+  } else {
+    None
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  } else {
+    None
+  }
+}
+<<< 2.10 #1747: split on then without else
+maxColumn = 40
+===
+object a {
+  val ok1 = if (a > 10)
+    Some(a)
+  val ok2 = if (a > 10) {
+    Some(a) }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+  val ok2 = if (a > 10) {
+    Some(a)
+  }
+  val ok3 = if (aaaa > 10000) {
+    Some(aaaa)
+  }
+}
+<<< 2.11 #1747: split on if
+maxColumn = 55
+===
+object a {
+  val ok1 =
+    if (a > 10) Some(a) else None
+  val ok2 =
+    if (a > 10) { Some(a) } else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) } else { None }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+    else
+      None
+  val ok2 =
+    if (a > 10) {
+      Some(a)
+    } else {
+      None
+    }
+  val ok3 =
+    if (aaaa > 10000) {
+      Some(aaaa)
+    } else {
+      None
+    }
+}
+<<< 2.12 #1747: split on if without else
+maxColumn = 40
+===
+object a {
+  val ok1 =
+    if (a > 10) Some(a)
+  val ok2 =
+    if (a > 10) { Some(a) }
+  val ok3 =
+   if (aaaa > 10000) { Some(aaaa) }
+}
+>>>
+object a {
+  val ok1 =
+    if (a > 10)
+      Some(a)
+  val ok2 =
+    if (a > 10) {
+      Some(a)
+    }
+  val ok3 =
+    if (aaaa > 10000) {
+      Some(aaaa)
+    }
+}
+<<< 2.13 val with for/yield
+maxColumn = 80
+===
+val attributes = for (_ ← 1 to count) yield {
+  val tag = d.readUnsignedShort()
+  val length = d.readInt()
+  if (debug) println(s"LNB:   tag ${c(tag)} ($length bytes)")
+  if (tag != s) {
+    skip(d, length)
+    None
+  } else {
+    val name = d.readUnsignedShort()
+    Some(c(name))
+  }
+}
+>>>
+val attributes =
+  for (_ ← 1 to count)
+    yield {
+      val tag = d.readUnsignedShort()
+      val length = d.readInt()
+      if (debug)
+        println(s"LNB:   tag ${c(tag)} ($length bytes)")
+      if (tag != s) {
+        skip(d, length)
+        None
+      } else {
+        val name = d.readUnsignedShort()
+        Some(c(name))
+      }
+    }
+<<< 2.14 val with short for/yield
+maxColumn = 80
+===
+val attributes =
+ for (i ← 1 to count)
+ yield i
+>>>
+val attributes =
+  for (i ← 1 to count)
+    yield i
+<<< 2.15 val with literal apply
+object a {
+   val a = b(0x1F, // ID1
+       0x8B, // ID2
+       8, // CM = Deflate
+       0, // FLG
+       0, // MTIME 1
+       0, // MTIME 2
+       0, // MTIME 3
+       0, // MTIME 4
+       0, // XFL
+       0 // OS
+    )
+ }
+>>>
+object a {
+  val a = b(0x1F, // ID1
+    0x8B, // ID2
+    8, // CM = Deflate
+    0, // FLG
+    0, // MTIME 1
+    0, // MTIME 2
+    0, // MTIME 3
+    0, // MTIME 4
+    0, // XFL
+    0 // OS
+    )
+}
+<<< 2.16 val with apply and comment
+danglingParentheses = false
+===
+val a = Set("b" // ...
+)
+>>>
+val a = Set("b" // ...
+)
+<<< 2.17 val with apply-apply-select
+val aaaaa = bbbbb.asss(as).ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+>>>
+val aaaaa = bbbbb
+  .asss(as)
+  .ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+<<< 2.18 val with apply-apply
+val aaaaa = (getSomeLongerFunction(c))(as)
+>>>
+val aaaaa =
+  (getSomeLongerFunction(c))(as)
+<<< 2.19 val with apply-select-select
+val aaaaa = bbbbb.asss.ccccc(
+    ddddd,
+    eeeee,
+    fffff
+  ) // comment
+>>>
+val aaaaa = bbbbb.asss.ccccc(
+  ddddd,
+  eeeee,
+  fffff
+) // comment
+<<< 2.20 val with apply-select-select
+val nested =
+  promiseIntercept(new Actor {
+    def receive = {
+      case _ ⇒
+    }
+  })(result)
+>>>
+val nested =
+  promiseIntercept(new Actor {
+    def receive = {
+      case _ ⇒
+    }
+  })(result)
+<<< 2.21 val with apply type
+  val deployment = system
+    .asInstanceOf[ActorSystemImpl]
+    .provider
+    .deployer
+    .lookup(service.split("/").drop(1))
+>>>
+val deployment = system
+  .asInstanceOf[ActorSystemImpl]
+  .provider
+  .deployer
+  .lookup(service.split("/").drop(1))

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -255,16 +255,18 @@ object a {
       Some(a)
     else
       None
-  val ok2 = if (a > 10) {
-    Some(a)
-  } else {
-    None
-  }
-  val ok3 = if (aaaa > 10000) {
-    Some(aaaa)
-  } else {
-    None
-  }
+  val ok2 =
+    if (a > 10) {
+      Some(a)
+    } else {
+      None
+    }
+  val ok3 =
+    if (aaaa > 10000) {
+      Some(aaaa)
+    } else {
+      None
+    }
 }
 <<< 2.7 #1747: one line without else
 maxColumn = 40
@@ -279,12 +281,14 @@ object a {
   val ok1 =
     if (a > 10)
       Some(a)
-  val ok2 = if (a > 10) {
-    Some(a)
-  }
-  val ok3 = if (aaaa > 10000) {
-    Some(aaaa)
-  }
+  val ok2 =
+    if (a > 10) {
+      Some(a)
+    }
+  val ok3 =
+    if (aaaa > 10000) {
+      Some(aaaa)
+    }
 }
 <<< 2.8 #1747: split on then with else
 maxColumn = 55
@@ -313,16 +317,18 @@ object a {
       Some(a)
     else
       None
-  val ok2 = if (a > 10) {
-    Some(a)
-  } else {
-    None
-  }
-  val ok3 = if (aaaa > 10000) {
-    Some(aaaa)
-  } else {
-    None
-  }
+  val ok2 =
+    if (a > 10) {
+      Some(a)
+    } else {
+      None
+    }
+  val ok3 =
+    if (aaaa > 10000) {
+      Some(aaaa)
+    } else {
+      None
+    }
 }
 <<< 2.9 #1747: split on else
 maxColumn = 55
@@ -344,16 +350,18 @@ object a {
       Some(a)
     else
       None
-  val ok2 = if (a > 10) {
-    Some(a)
-  } else {
-    None
-  }
-  val ok3 = if (aaaa > 10000) {
-    Some(aaaa)
-  } else {
-    None
-  }
+  val ok2 =
+    if (a > 10) {
+      Some(a)
+    } else {
+      None
+    }
+  val ok3 =
+    if (aaaa > 10000) {
+      Some(aaaa)
+    } else {
+      None
+    }
 }
 <<< 2.10 #1747: split on then without else
 maxColumn = 40
@@ -371,12 +379,14 @@ object a {
   val ok1 =
     if (a > 10)
       Some(a)
-  val ok2 = if (a > 10) {
-    Some(a)
-  }
-  val ok3 = if (aaaa > 10000) {
-    Some(aaaa)
-  }
+  val ok2 =
+    if (a > 10) {
+      Some(a)
+    }
+  val ok3 =
+    if (aaaa > 10000) {
+      Some(aaaa)
+    }
 }
 <<< 2.11 #1747: split on if
 maxColumn = 55
@@ -472,9 +482,7 @@ val attributes =
  for (i ← 1 to count)
  yield i
 >>>
-val attributes =
-  for (i ← 1 to count)
-    yield i
+val attributes = for (i ← 1 to count) yield i
 <<< 2.15 val with literal apply
 object a {
    val a = b(0x1F, // ID1

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -458,12 +458,13 @@ object a {
 }
 >>>
 object a {
-  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
-    case None =>
-      delegate.findAccountByAPIKey(apiKey) map {
-        _ map _ tap (add(apiKey, _)) unsafePerformIO
-      }
-  }
+  def findAccountByAPIKey(apiKey: APIKey) =
+    byKeyCache.get(apiKey) match {
+      case None =>
+        delegate.findAccountByAPIKey(apiKey) map {
+          _ map _ tap (add(apiKey, _)) unsafePerformIO
+        }
+    }
 }
 <<< #1633 1.3: func with placeholder and infix
 object a {
@@ -476,12 +477,13 @@ object a {
 }
 >>>
 object a {
-  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
-    case None =>
-      delegate.findAccountByAPIKey(apiKey) map {
-        _ map (_) tap (add(apiKey, _)) unsafePerformIO (foo)
-      }
-  }
+  def findAccountByAPIKey(apiKey: APIKey) =
+    byKeyCache.get(apiKey) match {
+      case None =>
+        delegate.findAccountByAPIKey(apiKey) map {
+          _ map (_) tap (add(apiKey, _)) unsafePerformIO (foo)
+        }
+    }
 }
 <<< #1633 1.4: func
 object a {
@@ -494,12 +496,13 @@ object a {
 }
 >>>
 object a {
-  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
-    case None =>
-      delegate.findAccountByAPIKey(apiKey) map { x =>
-        x._1 map x._2 tap (add(apiKey, _)) unsafePerformIO
-      }
-  }
+  def findAccountByAPIKey(apiKey: APIKey) =
+    byKeyCache.get(apiKey) match {
+      case None =>
+        delegate.findAccountByAPIKey(apiKey) map { x =>
+          x._1 map x._2 tap (add(apiKey, _)) unsafePerformIO
+        }
+    }
 }
 <<< #1633 1.5: partial func
 object a {
@@ -512,13 +515,14 @@ object a {
 }
 >>>
 object a {
-  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
-    case None =>
-      delegate.findAccountByAPIKey(apiKey) map {
-        case (x, y) =>
-          x map y tap (add(apiKey, _)) unsafePerformIO
-      }
-  }
+  def findAccountByAPIKey(apiKey: APIKey) =
+    byKeyCache.get(apiKey) match {
+      case None =>
+        delegate.findAccountByAPIKey(apiKey) map {
+          case (x, y) =>
+            x map y tap (add(apiKey, _)) unsafePerformIO
+        }
+    }
 }
 <<< #1633 2.1: function block in an if-statement
 object a {

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -211,10 +211,11 @@ def sourceMapper: js.UndefOr[js.Function1[ // scalastyle:ignore
     case _                         => th
    }
 >>>
-def unwrapJavaScriptException(th: Throwable): Any = th match {
-  case js.JavaScriptException(e) => e
-  case _                         => th
-}
+def unwrapJavaScriptException(th: Throwable): Any =
+  th match {
+    case js.JavaScriptException(e) => e
+    case _                         => th
+  }
 <<< no newline before { #305
 object RTCIceCandidateInit {
   @inline

--- a/scalafmt-tests/src/test/resources/unit/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/unit/DefDef.stat
@@ -84,9 +84,10 @@ def fill(points: Double) = x match {
 case ctx => 1
 }
 >>>
-def fill(points: Double) = x match {
-  case ctx => 1
-}
+def fill(points: Double) =
+  x match {
+    case ctx => 1
+  }
 <<< single line excluding last {} block
     def compare(): Int =
       if (startA == endA) {


### PR DESCRIPTION
Helps with #1627.

For fold/unfold cases, handle 'if' with/without braces consistently.

Also, use alwaysBeforeMultilineDef consistently for `def`; for some reason, it was not applied when def body ended in a closing `}` or used config-style parens.

`scala-repos` diffs:
* Router: use alwaysBeforeMultilineDef consistently: https://github.com/kitbellew/scala-repos/commit/21a7ff6cfbd0ef6faeb5e34f085feb75154f1e34?w=1
* Router: ignore line breaks in def/val assignments
  * _classic_: unchanged
  * _keep_: https://github.com/kitbellew/scala-repos/commit/c6f7305073e37113589c38f5abc5098f3273663e?w=1
  * _fold_: https://github.com/kitbellew/scala-repos/commit/4761e37e253bab868958ab62ccd92bbdc141989f?w=1
  * _unfold_: https://github.com/kitbellew/scala-repos/commit/459ab1872163c84013c8b0a8aecb703c8f1a3884?w=1
