### PR TITLE
#1627 [08]: Router: ignore line breaks in annotations

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
@@ -44,6 +44,16 @@ import metaconfig.generic.Surface
   *     foo.map(_ + 1).filter( > 2)
   *   }}}
   *
+  * @param annotationNewlines
+  *   - if newlines.source is missing or keep:
+  *     - if true, will keep existing line breaks around annotations
+  *   - if newlines.source is fold:
+  *     - if true, will break before the entity being annotatated
+  *     - will not force break between consecutive annotations
+  *   - if newlines.source is unfold:
+  *     - if true, will break between consecutive annotations
+  *     - will always break before the entity being annotatated
+  *
   * @param selfAnnotationNewline See https://github.com/scalameta/scalafmt/issues/938
   *                              If true, will force a line break before a self annotation
   *                              if there was a line break there before.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -180,11 +180,12 @@ class Router(formatOps: FormatOps) {
           case _ => None
         }
         val isSelfAnnotation =
-          style.optIn.selfAnnotationNewline &&
-            newlines > 0 &&
-            selfAnnotation.nonEmpty
+          style.optIn.selfAnnotationNewline && selfAnnotation.nonEmpty && (
+            formatToken.hasBreak || style.newlines.sourceIgnored
+          )
         val nl: Modification =
-          if (isSelfAnnotation) getModCheckIndent(formatToken)
+          if (isSelfAnnotation)
+            getModCheckIndent(formatToken, math.max(newlines, 1))
           else NewlineT(shouldGet2xNewlines(tok))
 
         val (lambdaExpire, lambdaArrow, lambdaIndent) =

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1010,3 +1010,303 @@ object foo {
     c = d
   )
 }
