### PR TITLE
#1627 [09]: Router: ignore line breaks in case clauses

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -373,19 +373,45 @@ class Router(formatOps: FormatOps) {
       case tok @ FormatToken(arrow @ T.RightArrow(), right, between)
           if leftOwner.isInstanceOf[Case] =>
         val caseStat = leftOwner.asInstanceOf[Case]
-        right match {
-          case _: T.LeftBrace if caseStat.body eq rightOwner =>
-            // Redundant {} block around case statements.
-            Seq(
-              Split(Space, 0)
-                .withIndent(-2, rightOwner.tokens.last, After)
-            )
-          case _ =>
-            Seq(
-              // Gets killed by `case` policy.
-              Split(Space, 0).onlyIf(newlines == 0),
-              Split(NewlineT(noIndent = rhsIsCommentedOut(tok)), 1)
-            )
+        if (right.is[T.LeftBrace] && (caseStat.body eq rightOwner))
+          // Redundant {} block around case statements.
+          Seq(Split(Space, 0).withIndent(-2, rightOwner.tokens.last, After))
+        else {
+          def newlineSplit(cost: Int) =
+            Split(NewlineT(noIndent = rhsIsCommentedOut(tok)), cost)
+          def foldedSplits = caseStat.body match {
+            case _ if right.is[T.KwCase] || isSingleLineComment(right) =>
+              Right(Split.ignored)
+            case t if t.tokens.isEmpty || caseStat.cond.isDefined =>
+              Right(Split(Space, 0).withSingleLineOpt(t.tokens.lastOption))
+            case t: Term.If if t.elsep.tokens.isEmpty =>
+              Right(Split(Space, 0).withSingleLine(t.cond.tokens.last))
+            case t @ (_: Term.ForYield | _: Term.Match) =>
+              val end = t.tokens.last
+              val exclude = insideBlockRanges[T.LeftBrace](tok, end)
+              Right(Split(Space, 0).withSingleLine(end, exclude = exclude))
+            case t @ SplitCallIntoParts(fun, _) if fun ne caseStat.body =>
+              val end = t.tokens.last
+              val exclude = insideBlockRanges[LeftParenOrBrace](tok, end)
+              val splits = Seq(
+                Split(Space, 0).withSingleLine(end, exclude),
+                newlineSplit(1).withPolicy(penalizeAllNewlines(end, 1))
+              )
+              Left(splits)
+            case t =>
+              Right(Split(Space, 0).withSingleLine(t.tokens.last))
+          }
+          val result = style.newlines.source match {
+            case Newlines.fold => foldedSplits
+            case Newlines.unfold =>
+              Right(Split(Space, 0).onlyIf(right.is[T.Semicolon]))
+            case _ =>
+              Right(Split(Space, 0).notIf(formatToken.hasBreak))
+          }
+          result.fold(identity, x => {
+            val nlCost = if (x.isIgnored) 0 else x.cost + 1
+            Seq(x, newlineSplit(nlCost))
+          })
         }
       // New statement
       case tok @ FormatToken(T.Semicolon(), right, between)
@@ -1392,7 +1418,8 @@ class Router(formatOps: FormatOps) {
                     if !right.isInstanceOf[T.LeftBrace] &&
                       !isAttachedSingleLineComment(t) =>
                   d.onlyNewlinesWithoutFallback
-              }
+              },
+              ignore = style.newlines.sourceIs(Newlines.fold)
             )
             .withIndent(2, expire, After) // case body indented by 2.
             .withIndent(2, arrow, After) // cond body indented by 4.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
@@ -91,3 +91,9 @@ object RightParenOrBracket {
   def unapply(tok: Token): Boolean =
     tok.is[RightParen] || tok.is[RightBracket]
 }
+
+@classifier
+trait LeftParenOrBrace
+object LeftParenOrBrace {
+  def unapply(tok: Token): Boolean = tok.is[LeftParen] || tok.is[LeftBrace]
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1310,3 +1310,41 @@ class Engine[TD, EI, PD, Q, P, A](
     val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
     val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]]
 ) extends BaseEngine[EI, Q, P, A]
