### PR TITLE
#1627 [17]: Several fixes for ApplyType, symbolic select, if in case clause

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1961,8 +1961,9 @@ class Router(formatOps: FormatOps) {
           case _: Term.ForYield => twoBranches
           case _: Term.Try | _: Term.TryWithHandler =>
             Right(SingleLineBlock(expire))
-          case SplitCallIntoParts(fun, _) if fun ne body =>
-            Left(baseSpaceSplit.withSingleLine(getEndOfFirstCall(fun)))
+          case EndOfFirstCall(end) =>
+            val policy = penalizeAllNewlines(end, 1)
+            Left(baseSpaceSplit.withOptimalToken(end).withPolicy(policy))
           case _ => Right(NoPolicy)
         }
 
@@ -1985,8 +1986,7 @@ class Router(formatOps: FormatOps) {
           case _: Term.Try | _: Term.TryWithHandler => Left(Split.ignored)
           // don't tuck curried apply
           case Term.Apply(_: Term.Apply, _) => Right(SingleLineBlock(expire))
-          case SplitCallIntoParts(fun, _) if fun ne body =>
-            Left(baseSpaceSplit.withSingleLine(getEndOfFirstCall(fun)))
+          case EndOfFirstCall(end) => Left(baseSpaceSplit.withSingleLine(end))
           case _ if okNewline && ft.meta.leftOwner.is[Defn] =>
             Right(SingleLineBlock(expire))
           case _ => Right(NoPolicy)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1126,12 +1126,6 @@ class Router(formatOps: FormatOps) {
         else
           getSplitsValEquals(formatToken, rhs)
 
-      case FormatToken(T.Ident(name), _: T.Dot, _) if isSymbolicName(name) =>
-        Seq(Split(NoSplit, 0))
-
-      case FormatToken(_: T.Underscore, _: T.Dot, _) =>
-        Seq(Split(NoSplit, 0))
-
       case FormatToken(_, _: T.Dot, _)
           if style.newlines.sourceIgnored &&
             rightOwner.is[Term.Select] && findTreeWithParent(rightOwner) {
@@ -1168,7 +1162,8 @@ class Router(formatOps: FormatOps) {
               }
               Seq(
                 Split(NoSplit, 0).withSingleLine(expire),
-                Split(Newline, 1).withPolicyOpt(forcedBreakPolicy)
+                Split(NewlineT(acceptNoSplit = true), 1)
+                  .withPolicyOpt(forcedBreakPolicy)
               )
             }
 
@@ -1177,7 +1172,7 @@ class Router(formatOps: FormatOps) {
             def exclude = insideBlockRanges[LeftParenOrBrace](t, end)
             Seq(
               Split(NoSplit, 0).withSingleLine(end, exclude),
-              Split(Newline, 1)
+              Split(NewlineT(acceptNoSplit = true), 1)
             )
         }
 
@@ -1198,6 +1193,12 @@ class Router(formatOps: FormatOps) {
 
         if (prevSelect.isEmpty) splits
         else baseSplits ++ splits.map(_.onlyFor(SplitTag.SelectChainFirstNL))
+
+      case FormatToken(T.Ident(name), _: T.Dot, _) if isSymbolicName(name) =>
+        Seq(Split(NoSplit, 0))
+
+      case FormatToken(_: T.Underscore, _: T.Dot, _) =>
+        Seq(Split(NoSplit, 0))
 
       case tok @ FormatToken(left, dot @ T.Dot() `:chain:` chain, _) =>
         val nestedPenalty = nestedSelect(rightOwner) + nestedApplies(leftOwner)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -417,7 +417,8 @@ class Router(formatOps: FormatOps) {
             case t if t.tokens.isEmpty || caseStat.cond.isDefined =>
               Right(Split(Space, 0).withSingleLineOpt(t.tokens.lastOption))
             case t: Term.If if t.elsep.tokens.isEmpty =>
-              Right(Split(Space, 0).withSingleLine(t.cond.tokens.last))
+              // must not use optimal token here, will lead to column overflow
+              Right(Split(Space, 0).withSingleLineNoOptimal(t.cond.tokens.last))
             case t @ (_: Term.ForYield | _: Term.Match) =>
               val end = t.tokens.last
               val exclude = insideBlockRanges[T.LeftBrace](tok, end)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -129,7 +129,13 @@ case class Split(
       killOnFail: Boolean = false
   )(implicit line: sourcecode.Line): Split =
     withOptimalToken(optimal, killOnFail)
-      .withPolicy(SingleLineBlock(expire, exclude))
+      .withSingleLineNoOptimal(expire, exclude)
+
+  def withSingleLineNoOptimal(
+      expire: Token,
+      exclude: => Set[Range] = Set.empty
+  )(implicit line: sourcecode.Line): Split =
+    withPolicy(SingleLineBlock(expire, exclude))
 
   def withPolicyOpt(newPolicy: => Option[Policy]): Split =
     if (isIgnored) this else newPolicy.fold(this)(withPolicy(_))

--- a/scalafmt-tests/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/src/test/resources/newlines/source.source
@@ -15,7 +15,8 @@ import a.b.c
 object a {
   val a =
     s"${a.b.c.d}"
-  val b = foo[
-    a.b.c.d.e
-  ](f.g)
+  val b =
+    foo[
+      a.b.c.d.e
+    ](f.g)
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -523,6 +523,38 @@ val deployment = system
   .provider
   .deployer
   .lookup(service.split("/").drop(1))
+<<< 2.22
+maxColumn = 80
+===
+val augassign: P[Ast.operator] = P(
+    "+=".!.map(_ => Ast.operator.Add) |
+    "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) |
+    "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) |
+    "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) |
+    "^=".!.map(_ => Ast.operator.BitXor) |
+    "<<=".!.map(_ => Ast.operator.LShift) |
+    ">>=".!.map(_ => Ast.operator.RShift) |
+    "**=".!.map(_ => Ast.operator.Pow) |
+    "//=".!.map(_ => Ast.operator.FloorDiv)
+  )
+>>>
+val augassign: P[Ast.operator] = P(
+  "+=".!.map(_ => Ast.operator.Add) |
+    "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) |
+    "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) |
+    "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) |
+    "^=".!.map(_ => Ast.operator.BitXor) |
+    "<<=".!.map(_ => Ast.operator.LShift) |
+    ">>=".!.map(_ => Ast.operator.RShift) |
+    "**=".!.map(_ => Ast.operator.Pow) |
+    "//=".!.map(_ => Ast.operator.FloorDiv)
+)
 <<< 3.1: def non-config-style, long
 def a( ccccccccccccccccc:Int,
  ddddddddddddddddd:String,
@@ -1009,6 +1041,15 @@ object foo {
   val a = b(
     c = d
   )
+}
+<<< 3.31
+object a {
+  val b: Bbbbb[Seq[Ccccc]] = writable[Seq[Ccccc]]
+}
+>>>
+object a {
+  val b: Bbbbb[Seq[Ccccc]] =
+    writable[Seq[Ccccc]]
 }
 <<< 4.1: annotation with newlines
 maxColumn = 50

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -491,30 +491,18 @@ val augassign: P[Ast.operator] = P(
   )
 >>>
 val augassign: P[Ast.operator] = P(
-  "+="
-    .!.map(_ => Ast.operator.Add) |
-    "-="
-      .!.map(_ => Ast.operator.Sub) |
-    "*="
-      .!.map(_ => Ast.operator.Mult) |
-    "/="
-      .!.map(_ => Ast.operator.Div) |
-    "%="
-      .!.map(_ => Ast.operator.Mod) |
-    "&="
-      .!.map(_ => Ast.operator.BitAnd) |
-    "|="
-      .!.map(_ => Ast.operator.BitOr) |
-    "^="
-      .!.map(_ => Ast.operator.BitXor) |
-    "<<="
-      .!.map(_ => Ast.operator.LShift) |
-    ">>="
-      .!.map(_ => Ast.operator.RShift) |
-    "**="
-      .!.map(_ => Ast.operator.Pow) |
-    "//="
-      .!.map(_ => Ast.operator.FloorDiv)
+  "+=".!.map(_ => Ast.operator.Add) |
+    "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) |
+    "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) |
+    "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) |
+    "^=".!.map(_ => Ast.operator.BitXor) |
+    "<<=".!.map(_ => Ast.operator.LShift) |
+    ">>=".!.map(_ => Ast.operator.RShift) |
+    "**=".!.map(_ => Ast.operator.Pow) |
+    "//=".!.map(_ => Ast.operator.FloorDiv)
 )
 <<< 3.1: def non-config-style, long
 def a( ccccccccccccccccc:Int,

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -472,6 +472,50 @@ val deployment = system
   .asInstanceOf[ActorSystemImpl]
   .provider.deployer
   .lookup(service.split("/").drop(1))
+<<< 2.22
+maxColumn = 80
+===
+val augassign: P[Ast.operator] = P(
+    "+=".!.map(_ => Ast.operator.Add) |
+    "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) |
+    "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) |
+    "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) |
+    "^=".!.map(_ => Ast.operator.BitXor) |
+    "<<=".!.map(_ => Ast.operator.LShift) |
+    ">>=".!.map(_ => Ast.operator.RShift) |
+    "**=".!.map(_ => Ast.operator.Pow) |
+    "//=".!.map(_ => Ast.operator.FloorDiv)
+  )
+>>>
+val augassign: P[Ast.operator] = P(
+  "+="
+    .!.map(_ => Ast.operator.Add) |
+    "-="
+      .!.map(_ => Ast.operator.Sub) |
+    "*="
+      .!.map(_ => Ast.operator.Mult) |
+    "/="
+      .!.map(_ => Ast.operator.Div) |
+    "%="
+      .!.map(_ => Ast.operator.Mod) |
+    "&="
+      .!.map(_ => Ast.operator.BitAnd) |
+    "|="
+      .!.map(_ => Ast.operator.BitOr) |
+    "^="
+      .!.map(_ => Ast.operator.BitXor) |
+    "<<="
+      .!.map(_ => Ast.operator.LShift) |
+    ">>="
+      .!.map(_ => Ast.operator.RShift) |
+    "**="
+      .!.map(_ => Ast.operator.Pow) |
+    "//="
+      .!.map(_ => Ast.operator.FloorDiv)
+)
 <<< 3.1: def non-config-style, long
 def a( ccccccccccccccccc:Int,
  ddddddddddddddddd:String,
@@ -917,6 +961,16 @@ object foo {
   val a = b(c = d)
   val a = b(c = d)
   val a = b(c = d)
+}
+<<< 3.31
+object a {
+  val b: Bbbbb[Seq[Ccccc]] = writable[Seq[Ccccc]]
+}
+>>>
+object a {
+  val b: Bbbbb[Seq[Ccccc]] = writable[
+    Seq[Ccccc]
+  ]
 }
 <<< 4.1: annotation with newlines
 maxColumn = 50

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -796,10 +796,11 @@ object a {
 }
 >>>
 object a {
-  val a = (intercept[
-    java.lang.IllegalStateException] {
-    in.readObject
-  })
+  val a =
+    (intercept[
+      java.lang.IllegalStateException] {
+      in.readObject
+    })
 }
 <<< 3.23 enclosed, assignment, infix on left, narrow
 maxColumn = 40
@@ -956,9 +957,8 @@ object a {
 }
 >>>
 object a {
-  val b: Bbbbb[Seq[Ccccc]] = writable[
-    Seq[Ccccc]
-  ]
+  val b: Bbbbb[Seq[Ccccc]] =
+    writable[Seq[Ccccc]]
 }
 <<< 4.1: annotation with newlines
 maxColumn = 50

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -538,7 +538,20 @@ val augassign: P[Ast.operator] = P(
     "//=".!.map(_ => Ast.operator.FloorDiv)
   )
 >>>
-UNABLE TO FORMAT
+val augassign: P[Ast.operator] = P(
+  "+=".!.map(_ => Ast.operator.Add) |
+    "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) |
+    "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) |
+    "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) |
+    "^=".!.map(_ => Ast.operator.BitXor) |
+    "<<=".!.map(_ => Ast.operator.LShift) |
+    ">>=".!.map(_ => Ast.operator.RShift) |
+    "**=".!.map(_ => Ast.operator.Pow) |
+    "//=".!.map(_ => Ast.operator.FloorDiv)
+)
 <<< 3.1: def non-config-style, long
 def a( ccccccccccccccccc:Int,
  ddddddddddddddddd:String,

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -520,6 +520,25 @@ val deployment = system
   .provider
   .deployer
   .lookup(service.split("/").drop(1))
+<<< 2.22
+maxColumn = 80
+===
+val augassign: P[Ast.operator] = P(
+    "+=".!.map(_ => Ast.operator.Add) |
+    "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) |
+    "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) |
+    "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) |
+    "^=".!.map(_ => Ast.operator.BitXor) |
+    "<<=".!.map(_ => Ast.operator.LShift) |
+    ">>=".!.map(_ => Ast.operator.RShift) |
+    "**=".!.map(_ => Ast.operator.Pow) |
+    "//=".!.map(_ => Ast.operator.FloorDiv)
+  )
+>>>
+UNABLE TO FORMAT
 <<< 3.1: def non-config-style, long
 def a( ccccccccccccccccc:Int,
  ddddddddddddddddd:String,
@@ -960,6 +979,15 @@ object foo {
   val a = b(
     c = d
   )
+}
+<<< 3.31
+object a {
+  val b: Bbbbb[Seq[Ccccc]] = writable[Seq[Ccccc]]
+}
+>>>
+object a {
+  val b: Bbbbb[Seq[Ccccc]] =
+    writable[Seq[Ccccc]]
 }
 <<< 4.1: annotation with newlines
 maxColumn = 50

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1110,9 +1110,8 @@ object a {
 }
 >>>
 object a {
-  val b: Bbbbb[Seq[Ccccc]] = writable[
-    Seq[Ccccc]
-  ]
+  val b: Bbbbb[Seq[Ccccc]] =
+    writable[Seq[Ccccc]]
 }
 <<< 4.1: annotation with newlines
 maxColumn = 50

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -593,7 +593,20 @@ val augassign: P[Ast.operator] = P(
     "//=".!.map(_ => Ast.operator.FloorDiv)
   )
 >>>
-UNABLE TO FORMAT
+val augassign: P[Ast.operator] = P(
+  "+=".!.map(_ => Ast.operator.Add) |
+    "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) |
+    "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) |
+    "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) |
+    "^=".!.map(_ => Ast.operator.BitXor) |
+    "<<=".!.map(_ => Ast.operator.LShift) |
+    ">>=".!.map(_ => Ast.operator.RShift) |
+    "**=".!.map(_ => Ast.operator.Pow) |
+    "//=".!.map(_ => Ast.operator.FloorDiv)
+)
 <<< 3.1: def non-config-style, long
 def a( ccccccccccccccccc:Int,
  ddddddddddddddddd:String,

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -575,6 +575,25 @@ val deployment = system
   .provider
   .deployer
   .lookup(service.split("/").drop(1))
+<<< 2.22
+maxColumn = 80
+===
+val augassign: P[Ast.operator] = P(
+    "+=".!.map(_ => Ast.operator.Add) |
+    "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) |
+    "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) |
+    "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) |
+    "^=".!.map(_ => Ast.operator.BitXor) |
+    "<<=".!.map(_ => Ast.operator.LShift) |
+    ">>=".!.map(_ => Ast.operator.RShift) |
+    "**=".!.map(_ => Ast.operator.Pow) |
+    "//=".!.map(_ => Ast.operator.FloorDiv)
+  )
+>>>
+UNABLE TO FORMAT
 <<< 3.1: def non-config-style, long
 def a( ccccccccccccccccc:Int,
  ddddddddddddddddd:String,
@@ -1071,6 +1090,16 @@ object foo {
   val a = b(c = d)
   val a = b(c = d)
   val a = b(c = d)
+}
+<<< 3.31
+object a {
+  val b: Bbbbb[Seq[Ccccc]] = writable[Seq[Ccccc]]
+}
+>>>
+object a {
+  val b: Bbbbb[Seq[Ccccc]] = writable[
+    Seq[Ccccc]
+  ]
 }
 <<< 4.1: annotation with newlines
 maxColumn = 50


### PR DESCRIPTION
* Router: prefer break before than inside ApplyType
  * `fold`: https://github.com/kitbellew/scala-repos/commit/748e5c345f4a9677ce82b08f8c6fa2ca90f0b2de?w=1
  * `unfold`: https://github.com/kitbellew/scala-repos/commit/c2aea7c7444b9d6f0441548c217a03065a511bdb?w=1
  * rest: unchanged
* Router: use "symbolic.xx" rules for source=classic
  * `fold`: https://github.com/kitbellew/scala-repos/commit/90a2a3dae89dc3a2420a5e86cbd486cfaba2ad0f?w=1
  * `unfold`: https://github.com/kitbellew/scala-repos/commit/9242b4e760b4a0fbac07e1b7fdead75e68377857?w=1
  * `keep`: https://github.com/kitbellew/scala-repos/commit/20e2d9517f3fbc412a5166d177826a96242fef84?w=1
  * `classic`: unchanged
* Router: fix the 'if' in the body of a case clause
  * all unchanged but would fail later, with infix changes

Helps with #1627.