### PR TITLE
Align strip margin: allow disabling the alignment

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,15 +67,28 @@ docstrings = JavaDoc
 
 ### `assumeStandardLibraryStripMargin`
 
+This parameter simply says the `.stripMargin` method was not redefined
+by the user to assign special meaning to indentation preceding
+the `|` character. Hence, that indentation can be modified.
+
 ```scala mdoc:defaults
 assumeStandardLibraryStripMargin
 ```
 
-If `true`, the margin character `|` is aligned with the opening triple quote
-`"""` in interpolated and raw string literals.
+```scala mdoc:defaults
+align.stripMargin
+```
+
+If `true`, lines starting with the margin character `|` (or another if
+specified in the `.stripMargin(...)` call) will be indented differently.
+
+If `align.stripMargin` is true, they will align with the opening triple-quote
+`"""` in interpolated and raw string literals. Otherwise, they will be indented
+relative to the _start_ of the opening line.
 
 ```scala mdoc:scalafmt
 assumeStandardLibraryStripMargin = true
+align.stripMargin = true
 ---
 val example1 =
   s"""Examples:
@@ -85,10 +98,23 @@ val example1 =
   |""".stripMargin
 ```
 
+```scala mdoc:scalafmt
+assumeStandardLibraryStripMargin = true
+align.stripMargin = false
+---
+val example1 =
+  s"""|Examples:
+      |  * one
+      |  * two
+      |  * $three
+      |""".stripMargin
+```
+
 The pipe character can immediately follow the opening `"""`
 
 ```scala mdoc:scalafmt
 assumeStandardLibraryStripMargin = true
+align.stripMargin = true
 ---
 val example2 =
   s"""|Examples:
@@ -157,6 +183,10 @@ x match { // false for case arrows
 > renamings and other refactorings, without having to ignore whitespace changes
 > in diffs or use `--ignore-all-space` to avoid conflicts when git merging or
 > rebasing.
+
+> Starting with the introduction of `align.stripMargin` parameter in v2.5.0,
+> one must explicitly enable it to get earlier behaviour of `align=none`.
+> See [assumeStandardLibraryStripMargin](#assumestandardlibrarystripmargin).
 
 #### `align=some`
 
@@ -378,6 +408,17 @@ class IntStringLong(
   long: Long
 )
 ```