+<<< 5.1: case statements
+a match {
+  case b =>
+    bb
+  case c => cc
+   ccc
+  case d =>
+   dd
+   ddd
+  case e =>
+  case f => ff
+}
+>>>
+a match {
+  case b =>
+    bb
+  case c =>
+    cc
+    ccc
+  case d =>
+    dd
+    ddd
+  case e =>
+  case f => ff
+}
+<<< 5.2 #1518
+a match {
+  case b: C => d.e match {
+    case f => "g"
+  }
+}
+>>>
+a match {
+  case b: C =>
+    d.e match {
+      case f => "g"
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -460,9 +460,7 @@ val nested =
 >>>
 val nested = promiseIntercept(
   new Actor {
-    def receive = {
-      case _ ⇒
-    }
+    def receive = { case _ ⇒ }
   }
 )(result)
 <<< 2.21 val with apply type
@@ -1234,8 +1232,7 @@ a match {
 }
 >>>
 a match {
-  case b =>
-    bb
+  case b => bb
   case c =>
     cc
     ccc
@@ -1252,8 +1249,7 @@ a match {
 }
 >>>
 a match {
-  case b: C =>
-    ddd.eee match {
+  case b: C => ddd.eee match {
       case fff => """ggg"""
     }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1220,3 +1220,40 @@ class Engine[TD, EI, PD, Q, P, A](
     val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
     val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]]
 ) extends BaseEngine[EI, Q, P, A]
+<<< 5.1: case statements
+a match {
+  case b =>
+    bb
+  case c => cc
+   ccc
+  case d =>
+   dd
+   ddd
+  case e =>
+  case f => ff
+}
+>>>
+a match {
+  case b =>
+    bb
+  case c =>
+    cc
+    ccc
+  case d =>
+    dd
+    ddd
+  case e =>
+  case f => ff
+}
+<<< 5.2 #1518
+a match {
+  case b: C =>
+    ddd.eee match { case fff => """ggg""" }
+}
+>>>
+a match {
+  case b: C =>
+    ddd.eee match {
+      case fff => """ggg"""
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1275,3 +1275,41 @@ class Engine[TD, EI, PD, Q, P, A](
     val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
     val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]]
 ) extends BaseEngine[EI, Q, P, A]
+<<< 5.1: case statements
+a match {
+  case b =>
+    bb
+  case c => cc
+   ccc
+  case d =>
+   dd
+   ddd
+  case e =>
+  case f => ff
+}
+>>>
+a match {
+  case b =>
+    bb
+  case c =>
+    cc
+    ccc
+  case d =>
+    dd
+    ddd
+  case e =>
+  case f => ff
+}
+<<< 5.2 #1518
+a match {
+  case b: C => d.e match {
+    case f => "g"
+  }
+}
+>>>
+a match {
+  case b: C =>
+    d.e match {
+      case f => "g"
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1386,3 +1386,41 @@ class Engine[TD, EI, PD, Q, P, A](
     val algorithmClassMap: Map[String, Class[_ <: BaseAlgorithm[PD, _, Q, P]]],
     val servingClassMap: Map[String, Class[_ <: BaseServing[Q, P]]]
 ) extends BaseEngine[EI, Q, P, A]
+<<< 5.1: case statements
+a match {
+  case b =>
+    bb
+  case c => cc
+   ccc
+  case d =>
+   dd
+   ddd
+  case e =>
+  case f => ff
+}
+>>>
+a match {
+  case b =>
+    bb
+  case c =>
+    cc
+    ccc
+  case d =>
+    dd
+    ddd
+  case e =>
+  case f => ff
+}
+<<< 5.2 #1518
+a match {
+  case b: C => d.e match {
+    case f => "g"
+  }
+}
+>>>
+a match {
+  case b: C =>
+    d.e match {
+      case f => "g"
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -989,8 +989,10 @@ def activationFutureFor(
       .ask(AwaitActivation(endpoint))(timeout)
     )
     .map[ActorRef]({
-      case EndpointActivated(`endpoint`) ⇒ endpoint
-      case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
+      case EndpointActivated(`endpoint`) ⇒
+        endpoint
+      case EndpointFailedToActivate(`endpoint`, cause) ⇒
+        throw cause
     })
 <<< SKIP 3.27 enclosed in block, def, chain follows
 maxColumn = 80
@@ -1314,8 +1316,10 @@ object a extends b with c {
       y: Int = 3
   ): Int = {
     "match" match {
-      case 1 | 2 => 3
-      case <A>2</A> => 2
+      case 1 | 2 =>
+        3
+      case <A>2</A> =>
+        2
     }
   }
 }
@@ -1362,8 +1366,10 @@ object a extends b with c {
       y: Int = 3
   ): Int = {
     "match" match {
-      case 1 | 2 => 3
-      case <A>2</A> => 2
+      case 1 | 2 =>
+        3
+      case <A>2</A> =>
+        2
     }
   }
 }
@@ -1409,7 +1415,8 @@ a match {
     dd
     ddd
   case e =>
-  case f => ff
+  case f =>
+    ff
 }
 <<< 5.2 #1518
 a match {
@@ -1421,6 +1428,7 @@ a match {
 a match {
   case b: C =>
     d.e match {
-      case f => "g"
+      case f =>
+        "g"
     }
 }


### PR DESCRIPTION
Helps with #1627.

`scala-repos` diffs:
* `fold`: https://github.com/kitbellew/scala-repos/commit/ad939026abd0c6c0eafeb4845f1d91987ecade4f
* `unfold`: https://github.com/kitbellew/scala-repos/commit/d058de644b623a84da6e1c73892fd524bef468d0
* rest: unchanged