### PR TITLE
Hide lambda body squashing under newlines.source=fold

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -651,6 +651,12 @@ rewrite.redundantBraces.stringInterpolation = true
 q"Hello ${name}"
 ```
 
+```scala mdoc:scalafmt
+rewrite.rules = [RedundantBraces]
+---
+List(1, 2, 3).map { x => x + 1 }
+```
+
 Configuration options and default values:
 
 // TODO(olafur): multiline defaults

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -529,6 +529,64 @@ else {
 }
 ```
 
+### `newlines.afterCurlyLambda`
+
+```scala mdoc:defaults
+newlines.afterCurlyLambda
+```
+
+```scala mdoc:scalafmt
+newlines.afterCurlyLambda = never
+---
+something.map { x =>
+
+
+
+  f(x)
+}
+
+something.map { x => f(x) }
+```
+
+```scala mdoc:scalafmt
+newlines.afterCurlyLambda = always
+---
+something.map { x =>
+
+
+
+  f(x)
+}
+
+something.map { x => f(x) }
+```
+
+```scala mdoc:scalafmt
+newlines.afterCurlyLambda = preserve
+---
+something.map { x =>
+
+
+
+  f(x)
+}
+
+something.map { x => f(x) }
+```
+
+```scala mdoc:scalafmt
+newlines.afterCurlyLambda = squash
+---
+something.map { x =>
+
+
+
+  f(x)
+}
+
+something.map { x => f(x) }
+```
+
 ### Newlines around `implicit` parameter list modifier
 
 #### Before
@@ -655,6 +713,22 @@ q"Hello ${name}"
 rewrite.rules = [RedundantBraces]
 ---
 List(1, 2, 3).map { x => x + 1 }