+
+### `align.stripMargin`
+
+See [assumeStandardLibraryStripMargin](#assumestandardlibrarystripmargin).
+
+```scala mdoc:defaults
+align.stripMargin
+```
+
+This functionality is enabled in all presets except `align=none` where it was
+disabled since the parameter's introduction in v2.5.0.
 
 ## Newlines
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -54,8 +54,14 @@ import metaconfig.generic.Surface
   *   Defn.Var, set the values to:
   *     Map("Defn.Var" -> "Assign", "Defn.Val" -> "Assign")
   *   Note. Requires mixedOwners to be true.
+  * @param stripMargin
+  *   If set, indent lines with a strip-margin character in a multiline string
+  *   constant relative to the opening quotes (or the strip-margin character if
+  *   present) on the first line; otherwise, indent relative to the beginning
+  *   of the first line, as usual.
   */
 case class Align(
+    stripMargin: Boolean = true,
     openParenCallSite: Boolean = false,
     openParenDefnSite: Boolean = false,
     tokens: Seq[AlignToken] = Seq(AlignToken.caseArrow),
@@ -82,6 +88,7 @@ object Align {
   // no vertical alignment whatsoever, if you find any vertical alignment with
   // this settings, please report an issue.
   val none: Align = Align(
+    stripMargin = false,
     openParenCallSite = false,
     openParenDefnSite = false,
     tokens = Seq.empty,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -43,8 +43,8 @@ class FormatWriter(formatOps: FormatOps) {
           sb.append(formatMarginizedString(token, state.indentation))
         case literal: T.Constant.String =>
           def indent = {
-            val prevState = entry.previous.state
-            if (prevState.split.modification.isNewline)
+            if (!initStyle.align.stripMargin ||
+              entry.previous.state.split.modification.isNewline)
               2 + state.indentation
             else {
               // compute indentation by locating the previous newline in output
@@ -115,7 +115,7 @@ class FormatWriter(formatOps: FormatOps) {
     pipeOpt.fold(token.syntax) { pipe =>
       val pattern =
         if (pipe == '|') leadingPipeSpace else getStripMarginPattern(pipe)
-      val firstChar: Char = token match {
+      def firstChar: Char = token match {
         case T.Interpolation.Part(_) =>
           (for {
             parent <- owners(token).parent
@@ -127,7 +127,8 @@ class FormatWriter(formatOps: FormatOps) {
         case _ =>
           token.syntax.find(_ != '"').getOrElse(' ')
       }
-      val extraIndent = if (firstChar == pipe) 1 else 0
+      val extraIndent =
+        if (initStyle.align.stripMargin && firstChar == pipe) 1 else 0
       val spaces = getIndentation(indent + extraIndent)
       pattern.matcher(token.syntax).replaceAll(spaces)
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -103,7 +103,10 @@ class FormatWriter(formatOps: FormatOps) {
     removeTrailingWhiteSpace(alignedComment)
   }
 
-  val leadingPipeSpace = Pattern.compile("\n *\\|", Pattern.MULTILINE)
+  private def getStripMarginPattern(pipe: Char) =
+    Pattern.compile(raw"(?<=\n) *(?=[$pipe])", Pattern.MULTILINE)
+  private val leadingPipeSpace = getStripMarginPattern('|')
+
   private def formatMarginizedString(token: Token, indent: => Int): String = {
     val shouldMarginize = initStyle.assumeStandardLibraryStripMargin &&
       (token.is[T.Interpolation.Part] || isMarginizedString(token))
@@ -122,7 +125,7 @@ class FormatWriter(formatOps: FormatOps) {
       }
       val extraIndent: Int = if (firstChar == '|') 1 else 0
       val spaces = getIndentation(indent + extraIndent)
-      leadingPipeSpace.matcher(token.syntax).replaceAll(s"\n$spaces\\|")
+      leadingPipeSpace.matcher(token.syntax).replaceAll(spaces)
     } else {
       token.syntax
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -89,7 +89,7 @@ class Router(formatOps: FormatOps) {
         val split = Split(NoSplit, 0).withPolicy(policy)
         Seq(
           // statecolumn - 1 because of margin characters |
-          if (getStripMarginChar(start).isDefined)
+          if (style.align.stripMargin && getStripMarginChar(start).isDefined)
             split
               .withIndent(StateColumn, end, After)
               .withIndent(-1, end, After)

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -33,10 +33,10 @@ val x = """Formatter changed AST
         .stripMargin('?')
 >>>
 val x = """Formatter changed AST
-          |=====================
-          |$diff
-      ?=====================
-      ?$diff
+      |=====================
+      |$diff
+          ?=====================
+          ?$diff
         """
   .stripMargin('?')
 <<< No align | margin 1, different char
@@ -51,10 +51,10 @@ val x = """Formatter changed AST
         .stripMargin('?')
 >>>
 val x = """Formatter changed AST
-          |=====================
-          |$diff
-      ?=====================
-      ?$diff
+      |=====================
+      |$diff
+          ?=====================
+          ?$diff
         """
   .stripMargin('?')
 <<< Align | margin 2

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -1,8 +1,8 @@
 assumeStandardLibraryStripMargin = true
 <<< Align | margin 1
 val x = """Formatter changed AST
-          |=====================
-          |$diff
+      |=====================
+      |$diff
         """
         .stripMargin
 >>>
@@ -10,6 +10,53 @@ val x = """Formatter changed AST
           |=====================
           |$diff
         """.stripMargin
+<<< No align | margin 1
+align.stripMargin = false
+===
+val x = """Formatter changed AST
+      |=====================
+      |$diff
+        """
+        .stripMargin
+>>>
+val x = """Formatter changed AST
+          |=====================
+          |$diff
+        """.stripMargin
+<<< Align | margin 1, different char
+val x = """Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+        .stripMargin('?')
+>>>
+val x = """Formatter changed AST
+          |=====================
+          |$diff
+      ?=====================
+      ?$diff
+        """
+  .stripMargin('?')
+<<< No align | margin 1, different char
+align.stripMargin = false
+===
+val x = """Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+        .stripMargin('?')
+>>>
+val x = """Formatter changed AST
+          |=====================
+          |$diff
+      ?=====================
+      ?$diff
+        """
+  .stripMargin('?')
 <<< Align | margin 2
 {
   val x = 1
@@ -34,6 +81,14 @@ val x =
     |Long line aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     |""".stripMargin
 <<< pipe char on first line #324
+"""|first
+  |second""".stripMargin
+>>>
+"""|first
+   |second""".stripMargin
+<<< pipe char on first line #324, no align
+align.stripMargin = false
+===
 """|first
   |second""".stripMargin
 >>>

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -20,8 +20,8 @@ val x = """Formatter changed AST
         .stripMargin
 >>>
 val x = """Formatter changed AST
-          |=====================
-          |$diff
+  |=====================
+  |$diff
         """.stripMargin
 <<< Align | margin 1, different char
 val x = """Formatter changed AST
@@ -53,8 +53,8 @@ val x = """Formatter changed AST
 val x = """Formatter changed AST
       |=====================
       |$diff
-          ?=====================
-          ?$diff
+    ?=====================
+    ?$diff
         """
   .stripMargin('?')
 <<< Align | margin 2
@@ -93,4 +93,4 @@ align.stripMargin = false
   |second""".stripMargin
 >>>
 """|first
-   |second""".stripMargin
+  |second""".stripMargin


### PR DESCRIPTION
Previously, using `assumeStandardLibraryStripMargin = true` (which means
the `.stripMargin` method was not redefined by the user and thus assigns
no special meaning to indentation preceding the `|` character) resulted
in aligning the pipe character with the end of the opening triple-quote.

Now, one can optionally set `align.stripMargin = false` to use a 2-space 
indentation offset relative to the start of the opening line instead.

```
// With align.stripMargin = true
val x = """
          |Hello world!
          |""".stripMargin
// With align.stripMargin = false
val x = """
  |Hello world!
  |""".stripMargin
```

Also, find the string margin char rather than assuming it's always `|` and inspect any parameter to `.stripMargin`.