### PR TITLE
GraalVM Native Image fix

### DIFF
--- a/bin/install-scalafmt-native.sh
+++ b/bin/install-scalafmt-native.sh
@@ -16,7 +16,7 @@ cd $TMP
 ZIP=$NAME.zip
 curl --fail -Lo $ZIP https://github.com/scalameta/scalafmt/releases/download/$VERSION/$ZIP
 unzip $ZIP
-cp $NAME/scalafmt $INSTALL_LOCATION
+cp scalafmt $INSTALL_LOCATION
 chmod +x $INSTALL_LOCATION
 
 cd $CWD

--- a/docs/contributing-scalafmt.md
+++ b/docs/contributing-scalafmt.md
@@ -44,7 +44,7 @@ Please always include concrete code examples with obtained and expected output.
 
 - Write release notes here: https://github.com/scalameta/scalafmt/releases/new
 - Pushing a git tag should trigger a release to Maven Central from the CI.
-- Once CI has finished releasing, update sbt-scalafmt to the latest release.
+- Attach GraalVM Native Images to GitHub release
 - Update the changelog on the website with the following command (assuming you
   have `docker` installed)
 


### PR DESCRIPTION
Helps with https://github.com/scalameta/scalafmt/issues/1769#issuecomment-599266171
Native Images were broken after 2.3.3 release.

We have GraalVM **build** on CI, but images can fail at runtime. And GraalVM is not completely stable technology, so builds _will_ be broken time to time. Any ideas how to test it?