+```
+
+Entire power of `RedundantBraces` can be accessed with `newlines.afterCurlyLambda=squash`.
+It will try to squash lambda body in one line and then replace braces with parens:
+```scala mdoc:scalafmt
+rewrite.rules = [RedundantBraces]
+newlines.afterCurlyLambda=squash
+---
+List(1, 2, 3).map { x =>
+  x + 1
+}
+
+List(1, 2, 3).map { x =>
+  println("you can't squash me!")
+  x + 1
+}
 ```
 
 Configuration options and default values:

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -55,6 +55,18 @@ import metaconfig.generic.Surface
   *   If `always`, it will always add one empty line (opposite of `never`).
   *   If `preserve`, and there isn't an empty line, it will keep it as it is.
   *   If there is one or more empty lines, it will place a single empty line.
+  *
+  *   If `squash`, it will try to squash lambda body in one line:
+  *
+  *   {{{
+  *     xs.map { x =>
+  *       x + 1
+  *     }
+  *   }}}
+  *   will become
+  *   {{{
+  *     xs.map { x => x + 1 }
+  *   }}}
   * @param alwaysBeforeElseAfterCurlyIf if true, add a new line between the end of a curly if and the following else.
   *   For example
   *   if(someCond) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -167,7 +167,8 @@ object NewlineCurlyLambda {
   case object preserve extends NewlineCurlyLambda
   case object always extends NewlineCurlyLambda
   case object never extends NewlineCurlyLambda
+  case object squash extends NewlineCurlyLambda
 
   implicit val newlineCurlyLambdaReader: ConfCodec[NewlineCurlyLambda] =
-    ReaderUtil.oneOf[NewlineCurlyLambda](preserve, always, never)
+    ReaderUtil.oneOf[NewlineCurlyLambda](preserve, always, never, squash)
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -168,6 +168,12 @@ case class ScalafmtConfig(
       if (optIn.configStyleArguments && align.openParenDefnSite)
         errors += s"optIn.configStyleArguments with align.openParenDefnSite"
     }
+    if (newlines.source == Newlines.fold && newlines.afterCurlyLambda != NewlineCurlyLambda.squash) {
+      errors += s"newlines.afterCurlyLambda=${newlines.afterCurlyLambda}"
+    }
+    if (newlines.source == Newlines.unfold && newlines.afterCurlyLambda == NewlineCurlyLambda.squash) {
+      errors += s"newlines.afterCurlyLambda=${newlines.afterCurlyLambda}"
+    }
     if (optIn.breaksInsideChains)
       errors += s"optIn.breaksInsideChains=${optIn.breaksInsideChains}"
     if (!includeCurlyBraceInSelectChains)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -168,12 +168,6 @@ case class ScalafmtConfig(
       if (optIn.configStyleArguments && align.openParenDefnSite)
         errors += s"optIn.configStyleArguments with align.openParenDefnSite"
     }
-    if (newlines.source == Newlines.fold && newlines.afterCurlyLambda != NewlineCurlyLambda.squash) {
-      errors += s"newlines.afterCurlyLambda=${newlines.afterCurlyLambda}"
-    }
-    if (newlines.source == Newlines.unfold && newlines.afterCurlyLambda == NewlineCurlyLambda.squash) {
-      errors += s"newlines.afterCurlyLambda=${newlines.afterCurlyLambda}"
-    }
     if (optIn.breaksInsideChains)
       errors += s"optIn.breaksInsideChains=${optIn.breaksInsideChains}"
     if (!includeCurlyBraceInSelectChains)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1084,7 +1084,13 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   )(implicit style: ScalafmtConfig): (Boolean, NewlineT) =
     style.newlines.afterCurlyLambda match {
       case NewlineCurlyLambda.squash => (true, Newline)
-      case NewlineCurlyLambda.never => (newlines == 0, Newline)
+      case NewlineCurlyLambda.never =>
+        val space = style.newlines.source match {
+          case Newlines.fold => true
+          case Newlines.unfold => false
+          case _ => newlines == 0
+        }
+        (space, Newline)
       case NewlineCurlyLambda.always => (false, Newline2x)
       case NewlineCurlyLambda.preserve =>
         (newlines == 0, if (newlines >= 2) Newline2x else Newline)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1,9 +1,10 @@
 package org.scalafmt.internal
 
 import java.{util => ju}
+
 import scala.collection.JavaConverters._
 import org.scalafmt.Error.UnexpectedTree
-import org.scalafmt.config.{NewlineCurlyLambda, ScalafmtConfig}
+import org.scalafmt.config.{NewlineCurlyLambda, Newlines, ScalafmtConfig}
 import org.scalafmt.internal.Length.Num
 import org.scalafmt.internal.Policy.NoPolicy
 import org.scalafmt.util._
@@ -1080,13 +1081,19 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
   def getSpaceAndNewlineAfterCurlyLambda(
       newlines: Int
-  )(implicit style: ScalafmtConfig): (Boolean, NewlineT) =
+  )(implicit style: ScalafmtConfig): (Boolean, NewlineT) = {
+    val tryToSquashLambdaInOneLine =
+      style.newlines.sourceIs(Newlines.fold) || newlines == 0
     style.newlines.afterCurlyLambda match {
-      case NewlineCurlyLambda.never => (true, Newline)
+      case NewlineCurlyLambda.never => (tryToSquashLambdaInOneLine, Newline)
       case NewlineCurlyLambda.always => (false, Newline2x)
       case NewlineCurlyLambda.preserve =>
-        (newlines == 0, if (newlines >= 2) Newline2x else Newline)
+        (
+          tryToSquashLambdaInOneLine,
+          if (newlines >= 2) Newline2x else Newline
+        )
     }
+  }
 
   def getNoSplit(
       ft: FormatToken,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1081,9 +1081,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
 
   def getSpaceAndNewlineAfterCurlyLambda(
       newlines: Int
-  )(implicit style: ScalafmtConfig): (Boolean, NewlineT) = {
-    val tryToSquashLambdaInOneLine =
-      style.newlines.sourceIs(Newlines.fold) || newlines == 0
+  )(implicit style: ScalafmtConfig): (Boolean, NewlineT) =
     style.newlines.afterCurlyLambda match {
       case NewlineCurlyLambda.squash => (true, Newline)
       case NewlineCurlyLambda.never => (newlines == 0, Newline)
@@ -1091,7 +1089,6 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       case NewlineCurlyLambda.preserve =>
         (newlines == 0, if (newlines >= 2) Newline2x else Newline)
     }
-  }
 
   def getNoSplit(
       ft: FormatToken,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1085,13 +1085,11 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     val tryToSquashLambdaInOneLine =
       style.newlines.sourceIs(Newlines.fold) || newlines == 0
     style.newlines.afterCurlyLambda match {
-      case NewlineCurlyLambda.never => (tryToSquashLambdaInOneLine, Newline)
+      case NewlineCurlyLambda.squash => (true, Newline)
+      case NewlineCurlyLambda.never => (newlines == 0, Newline)
       case NewlineCurlyLambda.always => (false, Newline2x)
       case NewlineCurlyLambda.preserve =>
-        (
-          tryToSquashLambdaInOneLine,
-          if (newlines >= 2) Newline2x else Newline
-        )
+        (newlines == 0, if (newlines >= 2) Newline2x else Newline)
     }
   }
 

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -132,7 +132,7 @@ if (fullInfo)
     .flatMap(_.toSeq)
     .map(_._1)
     .toSet
-<<< #1409 yes, it's ugly, but consistent with Scala grammar: {}
+<<< #1409 yes, it's ugly, but consistent with Scala grammar: {} owns by lambda body
 class Sample {
   def mkFunc(flag: Boolean): String => Boolean = {
     if(flag) {

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -132,7 +132,7 @@ if (fullInfo)
     .flatMap(_.toSeq)
     .map(_._1)
     .toSet
-<<< #1409
+<<< #1409 yes, it's ugly, but consistent with Scala grammar: {}
 class Sample {
   def mkFunc(flag: Boolean): String => Boolean = {
     if(flag) {
@@ -145,10 +145,14 @@ class Sample {
 >>>
 class Sample {
   def mkFunc(flag: Boolean): String => Boolean = {
-    if (flag) { (v => true) }
-    else { (v => false) }
+    if (flag) { (v =>
+      true)
+    } else { (v =>
+      false)
+    }
   }
 }
+
 <<< #1413
 if (Keys.useCoursier.value)
       Def.task {

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -266,7 +266,9 @@ object a {
     c.copy(commands = c.commands :+ "help")
   } children (
       arg[String]("<command>") optional ()
-        action { (x, c) => c.copy(commands = c.commands :+ x) }
+        action { (x, c) =>
+          c.copy(commands = c.commands :+ x)
+        }
   )
 }
 <<< one-line lambda: make sure multiline string is handled correctly

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -139,7 +139,9 @@ lst.map { x =>
 >>>
 LookupJoin
   .rightSumming(TypedPipe.from(in1))
-  .map { x => x }
+  .map { x =>
+    x
+  }
   .write(TypedTsv[(String, String, String, String)]("output2"))
 <<< scalding discardTestJob
 

--- a/scalafmt-tests/src/test/resources/default/Unindent.stat
+++ b/scalafmt-tests/src/test/resources/default/Unindent.stat
@@ -32,7 +32,9 @@
   {
     assert(
         backoffs.force.toSeq ==
-          (0 until 10 map { i => (1 << i).seconds }))
+          (0 until 10 map { i =>
+            (1 << i).seconds
+          }))
   }
 }
 

--- a/scalafmt-tests/src/test/resources/default/Val.stat
+++ b/scalafmt-tests/src/test/resources/default/Val.stat
@@ -67,7 +67,9 @@ val ps = params map { p =>
      JSMethodParam(p.info, p.asTerm.isParamWithDefault)
    }
 >>>
-val ps = params map { p => JSMethodParam(p.info, p.asTerm.isParamWithDefault) }
+val ps = params map { p =>
+  JSMethodParam(p.info, p.asTerm.isParamWithDefault)
+}
 <<< #269 2
 val wasBOM = if (endianness == AutoEndian) {
   // Read BOM
@@ -203,7 +205,9 @@ val myRoute = path("") {
         readFromFile(fileName)
       }
 >>>
-val vfile = options.jar map { jar => readFromJar(jar, fileName) } getOrElse {
+val vfile = options.jar map { jar =>
+  readFromJar(jar, fileName)
+} getOrElse {
   readFromFile(fileName)
 }
 <<< vfile 2
@@ -215,7 +219,9 @@ val vfile = options.jar map { jar => readFromJar(jar, fileName) } getOrElse {
       }
 >>>
 val vfile =
-  options.jar map { jar => readFromJar(jar, fileName) } getOrElse {
+  options.jar map { jar =>
+    readFromJar(jar, fileName)
+  } getOrElse {
     readFromFile(fileName)
   }
 <<< #590

--- a/scalafmt-tests/src/test/resources/newlines/AlwaysBeforeCurlyBraceLambdaParams.stat
+++ b/scalafmt-tests/src/test/resources/newlines/AlwaysBeforeCurlyBraceLambdaParams.stat
@@ -16,7 +16,8 @@ lst.map { x =>
 }
 >>>
 lst.map {
-  x => x
+  x =>
+    x
 }
 <<< apply to one-liners as well
 lst.map { x => x }
@@ -31,5 +32,6 @@ lst.map {
 }
 >>>
 lst.map {
-  x => x
+  x =>
+    x
 }

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
@@ -10,7 +10,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call { x => g(x) }
+  something.call { x =>
+    g(x)
+  }
 }
 
 <<< Preseve no-newline in lambda call
@@ -21,7 +23,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call { x => g(x) }
+  something.call { x =>
+    g(x)
+  }
 }
 
 <<< Remove many newlines in lambda call
@@ -35,7 +39,9 @@ def f = {
 }
 >>>
 def f = {
-  something.call { x => g(x) }
+  something.call { x =>
+    g(x)
+  }
 }
 <<< #1717
 maxColumn = 100
@@ -64,7 +70,8 @@ class Bar {
           case Nil => connection.pure(Right(toResponse(campaigns, Map.empty)))
           case _ =>
             getProfileEmails(request.securityContext, profileIds).to[ConnectionIO].map {
-              profileEmails => Right(toResponse(campaigns, profileEmails))
+              profileEmails =>
+                Right(toResponse(campaigns, profileEmails))
             }
         }
       }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1446,3 +1446,20 @@ for {
   if (z <= mean / (mean + x)) x
   else mean * mean / x
 }
+<<< #1409
+class Sample {
+  def mkFunc(): String => Boolean = {
+    if(flag) {
+      v => true
+    } else {
+      v => false
+    }
+  }
+}
+>>>
+class Sample {
+  def mkFunc(): String => Boolean = {
+    if (flag) { v => true }
+    else { v => false }
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1,6 +1,7 @@
 align = none
 maxColumn = 40
 newlines.source = fold
+newlines.afterCurlyLambda = squash
 runner.optimizer.forceConfigStyleOnOffset = 50
 <<< 1.1: block, if-else, line too long
 if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}

--- a/scalafmt-tests/src/test/resources/optIn/SelectChain.stat
+++ b/scalafmt-tests/src/test/resources/optIn/SelectChain.stat
@@ -11,8 +11,12 @@ includeCurlyBraceInSelectChains = true
 >>>
 def acceptParticipants =
   actions[Lottery]
-    .handleCommand { cmd: AddParticipant => ParticipantAdded(cmd.name, id) }
-    .handleEvent { evt: ParticipantAdded => this.addParticipant(evt.name) }
+    .handleCommand { cmd: AddParticipant =>
+      ParticipantAdded(cmd.name, id)
+    }
+    .handleEvent { evt: ParticipantAdded =>
+      this.addParticipant(evt.name)
+    }
 <<< .value #639
 val x = Def.taskDyn {
     println(1)

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
@@ -123,7 +123,9 @@ seq should have length 5
   perform(_ + 1)
 }
 >>>
-(1 to total).foreach { _ => perform(_ + 1) }
+(1 to total).foreach { _ =>
+  perform(_ + 1)
+}
 <<< excluded combinators in lhs 4
 seq should have length 5 and true
 >>>

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix3.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix3.stat
@@ -5,7 +5,9 @@ rewrite.rules = [AvoidInfix]
   x
 }
 >>>
-(NotQuoted ~ any.*).map { x => x }
+(NotQuoted ~ any.*).map { x =>
+  x
+}
 <<< settings
 Project("sub", file("sub")) delegateTo (root) settings (check <<= checkTask)
 >>>

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -139,7 +139,9 @@ override def run(args: List[String]): IO[ExitCode] =
 override def run(args: List[String]): IO[ExitCode] =
   Slf4jLogger
     .create[IO]
-    .flatMap { implicit logger: Logger[IO] => program }
+    .flatMap { implicit logger: Logger[IO] =>
+      program
+    }
 <<< #1707 2: don't rewrite to parens if typed lambda param
 def a(b: B): C[D] =
     C[String].contramap[D] { i: D =>
@@ -147,23 +149,27 @@ def a(b: B): C[D] =
     }
 >>>
 def a(b: B): C[D] =
-  C[String].contramap[D] { i: D => b.format(i) }
-<<< #1707 3: rewrite to parens if typed lambda param with parens
+  C[String].contramap[D] { i: D =>
+    b.format(i)
+  }
+<<< #1707 3: rewrite to parens if typed lambda param with parens and source=fold
+newlines.source=fold
+===
 def a(b: B): C[D] =
     C[String].contramap[D] { (i: D) =>
       b.format(i)
     }
 >>>
-def a(b: B): C[D] =
-  C[String].contramap[D]((i: D) => b.format(i))
-<<< #1707 4: rewrite to parens if multiple params
+def a(b: B): C[D] = C[String].contramap[D]((i: D) => b.format(i))
+<<< #1707 4: rewrite to parens if multiple params and source=fold
+newlines.source=fold
+===
 def a(b: B): C[D] =
     C[String].contramap[D] { (i: D, j: Int) =>
       b.format(i)
     }
 >>>
-def a(b: B): C[D] =
-  C[String].contramap[D]((i: D, j: Int) => b.format(i))
+def a(b: B): C[D] = C[String].contramap[D]((i: D, j: Int) => b.format(i))
 <<< #1708
 danglingParentheses = false
 ===

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -152,24 +152,26 @@ def a(b: B): C[D] =
   C[String].contramap[D] { i: D =>
     b.format(i)
   }
-<<< #1707 3: rewrite to parens if typed lambda param with parens and source=fold
-newlines.source=fold
+<<< #1707 3: rewrite to parens if typed lambda param with parens and newlines.afterCurlyLambda=squash
+newlines.afterCurlyLambda=squash
 ===
 def a(b: B): C[D] =
     C[String].contramap[D] { (i: D) =>
       b.format(i)
     }
 >>>
-def a(b: B): C[D] = C[String].contramap[D]((i: D) => b.format(i))
-<<< #1707 4: rewrite to parens if multiple params and source=fold
-newlines.source=fold
+def a(b: B): C[D] =
+  C[String].contramap[D]((i: D) => b.format(i))
+<<< #1707 4: rewrite to parens if multiple params and newlines.afterCurlyLambda=squash
+newlines.afterCurlyLambda=squash
 ===
 def a(b: B): C[D] =
     C[String].contramap[D] { (i: D, j: Int) =>
       b.format(i)
     }
 >>>
-def a(b: B): C[D] = C[String].contramap[D]((i: D, j: Int) => b.format(i))
+def a(b: B): C[D] =
+  C[String].contramap[D]((i: D, j: Int) => b.format(i))
 <<< #1708
 danglingParentheses = false
 ===

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -240,6 +240,8 @@ object a {
   }
 }
 <<< #1027 1.1: braces to parens yes: single-stat
+newlines.source=fold
+===
 object a {
   b.c { d =>
    e }
@@ -255,7 +257,9 @@ object a {
 }
 >>>
 object a {
-  b.c { d => e; f }
+  b.c { d =>
+    e; f
+  }
 }
 <<< #1027 1.3: braces to parens no: multi-stat block
 object a {
@@ -264,7 +268,9 @@ object a {
 }
 >>>
 object a {
-  b.c { d => e; f }
+  b.c { d =>
+    e; f
+  }
 }
 <<< #1027 1.4: braces to parens no: empty body
 object a {
@@ -443,7 +449,8 @@ class Test extends AnyWordSpec {
   println
   Post("/", urlEncodedForm) ~> {
     formFields('firstName, "age".as[Int], 'sex.?, "VIP" ? false) {
-      (firstName, age, sex, vip) ⇒ complete(firstName + age + sex + vip)
+      (firstName, age, sex, vip) ⇒
+        complete(firstName + age + sex + vip)
     }
   } ~> check(responseAs[String] shouldEqual "Mike42Nonefalse")
 }
@@ -534,8 +541,11 @@ object a {
 }
 >>>
 object a {
-  val select = if (max) { (a: CTuple, b: CTuple) => (a.compareTo(b) >= 0) }
-  else { (a: CTuple, b: CTuple) => (a.compareTo(b) <= 0) }
+  val select = if (max) { (a: CTuple, b: CTuple) =>
+    (a.compareTo(b) >= 0)
+  } else { (a: CTuple, b: CTuple) =>
+    (a.compareTo(b) <= 0)
+  }
 }
 <<< #1633 2.2: function block in a val statement
 object a {
@@ -545,7 +555,9 @@ object a {
 }
 >>>
 object a {
-  val select = { (a: CTuple, b: CTuple) => (a.compareTo(b) >= 0) }
+  val select = { (a: CTuple, b: CTuple) =>
+    (a.compareTo(b) >= 0)
+  }
 }
 <<< #1633 3.1: function block in a val statement
 object a {
@@ -685,6 +697,8 @@ object a {
     3
 }
 <<< #1633 5.1: verify correct newline removal
+newlines.source=fold
+===
 object a {
   val b = c(d => {
     e } // comment1

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -240,7 +240,7 @@ object a {
   }
 }
 <<< #1027 1.1: braces to parens yes: single-stat
-newlines.source=fold
+newlines.afterCurlyLambda=squash
 ===
 object a {
   b.c { d =>
@@ -697,7 +697,7 @@ object a {
     3
 }
 <<< #1633 5.1: verify correct newline removal
-newlines.source=fold
+newlines.afterCurlyLambda=squash
 ===
 object a {
   val b = c(d => {

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysOwners.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysOwners.stat
@@ -5,4 +5,6 @@ lst.map { x =>
   x + 1
 }
 >>>
-lst.map { x => x + 1 }
+lst.map { x =>
+  x + 1
+}

--- a/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
@@ -121,7 +121,9 @@ ctx.replace(
 ctx.replace(
     additionalImports =
       "" ::
-        foo.map { x => x + 1 }
+        foo.map { x =>
+          x + 1
+        }
 )
 <<< right assoc
 x ::
@@ -131,7 +133,9 @@ x ::
   z
 >>>
 x ::
-  y.map { x => x + 1 } ::
+  y.map { x =>
+    x + 1
+  } ::
   z
 <<< simple expr
 x ::

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -36,7 +36,9 @@ Thing() { implicit ctx => j =>
       ???
 }
 >>>
-Thing() { implicit ctx => j => ??? }
+Thing() { implicit ctx => j =>
+  ???
+}
 <<< curried break before first
 Thing() { implicit ctx => j => kkkkkkkkkk =>
       ???
@@ -55,7 +57,8 @@ Thing() {
   implicit ctx => j =>
     kkkkkkkkkkkkkkkkkkk =>
       llllllllllll =>
-        mmmmmmmmmmmmmmmmmmm => ???
+        mmmmmmmmmmmmmmmmmmm =>
+          ???
 }
 <<< curried with ()
 Thing(implicit ctx => j =>
@@ -79,7 +82,9 @@ Thing() { implicit ctx =>
       ???
 }
 >>>
-Thing() { implicit ctx => ??? }
+Thing() { implicit ctx =>
+  ???
+}
 <<< ( arg =>
 val groupedData = Array(topic1, topic2).flatMap(
         topic =>
@@ -94,7 +99,9 @@ val x: Int => Int =  { y =>
   y + 1
 }
 >>>
-val x: Int => Int = { y => y + 1 }
+val x: Int => Int = { y =>
+  y + 1
+}
 <<< indent
 map(() => {
   x =>

--- a/scalafmt-tests/src/test/resources/unit/Trait.source
+++ b/scalafmt-tests/src/test/resources/unit/Trait.source
@@ -35,7 +35,9 @@ trait Cap extends Util { self =>
     x
   }
 
-  val x: Int => Int = { y => y + 1 }
+  val x: Int => Int = { y =>
+    y + 1
+  }
 }
 <<< #370
 trait SampleTrait extends A with B with C with D with E{


### PR DESCRIPTION
Should fix #1826 for default behavior

Lambdas don't squash with default config, but «braces to parens» works with `fold`:
```
<<< squash
newlines.source=fold
rewrite.rules=[RedundantBraces]
===
files.test("basic") { name =>
  assertEquals(name, "basic-setup")
}
>>>
files.test("basic")(name => assertEquals(name, "basic-setup"))
```

#### Next steps

- squash blocks with `fold`:
```
<<< failing now
newlines.source=fold
===
files.test("basic") {
  assertEquals(name, "basic-setup")
}
>>>
files.test("basic") { assertEquals(name, "basic-setup") }
```
- note at the website documentation that entire power of `RedundantBraces` can be accessed only with `newlines.source=fold`

@kitbellew what do you think?

Also I really like the idea of keeping newlines configuration in universal formatting style sets like `fold`, `unfold`, etc. Now we have a lot of granular configs like `alwaysBeforeCurlyBraceLambdaParams` which affects formatting only in particular cases. They conflict each other. What about to gradually deprecate them and move its functionality into `newlines.source`? It may be related not only to `newlines`: I think that highly specialized settings from entire scalafmt config can be combined into several enums.