### PR TITLE
TokenOps bugfix: logic for newline on docstring

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -53,16 +53,21 @@ object TokenOps {
   def shouldGet2xNewlines(
       tok: FormatToken
   )(implicit style: ScalafmtConfig): Boolean =
-    !forceDocstringBlankLine(tok.left, style) && {
-      tok.hasBlankLine ||
-      (forceDocstringBlankLine(tok.right, style) && !tok.left.is[Comment])
-    }
+    tok.hasBlankLine || blankLineBeforeDocstring(tok.left, tok.right)
 
-  def forceDocstringBlankLine(token: Token, style: ScalafmtConfig): Boolean = {
+  def blankLineBeforeDocstring(
+      left: Token,
+      right: Token
+  )(implicit style: ScalafmtConfig): Boolean =
+    right.is[Token.Comment] &&
+      blankLineBeforeDocstring(left, right.asInstanceOf[Token.Comment])
+
+  def blankLineBeforeDocstring(
+      left: Token,
+      right: Token.Comment
+  )(implicit style: ScalafmtConfig): Boolean =
     style.optIn.forceNewlineBeforeDocstringSummary &&
-    token.is[Comment] &&
-    token.syntax.startsWith("/**")
-  }
+      !left.is[Token.Comment] && right.syntax.startsWith("/**")
 
   def lastToken(tree: Tree): Token = {
     // 2.13 has findLast

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -112,6 +112,7 @@ package a.b.c
 /**
   * docstring
   */
+
 import d.e.f
 <<< docstring: line after but not before [no force]
 optIn.forceBlankLineBeforeDocstring = false

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -96,4 +96,36 @@ import org.{
   K,
   L
 }
+<<< docstring: line after but not before [force]
+optIn.forceBlankLineBeforeDocstring = true
+optIn.blankLineBeforeDocstring = false
+===
+package a.b.c
+/**
+ * docstring
+ */
 
+import d.e.f
+>>>
+package a.b.c
+
+/**
+  * docstring
+  */
+import d.e.f
+<<< docstring: line after but not before [no force]
+optIn.forceBlankLineBeforeDocstring = false
+===
+package a.b.c
+/**
+ * docstring
+ */
+
+import d.e.f
+>>>
+package a.b.c
+/**
+  * docstring
+  */
+
+import d.e.f


### PR DESCRIPTION
With `optIn.forceBlankLineBeforeDocstring=true`, in addition to forcing a blank line before docstring, we also mistakenly removed one after it. Fixes #1426.