### PR TITLE
State: clarify how priority is determined

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -184,7 +184,7 @@ private class BestFirstSearch private (
             tokens(deepestYet.depth).left
           )
         } else {
-          val actualSplit = getActiveSplits(curr)
+          val actualSplit = getActiveSplits(curr, maxCost)
 
           var optimalNotFound = true
           actualSplit.foreach { split =>
@@ -244,7 +244,7 @@ private class BestFirstSearch private (
     null
   }
 
-  private def getActiveSplits(state: State): Seq[Split] = {
+  private def getActiveSplits(state: State, maxCost: Int): Seq[Split] = {
     val ft = tokens(state.depth)
     val useProvided = state.formatOff || !ft.inside(range)
     val splits = if (useProvided) Seq(provided(ft)) else routes(state.depth)
@@ -252,7 +252,7 @@ private class BestFirstSearch private (
     state.policy
       .execute(Decision(ft, splits))
       .splits
-      .filter(_.isActive)
+      .filter(x => x.isActive && x.cost <= maxCost)
       .sortBy(_.cost)
   }
 
@@ -272,7 +272,7 @@ private class BestFirstSearch private (
     if (state.depth >= tokens.length) state
     else {
       trackState(state, depth, 0)
-      val activeSplits = getActiveSplits(state)
+      val activeSplits = getActiveSplits(state, Int.MaxValue)
 
       if (activeSplits.lengthCompare(1) != 0)
         if (activeSplits.isEmpty) null else state // dead end if empty

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -14,6 +14,19 @@ case class OptimalToken(token: Token, killOnFail: Boolean = false)
   * Consider a split to be an edge in a search graph and [[FormatToken]]
   * are the nodes.
   *
+  * NB: there's a historical inconsistency in how splits are sorted; when
+  * they are initially considered, cost is the primary factor (and hence,
+  * because of stable sort, earlier split with the same cost will take
+  * precedence). However, when a search state is added into the priority
+  * queue, preference is given to states with lower cost, further token
+  * and, unlike above, a LATER line defining the split.
+  *
+  * A possible reason for the latter is to give those "secondary" splits
+  * a chance to move through the BestFirstSearch algorithm, as otherwise
+  * a sequence of primary splits might end up as the winning solution
+  * even if it exceeds the maxColumn margins, because a secondary split
+  * was deemed unlikely to win and moved to a backup priority queue.
+  *
   * @param modification Is this a space, no space, newline or 2 newlines?
   * @param cost How good is this output? Lower is better.
   * @param indents Does this add indentation?

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -124,9 +124,10 @@ object State {
   object Ordering extends Ordering[State] {
     override def compare(x: State, y: State): Int = compareAt(x, y, 0)
 
+    // each should compare priorities, i.e. define reverse ordering
     private val comparisons: Seq[(State, State) => Int] = Seq(
       compareCost,
-      compareSplitsLength,
+      compareDepth,
       compareSplitOrigin
     )
 
@@ -137,15 +138,15 @@ object State {
       else compareAt(s1, s2, i + 1)
     }
 
-    // priority on higher cost
+    // higher priority on lower cost
     private def compareCost(s1: State, s2: State): Int =
       Integer.compare(s2.cost, s1.cost)
 
-    // priority on fewer splits
-    private def compareSplitsLength(s1: State, s2: State): Int =
+    // higher priority on deeper state
+    private def compareDepth(s1: State, s2: State): Int =
       Integer.compare(s1.depth, s2.depth)
 
-    // priority on earlier line defining the last split
+    // higher priority on later line defining the last split
     @tailrec
     private def compareSplitOrigin(s1: State, s2: State): Int = {
       // We assume the same number of splits, see compareSplitsLength

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -36,13 +36,14 @@ final case class State(
       split: Split,
       tok: FormatToken
   ): State = {
-    val nonExpiredIndents = pushes.filterNot { push =>
-      val expireToken: Token =
-        if (push.expiresAt == ExpiresOn.After) tok.left else tok.right
-      push.expire.end <= expireToken.end
-    }
     val newIndents: Vector[Indent[Num]] =
-      nonExpiredIndents ++ split.indents.map(_.withNum(column, indentation))
+      if (tok.right.is[Token.EOF]) Vector.empty
+      else
+        pushes.filterNot { push =>
+          val expireToken: Token =
+            if (push.expiresAt == ExpiresOn.After) tok.left else tok.right
+          push.expire.end <= expireToken.end
+        } ++ split.indents.map(_.withNum(column, indentation))
     val newIndent = newIndents.foldLeft(0)(_ + _.length.n)
 
     val tokRightSyntax = tok.right.syntax


### PR DESCRIPTION
Closer inspection reveals that there's a peculiar inconsistency in how splits are sorted/prioritized (see scaladoc in Split.scala). Changing sorting to make it consistent produces significant changes in formatted output. For now, let's explain this inconsistency in the code.