### PR TITLE
FormatOps: don't start a statement on a comment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -42,7 +42,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   implicit val dialect = initStyle.runner.dialect
   private val ownersMap = getOwners(tree)
   val tokens: FormatTokens = FormatTokens(tree.tokens, owners)
-  val statementStarts = getStatementStarts(tree)
+  private val statementStarts = getStatementStarts(tree)
   val dequeueSpots = getDequeueSpots(tree) ++ statementStarts.keys
   private val matchingParentheses: Map[TokenHash, Token] =
     getMatchingParentheses(tree.tokens)
@@ -305,11 +305,12 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     }
   }
 
-  @tailrec
-  final def startsStatement(tok: FormatToken): Boolean = {
-    statementStarts.contains(hash(tok.right)) ||
-    (tok.right.is[T.Comment] && tok.hasBreak && startsStatement(next(tok)))
-  }
+  @inline
+  final def startsStatement(tok: FormatToken): Option[Tree] =
+    startsStatement(tok.right)
+  @inline
+  final def startsStatement(token: Token): Option[Tree] =
+    statementStarts.get(hash(token))
 
   def parensRange(token: Token): Option[Range] =
     matchingOpt(token).map(matchingParensRange(token, _))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -710,8 +710,9 @@ class Router(formatOps: FormatOps) {
                 insideBlock[T.LeftBracket](formatToken, close)
               else
                 insideBlock[T.LeftBrace](formatToken, close)
-            val excludeRanges: Set[Range] = exclude.flatMap(parensRange)
-            val unindent = UnindentAtExclude(exclude, Num(-indent.n))
+            val excludeRanges: Set[Range] =
+              exclude.map((matchingParensRange _).tupled).toSet
+            val unindent = UnindentAtExclude(exclude.keySet, Num(-indent.n))
             def ignoreBlocks(x: FormatToken): Boolean = {
               excludeRanges.exists(_.contains(x.left.end))
             }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -1,5 +1,6 @@
 package org.scalafmt.util
 
+import scala.meta.classifiers.Classifier
 import scala.meta.{Defn, Pkg, Template, Tree}
 import scala.meta.dialects.Scala211
 import scala.meta.tokens.Token
@@ -264,5 +265,8 @@ object TokenOps {
       case Newlines.fold => false
       case Newlines.unfold => true
     }
+
+  def classifyOnRight[A](cls: Classifier[Token, A])(ft: FormatToken): Boolean =
+    cls(ft.right)
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -48,11 +48,6 @@ object TokenOps {
     longHash
   }
 
-  def shouldGet2xNewlines(
-      tok: FormatToken
-  )(implicit style: ScalafmtConfig): Boolean =
-    tok.hasBlankLine || blankLineBeforeDocstring(tok.left, tok.right)
-
   def blankLineBeforeDocstring(
       left: Token,
       right: Token

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -104,30 +104,25 @@ object TreeOps {
     val ret = Map.newBuilder[TokenHash, Tree]
     ret.sizeHint(tree.tokens.length)
 
-    def addAll(trees: Seq[Tree]): Unit = {
-      trees.foreach { t =>
-        t.tokens.headOption.foreach { tok => ret += hash(tok) -> t }
-      }
-    }
+    def add(token: Token, tree: Tree) = ret += hash(token) -> tree
+    def addOne(t: Tree) = t.tokens.find(!_.is[Trivia]).foreach(add(_, t))
+    def addAll(trees: Seq[Tree]) = trees.foreach(addOne)
 
     def addDefn[T: ClassTag](mods: Seq[Mod], tree: Tree): Unit = {
       // Each @annotation gets a separate line
       val annotations = mods.filter(_.is[Mod.Annot])
       addAll(annotations)
-      val firstNonAnnotation: Token = mods
-        .collectFirst {
-          case x if !x.is[Mod.Annot] =>
-            // Non-annotation modifier, for example `sealed`/`abstract`
-            x.tokens.head
-        }
-        .getOrElse {
+      mods.find(!_.is[Mod.Annot]) match {
+        case Some(x) =>
+          // Non-annotation modifier, for example `sealed`/`abstract`
+          addOne(x)
+        case _ =>
           // No non-annotation modifier exists, fallback to keyword like `object`
-          tree.tokens.find(x => classTag[T].runtimeClass.isInstance(x)) match {
-            case Some(x) => x
+          tree.tokens.find(classTag[T].runtimeClass.isInstance) match {
+            case Some(x) => add(x, tree)
             case None => throw Error.CantFindDefnToken[T](tree)
           }
-        }
-      ret += hash(firstNonAnnotation) -> tree
+      }
     }
 
     def loop(x: Tree): Unit = {


### PR DESCRIPTION
This is required to introduce infix formatting (because it occasionally starts a statement). This also simplifies the logic of identifying docstrings.