### PR TITLE
Align lines with different columns count

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -663,7 +663,7 @@ class FormatWriter(formatOps: FormatOps) {
     val units = Vector.newBuilder[AlignmentUnit]
     while (i < block.length) {
       val line = block(i)
-      if (line.lengthCompare(column) == 1) {
+      if (column < line.length) {
         val location = line(column)
         val previousWidth =
           if (column == 0) 0 else line(column - 1).shift

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -562,7 +562,7 @@ class FormatWriter(formatOps: FormatOps) {
     else {
       var columnShift = 0
       val finalResult = Map.newBuilder[TokenHash, Int]
-      var minMatches = Integer.MAX_VALUE
+      var maxMatches = Integer.MIN_VALUE
       var block = Vector.empty[Array[FormatLocation]]
       val locationIter = new Iterator[FormatLocation] {
         private val iter = locations.iterator
@@ -596,14 +596,14 @@ class FormatWriter(formatOps: FormatOps) {
         } else {
           val matches =
             columnsMatch(block.last, candidates, location.formatToken)
-          minMatches = Math
-            .min(minMatches, if (matches > 0) matches else block.head.length)
+          maxMatches = Math
+            .max(maxMatches, if (matches > 0) matches else block.head.length)
           if (matches > 0) {
             block = block :+ candidates
           }
           if (matches == 0 || doubleNewline || !locationIter.hasNext) {
             var column = 0
-            val columns = minMatches
+            val columns = maxMatches
 
             /**
               * Separator length gap needed to align blocks with different token
@@ -646,7 +646,7 @@ class FormatWriter(formatOps: FormatOps) {
             } else {
               block = Vector(candidates)
             }
-            minMatches = Integer.MAX_VALUE
+            maxMatches = Integer.MIN_VALUE
           }
         }
       }
@@ -658,9 +658,12 @@ class FormatWriter(formatOps: FormatOps) {
       block: Vector[Array[FormatLocation]],
       separatorLengthGaps: Array[Int],
       column: Int
-  ): Vector[AlignmentUnit] =
-    block.zipWithIndex.map {
-      case (line, i) =>
+  ): Vector[AlignmentUnit] = {
+    var i = 0
+    val units = Vector.newBuilder[AlignmentUnit]
+    while (i < block.length) {
+      val line = block(i)
+      if (line.lengthCompare(column) == 1) {
         val location = line(column)
         val previousWidth =
           if (column == 0) 0 else line(column - 1).shift
@@ -668,13 +671,18 @@ class FormatWriter(formatOps: FormatOps) {
         val separatorLength =
           if (location.formatToken.right.is[Token.Comment]) 0
           else location.formatToken.right.syntax.length
-        AlignmentUnit(
+        units += AlignmentUnit(
           key,
           hash(location.formatToken.left),
           separatorLength,
           i
         )
+      }
+      i += 1
     }
+
+    units.result()
+  }
 
 }
 

--- a/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
+++ b/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
@@ -69,3 +69,15 @@ libraryDependencies ++= Seq(
   "com.geirsson1111111" %%% "metaconfig-core" % metaconfigV,
   "org.scalacheck"       %% "scalacheck"      % scalacheckV
 )
+<<< align all blocks
+libraryDependencies ++= Seq(
+"io.get-coursier" % "interface" %% "0.0.17",
+"com.geirsson1111111" %%% "metaconfig-core" % metaconfigV % Test,
+"org.scalacheck" %% "scalacheck" % sclacheckV % Test
+)
+>>>
+libraryDependencies ++= Seq(
+  "io.get-coursier"       % "interface"      %% "0.0.17",
+  "com.geirsson1111111" %%% "metaconfig-core" % metaconfigV % Test,
+  "org.scalacheck"       %% "scalacheck"      % sclacheckV  % Test
+)

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -212,9 +212,9 @@ def f[A](x: A)(f: A => Int) =
      )
 >>>
 libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value % "test",
+  "org.scala-lang" % "scala-reflect"   % scalaVersion.value % "test",
   "org.scala-lang" % "scala-compiler",
-  "ch.qos.logback" % "logback-classic" % "1.1.6" % "test"
+  "ch.qos.logback" % "logback-classic" % "1.1.6"            % "test"
 )
 <<< 2x newline is respected
 class A {


### PR DESCRIPTION
Fixes #1783 

TL;DR

```scala
//before
libraryDependencies ++= Seq(
  "a"   % "x" %% "1",
  "b" %%% "y"  % "2.2.2.2" % Test,
  "c"  %% "z"  % "3" % Test
)
//after
libraryDependencies ++= Seq(
  "a"   % "x" %% "1",
  "b" %%% "y"  % "2.2.2.2" % Test,
  "c"  %% "z"  % "3"       % Test
)