### PR TITLE
Preserve newlines in for comprehension generators and values 

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1493,8 +1493,32 @@ class Router(formatOps: FormatOps) {
           if (style.align.arrowEnumeratorGenerator) StateColumn
           else Num(0)
         Seq(
-          // Either everything fits in one line or break on =>
-          Split(Space, 0).withIndent(indent, lastToken, After)
+          Split(Space, 0)
+            .onlyIf(newlines == 0)
+            .withIndent(indent, lastToken, After),
+          Split(Newline, 1).withIndent(indent, lastToken, After)
+        )
+      case tok @ FormatToken(arrow @ T.Equals(), _, _)
+          if leftOwner.is[Enumerator.Val] =>
+        Seq(
+          Split(Space, 0).onlyIf(newlines == 0),
+          Split(Newline, 1)
+        )
+      case tok @ FormatToken(_, arrow @ T.LeftArrow(), _)
+          if rightOwner.is[Enumerator.Generator] =>
+        val lastToken = rightOwner.tokens.last
+        fitsOneLineOrBreakOnArrow(
+          lastToken,
+          arrow,
+          Seq(Indent(2, lastToken, After))
+        )
+      case tok @ FormatToken(_, arrow @ T.Equals(), _)
+          if rightOwner.is[Enumerator.Val] =>
+        val lastToken = rightOwner.tokens.last
+        fitsOneLineOrBreakOnArrow(
+          lastToken,
+          arrow,
+          Seq(Indent(2, lastToken, After))
         )
       case FormatToken(T.KwYield(), _, _) if leftOwner.is[Term.ForYield] =>
         if (style.newlines.avoidAfterYield && !rightOwner.is[Term.If]) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -962,7 +962,7 @@ class Router(formatOps: FormatOps) {
         val lastToken = leftOwner.tokens.last
         val indent: Length =
           if (shouldBreakAfterArrowInFor && right.is[T.LeftBrace]) Num(-2)
-        else if (right.is[T.LeftBrace]) Num(0)
+          else if (right.is[T.LeftBrace]) Num(0)
           else if (style.align.arrowEnumeratorGenerator) StateColumn
           else Num(0)
         Seq(
@@ -977,7 +977,7 @@ class Router(formatOps: FormatOps) {
         val lastToken = leftOwner.tokens.last
         val indent: Length =
           if (shouldBreakAfterArrowInFor && right.is[T.LeftBrace]) Num(-2)
-        else if (right.is[T.LeftBrace]) Num(0)
+          else if (right.is[T.LeftBrace]) Num(0)
           else if (style.align.arrowEnumeratorGenerator) StateColumn
           else Num(0)
         Seq(
@@ -1545,8 +1545,8 @@ class Router(formatOps: FormatOps) {
           Split(Newline, 1)
         )
       case tok @ FormatToken(_, arrow @ T.LeftArrow(), _)
-          if rightOwner
-            .is[Enumerator.Generator] && shouldBreakAfterArrowInFor =>
+          if rightOwner.is[Enumerator.Generator] &&
+            shouldBreakAfterArrowInFor =>
         val lastToken = rightOwner.tokens.last
         fitsOneLineOrBreakOnArrow(
           lastToken,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -956,6 +956,33 @@ class Router(formatOps: FormatOps) {
             .onlyIf(open.pos.endLine == close.pos.startLine)
             .withSingleLine(close, killOnFail = true)
         ) ++ oneArgPerLineSplits
+
+      case tok @ FormatToken(T.LeftArrow(), right, _)
+          if leftOwner.is[Enumerator.Generator] =>
+        val lastToken = leftOwner.tokens.last
+        val indent: Length =
+          if (style.align.arrowEnumeratorGenerator) StateColumn
+          else if (right.is[T.LeftBrace]) Num(-2)
+          else Num(0)
+        Seq(
+          Split(Space, 0)
+            .onlyIf(newlines == 0)
+            .withIndent(indent, lastToken, After),
+          Split(Newline, 1).withIndent(indent, lastToken, After)
+        )
+      case tok @ FormatToken(T.Equals(), right, _)
+          if leftOwner.is[Enumerator.Val] =>
+        val lastToken = leftOwner.tokens.last
+        val indent: Length =
+          if (right.is[T.LeftBrace]) Num(-2)
+          else Num(0)
+        Seq(
+          Split(Space, 0)
+            .onlyIf(newlines == 0)
+            .withIndent(indent, lastToken, After),
+          Split(Newline, 1).withIndent(indent, lastToken, After)
+        )
+
       case FormatToken(_, _: T.LeftBrace, _) =>
         Seq(Split(Space, 0))
 
@@ -1509,24 +1536,6 @@ class Router(formatOps: FormatOps) {
           if rightOwner.is[Enumerator.Guard] =>
         Seq(
           // Either everything fits in one line or break on =>
-          Split(Space, 0).onlyIf(newlines == 0),
-          Split(Newline, 1)
-        )
-      case tok @ FormatToken(arrow @ T.LeftArrow(), _, _)
-          if leftOwner.is[Enumerator.Generator] =>
-        val lastToken = leftOwner.tokens.last
-        val indent: Length =
-          if (style.align.arrowEnumeratorGenerator) StateColumn
-          else Num(0)
-        Seq(
-          Split(Space, 0)
-            .onlyIf(newlines == 0)
-            .withIndent(indent, lastToken, After),
-          Split(Newline, 1).withIndent(indent, lastToken, After)
-        )
-      case tok @ FormatToken(arrow @ T.Equals(), _, _)
-          if leftOwner.is[Enumerator.Val] =>
-        Seq(
           Split(Space, 0).onlyIf(newlines == 0),
           Split(Newline, 1)
         )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1930,7 +1930,7 @@ class Router(formatOps: FormatOps) {
       expire: Token,
       arrow: Token,
       indents: Seq[Indent[Length]]
-  )(implicit style: ScalafmtConfig): Seq[Split] =
+  )(implicit style: ScalafmtConfig, line: sourcecode.Line): Seq[Split] =
     Seq(
       Split(Space, 0).withSingleLine(expire, killOnFail = true),
       Split(Space, 1)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -132,6 +132,12 @@ case class Split(
         case x => copy(indents = Indent(x, expire, when) +: indents)
       }
 
+  def withIndent(indent: Indent[Length]): Split =
+    withIndent(indent.length, indent.expire, indent.expiresAt)
+
+  def withIndents(indents: Seq[Indent[Length]]): Split =
+    indents.foldLeft(this)(_ withIndent _)
+
   override def toString = {
     val prefix = tag match {
       case SplitTag.Ignored => "!"

--- a/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
+++ b/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
@@ -1,4 +1,5 @@
 align.arrowEnumeratorGenerator = true
+maxColumn = 40
 <<< alignByArrowEnumeratorGenerator
 for {
   x <- new Integer {
@@ -13,4 +14,63 @@ for {
       }
   y <- Int(2)
 } yield x + y
-
+<<< split long lines
+for {
+  variable <-
+    record.field.field1.map(_.toString)
+  cond <-
+    if (variable) doSomething
+    else doAnything
+} yield cond
+>>>
+for {
+  variable <- record.field.field1
+               .map(_.toString)
+  cond <- if (variable) doSomething
+         else doAnything
+} yield cond
+<<< insert newlines to for if no newlines origin
+for {
+  variable <- record.field.field1.map(_.toString)
+  cond <- if (variable) doSomething else doAnything
+} yield cond
+>>>
+for {
+  variable <- record.field.field1
+               .map(_.toString)
+  cond <- if (variable) doSomething
+         else doAnything
+} yield cond
+<<< keep oneliners if they fits maxColumn
+for {
+  variable <- record.field
+  cond <- doSomething
+} yield cond
+>>>
+for {
+  variable <- record.field
+  cond <- doSomething
+} yield cond
+<<< insert newlines also for values
+for {
+  variable <- record.field.field1.map(_.toString)
+  cond = if (variable) doSomething else doAnything
+} yield cond
+>>>
+for {
+  variable <- record.field.field1
+               .map(_.toString)
+  cond = if (variable) doSomething
+        else doAnything
+} yield cond
+<<< body in braces on right side
+for {
+  x <- { if (condition) doSomething else doOtherThing }
+} yield x
+>>>
+for {
+  x <- {
+    if (condition) doSomething
+    else doOtherThing
+  }
+} yield x

--- a/scalafmt-tests/src/test/resources/scalajs/For.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/For.stat
@@ -6,7 +6,8 @@ val k = for {
 } yield ()
 >>>
 val k = for {
-  _ <- FutureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA(aaaaaa, bbbbbbbbbbbb,
-      cccccccc) if one
+  _ <-
+    FutureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA(aaaaaa, bbbbbbbbbbbb,
+        cccccccc) if one
   _ <- Future(2)
 } yield ()

--- a/scalafmt-tests/src/test/resources/unit/For.stat
+++ b/scalafmt-tests/src/test/resources/unit/For.stat
@@ -254,3 +254,55 @@ val sizes =
         if (cell == null) 0
         else cell.toString.length
   }
+<<< preserve newlines in for
+for {
+  variable <-
+    record.field.field1.map(_.toString)
+  cond <-
+    if (variable) doSomething
+    else doAnything
+} yield cond
+>>>
+for {
+  variable <-
+    record.field.field1.map(_.toString)
+  cond <-
+    if (variable) doSomething
+    else doAnything
+} yield cond
+<<< insert newlines to for if no newlines origin
+for {
+  variable <- record.field.field1.map(_.toString)
+  cond <- if (variable) doSomething else doAnything
+} yield cond
+>>>
+for {
+  variable <-
+    record.field.field1.map(_.toString)
+  cond <-
+    if (variable) doSomething
+    else doAnything
+} yield cond
+<<< keep oneliners if they fits maxColumn
+for {
+  variable <- record.field
+  cond <- doSomething
+} yield cond
+>>>
+for {
+  variable <- record.field
+  cond <- doSomething
+} yield cond
+<<< insert newlines also for values
+for {
+  variable <- record.field.field1.map(_.toString)
+  cond = if (variable) doSomething else doAnything
+} yield cond
+>>>
+for {
+  variable <-
+    record.field.field1.map(_.toString)
+  cond =
+    if (variable) doSomething
+    else doAnything
+} yield cond

--- a/scalafmt-tests/src/test/resources/unit/For.stat
+++ b/scalafmt-tests/src/test/resources/unit/For.stat
@@ -73,9 +73,10 @@ val k = for {
 } yield ()
 >>>
 val k = for {
-  _ <- Future(aaaaaa,
-              bbbbbbbbbbbb,
-              cccccccc) if one
+  _ <-
+    Future(aaaaaa,
+           bbbbbbbbbbbb,
+           cccccccc) if one
   _ <- Future(2)
 } yield ()
 <<< enumerator val
@@ -233,9 +234,10 @@ for {
 } yield x + y
 >>>
 for {
-  x <- new Integer {
-    def value = 2
-  }
+  x <-
+    new Integer {
+      def value = 2
+    }
   y <- Int(2)
 } yield x + y
 <<< normal way #592
@@ -306,3 +308,14 @@ for {
     if (variable) doSomething
     else doAnything
 } yield cond
+<<< body in braces on right side
+for {
+  x <- { if (condition) doSomething else doOtherThing }
+} yield x
+>>>
+for {
+  x <- {
+    if (condition) doSomething
+    else doOtherThing
+  }
+} yield x

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -41,7 +41,7 @@ trait HasTests extends FormatAssertions {
   )
 
   lazy val debugResults = mutable.ArrayBuilder.make[Result]
-  val testDir = new File(getClass.getClassLoader.getResource("").toURI).getAbsolutePath
+  val testDir = new File(getClass.getClassLoader.getResource("test").toURI).getParent
 
   def tests: Seq[DiffTest]
 


### PR DESCRIPTION
Fixes #1256

Before:
```scala
for {
  myLongBooleanValue <- some.very.very.very.very.very.very.long.option
    .map(_ => true)
  myResult = if (myLongBooleanValue) compute_one_thing
  else compute_another_thing
} yield myResult
```
After:
```scala
for {
  myLongBooleanValue <- 
    some.very.very.very.very.very.very.long.option.map(_ => true)
  myResult = 
    if (myLongBooleanValue) compute_one_thing
    else compute_another_thing
} yield myResult
```

Especially I don't like current formatting of long `if-else` in for comprehensions. `else` after split located on the same column with left-side identifiers. It makes code reading difficult.

scala-repos vs master: https://github.com/poslegm/scala-repos/commit/0addbc83430c0bb6d30cfc38daa862fb69741ba8