### PR TITLE
Add script to test that a release succeeded

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eux
+
+version=$1
+
+coursier resolve \
+  org.scalameta:scalafmt-cli_2.13:$version \
+  org.scalameta:scalafmt-cli_2.12:$version \
+  org.scalameta:scalafmt-cli_2.11:$version


### PR DESCRIPTION
I think scalafmt-cli transitively brings in all the publishable
artifacts.  This kind of script is helpful just to sanity check that the
full cross-build released.