### PR TITLE
#1627 [07]: FormatOps: ignore line breaks in rhsOptimalToken

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -210,8 +210,12 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       start: FormatToken
   )(implicit style: ScalafmtConfig): Token = {
     val found = start.right match {
-      case T.Comma() | T.LeftParen() | T.RightParen() | T.RightBracket() |
-          T.Semicolon() | T.RightArrow() | T.Equals()
+      case _: T.RightParen
+          if start.left.is[T.RightParen] || start.left.is[T.LeftParen] =>
+        None
+      case _: T.RightBracket if start.left.is[T.RightBracket] => None
+      case _: T.Comma | _: T.LeftParen | _: T.Semicolon | _: T.RightArrow |
+          _: T.Equals
           if start.noBreak &&
             (style.activeForEdition_2020_03 && isInfixRhs(start) ||
               !startsNewBlockOnRight(start)) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -631,10 +631,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
     // we don't modify line breaks generally around infix expressions
     // TODO: if that ever changes, modify how rewrite rules handle infix
-    val modification = newlines2Modification(
-      formatToken.newlinesBetween,
-      isNoIndent(formatToken)
-    )
+    val modification = getModCheckIndent(formatToken)
     val isNewline = modification.isNewline
     val indent = infixIndent(owner, op, rhsArgs, formatToken, isNewline)
     val split =
@@ -1061,7 +1058,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   // Returns leading comment, if there exists one, otherwise formatToken.right
   @tailrec
   final def leadingComment(formatToken: FormatToken): Token = {
-    if (formatToken.newlinesBetween <= 1 && formatToken.left.is[T.Comment])
+    if (!formatToken.hasBlankLine && formatToken.left.is[T.Comment])
       leadingComment(prev(formatToken))
     else formatToken.right
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -210,15 +210,15 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       start: FormatToken
   )(implicit style: ScalafmtConfig): Token = {
     val found = start.right match {
+      case _ if start.hasBlankLine => Some(start.left)
       case _: T.RightParen
           if start.left.is[T.RightParen] || start.left.is[T.LeftParen] =>
         None
       case _: T.RightBracket if start.left.is[T.RightBracket] => None
       case _: T.Comma | _: T.LeftParen | _: T.Semicolon | _: T.RightArrow |
           _: T.Equals
-          if start.noBreak &&
-            (style.activeForEdition_2020_03 && isInfixRhs(start) ||
-              !startsNewBlockOnRight(start)) =>
+          if (style.activeForEdition_2020_03 && isInfixRhs(start) ||
+            !startsNewBlockOnRight(start)) =>
         None
       case c: T.Comment
           if style.activeForEdition_2020_01 && start.noBreak &&

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -27,8 +27,9 @@ case class FormatToken(left: Token, right: Token, meta: FormatToken.Meta) {
 
   def between = meta.between
   lazy val newlinesBetween: Int = meta.between.count(_.is[Token.LF])
-  @inline def noBreak: Boolean = newlinesBetween == 0
+  @inline def noBreak: Boolean = FormatToken.noBreak(newlinesBetween)
   @inline def hasBreak: Boolean = newlinesBetween != 0
+  @inline def hasBlankLine: Boolean = FormatToken.hasBlankLine(newlinesBetween)
 
   val leftHasNewline = left.syntax.contains('\n')
 
@@ -39,6 +40,9 @@ case class FormatToken(left: Token, right: Token, meta: FormatToken.Meta) {
 }
 
 object FormatToken {
+
+  @inline def noBreak(newlines: Int): Boolean = newlines == 0
+  @inline def hasBlankLine(newlines: Int): Boolean = newlines > 1
 
   /**
     * @param between The whitespace tokens between left and right.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -184,7 +184,7 @@ class Router(formatOps: FormatOps) {
             newlines > 0 &&
             selfAnnotation.nonEmpty
         val nl: Modification =
-          if (isSelfAnnotation) newlines2Modification(newlines, isNoIndent(tok))
+          if (isSelfAnnotation) getModCheckIndent(formatToken)
           else NewlineT(shouldGet2xNewlines(tok))
 
         val (lambdaExpire, lambdaArrow, lambdaIndent) =
@@ -419,7 +419,7 @@ class Router(formatOps: FormatOps) {
         val annoLeft = isSingleIdentifierAnnotation(prev(tok))
 
         if ((annoRight || annoLeft) && style.optIn.annotationNewlines)
-          Seq(Split(newlines2Modification(newlines), 0))
+          Seq(Split(getMod(formatToken), 0))
         else {
           val spaceCouldBeOk = annoLeft &&
             newlines == 0 && right.is[Keyword]
@@ -436,7 +436,7 @@ class Router(formatOps: FormatOps) {
       case FormatToken(_, T.RightBrace(), _) =>
         Seq(
           Split(xmlSpace(rightOwner), 0),
-          Split(NewlineT(isDouble = newlines > 1), 0)
+          Split(NewlineT(isDouble = formatToken.hasBlankLine), 0)
         )
       case FormatToken(left @ T.KwPackage(), _, _) if leftOwner.is[Pkg] =>
         Seq(
@@ -609,7 +609,7 @@ class Router(formatOps: FormatOps) {
             case _ => noSplitPenalizeNewlines
           }
           val noSplitModification =
-            if (right.is[T.Comment]) newlines2Modification(newlines)
+            if (right.is[T.Comment]) getMod(formatToken)
             else NoSplit
 
           Seq(
@@ -1398,12 +1398,12 @@ class Router(formatOps: FormatOps) {
         )
       // Inline comment
       case FormatToken(_, c: T.Comment, _) =>
-        Seq(Split(newlines2Modification(newlines), 0))
+        Seq(Split(getMod(formatToken), 0))
       // Commented out code should stay to the left
       case FormatToken(c: T.Comment, _, _) if isSingleLineComment(c) =>
         Seq(Split(Newline, 0))
       case FormatToken(c: T.Comment, _, _) =>
-        Seq(Split(newlines2Modification(newlines), 0))
+        Seq(Split(getMod(formatToken), 0))
 
       case FormatToken(_: T.KwImplicit, _, _)
           if style.activeForEdition_2020_03 &&
@@ -1423,7 +1423,7 @@ class Router(formatOps: FormatOps) {
       case opt
           if style.optIn.annotationNewlines &&
             optionalNewlines(hash(opt.right)) =>
-        Seq(Split(newlines2Modification(newlines), 0))
+        Seq(Split(getMod(formatToken), 0))
 
       // Pat
       case tok @ FormatToken(T.Ident("|"), _, _)

--- a/scalafmt-core/shared/src/test/scala/org/scalafmt/ScalafmtTest.scala
+++ b/scalafmt-core/shared/src/test/scala/org/scalafmt/ScalafmtTest.scala
@@ -24,6 +24,7 @@ class ScalafmtTest extends AnyFunSuite {
       |// comment
       """.stripMargin,
     """|object A { println("HELLO!") }
+       |
        |// comment
        |""".stripMargin
   )

--- a/scalafmt-tests/src/test/resources/default/Val.stat
+++ b/scalafmt-tests/src/test/resources/default/Val.stat
@@ -252,4 +252,63 @@ val component = // ← look, you can even use fancy names!
       (RewriteCtx[ScalafixMirror]) => Seq[Patch]) => Rewrite[ScalafixMirror] =
     Rewrite.apply[ScalafixMirror]
 }
-
+<<< apply with optimal token inside
+val currentName = currentNameOption | info.hasSimul
+  .fold(
+    Playing,
+    if (!info.user.hasGames && info.nbImported > 0) Imported else All
+  )
+  .name
+>>>
+val currentName = currentNameOption | info.hasSimul
+  .fold(
+      Playing,
+      if (!info.user.hasGames && info.nbImported > 0) Imported else All
+  )
+  .name
+<<< apply with optimal token inside, and comment
+val currentName = currentNameOption | info.hasSimul
+  .fold(
+    Playing,
+    if (!info.user.hasGames && info.nbImported > 0) Imported else All // c1
+  )
+  .name
+>>>
+val currentName = currentNameOption | info.hasSimul
+  .fold(
+      Playing,
+      if (!info.user.hasGames && info.nbImported > 0) Imported else All // c1
+  )
+  .name
+<<< apply with optimal token inside, no dangle
+danglingParentheses = false
+===
+val currentName = currentNameOption | info.hasSimul
+  .fold(
+    Playing,
+    if (!info.user.hasGames && info.nbImported > 0) Imported else All
+  )
+  .name
+>>>
+val currentName = currentNameOption | info.hasSimul
+  .fold(
+      Playing,
+      if (!info.user.hasGames && info.nbImported > 0) Imported else All
+  )
+  .name
+<<< apply with optimal token inside, and comment, no dangle
+danglingParentheses = false
+===
+val currentName = currentNameOption | info.hasSimul
+  .fold(
+    Playing,
+    if (!info.user.hasGames && info.nbImported > 0) Imported else All // c1
+  )
+  .name
+>>>
+val currentName = currentNameOption | info.hasSimul
+  .fold(
+      Playing,
+      if (!info.user.hasGames && info.nbImported > 0) Imported else All // c1
+  )
+  .name

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -966,8 +966,7 @@ case class AttributeInfo(
     typeRef: Type,
     value: Option[Any],
     values: Seq[
-      String ~ Any
-    ]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
+      String ~ Any]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
 <<< 3.29 apply with optimal token
 maxColumn = 80
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -887,8 +887,7 @@ case class AttributeInfo(
     typeRef: Type,
     value: Option[Any],
     values: Seq[
-      String ~ Any
-    ]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
+      String ~ Any]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
 <<< 3.29 apply with optimal token
 maxColumn = 80
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -917,8 +917,7 @@ case class AttributeInfo(
     typeRef: Type,
     value: Option[Any],
     values: Seq[
-      String ~ Any
-    ]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
+      String ~ Any]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
 <<< 3.29 apply with optimal token
 maxColumn = 80
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1027,8 +1027,7 @@ case class AttributeInfo(
     typeRef: Type,
     value: Option[Any],
     values: Seq[
-      String ~ Any
-    ]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
+      String ~ Any]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
 <<< 3.29 apply with optimal token
 maxColumn = 80
 ===


### PR DESCRIPTION
Actually, line breaks are already ignored in `rhsOptimalToken` except for a couple of bugs:

* TokenOps bugfix: correctly identify a blank line: https://github.com/kitbellew/scala-repos/commit/b89051f7094a0117560431af751b56f9e4faee79
* FormatOps bugfix: relax ")}" in rhsOptimalToken: https://github.com/kitbellew/scala-repos/commit/1e75fbecd3f8e91807aa188956c3a71936a991a2

Helps with #1627.