### PR TITLE
#1627 [12]: Router: ignore line breaks in enumerators

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1333,9 +1333,11 @@ class Router(formatOps: FormatOps) {
         val indent: Length =
           if (style.align.ifWhileOpenParen) StateColumn
           else style.continuationIndent.callSite
+        val oldClassic = !style.activeForEdition_2020_03 &&
+          style.newlines.sourceIs(Newlines.classic)
         Seq(
           Split(NoSplit, 0)
-            .withIndent(indent, close, After)
+            .withIndent(indent, close, if (oldClassic) After else Before)
             .withPolicy(penalizeNewlines)
         )
       case FormatToken(T.KwIf(), _, _) if leftOwner.is[Term.If] =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -946,23 +946,8 @@ class Router(formatOps: FormatOps) {
             .withSingleLine(close, killOnFail = true)
         ) ++ oneArgPerLineSplits
 
-      case tok @ FormatToken(T.LeftArrow(), right, _)
-          if leftOwner.is[Enumerator.Generator] =>
-        val lastToken = leftOwner.tokens.last
-        val indent: Length =
-          if (shouldBreakAfterArrowInFor && right.is[T.LeftBrace]) Num(-2)
-          else if (right.is[T.LeftBrace]) Num(0)
-          else if (style.align.arrowEnumeratorGenerator) StateColumn
-          else Num(0)
-        Seq(
-          Split(Space, 0)
-            .withIndent(indent, lastToken, After),
-          Split(Newline, 1)
-            .onlyIf(shouldBreakAfterArrowInFor)
-            .withIndent(indent, lastToken, After)
-        )
-      case tok @ FormatToken(T.Equals(), right, _)
-          if leftOwner.is[Enumerator.Val] =>
+      case tok @ FormatToken(_: T.LeftArrow | _: T.Equals, right, _)
+          if leftOwner.is[Enumerator] =>
         val lastToken = leftOwner.tokens.last
         val indent: Length =
           if (shouldBreakAfterArrowInFor && right.is[T.LeftBrace]) Num(-2)

--- a/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
+++ b/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
@@ -1,5 +1,5 @@
 align.arrowEnumeratorGenerator = true
-maxColumn = 40
+maxColumn = 38
 <<< alignByArrowEnumeratorGenerator
 for {
   x <- new Integer {

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -25,7 +25,7 @@ for ((key, value) <- properties)
 for ((key, value) <- properties)
   yield result(key) = value
 <<< multiline for
-for ((l, r) ← Seq(
+for ((l, r) ← /* c1 */ Seq(
     SelectString("a/b/c") -> None,
     SelectString("akka://all-systems/Nobody") -> None,
     SelectPath(system / "hallo") -> None,
@@ -34,17 +34,16 @@ for ((l, r) ← Seq(
   ) // test Java API
 ) checkOne(looker, l, r)
 >>>
-for ((l, r) ←
-       Seq(
-           SelectString("a/b/c") -> None,
-           SelectString("akka://all-systems/Nobody") -> None,
-           SelectPath(system / "hallo") -> None,
-           SelectPath(looker.path child "hallo") -> None, // test Java API
-           SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
-       ) // test Java API
+for ((l, r) ← /* c1 */ Seq(
+         SelectString("a/b/c") -> None,
+         SelectString("akka://all-systems/Nobody") -> None,
+         SelectPath(system / "hallo") -> None,
+         SelectPath(looker.path child "hallo") -> None, // test Java API
+         SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+     ) // test Java API
 ) checkOne(looker, l, r)
 <<< multiline for with brace
-for ((l, r) ← { /* c2 */ Seq(
+for ((l, r) ← /* c1 */ { /* c2 */ Seq(
     SelectString("a/b/c") -> None,
     SelectString("akka://all-systems/Nobody") -> None,
     SelectPath(system / "hallo") -> None,
@@ -54,18 +53,18 @@ for ((l, r) ← { /* c2 */ Seq(
   }
 ) checkOne(looker, l, r)
 >>>
-for ((l, r) ← {
-       /* c2 */
-       Seq(
-           SelectString("a/b/c") -> None,
-           SelectString("akka://all-systems/Nobody") -> None,
-           SelectPath(system / "hallo") -> None,
-           SelectPath(looker.path child "hallo") -> None, // test Java API
-           SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
-       ) // test Java API
+for ((l, r) ← /* c1 */ {
+         /* c2 */
+         Seq(
+             SelectString("a/b/c") -> None,
+             SelectString("akka://all-systems/Nobody") -> None,
+             SelectPath(system / "hallo") -> None,
+             SelectPath(looker.path child "hallo") -> None, // test Java API
+             SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+         ) // test Java API
      }) checkOne(looker, l, r)
 <<< multiline for with paren
-for ((l, r) ← ( /* c2 */ Seq(
+for ((l, r) ← /* c1 */ ( /* c2 */ Seq(
     SelectString("a/b/c") -> None,
     SelectString("akka://all-systems/Nobody") -> None,
     SelectPath(system / "hallo") -> None,
@@ -75,19 +74,18 @@ for ((l, r) ← ( /* c2 */ Seq(
   )
 ) checkOne(looker, l, r)
 >>>
-for ((l, r) ←
-       (/* c2 */ Seq(
+for ((l, r) ← /* c1 */ (/* c2 */ Seq(
            SelectString("a/b/c") -> None,
            SelectString("akka://all-systems/Nobody") -> None,
            SelectPath(system / "hallo") -> None,
            SelectPath(looker.path child "hallo") -> None, // test Java API
            SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
        ) // test Java API
-       )) checkOne(looker, l, r)
+     )) checkOne(looker, l, r)
 <<< multiline for with paren, no align
 align = none
 ===
-for ((l, r) ← ( /* c2 */Seq(
+for ((l, r) ← /* c1 */ ( /* c2 */Seq(
     SelectString("a/b/c") -> None,
     SelectString("akka://all-systems/Nobody") -> None,
     SelectPath(system / "hallo") -> None,
@@ -97,12 +95,11 @@ for ((l, r) ← ( /* c2 */Seq(
   )
 ) checkOne(looker, l, r)
 >>>
-for ((l, r) ←
-      (/* c2 */ Seq(
+for ((l, r) ← /* c1 */ (/* c2 */ Seq(
           SelectString("a/b/c") -> None,
           SelectString("akka://all-systems/Nobody") -> None,
           SelectPath(system / "hallo") -> None,
           SelectPath(looker.path child "hallo") -> None, // test Java API
           SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
       ) // test Java API
-      )) checkOne(looker, l, r)
+    )) checkOne(looker, l, r)

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -42,7 +42,7 @@ for ((l, r) ←
            SelectPath(looker.path child "hallo") -> None, // test Java API
            SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
        ) // test Java API
-     ) checkOne(looker, l, r)
+) checkOne(looker, l, r)
 <<< multiline for with brace
 for ((l, r) ← { /* c2 */ Seq(
     SelectString("a/b/c") -> None,

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -24,3 +24,85 @@ for ((key, value) <- properties)
 >>>
 for ((key, value) <- properties)
   yield result(key) = value
+<<< multiline for
+for ((l, r) ← Seq(
+    SelectString("a/b/c") -> None,
+    SelectString("akka://all-systems/Nobody") -> None,
+    SelectPath(system / "hallo") -> None,
+    SelectPath(looker.path child "hallo") -> None, // test Java API
+    SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+  ) // test Java API
+) checkOne(looker, l, r)
+>>>
+for ((l, r) ←
+       Seq(
+           SelectString("a/b/c") -> None,
+           SelectString("akka://all-systems/Nobody") -> None,
+           SelectPath(system / "hallo") -> None,
+           SelectPath(looker.path child "hallo") -> None, // test Java API
+           SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+       ) // test Java API
+     ) checkOne(looker, l, r)
+<<< multiline for with brace
+for ((l, r) ← { /* c2 */ Seq(
+    SelectString("a/b/c") -> None,
+    SelectString("akka://all-systems/Nobody") -> None,
+    SelectPath(system / "hallo") -> None,
+    SelectPath(looker.path child "hallo") -> None, // test Java API
+    SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+  ) // test Java API
+  }
+) checkOne(looker, l, r)
+>>>
+for ((l, r) ← {
+       /* c2 */
+       Seq(
+           SelectString("a/b/c") -> None,
+           SelectString("akka://all-systems/Nobody") -> None,
+           SelectPath(system / "hallo") -> None,
+           SelectPath(looker.path child "hallo") -> None, // test Java API
+           SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+       ) // test Java API
+     }) checkOne(looker, l, r)
+<<< multiline for with paren
+for ((l, r) ← ( /* c2 */ Seq(
+    SelectString("a/b/c") -> None,
+    SelectString("akka://all-systems/Nobody") -> None,
+    SelectPath(system / "hallo") -> None,
+    SelectPath(looker.path child "hallo") -> None, // test Java API
+    SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+  ) // test Java API
+  )
+) checkOne(looker, l, r)
+>>>
+for ((l, r) ←
+       (/* c2 */ Seq(
+           SelectString("a/b/c") -> None,
+           SelectString("akka://all-systems/Nobody") -> None,
+           SelectPath(system / "hallo") -> None,
+           SelectPath(looker.path child "hallo") -> None, // test Java API
+           SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+       ) // test Java API
+       )) checkOne(looker, l, r)
+<<< multiline for with paren, no align
+align = none
+===
+for ((l, r) ← ( /* c2 */Seq(
+    SelectString("a/b/c") -> None,
+    SelectString("akka://all-systems/Nobody") -> None,
+    SelectPath(system / "hallo") -> None,
+    SelectPath(looker.path child "hallo") -> None, // test Java API
+    SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+  ) // test Java API
+  )
+) checkOne(looker, l, r)
+>>>
+for ((l, r) ←
+      (/* c2 */ Seq(
+          SelectString("a/b/c") -> None,
+          SelectString("akka://all-systems/Nobody") -> None,
+          SelectPath(system / "hallo") -> None,
+          SelectPath(looker.path child "hallo") -> None, // test Java API
+          SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+      ) // test Java API
+      )) checkOne(looker, l, r)

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1423,3 +1423,154 @@ object a {
       }
     }
 }
+<<< 7.1: enumerator and guard short, for long
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+>>>
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+<<< 7.2: enumerator shoft, guard long
+maxColumn = 30
+===
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b if (b ++ b).length >= 2
+    } yield a
+}
+>>>
+object a {
+  def c(
+      b: List[Int]
+  ): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+<<< 7.3: enumerator and guard short, for short
+for (a <- b.sortBy(c)
+ if a > 0) yield x
+>>>
+for (a <- b.sortBy(c)
+  if a > 0) yield x
+<<< 7.4: enumerator and guard long
+maxColumn = 17
+===
+val k = for {
+  _ <- aaa + bbb
+    if !onlyOne
+  _ <- Future(aaa)
+    if !onlyOne
+  _ <- Future(2)
+} yield ()
+>>>
+val k = for {
+  _ <- aaa + bbb
+  if !onlyOne
+  _ <- Future(
+    aaa
+  )
+  if !onlyOne
+  _ <- Future(2)
+} yield ()
+<<< 7.5: multiple consecutive guards
+maxColumn = 80
+===
+val allOps = (
+  for {
+    c ← classes
+    m ← c.getMethods if !Modifier.isStatic(m.getModifiers); if !ignore(m.getName)
+    if !m.getName.contains("$"); if !materializing(m)
+  } yield m.getName
+).toSet
+>>>
+val allOps = (
+  for {
+    c ← classes
+    m ← c.getMethods if !Modifier.isStatic(m.getModifiers);
+    if !ignore(m.getName)
+    if !m.getName.contains("$"); if !materializing(m)
+  } yield m.getName
+).toSet
+<<< 7.6: for-yield with select chain
+maxColumn = 80
+===
+object a {
+for {
+       (listenAddress, listenerPromise) ← wrappedTransport.listen
+       // Enforce ordering between the signalling of "listen ready" to upstream
+       // and initialization happening in interceptListen
+      _ ←
+        listenerPromise
+          .tryCompleteWith(
+            interceptListen(listenAddress, upstreamListenerPromise.future1))
+          .future2
+     } yield (augmentScheme(listenAddress), upstreamListenerPromise)
+        listenerPromise
+          .tryCompleteWith(
+            interceptListen(listenAddress, upstreamListenerPromise.future1))
+          .future2
+}
+>>>
+object a {
+  for {
+    (listenAddress, listenerPromise) ← wrappedTransport.listen
+    // Enforce ordering between the signalling of "listen ready" to upstream
+    // and initialization happening in interceptListen
+    _ ←
+      listenerPromise
+        .tryCompleteWith(
+          interceptListen(listenAddress, upstreamListenerPromise.future1)
+        )
+        .future2
+  } yield (augmentScheme(listenAddress), upstreamListenerPromise)
+  listenerPromise
+    .tryCompleteWith(
+      interceptListen(listenAddress, upstreamListenerPromise.future1)
+    )
+    .future2
+}
+<<< 7.7: for-yield enclosed in parens
+for {
+  nu <- rand.gaussian(0, 1)
+  y = nu * nu
+  x = (mean
+        + mean * mean * y * 0.5 / shape
+        - 0.5 * mean / shape * math
+          .sqrt(4 * mean * shape * y + mean * mean * y * y)
+    )
+  z <- rand.uniform
+} yield {
+  if (z <= mean / (mean + x))
+    x
+  else
+    mean * mean / x
+}
+>>>
+for {
+  nu <- rand.gaussian(0, 1)
+  y = nu * nu
+  x = (mean
+      + mean * mean * y * 0.5 / shape
+      - 0.5 * mean / shape * math
+        .sqrt(
+          4 * mean * shape * y + mean * mean * y * y
+        ))
+  z <- rand.uniform
+} yield {
+  if (z <= mean / (mean + x))
+    x
+  else
+    mean * mean / x
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1309,3 +1309,143 @@ object a {
       }
     }
 }
+<<< 7.1: enumerator and guard short, for long
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+>>>
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+<<< 7.2: enumerator shoft, guard long
+maxColumn = 28
+===
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b if (b ++ b).length >= 2
+    } yield a
+}
+>>>
+object a {
+  def c(
+      b: List[Int]
+  ): List[Int] =
+    for {
+      a <- b if (b ++ b)
+        .length >= 2
+    } yield a
+}
+<<< 7.3: enumerator and guard short, for short
+for (a <- b.sortBy(c)
+ if a > 0) yield x
+>>>
+for (a <- b.sortBy(c)
+  if a > 0) yield x
+<<< 7.4: enumerator and guard long
+maxColumn = 17
+===
+val k = for {
+  _ <- aaa + bbb
+    if !onlyOne
+  _ <- Future(aaa)
+    if !onlyOne
+  _ <- Future(2)
+} yield ()
+>>>
+val k = for {
+  _ <- aaa + bbb
+  if !onlyOne
+  _ <- Future(
+    aaa
+  )
+  if !onlyOne
+  _ <- Future(2)
+} yield ()
+<<< 7.5: multiple consecutive guards
+maxColumn = 80
+===
+val allOps = (
+  for {
+    c ← classes
+    m ← c.getMethods if !Modifier.isStatic(m.getModifiers); if !ignore(m.getName)
+    if !m.getName.contains("$"); if !materializing(m)
+  } yield m.getName
+).toSet
+>>>
+val allOps = (for {
+  c ← classes
+  m ← c.getMethods if !Modifier.isStatic(m.getModifiers); if !ignore(m.getName)
+  if !m.getName.contains("$"); if !materializing(m)
+} yield m.getName).toSet
+<<< 7.6: for-yield with select chain
+maxColumn = 80
+===
+object a {
+for {
+       (listenAddress, listenerPromise) ← wrappedTransport.listen
+       // Enforce ordering between the signalling of "listen ready" to upstream
+       // and initialization happening in interceptListen
+      _ ←
+        listenerPromise
+          .tryCompleteWith(
+            interceptListen(listenAddress, upstreamListenerPromise.future1))
+          .future2
+     } yield (augmentScheme(listenAddress), upstreamListenerPromise)
+        listenerPromise
+          .tryCompleteWith(
+            interceptListen(listenAddress, upstreamListenerPromise.future1))
+          .future2
+}
+>>>
+object a {
+  for {
+    (listenAddress, listenerPromise) ← wrappedTransport.listen
+    // Enforce ordering between the signalling of "listen ready" to upstream
+    // and initialization happening in interceptListen
+    _ ← listenerPromise.tryCompleteWith(
+      interceptListen(listenAddress, upstreamListenerPromise.future1)
+    ).future2
+  } yield (augmentScheme(listenAddress), upstreamListenerPromise)
+  listenerPromise.tryCompleteWith(
+    interceptListen(listenAddress, upstreamListenerPromise.future1)
+  ).future2
+}
+<<< 7.7: for-yield enclosed in parens
+for {
+  nu <- rand.gaussian(0, 1)
+  y = nu * nu
+  x = (mean
+        + mean * mean * y * 0.5 / shape
+        - 0.5 * mean / shape * math
+          .sqrt(4 * mean * shape * y + mean * mean * y * y)
+    )
+  z <- rand.uniform
+} yield {
+  if (z <= mean / (mean + x))
+    x
+  else
+    mean * mean / x
+}
+>>>
+for {
+  nu <- rand.gaussian(0, 1)
+  y = nu * nu
+  x = (mean
+      + mean * mean * y * 0.5 / shape
+      - 0.5 * mean / shape * math.sqrt(
+        4 * mean * shape * y + mean * mean * y * y
+      ))
+  z <- rand.uniform
+} yield {
+  if (z <= mean / (mean + x)) x
+  else mean * mean / x
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1321,8 +1321,7 @@ object a {
 object a {
   def c(b: List[Int]): List[Int] =
     for {
-      a <- b
-      if (b ++ b).length >= 2
+      a <- b if (b ++ b).length >= 2
     } yield a
 }
 <<< 7.2: enumerator shoft, guard long
@@ -1348,8 +1347,7 @@ object a {
 for (a <- b.sortBy(c)
  if a > 0) yield x
 >>>
-for (a <- b.sortBy(c)
-  if a > 0) yield x
+for (a <- b.sortBy(c) if a > 0) yield x
 <<< 7.4: enumerator and guard long
 maxColumn = 17
 ===
@@ -1357,7 +1355,7 @@ val k = for {
   _ <- aaa + bbb
     if !onlyOne
   _ <- Future(aaa)
-    if !onlyOne
+  if !onlyOne
   _ <- Future(2)
 } yield ()
 >>>
@@ -1366,8 +1364,7 @@ val k = for {
   if !onlyOne
   _ <- Future(
     aaa
-  )
-  if !onlyOne
+  ) if !onlyOne
   _ <- Future(2)
 } yield ()
 <<< 7.5: multiple consecutive guards

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1522,11 +1522,11 @@ for {
   nu <- rand.gaussian(0, 1)
   y = nu * nu
   x = (mean
-      + mean * mean * y * 0.5 / shape
-      - 0.5 * mean / shape * math
-        .sqrt(
-          4 * mean * shape * y + mean * mean * y * y
-        ))
+    + mean * mean * y * 0.5 / shape
+    - 0.5 * mean / shape * math
+      .sqrt(
+        4 * mean * shape * y + mean * mean * y * y
+      ))
   z <- rand.uniform
 } yield {
   if (z <= mean / (mean + x))

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1383,3 +1383,154 @@ object a {
       }
     }
 }
+<<< 7.1: enumerator and guard short, for long
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+>>>
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+<<< 7.2: enumerator shoft, guard long
+maxColumn = 30
+===
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b if (b ++ b).length >= 2
+    } yield a
+}
+>>>
+object a {
+  def c(
+      b: List[Int]
+  ): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+<<< 7.3: enumerator and guard short, for short
+for (a <- b.sortBy(c)
+ if a > 0) yield x
+>>>
+for (a <- b.sortBy(c)
+  if a > 0) yield x
+<<< 7.4: enumerator and guard long
+maxColumn = 17
+===
+val k = for {
+  _ <- aaa + bbb
+    if !onlyOne
+  _ <- Future(aaa)
+    if !onlyOne
+  _ <- Future(2)
+} yield ()
+>>>
+val k = for {
+  _ <- aaa + bbb
+  if !onlyOne
+  _ <- Future(
+    aaa
+  )
+  if !onlyOne
+  _ <- Future(2)
+} yield ()
+<<< 7.5: multiple consecutive guards
+maxColumn = 80
+===
+val allOps = (
+  for {
+    c ← classes
+    m ← c.getMethods if !Modifier.isStatic(m.getModifiers); if !ignore(m.getName)
+    if !m.getName.contains("$"); if !materializing(m)
+  } yield m.getName
+).toSet
+>>>
+val allOps = (
+  for {
+    c ← classes
+    m ← c.getMethods if !Modifier.isStatic(m.getModifiers);
+    if !ignore(m.getName)
+    if !m.getName.contains("$"); if !materializing(m)
+  } yield m.getName
+).toSet
+<<< 7.6: for-yield with select chain
+maxColumn = 80
+===
+object a {
+for {
+       (listenAddress, listenerPromise) ← wrappedTransport.listen
+       // Enforce ordering between the signalling of "listen ready" to upstream
+       // and initialization happening in interceptListen
+      _ ←
+        listenerPromise
+          .tryCompleteWith(
+            interceptListen(listenAddress, upstreamListenerPromise.future1))
+          .future2
+     } yield (augmentScheme(listenAddress), upstreamListenerPromise)
+        listenerPromise
+          .tryCompleteWith(
+            interceptListen(listenAddress, upstreamListenerPromise.future1))
+          .future2
+}
+>>>
+object a {
+  for {
+    (listenAddress, listenerPromise) ← wrappedTransport.listen
+    // Enforce ordering between the signalling of "listen ready" to upstream
+    // and initialization happening in interceptListen
+    _ ←
+      listenerPromise
+        .tryCompleteWith(
+          interceptListen(listenAddress, upstreamListenerPromise.future1)
+        )
+        .future2
+  } yield (augmentScheme(listenAddress), upstreamListenerPromise)
+  listenerPromise
+    .tryCompleteWith(
+      interceptListen(listenAddress, upstreamListenerPromise.future1)
+    )
+    .future2
+}
+<<< 7.7: for-yield enclosed in parens
+for {
+  nu <- rand.gaussian(0, 1)
+  y = nu * nu
+  x = (mean
+        + mean * mean * y * 0.5 / shape
+        - 0.5 * mean / shape * math
+          .sqrt(4 * mean * shape * y + mean * mean * y * y)
+    )
+  z <- rand.uniform
+} yield {
+  if (z <= mean / (mean + x))
+    x
+  else
+    mean * mean / x
+}
+>>>
+for {
+  nu <- rand.gaussian(0, 1)
+  y = nu * nu
+  x = (mean
+      + mean * mean * y * 0.5 / shape
+      - 0.5 * mean / shape * math
+        .sqrt(
+          4 * mean * shape * y + mean * mean * y * y
+        ))
+  z <- rand.uniform
+} yield {
+  if (z <= mean / (mean + x))
+    x
+  else
+    mean * mean / x
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1547,7 +1547,8 @@ object a {
       b: List[Int]
   ): List[Int] =
     for {
-      a <- b if (b ++ b)
+      a <- b
+      if (b ++ b)
         .length >= 2
     } yield a
 }
@@ -1573,13 +1574,11 @@ val k =
   for {
     _ <- aa + bb
     if !onlyOne
-    _ <- Future(
-      aaa
-    )
+    _ <-
+      Future(aaa)
     if !onlyOne
-    _ <- Future(
-      2
-    )
+    _ <-
+      Future(2)
   } yield ()
 <<< 7.5: multiple consecutive guards
 maxColumn = 80
@@ -1596,7 +1595,8 @@ val allOps =
   (
     for {
       c ← classes
-      m ← c.getMethods if !Modifier.isStatic(m.getModifiers);
+      m ← c.getMethods
+      if !Modifier.isStatic(m.getModifiers);
       if !ignore(m.getName)
       if !m.getName.contains("$");
       if !materializing(m)

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1516,3 +1516,162 @@ object a {
       }
     }
 }
+<<< 7.1: enumerator and guard short, for long
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+>>>
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b
+      if (b ++ b).length >= 2
+    } yield a
+}
+<<< 7.2: enumerator shoft, guard long
+maxColumn = 28
+===
+object a {
+  def c(b: List[Int]): List[Int] =
+    for {
+      a <- b if (b ++ b).length >= 2
+    } yield a
+}
+>>>
+object a {
+  def c(
+      b: List[Int]
+  ): List[Int] =
+    for {
+      a <- b if (b ++ b)
+        .length >= 2
+    } yield a
+}
+<<< 7.3: enumerator and guard short, for short
+for (a <- b.sortBy(c)
+ if a > 0) yield x
+>>>
+for (a <- b.sortBy(c)
+  if a > 0)
+  yield x
+<<< 7.4: enumerator and guard long
+maxColumn = 17
+===
+val k = for {
+  _ <- aa + bb
+    if !onlyOne
+  _ <- Future(aaa)
+    if !onlyOne
+  _ <- Future(2)
+} yield ()
+>>>
+val k =
+  for {
+    _ <- aa + bb
+    if !onlyOne
+    _ <- Future(
+      aaa
+    )
+    if !onlyOne
+    _ <- Future(
+      2
+    )
+  } yield ()
+<<< 7.5: multiple consecutive guards
+maxColumn = 80
+===
+val allOps = (
+  for {
+    c ← classes
+    m ← c.getMethods if !Modifier.isStatic(m.getModifiers); if !ignore(m.getName)
+    if !m.getName.contains("$"); if !materializing(m)
+  } yield m.getName
+).toSet
+>>>
+val allOps =
+  (
+    for {
+      c ← classes
+      m ← c.getMethods if !Modifier.isStatic(m.getModifiers);
+      if !ignore(m.getName)
+      if !m.getName.contains("$");
+      if !materializing(m)
+    } yield m.getName
+  ).toSet
+<<< 7.6: for-yield with select chain
+maxColumn = 80
+===
+object a {
+for {
+       (listenAddress, listenerPromise) ← wrappedTransport.listen
+       // Enforce ordering between the signalling of "listen ready" to upstream
+       // and initialization happening in interceptListen
+      _ ←
+        listenerPromise
+          .tryCompleteWith(
+            interceptListen(listenAddress, upstreamListenerPromise.future1))
+          .future2
+     } yield (augmentScheme(listenAddress), upstreamListenerPromise)
+        listenerPromise
+          .tryCompleteWith(
+            interceptListen(listenAddress, upstreamListenerPromise.future1))
+          .future2
+}
+>>>
+object a {
+  for {
+    (listenAddress, listenerPromise) ← wrappedTransport.listen
+    // Enforce ordering between the signalling of "listen ready" to upstream
+    // and initialization happening in interceptListen
+    _ ←
+      listenerPromise
+        .tryCompleteWith(
+          interceptListen(listenAddress, upstreamListenerPromise.future1)
+        )
+        .future2
+  } yield (augmentScheme(listenAddress), upstreamListenerPromise)
+  listenerPromise
+    .tryCompleteWith(
+      interceptListen(listenAddress, upstreamListenerPromise.future1)
+    )
+    .future2
+}
+<<< 7.7: for-yield enclosed in parens
+for {
+  nu <- rand.gaussian(0, 1)
+  y = nu * nu
+  x =
+    (mean
+        + mean * mean * y * 0.5 / shape
+        - 0.5 * mean / shape * math
+          .sqrt(4 * mean * shape * y + mean * mean * y * y)
+    )
+  z <- rand.uniform
+} yield {
+  if (z <= mean / (mean + x))
+    x
+  else
+    mean * mean / x
+}
+>>>
+for {
+  nu <- rand.gaussian(0, 1)
+  y = nu * nu
+  x = (
+      mean
+        + mean * mean * y * 0.5 / shape
+        - 0.5 * mean / shape * math.sqrt(
+          4 * mean * shape * y + mean * mean * y * y
+        )
+  )
+  z <- rand.uniform
+} yield {
+  if (z <= mean / (mean + x))
+    x
+  else
+    mean * mean / x
+}

--- a/scalafmt-tests/src/test/resources/scalajs/For.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/For.stat
@@ -6,8 +6,7 @@ val k = for {
 } yield ()
 >>>
 val k = for {
-  _ <-
-    FutureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA(aaaaaa, bbbbbbbbbbbb,
-        cccccccc) if one
+  _ <- FutureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA(aaaaaa, bbbbbbbbbbbb,
+      cccccccc) if one
   _ <- Future(2)
 } yield ()

--- a/scalafmt-tests/src/test/resources/unit/For.stat
+++ b/scalafmt-tests/src/test/resources/unit/For.stat
@@ -73,10 +73,9 @@ val k = for {
 } yield ()
 >>>
 val k = for {
-  _ <-
-    Future(aaaaaa,
-           bbbbbbbbbbbb,
-           cccccccc) if one
+  _ <- Future(aaaaaa,
+              bbbbbbbbbbbb,
+              cccccccc) if one
   _ <- Future(2)
 } yield ()
 <<< enumerator val
@@ -234,10 +233,9 @@ for {
 } yield x + y
 >>>
 for {
-  x <-
-    new Integer {
-      def value = 2
-    }
+  x <- new Integer {
+    def value = 2
+  }
   y <- Int(2)
 } yield x + y
 <<< normal way #592


### PR DESCRIPTION
Helps with #1627. `scala-repos` diffs:

* _fold_: https://github.com/kitbellew/scala-repos/commit/496e6c6b0d8ec3e8eb1b8d91f618a42a3a3617e4?w=1
* _unfold_: https://github.com/kitbellew/scala-repos/commit/9043367b87139aded36e6b6c1737f70d3c874275?w=1
* _keep_: https://github.com/kitbellew/scala-repos/commit/52486acaa1e141dbc8805d0c57e542c5f2f4a67f?w=1
* _classic_: unchanged

Also, add a follow-up to changes in #1795, diffs at https://github.com/kitbellew/scala-repos/commit/5e73de35b1e365ee2ee17ba273f344ea6b71f1fc
* the closing paren in `ForYield` was unindented late so there was an extra indentation in some cases
* simplify the delayed arrow logic (in case clauses, the rule applies it on `case`, while the enumerator rules is applied just before arrow, hence it can simply be done right after)