+<<< 4.1: annotation with newlines
+maxColumn = 50
+optIn.annotationNewlines = true
+===
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated private implicit val x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot @deprecated class B(
+      @annot @deprecated private implicit val x: Int
+  ) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = { 1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(
+        @annot @deprecated x: Int
+    ) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(
+      value = "foo",
+      someInt = 5
+    ) @annot3
+    @deprecated(value = "bar") def bar2 = 1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< 4.2: annotation without newlines
+maxColumn = 50
+optIn.annotationNewlines = false
+===
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated private implicit val x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot
+  @deprecated
+  class B(
+      @annot @deprecated private implicit val x: Int
+  ) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = { 1 }
+
+    @annot
+    @annot2
+    @annot3
+    @annot4 /*comment4*/
+    @annot5
+    @deprecated
+    def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot
+    @annot2(value = "foo", someInt = 5)
+    @annot3
+    @deprecated(value = "bar") def bar2 = 1
+  }
+
+  @annot
+  @annot2
+  @annot3
+  @annot4
+  @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< 4.3: #938 flag false, newline no
+optIn.selfAnnotationNewline = false
+maxColumn = 20
+===
+trait a { self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.4: #938 flag true, newline no
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a { self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.5: #938 flag false, newline yes
+optIn.selfAnnotationNewline = false
+maxColumn = 20
+===
+trait a {
+  self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.6: #938 flag true, newline yes
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a {
+ self =>
+    blah
+}
+>>>
+trait a {
+  self =>
+  blah
+}
+<<< 4.7: #938 flag true, newline no, line too long
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a { selfaaaaaaaaaaaaaaaa =>
+    blah
+}
+>>>
+trait a {
+  selfaaaaaaaaaaaaaaaa =>
+  blah
+}
+<<< 4.8 flag true, annot in param
+optIn.annotationNewlines = true
+===
+@ foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+ object
+  a  extends b with c {
+
+   def
+   foo[T: Int#Double#Triple,
+       R <% String](
+    @annot1
+    x
+    : Int @annot2 = 2
+    , y: Int = 3): Int = {
+    "match" match {
+      case 1 | 2 =>   3
+      case <A>2</A> => 2
+    }
+   }
+}
+>>>
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1
+      x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 => 3
+      case <A>2</A> => 2
+    }
+  }
+}
+<<< 4.9 flag false, annot in param
+optIn.annotationNewlines = false
+===
+@ foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+ object
+  a  extends b with c {
+
+   def
+   foo[T: Int#Double#Triple,
+       R <% String](
+    @annot1
+    x
+    : Int @annot2 = 2
+    , y: Int = 3): Int = {
+    "match" match {
+      case 1 | 2 =>   3
+      case <A>2</A> => 2
+    }
+   }
+}
+>>>
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1 x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 => 3
+      case <A>2</A> => 2
+    }
+  }
+}
+<<< 4.10
+maxColumn = 80
+===
+class Engine[TD, EI, PD, Q, P, A](
+    val dataSourceClassMap: Map[String, Class[
+      _ <: BaseDataSource[TD, EI, Q, A]]],
+     val preparatorClassMap: Map[String, Class[_ <: BasePreparator[TD, PD]]],
+     val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
+     val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]])
+     extends BaseEngine[EI, Q, P, A]
+>>>
+class Engine[TD, EI, PD, Q, P, A](
+    val dataSourceClassMap: Map[String, Class[
+      _ <: BaseDataSource[TD, EI, Q, A]
+    ]],
+    val preparatorClassMap: Map[String, Class[_ <: BasePreparator[TD, PD]]],
+    val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
+    val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]]
+) extends BaseEngine[EI, Q, P, A]

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -960,33 +960,35 @@ object WrapperToHaveStatTestCaseParserWorking {
 }
 >>>
 object WrapperToHaveStatTestCaseParserWorking {
-  @annot @deprecated class B(
-      @annot @deprecated private implicit val x: Int
+  @annot @deprecated
+  class B(
+      @annot @deprecated
+      private implicit val x: Int
   ) extends A {
-    @annot override def foo = 1
+    @annot
+    override def foo = 1
 
     @annot
     override def bar = { 1 }
 
-    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(
-        @annot @deprecated x: Int
+    @annot @annot2 @annot3 @annot4 /*comment4*/
+    @annot5 @deprecated
+    def foo2(
+        @annot @deprecated
+        x: Int
     ) = 1
 
     // in case of annotations with params located in many lines
     // let's live with changed lines of params
-    @annot @annot2(
-      value = "foo",
-      someInt = 5
-    ) @annot3
-    @deprecated(value = "bar") def bar2 = 1
+    @annot @annot2(value = "foo", someInt = 5)
+    @annot3 @deprecated(value = "bar")
+    def bar2 = 1
   }
 
-  @annot @annot2
-  @annot3
-  @annot4 @deprecated class C
+  @annot @annot2 @annot3 @annot4 @deprecated
+  class C
 
-  @annot
-  @deprecated
+  @annot @deprecated
   class D
 }
 <<< 4.2: annotation without newlines
@@ -1020,41 +1022,30 @@ object WrapperToHaveStatTestCaseParserWorking {
 }
 >>>
 object WrapperToHaveStatTestCaseParserWorking {
-  @annot
-  @deprecated
+  @annot @deprecated
   class B(
-      @annot @deprecated private implicit val x: Int
+      @annot @deprecated
+      private implicit val x: Int
   ) extends A {
     @annot override def foo = 1
 
-    @annot
-    override def bar = { 1 }
+    @annot override def bar = { 1 }
 
-    @annot
-    @annot2
-    @annot3
-    @annot4 /*comment4*/
-    @annot5
-    @deprecated
+    @annot @annot2 @annot3 @annot4 /*comment4*/
+    @annot5 @deprecated
     def foo2(@annot @deprecated x: Int) = 1
 
     // in case of annotations with params located in many lines
     // let's live with changed lines of params
-    @annot
-    @annot2(value = "foo", someInt = 5)
-    @annot3
-    @deprecated(value = "bar") def bar2 = 1
+    @annot @annot2(value = "foo", someInt = 5)
+    @annot3 @deprecated(value = "bar") def bar2 =
+      1
   }
 
-  @annot
-  @annot2
-  @annot3
-  @annot4
-  @deprecated class C
+  @annot @annot2 @annot3 @annot4 @deprecated
+  class C
 
-  @annot
-  @deprecated
-  class D
+  @annot @deprecated class D
 }
 <<< 4.3: #938 flag false, newline no
 optIn.selfAnnotationNewline = false
@@ -1194,8 +1185,7 @@ optIn.annotationNewlines = false
     val y = 2 // y=2
     x + y
   }
-)
-object a extends b with c {
+) object a extends b with c {
 
   def foo[
       T: Int#Double#Triple,

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -929,3 +929,303 @@ object foo {
   val a = b(c = d)
   val a = b(c = d)
 }
+<<< 4.1: annotation with newlines
+maxColumn = 50
+optIn.annotationNewlines = true
+===
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated private implicit val x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot @deprecated class B(
+      @annot @deprecated private implicit val x: Int
+  ) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = { 1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(
+        @annot @deprecated x: Int
+    ) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(
+      value = "foo",
+      someInt = 5
+    ) @annot3
+    @deprecated(value = "bar") def bar2 = 1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< 4.2: annotation without newlines
+maxColumn = 50
+optIn.annotationNewlines = false
+===
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated private implicit val x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot
+  @deprecated
+  class B(
+      @annot @deprecated private implicit val x: Int
+  ) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = { 1 }
+
+    @annot
+    @annot2
+    @annot3
+    @annot4 /*comment4*/
+    @annot5
+    @deprecated
+    def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot
+    @annot2(value = "foo", someInt = 5)
+    @annot3
+    @deprecated(value = "bar") def bar2 = 1
+  }
+
+  @annot
+  @annot2
+  @annot3
+  @annot4
+  @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< 4.3: #938 flag false, newline no
+optIn.selfAnnotationNewline = false
+maxColumn = 20
+===
+trait a { self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.4: #938 flag true, newline no
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a { self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.5: #938 flag false, newline yes
+optIn.selfAnnotationNewline = false
+maxColumn = 20
+===
+trait a {
+  self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.6: #938 flag true, newline yes
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a {
+ self =>
+    blah
+}
+>>>
+trait a {
+  self =>
+  blah
+}
+<<< 4.7: #938 flag true, newline no, line too long
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a { selfaaaaaaaaaaaaaaaa =>
+    blah
+}
+>>>
+trait a {
+  selfaaaaaaaaaaaaaaaa =>
+  blah
+}
+<<< 4.8 flag true, annot in param
+optIn.annotationNewlines = true
+===
+@ foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+ object
+  a  extends b with c {
+
+   def
+   foo[T: Int#Double#Triple,
+       R <% String](
+    @annot1
+    x
+    : Int @annot2 = 2
+    , y: Int = 3): Int = {
+    "match" match {
+      case 1 | 2 =>   3
+      case <A>2</A> => 2
+    }
+   }
+}
+>>>
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1
+      x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 => 3
+      case <A>2</A> => 2
+    }
+  }
+}
+<<< 4.9 flag false, annot in param
+optIn.annotationNewlines = false
+===
+@ foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+ object
+  a  extends b with c {
+
+   def
+   foo[T: Int#Double#Triple,
+       R <% String](
+    @annot1
+    x
+    : Int @annot2 = 2
+    , y: Int = 3): Int = {
+    "match" match {
+      case 1 | 2 =>   3
+      case <A>2</A> => 2
+    }
+   }
+}
+>>>
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1 x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 => 3
+      case <A>2</A> => 2
+    }
+  }
+}
+<<< 4.10
+maxColumn = 80
+===
+class Engine[TD, EI, PD, Q, P, A](
+    val dataSourceClassMap: Map[String, Class[
+      _ <: BaseDataSource[TD, EI, Q, A]]],
+     val preparatorClassMap: Map[String, Class[_ <: BasePreparator[TD, PD]]],
+     val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
+     val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]])
+     extends BaseEngine[EI, Q, P, A]
+>>>
+class Engine[TD, EI, PD, Q, P, A](
+    val dataSourceClassMap: Map[String, Class[
+      _ <: BaseDataSource[TD, EI, Q, A]
+    ]],
+    val preparatorClassMap: Map[String, Class[_ <: BasePreparator[TD, PD]]],
+    val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
+    val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]]
+) extends BaseEngine[EI, Q, P, A]

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1066,7 +1066,8 @@ trait a { self =>
     blah
 }
 >>>
