### PR TITLE
#1627 [10]: Router: ignore line breaks in select chains

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
@@ -10,6 +10,7 @@ import metaconfig.generic.Surface
   *                             If true, preserves the newlines and keeps one
   *                             line per argument.
   * @param breaksInsideChains
+  *  NB: failure unless newlines.source=classic
   *  If true, then the user can opt out of line breaks
   *  inside select chains.
   *
@@ -30,6 +31,7 @@ import metaconfig.generic.Surface
   * }}}
   *
   * @param breakChainOnFirstMethodDot
+  *   NB: ignored unless newlines.source=classic
   *   If true, keeps the line break before a dot if it already exists.
   *   {{{
   *     // original

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -89,6 +89,7 @@ import org.scalafmt.util.ValidationOps
   *                    file (windows if there was at least one windows line ending, unix if there
   *                    was zero occurrences of windows line endings)
   * @param includeCurlyBraceInSelectChains
+  *  NB: failure unless newlines.source=classic
   *  If true, includes curly brace applications in select chains/pipelines.
   *  {{{
   *    // If true
@@ -103,6 +104,7 @@ import org.scalafmt.util.ValidationOps
   *    }.filter(_ > 2)
   *  }}}
   * @param includeNoParensInSelectChains
+  *  NB: ignored unless newlines.source=classic
   *  If true, includes applications without parens in select chains/pipelines.
   *  {{{
   *    // If true
@@ -166,6 +168,10 @@ case class ScalafmtConfig(
       if (optIn.configStyleArguments && align.openParenDefnSite)
         errors += s"optIn.configStyleArguments with align.openParenDefnSite"
     }
+    if (optIn.breaksInsideChains)
+      errors += s"optIn.breaksInsideChains=${optIn.breaksInsideChains}"
+    if (!includeCurlyBraceInSelectChains)
+      errors += s"includeCurlyBraceInSelectChains=${includeCurlyBraceInSelectChains}"
     if (errors.nonEmpty) {
       val prefix = s"newlines: can't use source=${newlines.source} and ["
       throw new IllegalArgumentException(errors.mkString(prefix, ",", "]"))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -550,13 +550,13 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   def getOptimalTokenFor(ft: FormatToken): Token =
     if (isAttachedSingleLineComment(ft)) ft.right else ft.left
 
-  def chainOptimalToken(chain: Vector[Term.Select]): Token = {
-    val lastDotIndex = chain.last.tokens.lastIndexWhere(_.is[T.Dot])
-    val lastDot =
-      if (lastDotIndex != -1)
-        chain.last.tokens(dialect)(lastDotIndex).asInstanceOf[T.Dot]
-      else
-        throw new IllegalStateException(s"Missing . in select ${chain.last}")
+  def getSelectOptimalToken(tree: Tree): Token = {
+    // 2.13 has findLast
+    val tokens = tree.tokens
+    val index = tokens.lastIndexWhere(_.is[T.Dot])
+    if (index == -1)
+      throw new IllegalStateException(s"Missing . in select $tree")
+    val lastDot = tokens(index).asInstanceOf[T.Dot]
     lastToken(getSelectsLastToken(lastDot).meta.leftOwner)
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -523,6 +523,8 @@ class FormatWriter(formatOps: FormatOps) {
       b: Array[FormatLocation],
       endOfLine: FormatToken
   ): Int = {
+    val findParentOnRight =
+      TreeOps.findTreeWithParentSimple(endOfLine.meta.rightOwner) _
     val result = a.zip(b).takeWhile {
       case (row1, row2) =>
         // skip checking if row1 and row2 matches if both of them continues to a single line of comment
@@ -535,14 +537,9 @@ class FormatWriter(formatOps: FormatOps) {
           val row1Owner = getAlignOwner(row1.formatToken)
           def sameLengthToRoot =
             vAlignDepth(row1Owner) == vAlignDepth(row2Owner)
+          def isRowOwner(x: Tree) = (x eq row1Owner) || (x eq row2Owner)
           key(row1.formatToken.right) == key(row2.formatToken.right) &&
-          sameLengthToRoot &&
-          TreeOps
-            .findTreeWithParent(endOfLine.meta.rightOwner) {
-              case `row1Owner` | `row2Owner` => Some(true)
-              case _ => None
-            }
-            .isEmpty
+          sameLengthToRoot && findParentOnRight(isRowOwner).isEmpty
         }
     }
     result.length

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -17,6 +17,7 @@ import scala.meta.{
   Defn,
   Enumerator,
   Import,
+  Importer,
   Init,
   Lit,
   Mod,
@@ -1094,6 +1095,74 @@ class Router(formatOps: FormatOps) {
 
       case FormatToken(_: T.Underscore, _: T.Dot, _) =>
         Seq(Split(NoSplit, 0))
+
+      case FormatToken(_, _: T.Dot, _)
+          if style.newlines.sourceIgnored &&
+            rightOwner.is[Term.Select] && findTreeWithParent(rightOwner) {
+            case _: Type.Select | _: Term.Interpolate => Some(true)
+            case _: Importer | _: Pkg => Some(true)
+            case _: Term.Select | SplitCallIntoParts(_, _) => None
+            case _ => Some(false)
+          }.isDefined =>
+        Seq(Split(NoSplit, 0))
+
+      case t @ FormatToken(left, _: T.Dot, _)
+          if !style.newlines.sourceIs(Newlines.classic) &&
+            rightOwner.is[Term.Select] =>
+        val (expireTree, nextSelect) = findLastApplyAndNextSelect(rightOwner)
+        val prevSelect = findPrevSelect(rightOwner.asInstanceOf[Term.Select])
+        val expire = lastToken(expireTree)
+
+        val baseSplits = style.newlines.source match {
+          case _ if left.is[T.Comment] =>
+            Seq(Split(Space.orNL(t.noBreak), 0))
+
+          case Newlines.keep =>
+            Seq(Split(NoSplit.orNL(t.noBreak), 0))
+
+          case Newlines.unfold =>
+            if (prevSelect.isEmpty && nextSelect.isEmpty)
+              Seq(Split(NoSplit, 0), Split(Newline, 1))
+            else {
+              val forcedBreakPolicy = nextSelect.map { tree =>
+                Policy(tree.name.tokens.head) {
+                  case Decision(t @ FormatToken(_, _: T.Dot, _), s)
+                      if t.meta.rightOwner eq tree =>
+                    s.filter(_.modification.isNewline)
+                }
+              }
+              Seq(
+                Split(NoSplit, 0).withSingleLine(expire),
+                Split(Newline, 1).withPolicyOpt(forcedBreakPolicy)
+              )
+            }
+
+          case Newlines.fold =>
+            val end = nextSelect.fold(expire)(x => lastToken(x.qual))
+            def exclude = insideBlockRanges[LeftParenOrBrace](t, end)
+            Seq(
+              Split(NoSplit, 0).withSingleLine(end, exclude),
+              Split(Newline, 1)
+            )
+        }
+
+        val delayedBreakPolicy = nextSelect.map { tree =>
+          Policy(tree.name.tokens.head) {
+            case Decision(t @ FormatToken(_, _: T.Dot, _), s)
+                if t.meta.rightOwner eq tree =>
+              SplitTag.SelectChainFirstNL.activateOnly(s)
+          }
+        }
+
+        // trigger indent only on the first newline
+        val indent = Indent(Num(2), expire, After)
+        val splits = baseSplits.map { s =>
+          if (s.modification.isNewline) s.withIndent(indent)
+          else s.andThenPolicyOpt(delayedBreakPolicy)
+        }
+
+        if (prevSelect.isEmpty) splits
+        else baseSplits ++ splits.map(_.onlyFor(SplitTag.SelectChainFirstNL))
 
       case tok @ FormatToken(left, dot @ T.Dot() `:chain:` chain, _) =>
         val nestedPenalty = nestedSelect(rightOwner) + nestedApplies(leftOwner)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -26,7 +26,7 @@ case class Split(
     modification: Modification,
     cost: Int,
     tag: SplitTag = SplitTag.Active,
-    indents: Vector[Indent[Length]] = Vector.empty[Indent[Length]],
+    indents: Seq[Indent[_]] = Seq.empty,
     policy: Policy = NoPolicy,
     optimalAt: Option[OptimalToken] = None
 )(implicit val line: sourcecode.Line) {
@@ -131,6 +131,10 @@ case class Split(
     else if (policy.isEmpty) copy(policy = newPolicy)
     else copy(policy = policy.andThen(newPolicy))
 
+  def andThenPolicyOpt(newPolicy: => Option[Policy]): Split =
+    if (isIgnored) this
+    else newPolicy.fold(this)(andThenPolicy)
+
   def withPenalty(penalty: Int): Split =
     if (isIgnored) this else copy(cost = cost + penalty)
 
@@ -139,8 +143,23 @@ case class Split(
     else
       length match {
         case Num(0) => this
-        case x => copy(indents = Indent(x, expire, when) +: indents)
+        case x => withIndentImpl(Indent(x, expire, when))
       }
+
+  def withIndent(indent: => Indent[_]): Split =
+    if (isIgnored) this
+    else
+      indent match {
+        case Indent(Num(0), _, _) => this
+        case x => withIndentImpl(x)
+      }
+
+  def withIndentOpt(indent: => Option[Indent[_]]): Split =
+    if (isIgnored) this
+    else indent.fold(this)(withIndent(_))
+
+  private def withIndentImpl(indent: Indent[_]): Split =
+    copy(indents = indent +: indents)
 
   override def toString = {
     val prefix = tag match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -23,5 +23,6 @@ object SplitTag {
   case object Ignored extends Base
 
   case object OneArgPerLine extends Custom
+  case object SelectChainFirstNL extends Custom
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -67,6 +67,9 @@ object LoggerOps {
             |""".stripMargin
   }
 
+  def logOpt(t: Option[Tree], tokensOnly: Boolean = false): String =
+    t.fold("")(log(_, tokensOnly))
+
   def stripTrailingSpace(s: String): String = s.replaceAll("\\s+\n", "\n")
 
   def reveal(s: String): String = s.map {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -65,12 +65,13 @@ object TokenOps {
   }
 
   def lastToken(tree: Tree): Token = {
-    val lastIndex = tree.tokens.lastIndexWhere {
+    // 2.13 has findLast
+    val tokens = tree.tokens
+    val index = tokens.lastIndexWhere {
       case Trivia() | _: EOF => false
       case _ => true
     }
-    if (lastIndex == -1) tree.tokens.last
-    else tree.tokens(Scala211)(lastIndex)
+    if (index == -1) tokens.last else tokens(index)
   }
 
   def endsWithNoIndent(between: Seq[Token]): Boolean =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -242,6 +242,10 @@ object TreeOps {
           case None => findTreeWithParent(p)(pred)
         }
     }
+  def findTreeWithParentSimple(
+      tree: Tree
+  )(pred: Tree => Boolean): Option[Tree] =
+    findTreeWithParent(tree)(x => if (pred(x)) Some(true) else None)
 
   /**
     * Returns first ancestor with a parent of a given type.
@@ -249,7 +253,7 @@ object TreeOps {
   def findTreeWithParentOfType[A <: Tree](tree: Tree)(
       implicit classifier: Classifier[Tree, A]
   ): Option[Tree] =
-    findTreeWithParent(tree)(p => if (classifier(p)) Some(true) else None)
+    findTreeWithParentSimple(tree)(classifier.apply)
 
   /**
     * Returns true if a matching ancestor of a given type exists.

--- a/scalafmt-tests/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/src/test/resources/newlines/source.source
@@ -1,0 +1,21 @@
+maxColumn = 80
+<<< select chain: interpolate, package, import
+newlines.source = unfold
+maxColumn = 10
+===
+package a.b.c
+import a.b.c
+object a {
+val a = s"${a.b.c.d}"
+val b = foo[a.b.c.d.e](f.g)
+}
+>>>
+package a.b.c
+import a.b.c
+object a {
+  val a =
+    s"${a.b.c.d}"
+  val b = foo[
+    a.b.c.d.e
+  ](f.g)
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -951,9 +951,9 @@ def activationFutureFor(
   supervisor
     .ask(AwaitActivation(endpoint))(timeout)
 }.map[ActorRef]({
-  case EndpointActivated(`endpoint`) ⇒ endpoint
-  case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
-})
+    case EndpointActivated(`endpoint`) ⇒ endpoint
+    case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
+  })
 <<< 3.28 apply with optimal token
 maxColumn = 80
 danglingParentheses = false
@@ -1346,5 +1346,80 @@ a match {
   case b: C =>
     d.e match {
       case f => "g"
+    }
+}
+<<< 6.1: chain, no break
+val a = b.c.d.e().f.g.h()
+>>>
+val a = b.c.d.e().f.g.h()
+<<< 6.2: chain, break on =
+val a =
+ b.c
+ .d.e(f)
+ .g.h { i => j }
+ .k().l({ m => n}, o)
+>>>
+val a =
+  b.c.d
+    .e(f)
+    .g
+    .h { i => j }
+    .k()
+    .l({ m => n }, o)
+<<< 6.3: chain, breaks in the middle
+val a = b.c
+ .d.e() .f
+ .g .h()
+>>>
+val a = b.c.d.e().f.g.h()
+<<< 6.4: chain without apply
+maxColumn = 72
+includeNoParensInSelectChains = true
+===
+object a {
+created filter (ref ⇒
+         !ref.isTerminated && !ref
+          .asInstanceOf[ActorRefWithCell]
+          .underlying.isInstanceOf[UnstartedCell]) should ===(
+        Seq.empty[ActorRef])
+}
+>>>
+object a {
+  created filter (ref ⇒
+    !ref.isTerminated && !ref
+      .asInstanceOf[ActorRefWithCell]
+      .underlying
+      .isInstanceOf[UnstartedCell]
+  ) should ===(Seq.empty[ActorRef])
+}
+<<< 6.5: chain with delayed indent after break
+maxColumn = 70
+===
+object a {
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+    .union(algoPredicts).groupByKey().mapValues { ps =>
+      {
+        assert(
+          ps.size == algoCount,
+          "Must have same length as algoCount")
+        // TODO. Check size == algoCount
+        ps.toSeq.sortBy(_._1).map(_._2)
+      }
+    }
+}
+>>>
+object a {
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+    .union(algoPredicts)
+    .groupByKey()
+    .mapValues { ps =>
+      {
+        assert(
+          ps.size == algoCount,
+          "Must have same length as algoCount"
+        )
+        // TODO. Check size == algoCount
+        ps.toSeq.sortBy(_._1).map(_._2)
+      }
     }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -931,7 +931,7 @@ def activationFutureFor(
       case EndpointActivated(`endpoint`) ⇒ endpoint
       case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
     })
-<<< SKIP 3.27 enclosed in block, def, chain follows
+<<< SKIP 3.27 enclosed in block, def, chain follows (can't be fixed due to acceptNoSplit)
 maxColumn = 80
 ===
   def activationFutureFor(endpoint: ActorRef)(implicit

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -429,8 +429,7 @@ val aaaaa = bbbbb.asss(as).ccccc(
     fffff
   ) // comment
 >>>
-val aaaaa = bbbbb
-  .asss(as)
+val aaaaa = bbbbb.asss(as)
   .ccccc(ddddd, eeeee, fffff) // comment
 <<< 2.18 val with apply-apply
 val aaaaa = (getSomeLongerFunction(c))(as)
@@ -445,11 +444,8 @@ val aaaaa = bbbbb.asss.ccccc(
     fffff
   ) // comment
 >>>
-val aaaaa = bbbbb.asss.ccccc(
-  ddddd,
-  eeeee,
-  fffff
-) // comment
+val aaaaa = bbbbb.asss
+  .ccccc(ddddd, eeeee, fffff) // comment
 <<< 2.20 val with apply-select-select
 val nested =
   promiseIntercept(new Actor {
@@ -473,8 +469,7 @@ val nested = promiseIntercept(
 >>>
 val deployment = system
   .asInstanceOf[ActorSystemImpl]
-  .provider
-  .deployer
+  .provider.deployer
   .lookup(service.split("/").drop(1))
 <<< 3.1: def non-config-style, long
 def a( ccccccccccccccccc:Int,
@@ -623,9 +618,8 @@ object a {
 }
 >>>
 object a {
-  (intercept[java.lang.IllegalStateException] {
-    in.readObject
-  }).getMessage should ===(
+  (intercept[java.lang.IllegalStateException] { in.readObject })
+    .getMessage should ===(
     "Trying to deserialize a serialized ActorRef without an ActorSystem in scope." +
       " Use 'akka.serialization.Serialization.currentSystem.withValue(system) { ... }'")
 }
@@ -844,12 +838,10 @@ maxColumn = 80
 def activationFutureFor(
     endpoint: ActorRef
 )(implicit timeout: Timeout, executor: ExecutionContext): Future[ActorRef] =
-  (supervisor
-    .ask(AwaitActivation(endpoint))(timeout))
-    .map[ActorRef]({
-      case EndpointActivated(`endpoint`) ⇒ endpoint
-      case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
-    })
+  (supervisor.ask(AwaitActivation(endpoint))(timeout)).map[ActorRef]({
+    case EndpointActivated(`endpoint`) ⇒ endpoint
+    case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
+  })
 <<< 3.27 enclosed in block, def, chain follows
 maxColumn = 80
 ===
@@ -863,16 +855,14 @@ maxColumn = 80
         case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
       })
 >>>
-Idempotency violated
 def activationFutureFor(
     endpoint: ActorRef
 )(implicit timeout: Timeout, executor: ExecutionContext): Future[ActorRef] = {
-  supervisor
-    .ask(AwaitActivation(endpoint))(timeout)
+  supervisor.ask(AwaitActivation(endpoint))(timeout)
 }.map[ActorRef]({
-    case EndpointActivated(`endpoint`) ⇒ endpoint
-    case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
-  })
+  case EndpointActivated(`endpoint`) ⇒ endpoint
+  case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
+})
 <<< 3.28 apply with optimal token
 maxColumn = 80
 danglingParentheses = false
@@ -1264,11 +1254,7 @@ val a =
  .g.h { i => j }
  .k().l({ m => n}, o)
 >>>
-val a = b.c.d
-  .e(f)
-  .g
-  .h { i => j }
-  .k()
+val a = b.c.d.e(f).g.h { i => j }.k()
   .l({ m => n }, o)
 <<< 6.3: chain, breaks in the middle
 val a = b.c
@@ -1290,9 +1276,7 @@ created filter (ref ⇒
 >>>
 object a {
   created filter (ref ⇒
-    !ref.isTerminated && !ref
-      .asInstanceOf[ActorRefWithCell]
-      .underlying
+    !ref.isTerminated && !ref.asInstanceOf[ActorRefWithCell].underlying
       .isInstanceOf[UnstartedCell]
   ) should ===(Seq.empty[ActorRef])
 }
@@ -1313,10 +1297,8 @@ object a {
 }
 >>>
 object a {
-  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
-    .union(algoPredicts)
-    .groupByKey()
-    .mapValues { ps =>
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc.union(algoPredicts)
+    .groupByKey().mapValues { ps =>
       {
         assert(
           ps.size == algoCount,

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -850,7 +850,7 @@ def activationFutureFor(
       case EndpointActivated(`endpoint`) ⇒ endpoint
       case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
     })
-<<< SKIP 3.27 enclosed in block, def, chain follows
+<<< 3.27 enclosed in block, def, chain follows
 maxColumn = 80
 ===
   def activationFutureFor(endpoint: ActorRef)(implicit
@@ -870,9 +870,9 @@ def activationFutureFor(
   supervisor
     .ask(AwaitActivation(endpoint))(timeout)
 }.map[ActorRef]({
-  case EndpointActivated(`endpoint`) ⇒ endpoint
-  case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
-})
+    case EndpointActivated(`endpoint`) ⇒ endpoint
+    case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
+  })
 <<< 3.28 apply with optimal token
 maxColumn = 80
 danglingParentheses = false
@@ -1251,5 +1251,79 @@ a match {
 a match {
   case b: C => ddd.eee match {
       case fff => """ggg"""
+    }
+}
+<<< 6.1: chain, no break
+val a = b.c.d.e().f.g.h()
+>>>
+val a = b.c.d.e().f.g.h()
+<<< 6.2: chain, break on =
+val a =
+ b.c
+ .d.e(f)
+ .g.h { i => j }
+ .k().l({ m => n}, o)
+>>>
+val a = b.c.d
+  .e(f)
+  .g
+  .h { i => j }
+  .k()
+  .l({ m => n }, o)
+<<< 6.3: chain, breaks in the middle
+val a = b.c
+ .d.e() .f
+ .g .h()
+>>>
+val a = b.c.d.e().f.g.h()
+<<< 6.4: chain without apply
+maxColumn = 72
+includeNoParensInSelectChains = true
+===
+object a {
+created filter (ref ⇒
+         !ref.isTerminated && !ref
+          .asInstanceOf[ActorRefWithCell]
+          .underlying.isInstanceOf[UnstartedCell]) should ===(
+        Seq.empty[ActorRef])
+}
+>>>
+object a {
+  created filter (ref ⇒
+    !ref.isTerminated && !ref
+      .asInstanceOf[ActorRefWithCell]
+      .underlying
+      .isInstanceOf[UnstartedCell]
+  ) should ===(Seq.empty[ActorRef])
+}
+<<< 6.5: chain with delayed indent after break
+maxColumn = 70
+===
+object a {
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+    .union(algoPredicts).groupByKey().mapValues { ps =>
+      {
+        assert(
+          ps.size == algoCount,
+          "Must have same length as algoCount")
+        // TODO. Check size == algoCount
+        ps.toSeq.sortBy(_._1).map(_._2)
+      }
+    }
+}
+>>>
+object a {
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+    .union(algoPredicts)
+    .groupByKey()
+    .mapValues { ps =>
+      {
+        assert(
+          ps.size == algoCount,
+          "Must have same length as algoCount"
+        )
+        // TODO. Check size == algoCount
+        ps.toSeq.sortBy(_._1).map(_._2)
+      }
     }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -882,7 +882,7 @@ def activationFutureFor(
       case EndpointActivated(`endpoint`) ⇒ endpoint
       case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
     })
-<<< SKIP 3.27 enclosed in block, def, chain follows
+<<< 3.27 enclosed in block, def, chain follows
 maxColumn = 80
 ===
   def activationFutureFor(endpoint: ActorRef)(implicit
@@ -902,9 +902,9 @@ def activationFutureFor(
   supervisor
     .ask(AwaitActivation(endpoint))(timeout)
 }.map[ActorRef]({
-  case EndpointActivated(`endpoint`) ⇒ endpoint
-  case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
-})
+    case EndpointActivated(`endpoint`) ⇒ endpoint
+    case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
+  })
 <<< 3.28 apply with optimal token
 maxColumn = 80
 danglingParentheses = false
@@ -1311,5 +1311,80 @@ a match {
   case b: C =>
     d.e match {
       case f => "g"
+    }
+}
+<<< 6.1: chain, no break
+val a = b.c.d.e().f.g.h()
+>>>
+val a = b.c.d.e().f.g.h()
+<<< 6.2: chain, break on =
+val a =
+ b.c
+ .d.e(f)
+ .g.h { i => j }
+ .k().l({ m => n}, o)
+>>>
+val a =
+  b.c.d
+    .e(f)
+    .g
+    .h { i => j }
+    .k()
+    .l({ m => n }, o)
+<<< 6.3: chain, breaks in the middle
+val a = b.c
+ .d.e() .f
+ .g .h()
+>>>
+val a = b.c.d.e().f.g.h()
+<<< 6.4: chain without apply
+maxColumn = 72
+includeNoParensInSelectChains = true
+===
+object a {
+created filter (ref ⇒
+         !ref.isTerminated && !ref
+          .asInstanceOf[ActorRefWithCell]
+          .underlying.isInstanceOf[UnstartedCell]) should ===(
+        Seq.empty[ActorRef])
+}
+>>>
+object a {
+  created filter (ref ⇒
+    !ref.isTerminated && !ref
+      .asInstanceOf[ActorRefWithCell]
+      .underlying
+      .isInstanceOf[UnstartedCell]
+  ) should ===(Seq.empty[ActorRef])
+}
+<<< 6.5: chain with delayed indent after break
+maxColumn = 70
+===
+object a {
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+    .union(algoPredicts).groupByKey().mapValues { ps =>
+      {
+        assert(
+          ps.size == algoCount,
+          "Must have same length as algoCount")
+        // TODO. Check size == algoCount
+        ps.toSeq.sortBy(_._1).map(_._2)
+      }
+    }
+}
+>>>
+object a {
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+    .union(algoPredicts)
+    .groupByKey()
+    .mapValues { ps =>
+      {
+        assert(
+          ps.size == algoCount,
+          "Must have same length as algoCount"
+        )
+        // TODO. Check size == algoCount
+        ps.toSeq.sortBy(_._1).map(_._2)
+      }
     }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -472,13 +472,11 @@ val aaaaa = bbbbb.asss(as).ccccc(
     fffff
   ) // comment
 >>>
-val aaaaa = bbbbb
-  .asss(as)
-  .ccccc(
-    ddddd,
-    eeeee,
-    fffff
-  ) // comment
+val aaaaa = bbbbb.asss(as).ccccc(
+  ddddd,
+  eeeee,
+  fffff
+) // comment
 <<< 2.18 val with apply-apply
 val aaaaa = (getSomeLongerFunction(c))(as)
 >>>
@@ -895,13 +893,13 @@ maxColumn = 80
         case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
       })
 >>>
-Idempotency violated
 def activationFutureFor(
     endpoint: ActorRef
 )(implicit timeout: Timeout, executor: ExecutionContext): Future[ActorRef] = {
   supervisor
     .ask(AwaitActivation(endpoint))(timeout)
-}.map[ActorRef]({
+}
+  .map[ActorRef]({
     case EndpointActivated(`endpoint`) ⇒ endpoint
     case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
   })
@@ -1325,18 +1323,18 @@ val a =
  .k().l({ m => n}, o)
 >>>
 val a =
-  b.c.d
-    .e(f)
-    .g
-    .h { i => j }
-    .k()
-    .l({ m => n }, o)
+  b.c
+    .d.e(f)
+    .g.h { i => j }
+    .k().l({ m => n }, o)
 <<< 6.3: chain, breaks in the middle
 val a = b.c
  .d.e() .f
  .g .h()
 >>>
-val a = b.c.d.e().f.g.h()
+val a = b.c
+  .d.e().f
+  .g.h()
 <<< 6.4: chain without apply
 maxColumn = 72
 includeNoParensInSelectChains = true
@@ -1353,8 +1351,7 @@ object a {
   created filter (ref ⇒
     !ref.isTerminated && !ref
       .asInstanceOf[ActorRefWithCell]
-      .underlying
-      .isInstanceOf[UnstartedCell]
+      .underlying.isInstanceOf[UnstartedCell]
   ) should ===(Seq.empty[ActorRef])
 }
 <<< 6.5: chain with delayed indent after break
@@ -1375,9 +1372,7 @@ object a {
 >>>
 object a {
   val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
-    .union(algoPredicts)
-    .groupByKey()
-    .mapValues { ps =>
+    .union(algoPredicts).groupByKey().mapValues { ps =>
       {
         assert(
           ps.size == algoCount,

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -544,11 +544,9 @@ val aaaaa = bbbbb.asss.ccccc(
     fffff
   ) // comment
 >>>
-val aaaaa = bbbbb.asss.ccccc(
-  ddddd,
-  eeeee,
-  fffff
-) // comment
+val aaaaa = bbbbb
+  .asss
+  .ccccc(ddddd, eeeee, fffff) // comment
 <<< 2.20 val with apply-select-select
 val nested =
   promiseIntercept(new Actor {
@@ -566,11 +564,11 @@ val nested =
     }
   )(result)
 <<< 2.21 val with apply type
-  val deployment = system
-    .asInstanceOf[ActorSystemImpl]
-    .provider
-    .deployer
-    .lookup(service.split("/").drop(1))
+val deployment = system
+  .asInstanceOf[ActorSystemImpl]
+  .provider
+  .deployer
+  .lookup(service.split("/").drop(1))
 >>>
 val deployment = system
   .asInstanceOf[ActorSystemImpl]
@@ -984,16 +982,12 @@ maxColumn = 80
 def activationFutureFor(
     endpoint: ActorRef
 )(implicit timeout: Timeout, executor: ExecutionContext): Future[ActorRef] =
-  (
-    supervisor
-      .ask(AwaitActivation(endpoint))(timeout)
-    )
-    .map[ActorRef]({
-      case EndpointActivated(`endpoint`) ⇒
-        endpoint
-      case EndpointFailedToActivate(`endpoint`, cause) ⇒
-        throw cause
-    })
+  (supervisor.ask(AwaitActivation(endpoint))(timeout)).map[ActorRef]({
+    case EndpointActivated(`endpoint`) ⇒
+      endpoint
+    case EndpointFailedToActivate(`endpoint`, cause) ⇒
+      throw cause
+  })
 <<< 3.27 enclosed in block, def, chain follows
 maxColumn = 80
 ===
@@ -1007,18 +1001,16 @@ maxColumn = 80
         case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
       })
 >>>
-Idempotency violated
 def activationFutureFor(
     endpoint: ActorRef
 )(implicit timeout: Timeout, executor: ExecutionContext): Future[ActorRef] = {
-  supervisor
-    .ask(AwaitActivation(endpoint))(timeout)
+  supervisor.ask(AwaitActivation(endpoint))(timeout)
 }.map[ActorRef]({
-    case EndpointActivated(`endpoint`) ⇒
-      endpoint
-    case EndpointFailedToActivate(`endpoint`, cause) ⇒
-      throw cause
-  })
+  case EndpointActivated(`endpoint`) ⇒
+    endpoint
+  case EndpointFailedToActivate(`endpoint`, cause) ⇒
+    throw cause
+})
 <<< 3.28 apply with optimal token
 maxColumn = 80
 danglingParentheses = false
@@ -1035,6 +1027,7 @@ case class AttributeInfo(
 <<< 3.29 apply with optimal token
 maxColumn = 80
 ===
+object a {
 Multipart.FormData.BodyPart.Strict(
   "userfile",
   HttpEntity(`application/pdf`, ByteString("filecontent")),
@@ -1044,17 +1037,23 @@ Multipart.FormData.BodyPart.Strict(
     RawHeader("Content-Additional-1", "anything"),
     RawHeader("Content-Additional-2", "really-anything"))
 )
+}
 >>>
-Multipart.FormData.BodyPart.Strict(
-  "userfile",
-  HttpEntity(`application/pdf`, ByteString("filecontent")),
-  Map("filename" -> "test€.dat"),
-  List(
-    RawHeader("Content-Transfer-Encoding", "binary"),
-    RawHeader("Content-Additional-1", "anything"),
-    RawHeader("Content-Additional-2", "really-anything")
-  )
-)
+object a {
+  Multipart
+    .FormData
+    .BodyPart
+    .Strict(
+      "userfile",
+      HttpEntity(`application/pdf`, ByteString("filecontent")),
+      Map("filename" -> "test€.dat"),
+      List(
+        RawHeader("Content-Transfer-Encoding", "binary"),
+        RawHeader("Content-Additional-1", "anything"),
+        RawHeader("Content-Additional-2", "really-anything")
+      )
+    )
+}
 <<< 3.30: apply with single-arg assign; open nl, close nonl
 object foo {
 val a = b(c = d)
@@ -1445,7 +1444,9 @@ val a =
  .g.h { i => j }
  .k().l({ m => n}, o)
 >>>
-val a = b.c.d
+val a = b
+  .c
+  .d
   .e(f)
   .g
   .h { i =>

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -994,7 +994,7 @@ def activationFutureFor(
       case EndpointFailedToActivate(`endpoint`, cause) ⇒
         throw cause
     })
-<<< SKIP 3.27 enclosed in block, def, chain follows
+<<< 3.27 enclosed in block, def, chain follows
 maxColumn = 80
 ===
   def activationFutureFor(endpoint: ActorRef)(implicit
@@ -1014,9 +1014,11 @@ def activationFutureFor(
   supervisor
     .ask(AwaitActivation(endpoint))(timeout)
 }.map[ActorRef]({
-  case EndpointActivated(`endpoint`) ⇒ endpoint
-  case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
-})
+    case EndpointActivated(`endpoint`) ⇒
+      endpoint
+    case EndpointFailedToActivate(`endpoint`, cause) ⇒
+      throw cause
+  })
 <<< 3.28 apply with optimal token
 maxColumn = 80
 danglingParentheses = false
@@ -1430,5 +1432,86 @@ a match {
     d.e match {
       case f =>
         "g"
+    }
+}
+<<< 6.1: chain, no break
+val a = b.c.d.e().f.g.h()
+>>>
+val a = b.c.d.e().f.g.h()
+<<< 6.2: chain, break on =
+val a =
+ b.c
+ .d.e(f)
+ .g.h { i => j }
+ .k().l({ m => n}, o)
+>>>
+val a = b.c.d
+  .e(f)
+  .g
+  .h { i =>
+    j
+  }
+  .k()
+  .l(
+    { m =>
+      n
+    },
+    o
+  )
+<<< 6.3: chain, breaks in the middle
+val a = b.c
+ .d.e() .f
+ .g .h()
+>>>
+val a = b.c.d.e().f.g.h()
+<<< 6.4: chain without apply
+maxColumn = 72
+includeNoParensInSelectChains = true
+===
+object a {
+created filter (ref ⇒
+         !ref.isTerminated && !ref
+          .asInstanceOf[ActorRefWithCell]
+          .underlying.isInstanceOf[UnstartedCell]) should ===(
+        Seq.empty[ActorRef])
+}
+>>>
+object a {
+  created filter (ref ⇒
+    !ref.isTerminated && !ref
+      .asInstanceOf[ActorRefWithCell]
+      .underlying
+      .isInstanceOf[UnstartedCell]
+  ) should ===(Seq.empty[ActorRef])
+}
+<<< 6.5: chain with delayed indent after break
+maxColumn = 70
+===
+object a {
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+    .union(algoPredicts).groupByKey().mapValues { ps =>
+      {
+        assert(
+          ps.size == algoCount,
+          "Must have same length as algoCount")
+        // TODO. Check size == algoCount
+        ps.toSeq.sortBy(_._1).map(_._2)
+      }
+    }
+}
+>>>
+object a {
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+    .union(algoPredicts)
+    .groupByKey()
+    .mapValues { ps =>
+      {
+        assert(
+          ps.size == algoCount,
+          "Must have same length as algoCount"
+        )
+        // TODO. Check size == algoCount
+        ps.toSeq.sortBy(_._1).map(_._2)
+      }
     }
 }


### PR DESCRIPTION
Helps with #1627.

`scala-repos` diffs:
* _fold_: https://github.com/kitbellew/scala-repos/commit/09d4b43104eafdf9784b3397bc3495bd34ef7218
* _unfold_: https://github.com/kitbellew/scala-repos/commit/15d30f82ad4090d9d68f0c1dfd9cb9e8ae954d70
* _keep_: https://github.com/kitbellew/scala-repos/commit/b3267ad3da764df77385ec4a6ce4df2da47a5aad
* _classic_: unchanged