### PR TITLE
#1627 [11]: Router: relax restrictions on breaks within interpolate

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1119,8 +1119,7 @@ class Router(formatOps: FormatOps) {
       case FormatToken(_, _: T.Dot, _)
           if style.newlines.sourceIgnored &&
             rightOwner.is[Term.Select] && findTreeWithParent(rightOwner) {
-            case _: Type.Select | _: Term.Interpolate => Some(true)
-            case _: Importer | _: Pkg => Some(true)
+            case _: Type.Select | _: Importer | _: Pkg => Some(true)
             case _: Term.Select | SplitCallIntoParts(_, _) => None
             case _ => Some(false)
           }.isDefined =>


### PR DESCRIPTION
Partial undo of #1796 