-trait a { self =>
+trait a {
+  self =>
   blah
 }
 <<< 4.5: #938 flag false, newline yes

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -963,3 +963,315 @@ object foo {
     c = d
   )
 }
+<<< 4.1: annotation with newlines
+maxColumn = 50
+optIn.annotationNewlines = true
+===
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated private implicit val x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot @deprecated class B(
+      @annot @deprecated private implicit val x: Int
+  ) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = { 1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(
+        @annot @deprecated x: Int
+    ) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(
+      value =
+        "foo",
+      someInt = 5
+    ) @annot3
+    @deprecated(
+      value =
+        "bar"
+    ) def bar2 = 1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< 4.2: annotation without newlines
+maxColumn = 50
+optIn.annotationNewlines = false
+===
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated private implicit val x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot
+  @deprecated
+  class B(
+      @annot @deprecated private implicit val x: Int
+  ) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = { 1 }
+
+    @annot
+    @annot2
+    @annot3
+    @annot4 /*comment4*/
+    @annot5
+    @deprecated
+    def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot
+    @annot2(
+      value =
+        "foo",
+      someInt = 5
+    )
+    @annot3
+    @deprecated(
+      value =
+        "bar"
+    ) def bar2 = 1
+  }
+
+  @annot
+  @annot2
+  @annot3
+  @annot4
+  @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< 4.3: #938 flag false, newline no
+optIn.selfAnnotationNewline = false
+maxColumn = 20
+===
+trait a { self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.4: #938 flag true, newline no
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a { self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.5: #938 flag false, newline yes
+optIn.selfAnnotationNewline = false
+maxColumn = 20
+===
+trait a {
+  self =>
+    blah
+}
+>>>
+trait a {
+  self =>
+  blah
+}
+<<< 4.6: #938 flag true, newline yes
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a {
+ self =>
+    blah
+}
+>>>
+trait a {
+  self =>
+  blah
+}
+<<< 4.7: #938 flag true, newline no, line too long
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a { selfaaaaaaaaaaaaaaaa =>
+    blah
+}
+>>>
+trait a {
+  selfaaaaaaaaaaaaaaaa =>
+  blah
+}
+<<< 4.8 flag true, annot in param
+optIn.annotationNewlines = true
+===
+@ foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+ object
+  a  extends b with c {
+
+   def
+   foo[T: Int#Double#Triple,
+       R <% String](
+    @annot1
+    x
+    : Int @annot2 = 2
+    , y: Int = 3): Int = {
+    "match" match {
+      case 1 | 2 =>   3
+      case <A>2</A> => 2
+    }
+   }
+}
+>>>
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1
+      x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 => 3
+      case <A>2</A> => 2
+    }
+  }
+}
+<<< 4.9 flag false, annot in param
+optIn.annotationNewlines = false
+===
+@ foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+ object
+  a  extends b with c {
+
+   def
+   foo[T: Int#Double#Triple,
+       R <% String](
+    @annot1
+    x
+    : Int @annot2 = 2
+    , y: Int = 3): Int = {
+    "match" match {
+      case 1 | 2 =>   3
+      case <A>2</A> => 2
+    }
+   }
+}
+>>>
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1 x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 => 3
+      case <A>2</A> => 2
+    }
+  }
+}
+<<< 4.10
+maxColumn = 80
+===
+class Engine[TD, EI, PD, Q, P, A](
+    val dataSourceClassMap: Map[String, Class[
+      _ <: BaseDataSource[TD, EI, Q, A]]],
+     val preparatorClassMap: Map[String, Class[_ <: BasePreparator[TD, PD]]],
+     val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
+     val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]])
+     extends BaseEngine[EI, Q, P, A]
+>>>
+class Engine[TD, EI, PD, Q, P, A](
+    val dataSourceClassMap: Map[String, Class[
+      _ <: BaseDataSource[TD, EI, Q, A]
+    ]],
+    val preparatorClassMap: Map[String, Class[_ <: BasePreparator[TD, PD]]],
+    val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
+    val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]]
+) extends BaseEngine[EI, Q, P, A]

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1100,32 +1100,48 @@ object WrapperToHaveStatTestCaseParserWorking {
 }
 >>>
 object WrapperToHaveStatTestCaseParserWorking {
-  @annot @deprecated class B(
-      @annot @deprecated private implicit val x: Int
+  @annot
+  @deprecated
+  class B(
+      @annot
+      @deprecated
+      private implicit val x: Int
   ) extends A {
-    @annot override def foo = 1
+    @annot
+    override def foo = 1
 
     @annot
     override def bar = {
       1
     }
 
-    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(
-        @annot @deprecated x: Int
+    @annot
+    @annot2
+    @annot3
+    @annot4 /*comment4*/
+    @annot5
+    @deprecated
+    def foo2(
+        @annot
+        @deprecated
+        x: Int
     ) = 1
 
     // in case of annotations with params located in many lines
     // let's live with changed lines of params
-    @annot @annot2(
-      value = "foo",
-      someInt = 5
-    ) @annot3
-    @deprecated(value = "bar") def bar2 = 1
+    @annot
+    @annot2(value = "foo", someInt = 5)
+    @annot3
+    @deprecated(value = "bar")
+    def bar2 = 1
   }
 
-  @annot @annot2
+  @annot
+  @annot2
   @annot3
-  @annot4 @deprecated class C
+  @annot4
+  @deprecated
+  class C
 
   @annot
   @deprecated
@@ -1162,42 +1178,37 @@ object WrapperToHaveStatTestCaseParserWorking {
 }
 >>>
 object WrapperToHaveStatTestCaseParserWorking {
-  @annot
-  @deprecated
+  @annot @deprecated
   class B(
-      @annot @deprecated private implicit val x: Int
+      @annot @deprecated
+      private implicit val x: Int
   ) extends A {
-    @annot override def foo = 1
+    @annot
+    override def foo = 1
 
     @annot
     override def bar = {
       1
     }
 
-    @annot
-    @annot2
-    @annot3
-    @annot4 /*comment4*/
-    @annot5
-    @deprecated
-    def foo2(@annot @deprecated x: Int) = 1
+    @annot @annot2 @annot3 @annot4 /*comment4*/
+    @annot5 @deprecated
+    def foo2(
+        @annot @deprecated
+        x: Int
+    ) = 1
 
     // in case of annotations with params located in many lines
     // let's live with changed lines of params
-    @annot
-    @annot2(value = "foo", someInt = 5)
-    @annot3
-    @deprecated(value = "bar") def bar2 = 1
+    @annot @annot2(value = "foo", someInt = 5)
+    @annot3 @deprecated(value = "bar")
+    def bar2 = 1
   }
 
-  @annot
-  @annot2
-  @annot3
-  @annot4
-  @deprecated class C
+  @annot @annot2 @annot3 @annot4 @deprecated
+  class C
 
-  @annot
-  @deprecated
+  @annot @deprecated
   class D
 }
 <<< 4.3: #938 flag false, newline no
@@ -1345,7 +1356,8 @@ object a extends b with c {
       T: Int#Double#Triple,
       R <% String
   ](
-      @annot1 x: Int @annot2 = 2,
+      @annot1
+      x: Int @annot2 = 2,
       y: Int = 3
   ): Int = {
     "match" match {

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1230,7 +1230,8 @@ trait a { self =>
     blah
 }
 >>>
-trait a { self =>
+trait a {
+  self =>
   blah
 }
 <<< 4.5: #938 flag false, newline yes

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1069,3 +1069,307 @@ object foo {
   val a = b(c = d)
   val a = b(c = d)
 }
+<<< 4.1: annotation with newlines
+maxColumn = 50
+optIn.annotationNewlines = true
+===
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated private implicit val x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot @deprecated class B(
+      @annot @deprecated private implicit val x: Int
+  ) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {
+      1
+    }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(
+        @annot @deprecated x: Int
+    ) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(
+      value = "foo",
+      someInt = 5
+    ) @annot3
+    @deprecated(value = "bar") def bar2 = 1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< 4.2: annotation without newlines
+maxColumn = 50
+optIn.annotationNewlines = false
+===
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot   @deprecated   class B(@annot @deprecated private implicit val x: Int) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {   1 }
+
+    @annot @annot2 @annot3 @annot4 /*comment4*/ @annot5 @deprecated def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot @annot2(value =
+    "foo", someInt = 5) @annot3
+    @deprecated(value =
+    "bar") def bar2  =  1
+  }
+
+  @annot @annot2
+  @annot3
+  @annot4 @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+>>>
+object WrapperToHaveStatTestCaseParserWorking {
+  @annot
+  @deprecated
+  class B(
+      @annot @deprecated private implicit val x: Int
+  ) extends A {
+    @annot override def foo = 1
+
+    @annot
+    override def bar = {
+      1
+    }
+
+    @annot
+    @annot2
+    @annot3
+    @annot4 /*comment4*/
+    @annot5
+    @deprecated
+    def foo2(@annot @deprecated x: Int) = 1
+
+    // in case of annotations with params located in many lines
+    // let's live with changed lines of params
+    @annot
+    @annot2(value = "foo", someInt = 5)
+    @annot3
+    @deprecated(value = "bar") def bar2 = 1
+  }
+
+  @annot
+  @annot2
+  @annot3
+  @annot4
+  @deprecated class C
+
+  @annot
+  @deprecated
+  class D
+}
+<<< 4.3: #938 flag false, newline no
+optIn.selfAnnotationNewline = false
+maxColumn = 20
+===
+trait a { self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.4: #938 flag true, newline no
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a { self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.5: #938 flag false, newline yes
+optIn.selfAnnotationNewline = false
+maxColumn = 20
+===
+trait a {
+  self =>
+    blah
+}
+>>>
+trait a { self =>
+  blah
+}
+<<< 4.6: #938 flag true, newline yes
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a {
+ self =>
+    blah
+}
+>>>
+trait a {
+  self =>
+  blah
+}
+<<< 4.7: #938 flag true, newline no, line too long
+optIn.selfAnnotationNewline = true
+maxColumn = 20
+===
+trait a { selfaaaaaaaaaaaaaaaa =>
+    blah
+}
+>>>
+trait a {
+  selfaaaaaaaaaaaaaaaa =>
+  blah
+}
+<<< 4.8 flag true, annot in param
+optIn.annotationNewlines = true
+===
+@ foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+ object
+  a  extends b with c {
+
+   def
+   foo[T: Int#Double#Triple,
+       R <% String](
+    @annot1
+    x
+    : Int @annot2 = 2
+    , y: Int = 3): Int = {
+    "match" match {
+      case 1 | 2 =>   3
+      case <A>2</A> => 2
+    }
+   }
+}
+>>>
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1
+      x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 => 3
+      case <A>2</A> => 2
+    }
+  }
+}
+<<< 4.9 flag false, annot in param
+optIn.annotationNewlines = false
+===
+@ foobar("annot", {
+  val x = 2
+  val y = 2 // y=2
+  x + y
+})
+ object
+  a  extends b with c {
+
+   def
+   foo[T: Int#Double#Triple,
+       R <% String](
+    @annot1
+    x
+    : Int @annot2 = 2
+    , y: Int = 3): Int = {
+    "match" match {
+      case 1 | 2 =>   3
+      case <A>2</A> => 2
+    }
+   }
+}
+>>>
+@foobar(
+  "annot", {
+    val x = 2
+    val y = 2 // y=2
+    x + y
+  }
+)
+object a extends b with c {
+
+  def foo[
+      T: Int#Double#Triple,
+      R <% String
+  ](
+      @annot1 x: Int @annot2 = 2,
+      y: Int = 3
+  ): Int = {
+    "match" match {
+      case 1 | 2 => 3
+      case <A>2</A> => 2
+    }
+  }
+}
+<<< 4.10
+maxColumn = 80
+===
+class Engine[TD, EI, PD, Q, P, A](
+    val dataSourceClassMap: Map[String, Class[
+      _ <: BaseDataSource[TD, EI, Q, A]]],
+     val preparatorClassMap: Map[String, Class[_ <: BasePreparator[TD, PD]]],
+     val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
+     val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]])
+     extends BaseEngine[EI, Q, P, A]
+>>>
+class Engine[TD, EI, PD, Q, P, A](
+    val dataSourceClassMap: Map[String, Class[
+      _ <: BaseDataSource[TD, EI, Q, A]
+    ]],
+    val preparatorClassMap: Map[String, Class[_ <: BasePreparator[TD, PD]]],
+    val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
+    val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]]
+) extends BaseEngine[EI, Q, P, A]


### PR DESCRIPTION
Bundling together the annotation modifiers and self-annotations. Helps with #1627.

`scala-repos`:
* `fold`: https://github.com/kitbellew/scala-repos/commit/b8f351c03ae39b5a08e74f2b20f682e9da72dd86
* `unfold`: https://github.com/kitbellew/scala-repos/commit/d5a8edca1d1c7e8f73120483b545db056eca889c
* rest: unchanged