### PR TITLE
Fixed newlines on NewAnonymous with empty arguments lambda

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaSquash.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaSquash.stat
@@ -1,0 +1,50 @@
+newlines.afterCurlyLambda = squash
+
+<<< squash newline in lambda call
+def f = {
+  something.call { x =>
+
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x => g(x) }
+}
+
+<<< squash no newline in lambda call
+def f = {
+  something.call { x =>    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x => g(x) }
+}
+<<< squash no empty line in lambda call
+def f = {
+  something.call { x =>
+    g(x)
+  }
+}
+>>>
+def f = {
+  something.call { x => g(x) }
+}
+
+<<< don't touch constructors with zero args lambda
+val foo = new Bar { () =>
+  println("hello")
+}
+>>>
+val foo = new Bar { () =>
+  println("hello")
+}
+<<< don't touch constructors with wildcard arg lambda
+val foo = new Bar { _ =>
+  println("hello")
+}
+>>>
+val foo = new Bar { _ =>
+  println("hello")
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1464,3 +1464,25 @@ class Sample {
     else { v => false }
   }
 }
+<<< fold ctor body with zero args
+val foo = new Bar { () =>
+  f(42)
+}
+>>>
+val foo = new Bar { () => f(42) }
+<<< preserve ctor body with zero args
+val foo = new Bar { () => f(42) }
+>>>
+val foo = new Bar { () => f(42) }
+<<< fold ctor body with wildcard arg
+val foo = Bar { _ =>
+  println("a")
+}
+>>>
+val foo = Bar { _ => println("a") }
+<<< fold apply with zero args
+val foo = Bar { () =>
+  f(42)
+}
+>>>
+val foo = Bar { () => f(42) }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1534,3 +1534,31 @@ for {
   else
     mean * mean / x
 }
+<<< keep ctor body with zero args
+val foo = new Bar { () =>
+  f(42)
+}
+>>>
+val foo = new Bar { () =>
+  f(42)
+}
+<<< keep ctor body with zero args
+val foo = new Bar { () => f(42) }
+>>>
+val foo = new Bar { () => f(42) }
+<<< keep ctor body with wildcard arg
+val foo = Bar { _ =>
+  println("a")
+}
+>>>
+val foo = Bar { _ =>
+  println("a")
+}
+<<< keep apply with zero args
+val foo = Bar { () =>
+  f(42)
+}
+>>>
+val foo = Bar { () =>
+  f(42)
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1675,3 +1675,35 @@ for {
   else
     mean * mean / x
 }
+<<< unfold ctor body with zero args
+val foo = new Bar { () =>
+  f(42)
+}
+>>>
+val foo =
+  new Bar { () =>
+    f(42)
+  }
+<<< unfold ctor body with zero args
+val foo = new Bar { () => f(42) }
+>>>
+val foo =
+  new Bar { () =>
+    f(42)
+  }
+<<< unfold ctor body with wildcard arg
+val foo = Bar { _ =>
+  println("a")
+}
+>>>
+val foo = Bar { _ =>
+  println("a")
+}
+<<< unfold apply with zero args
+val foo = Bar { () =>
+  f(42)
+}
+>>>
+val foo = Bar { () =>
+  f(42)
+}

--- a/scalafmt-tests/src/test/resources/spaces/Constructor.stat
+++ b/scalafmt-tests/src/test/resources/spaces/Constructor.stat
@@ -13,3 +13,33 @@ class MyComponent @Inject() (ctx: Context)(ws: WSClient)
 new ShardEntity(rts) (onMessage)
 >>>
 new ShardEntity(rts)(onMessage)
+<<< preserve ctor lambda with zero args
+val foo = new Bar { () =>
+  println("a")
+}
+>>>
+val foo = new Bar { () =>
+  println("a")
+}
+<<< preserve ctor lambda with wildcard arg
+val foo = new Bar { _ =>
+  println("a")
+}
+>>>
+val foo = new Bar { _ =>
+  println("a")
+}
+<<< preserve ctor one line lambda with zero args
+val foo = new Bar { () => println("a") }
+>>>
+val foo = new Bar { () => println("a") }
+<<< preserve ctor lambda with zero args and parens
+val foo = new Bar ( () => println("a") )
+>>>
+val foo = new Bar(() => println("a"))
+<<< squash ctor lambda with zero args and parens
+val foo = new Bar(() =>
+  println("a")
+)
+>>>
+val foo = new Bar(() => println("a"))


### PR DESCRIPTION
Fixes #1281 

Currently `() => ...` in `NewAnonymous` always squashes:
```
<<<
val foo = new Bar { () =>
  println("hello")
}
>>>
val foo = new Bar { () => println("hello") }
```

it's little inconsistent with:
```
<<<
val foo = new Bar { x =>
  println("hello")
}
>>>
val foo = new Bar { x =>
  println("hello")
}
```

After this changes newlines would be respected in both cases.

Also added tests for `newlines.afterCurlyLambda=squash` from #1832 