### PR TITLE
Fixed unclear example for danglingParentheses in documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -420,18 +420,14 @@ danglingParentheses.defnSite
 ```scala mdoc:scalafmt
 danglingParentheses.defnSite = true
 danglingParentheses.callSite = false
+maxColumn=25
 ---
 object a {
   // defnSite
-  def method(
-    a: Int,
-    b: String): Boolean
+  def method(a: Int, b: String): Boolean
 
   // callSite
-  method(
-    a,
-    b
-  )
+  method(argument1, argument2)
 }
 ```
 
@@ -442,18 +438,14 @@ danglingParentheses.callSite
 ```scala mdoc:scalafmt
 danglingParentheses.defnSite = false
 danglingParentheses.callSite = true
+maxColumn=25
 ---
 object a {
   // defnSite
-  def method(
-    a: Int,
-    b: String
-  ): Boolean
+  def method(a: Int, b: String): Boolean
 
   // callSite
-  method(
-    a,
-    b)
+  method(argument1, argument2)
 }
 ```
 


### PR DESCRIPTION
Current example doesn't illustrate how `danglingParentheses` works:
![Screenshot from 2020-03-26 21-56-26](https://user-images.githubusercontent.com/4687050/77685915-3bb58a80-6fad-11ea-95ec-8ed535f555d0.png)
