### PR TITLE
#1627 [18]: FormatOps: ignore line breaks in infix expressions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -232,9 +232,6 @@ object ScalafmtConfig {
   implicit lazy val codecEncoder: ConfEncoder[Codec] =
     ConfEncoder.StringEncoder.contramap(_.name)
 
-  val indentOperatorsIncludeAkka = "^.*=$"
-  val indentOperatorsExcludeAkka = "^$"
-
   val default = ScalafmtConfig()
 
   val intellij: ScalafmtConfig = default.copy(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -233,8 +233,8 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
   final def isInfixRhs(ft: FormatToken): Boolean = {
     val tree = ft.meta.rightOwner
     tree.parent.exists {
-      case y: Term.ApplyInfix =>
-        (y.op eq tree) || y.args.headOption.forall { arg =>
+      case InfixApplication(_, op, rhs) =>
+        (op eq tree) || rhs.headOption.forall { arg =>
           (arg eq tree) && arg.tokens.headOption.contains(ft.right)
         }
       case _ => false

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -599,9 +599,7 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
       token <- {
         if (isRightAssociative) {
           arg match {
-            case Term.ApplyInfix(lhs, _, _, _) =>
-              lhs.tokens.lastOption
-            case Pat.ExtractInfix(lhs, _, _) =>
+            case InfixApplication(lhs, _, _) =>
               lhs.tokens.lastOption
             case _ =>
               arg.tokens.lastOption

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -530,12 +530,10 @@ class FormatOps(val tree: Tree, val initStyle: ScalafmtConfig) {
     if (isAttachedSingleLineComment(ft)) ft.right else ft.left
 
   def getSelectOptimalToken(tree: Tree): Token = {
-    // 2.13 has findLast
-    val tokens = tree.tokens
-    val index = tokens.lastIndexWhere(_.is[T.Dot])
-    if (index == -1)
+    val lastDotOpt = findLast(tree.tokens)(_.is[T.Dot])
+    if (lastDotOpt.isEmpty)
       throw new IllegalStateException(s"Missing . in select $tree")
-    val lastDot = tokens(index).asInstanceOf[T.Dot]
+    val lastDot = lastDotOpt.get.asInstanceOf[T.Dot]
     lastToken(getSelectsLastToken(lastDot).meta.leftOwner)
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -248,6 +248,7 @@ class FormatWriter(formatOps: FormatOps) {
 
   class FormatLocations(val locations: Array[FormatLocation]) {
 
+    private implicit val style = initStyle
     val tokenAligns: Map[TokenHash, Int] = alignmentTokens(locations)
 
     def iterate: Iterator[Entry] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Indent.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Indent.scala
@@ -10,6 +10,9 @@ object ExpiresOn {
   case object After extends ExpiresOn
 
   case object Before extends ExpiresOn
+
+  @inline
+  def beforeIf(flag: Boolean) = if (flag) Before else After
 }
 
 sealed abstract class Length

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1492,13 +1492,11 @@ class Router(formatOps: FormatOps) {
           }
 
       // Infix operator.
-      case tok @ FormatToken(op @ T.Ident(_), right, between)
-          if isApplyInfix(op, leftOwner) =>
+      case FormatToken(_: T.Ident, _, _) if isInfixOp(leftOwner) =>
         // TODO(olafur) move extractor into pattern match.
         val InfixApplication(_, op, args) = leftOwner.parent.get
         infixSplit(leftOwner, op, args, formatToken)
-      case FormatToken(left, op @ T.Ident(_), between)
-          if isApplyInfix(op, rightOwner) =>
+      case FormatToken(_, _: T.Ident, _) if isInfixOp(rightOwner) =>
         val InfixApplication(_, op, args) = rightOwner.parent.get
         infixSplit(rightOwner, op, args, formatToken)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1124,7 +1124,7 @@ class Router(formatOps: FormatOps) {
         }
 
         if (rhs.is[Term.ApplyInfix])
-          infixSplit(rhs.asInstanceOf[Term.ApplyInfix], formatToken)
+          beforeInfixSplit(rhs.asInstanceOf[Term.ApplyInfix], formatToken)
         else
           getSplitsValEquals(formatToken, rhs)
 
@@ -1495,10 +1495,10 @@ class Router(formatOps: FormatOps) {
       case FormatToken(_: T.Ident, _, _) if isInfixOp(leftOwner) =>
         // TODO(olafur) move extractor into pattern match.
         val InfixApplication(_, op, args) = leftOwner.parent.get
-        infixSplit(leftOwner, op, args, formatToken)
+        insideInfixSplit(leftOwner, op, args, formatToken)
       case FormatToken(_, _: T.Ident, _) if isInfixOp(rightOwner) =>
         val InfixApplication(_, op, args) = rightOwner.parent.get
-        infixSplit(rightOwner, op, args, formatToken)
+        insideInfixSplit(rightOwner, op, args, formatToken)
 
       // Case
       case tok @ FormatToken(cs @ T.KwCase(), _, _) if leftOwner.is[Case] =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1493,12 +1493,11 @@ class Router(formatOps: FormatOps) {
 
       // Infix operator.
       case FormatToken(_: T.Ident, _, _) if isInfixOp(leftOwner) =>
-        // TODO(olafur) move extractor into pattern match.
-        val InfixApplication(_, op, args) = leftOwner.parent.get
-        insideInfixSplit(leftOwner, op, args, formatToken)
+        val InfixApp(app) = leftOwner.parent.get
+        insideInfixSplit(app, formatToken)
       case FormatToken(_, _: T.Ident, _) if isInfixOp(rightOwner) =>
-        val InfixApplication(_, op, args) = rightOwner.parent.get
-        insideInfixSplit(rightOwner, op, args, formatToken)
+        val InfixApp(app) = rightOwner.parent.get
+        insideInfixSplit(app, formatToken)
 
       // Case
       case tok @ FormatToken(cs @ T.KwCase(), _, _) if leftOwner.is[Case] =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -14,9 +14,7 @@ object SplitTag {
 
   abstract class Custom extends SplitTag {
     override final def activateOnly(splits: Seq[Split]): Seq[Split] =
-      splits.flatMap { s =>
-        if (s.isTaggedFor(this)) Some(s.copy(tag = SplitTag.Active)) else None
-      }
+      splits.map(_.activateFor(this)).filter(_.isActive)
   }
 
   case object Active extends Base

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -22,5 +22,6 @@ object SplitTag {
 
   case object OneArgPerLine extends Custom
   case object SelectChainFirstNL extends Custom
+  case object InfixChainNoNL extends Custom
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -52,6 +52,20 @@ case class RewriteCtx(
   def onlyWhitespaceBefore(token: Token): Boolean =
     tokenTraverser.findBefore(token)(RewriteCtx.isLFSkipWhitespace).isDefined
 
+  def findNonWhitespaceWith(
+      f: (Token => Option[Boolean]) => Option[Token]
+  ): Option[(Token, Option[LF])] = {
+    var lf: Option[LF] = None
+    val nonWs = f {
+      case t: LF =>
+        if (lf.nonEmpty) Some(false)
+        else { lf = Some(t); None }
+      case Whitespace() => None
+      case _ => Some(true)
+    }
+    nonWs.map((_, lf))
+  }
+
   def getPatchToAvoidEmptyLine(token: Token): Option[TokenPatch] =
     if (!onlyWhitespaceBefore(token)) None
     else

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -2,9 +2,9 @@ package org.scalafmt.util
 
 import scala.meta.classifiers.Classifier
 import scala.meta.{Defn, Pkg, Template, Tree}
-import scala.meta.dialects.Scala211
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
+import scala.meta.tokens.Tokens
 
 import org.scalafmt.config.Newlines
 import org.scalafmt.config.ScalafmtConfig
@@ -62,15 +62,18 @@ object TokenOps {
     style.optIn.forceNewlineBeforeDocstringSummary &&
       !left.is[Token.Comment] && right.syntax.startsWith("/**")
 
-  def lastToken(tree: Tree): Token = {
-    // 2.13 has findLast
-    val tokens = tree.tokens
-    val index = tokens.lastIndexWhere {
+  // 2.13 implements SeqOps.findLast
+  def findLast[A](seq: Seq[A])(cond: A => Boolean): Option[A] =
+    seq.reverseIterator.find(cond)
+
+  def lastToken(tokens: Tokens): Token = {
+    findLast(tokens) {
       case Trivia() | _: EOF => false
       case _ => true
-    }
-    if (index == -1) tokens.last else tokens(index)
+    }.getOrElse(tokens.last)
   }
+
+  def lastToken(tree: Tree): Token = lastToken(tree.tokens)
 
   def endsWithNoIndent(between: Seq[Token]): Boolean =
     between.lastOption.exists(_.is[LF])

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -94,26 +94,6 @@ object TokenOps {
     booleanOperators.contains(token.syntax) ||
       newlineOkOperators.contains(token.syntax)
 
-  // See http://scala-lang.org/files/archive/spec/2.11/06-expressions.html#assignment-operators
-  val specialAssignmentOperators = Set("<=", ">=", "!=")
-
-  def isAssignmentOperator(token: Token): Boolean = {
-    val code = token.syntax
-    code.last == '=' && code.head != '=' &&
-    !specialAssignmentOperators.contains(code)
-  }
-
-  val symbolOperatorPrecendence: PartialFunction[Char, Int] = {
-    case '|' => 2
-    case '^' => 3
-    case '&' => 4
-    case '=' | '!' => 5
-    case '<' | '>' => 6
-    case ':' => 7
-    case '+' | '-' => 8
-    case '*' | '/' | '%' => 9
-  }
-
   def identModification(ident: Ident): Modification = {
     val lastCharacter = ident.syntax.last
     Space(!Character.isLetterOrDigit(lastCharacter) && lastCharacter != '`')
@@ -246,11 +226,6 @@ object TokenOps {
     // an `_`, operators cannot. This check should suffice.
     !head.isLetter && head != '_'
   }
-
-  // According to spec:
-  // "Operators ending in a colon `:' are right-associative. All other operators are left-associative."
-  // See https://www.scala-lang.org/files/archive/spec/2.11/06-expressions.html
-  def isRightAssociativeOperator(op: String): Boolean = op.endsWith(":")
 
   val formatOnCode = Set(
     "// @formatter:on", // IntelliJ

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -12,7 +12,7 @@ import scala.meta.Type
 
 object InfixApplication {
   def unapply(tree: Tree): Option[(Tree, Name, Seq[Tree])] = tree match {
-    case infix: Type.ApplyInfix => Some((infix.lhs, infix.op, infix.children))
+    case infix: Type.ApplyInfix => Some((infix.lhs, infix.op, Seq(infix.rhs)))
     case infix: Term.ApplyInfix => Some((infix.lhs, infix.op, infix.args))
     case infix: Pat.ExtractInfix => Some((infix.lhs, infix.op, infix.rhs))
     case _ => None

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -10,13 +10,60 @@ import scala.meta.Term
 import scala.meta.Tree
 import scala.meta.Type
 
-object InfixApplication {
-  def unapply(tree: Tree): Option[(Tree, Name, Seq[Tree])] = tree match {
-    case infix: Type.ApplyInfix => Some((infix.lhs, infix.op, Seq(infix.rhs)))
-    case infix: Term.ApplyInfix => Some((infix.lhs, infix.op, infix.args))
-    case infix: Pat.ExtractInfix => Some((infix.lhs, infix.op, infix.rhs))
+case class InfixApp(lhs: Tree, op: Name, rhs: Seq[Tree], all: Tree) {
+
+  @inline
+  def isAssignment: Boolean = InfixApp.isAssignment(op.value)
+
+  // https://scala-lang.org/files/archive/spec/2.11/06-expressions.html#infix-operations
+  // Operators ending in a colon `:' are right-associative. All other operators are left-associative.
+  @inline
+  def isRightAssoc: Boolean = op.value.last == ':'
+
+  @inline
+  lazy val precedence: Int =
+    InfixApp.infixOpPrecedence.getOrElse(op.value.head, 0)
+
+}
+
+object InfixApp {
+
+  def unapply(tree: Tree): Option[InfixApp] = tree match {
+    case t: Type.ApplyInfix => Some(InfixApp(t.lhs, t.op, Seq(t.rhs), t))
+    case t: Term.ApplyInfix => Some(InfixApp(t.lhs, t.op, t.args, t))
+    case t: Pat.ExtractInfix => Some(InfixApp(t.lhs, t.op, t.rhs, t))
     case _ => None
   }
+
+  // https://scala-lang.org/files/archive/spec/2.11/06-expressions.html#infix-operations
+  private val infixOpPrecedence: Map[Char, Int] = {
+    val builder = Map.newBuilder[Char, Int]
+    def add(precedence: Int, ops: Char*): Unit = addSeq(precedence, ops)
+    def addSeq(precedence: Int, ops: Iterable[Char]): Unit =
+      ops.foreach(builder += _ -> precedence)
+    // start with 1; all other special characters will get 0 by omission
+    add(1, '*', '/', '%')
+    add(2, '+', '-')
+    add(3, ':')
+    add(4, '<', '>')
+    add(5, '=', '!')
+    add(6, '&')
+    add(7, '^')
+    add(8, '|')
+    addSeq(9, 'a' to 'z')
+    addSeq(9, 'A' to 'Z')
+    builder.result()
+  }
+
+  // https://scala-lang.org/files/archive/spec/2.11/06-expressions.html#assignment-operators
+  private val nonAssignmentOperators = Set("<=", ">=", "!=")
+
+  // https://scala-lang.org/files/archive/spec/2.11/06-expressions.html#infix-operations
+  // The precedence of an assignment ... is lower than the precedence of any other ...
+  def isAssignment(op: String): Boolean =
+    op.lastOption.contains('=') && (op.length == 1 ||
+      op.head != '=' && !nonAssignmentOperators.contains(op))
+
 }
 
 /**

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -491,14 +491,23 @@ object TreeOps {
 
   final def isInfixOp(tree: Tree): Boolean =
     tree.parent.exists {
-      case InfixApplication(_, op, _) => op eq tree
+      case InfixApp(ia) => ia.op eq tree
       case _ => false
     }
+
+  final def asInfixApp(tree: Tree): Option[InfixApp] = InfixApp.unapply(tree)
+
+  @inline
+  final def asInfixApp(tree: Tree, flag: Boolean = true): Option[InfixApp] =
+    if (flag) asInfixApp(tree) else None
+
+  @inline
+  final def isInfixApp(tree: Tree): Boolean = asInfixApp(tree).isDefined
 
   @tailrec
   final def isTopLevelInfixApplication(child: Tree): Boolean =
     child.parent match {
-      case Some(p @ InfixApplication(_)) => isTopLevelInfixApplication(p)
+      case Some(p @ InfixApp(_)) => isTopLevelInfixApplication(p)
       case Some(_: Term.Block | _: Term.If | _: Term.While | _: Source) => true
       case Some(fun: Term.Function) => isBlockFunction(fun)
       case _ => false

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -489,25 +489,18 @@ object TreeOps {
       case _ => first
     }
 
-  final def isApplyInfix(op: Token.Ident, owner: Tree): Boolean =
-    owner.parent.exists {
-      case infix: Type.ApplyInfix => infix.op == owner
-      case infix: Term.ApplyInfix => infix.op == owner
-      case infix: Pat.ExtractInfix => infix.op == owner
+  final def isInfixOp(tree: Tree): Boolean =
+    tree.parent.exists {
+      case InfixApplication(_, op, _) => op eq tree
       case _ => false
     }
 
   @tailrec
   final def isTopLevelInfixApplication(child: Tree): Boolean =
     child.parent match {
-      case Some(parent) =>
-        parent match {
-          case _: Term.ApplyInfix | _: Type.ApplyInfix =>
-            isTopLevelInfixApplication(parent)
-          case _: Term.Block | _: Term.If | _: Term.While | _: Source => true
-          case fun: Term.Function => isBlockFunction(fun)
-          case _ => false
-        }
+      case Some(p @ InfixApplication(_)) => isTopLevelInfixApplication(p)
+      case Some(_: Term.Block | _: Term.If | _: Term.While | _: Source) => true
+      case Some(fun: Term.Function) => isBlockFunction(fun)
       case _ => false
     }
 

--- a/scalafmt-tests/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/src/test/resources/newlines/source.source
@@ -21,6 +21,7 @@ object a {
     ](f.g)
 }
 <<< complex infix source, fold
+runner.optimizer.maxVisitsPerToken = 2000
 maxColumn = 80
 danglingParentheses = false
 newlines.source = fold
@@ -82,28 +83,31 @@ private[parser] trait CacheControlHeader {
   // http://tools.ietf.org/html/rfc7234#section-5.2
   def `cache-control` =
     rule {
-      oneOrMore(`cache-directive`).separatedBy(listSep) ~ EOI ~> (
-        `Cache-Control`(_)
-      )
+      oneOrMore(`cache-directive`).separatedBy(listSep) ~ EOI ~>
+        (`Cache-Control`(_))
     }
 
   def `cache-directive` =
     rule(
-      "no-store" ~ push(`no-store`)
-        | "no-transform" ~ push(`no-transform`)
-        | "max-age=" ~ `delta-seconds` ~> (`max-age`(_))
-        | "max-stale" ~ optional(ws('=') ~ `delta-seconds`) ~> (`max-stale`(_))
-        | "min-fresh=" ~ `delta-seconds` ~> (`min-fresh`(_))
-        | "only-if-cached" ~ push(`only-if-cached`)
-        | "public" ~ push(`public`)
-        | "private" ~ (ws('=') ~ `field-names` ~> (`private`(_: _*)) | push(
-          `private`(Nil: _*)))
-        | "no-cache" ~ (ws('=') ~ `field-names` ~> (`no-cache`(_: _*)) | push(
-          `no-cache`))
-        | "must-revalidate" ~ push(`must-revalidate`)
-        | "proxy-revalidate" ~ push(`proxy-revalidate`)
-        | "s-maxage=" ~ `delta-seconds` ~> (`s-maxage`(_))
-        | token ~ optional(ws('=') ~ word) ~> (CacheDirective.custom(_, _)))
+      "no-store" ~ push(`no-store`) | "no-transform" ~ push(`no-transform`) |
+        "max-age=" ~ `delta-seconds` ~>
+        (`max-age`(_)) |
+        "max-stale" ~ optional(ws('=') ~ `delta-seconds`) ~>
+        (`max-stale`(_)) |
+        "min-fresh=" ~ `delta-seconds` ~>
+        (`min-fresh`(_)) | "only-if-cached" ~ push(`only-if-cached`) |
+        "public" ~ push(`public`) |
+        "private" ~
+        (ws('=') ~ `field-names` ~> (`private`(_: _*)) |
+          push(`private`(Nil: _*))) |
+        "no-cache" ~
+        (ws('=') ~ `field-names` ~> (`no-cache`(_: _*)) | push(`no-cache`)) |
+        "must-revalidate" ~ push(`must-revalidate`) |
+        "proxy-revalidate" ~ push(`proxy-revalidate`) |
+        "s-maxage=" ~ `delta-seconds` ~>
+        (`s-maxage`(_)) |
+        token ~ optional(ws('=') ~ word) ~>
+        (CacheDirective.custom(_, _)))
 
   def `field-names` = rule { `quoted-tokens` | token ~> (Seq(_)) }
 
@@ -112,7 +116,8 @@ private[parser] trait CacheControlHeader {
 
   def `quoted-tokens-elem` =
     rule {
-      clearSB() ~ zeroOrMore(
-        !'"' ~ !',' ~ qdtext ~ appendSB() | `quoted-pair`) ~ push(sb.toString)
+      clearSB() ~
+        zeroOrMore(!'"' ~ !',' ~ qdtext ~ appendSB() | `quoted-pair`) ~
+        push(sb.toString)
     }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/src/test/resources/newlines/source.source
@@ -20,3 +20,99 @@ object a {
       a.b.c.d.e
     ](f.g)
 }
+<<< complex infix source, fold
+maxColumn = 80
+danglingParentheses = false
+newlines.source = fold
+===
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.http.impl.model.parser
+
+import akka.parboiled2.Parser
+import akka.http.scaladsl.model.headers._
+import CacheDirectives._
+
+private[parser] trait CacheControlHeader { this: Parser with CommonRules with CommonActions with StringBuilding ⇒
+
+  // http://tools.ietf.org/html/rfc7234#section-5.2
+  def `cache-control` = rule {
+    oneOrMore(`cache-directive`).separatedBy(listSep) ~ EOI ~> (`Cache-Control`(_))
+  }
+
+  def `cache-directive` = rule(
+    "no-store" ~ push(`no-store`)
+      | "no-transform" ~ push(`no-transform`)
+      | "max-age=" ~ `delta-seconds` ~> (`max-age`(_))
+      | "max-stale" ~ optional(ws('=') ~ `delta-seconds`) ~> (`max-stale`(_))
+      | "min-fresh=" ~ `delta-seconds` ~> (`min-fresh`(_))
+      | "only-if-cached" ~ push(`only-if-cached`)
+      | "public" ~ push(`public`)
+      | "private" ~ (ws('=') ~ `field-names` ~> (`private`(_: _*)) | push(`private`(Nil: _*)))
+      | "no-cache" ~ (ws('=') ~ `field-names` ~> (`no-cache`(_: _*)) | push(`no-cache`))
+      | "must-revalidate" ~ push(`must-revalidate`)
+      | "proxy-revalidate" ~ push(`proxy-revalidate`)
+      | "s-maxage=" ~ `delta-seconds` ~> (`s-maxage`(_))
+      | token ~ optional(ws('=') ~ word) ~> (CacheDirective.custom(_, _)))
+
+  def `field-names` = rule { `quoted-tokens` | token ~> (Seq(_)) }
+
+  def `quoted-tokens` = rule { '"' ~ zeroOrMore(`quoted-tokens-elem`).separatedBy(listSep) ~ '"' }
+
+  def `quoted-tokens-elem` = rule {
+    clearSB() ~ zeroOrMore(!'"' ~ !',' ~ qdtext ~ appendSB() | `quoted-pair`) ~ push(sb.toString)
+  }
+}
+>>>
+/**
+  * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+  */
+
+package akka.http.impl.model.parser
+
+import akka.parboiled2.Parser
+import akka.http.scaladsl.model.headers._
+import CacheDirectives._
+
+private[parser] trait CacheControlHeader {
+  this: Parser with CommonRules with CommonActions with StringBuilding ⇒
+
+  // http://tools.ietf.org/html/rfc7234#section-5.2
+  def `cache-control` =
+    rule {
+      oneOrMore(`cache-directive`).separatedBy(listSep) ~ EOI ~> (
+        `Cache-Control`(_)
+      )
+    }
+
+  def `cache-directive` =
+    rule(
+      "no-store" ~ push(`no-store`)
+        | "no-transform" ~ push(`no-transform`)
+        | "max-age=" ~ `delta-seconds` ~> (`max-age`(_))
+        | "max-stale" ~ optional(ws('=') ~ `delta-seconds`) ~> (`max-stale`(_))
+        | "min-fresh=" ~ `delta-seconds` ~> (`min-fresh`(_))
+        | "only-if-cached" ~ push(`only-if-cached`)
+        | "public" ~ push(`public`)
+        | "private" ~ (ws('=') ~ `field-names` ~> (`private`(_: _*)) | push(
+          `private`(Nil: _*)))
+        | "no-cache" ~ (ws('=') ~ `field-names` ~> (`no-cache`(_: _*)) | push(
+          `no-cache`))
+        | "must-revalidate" ~ push(`must-revalidate`)
+        | "proxy-revalidate" ~ push(`proxy-revalidate`)
+        | "s-maxage=" ~ `delta-seconds` ~> (`s-maxage`(_))
+        | token ~ optional(ws('=') ~ word) ~> (CacheDirective.custom(_, _)))
+
+  def `field-names` = rule { `quoted-tokens` | token ~> (Seq(_)) }
+
+  def `quoted-tokens` =
+    rule { '"' ~ zeroOrMore(`quoted-tokens-elem`).separatedBy(listSep) ~ '"' }
+
+  def `quoted-tokens-elem` =
+    rule {
+      clearSB() ~ zeroOrMore(
+        !'"' ~ !',' ~ qdtext ~ appendSB() | `quoted-pair`) ~ push(sb.toString)
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1615,3 +1615,640 @@ for {
   else
     mean * mean / x
 }
+<<< 8.1: infix with longer left ||
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op
+    7 map {
+      8 % 9
+    }
+>>>
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op
+    7 map {
+    8 % 9
+  }
+<<< 8.2: infix with shorter left ||
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
+>>>
+val a =
+  1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+    8 % 9
+  }
+<<< 8.3: infix with longer left ||, narrow
+maxColumn = 20
+===
+val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
+>>>
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+    8 % 9
+  }
+<<< 8.4: infix with shorter left ||, narrow
+maxColumn = 17
+===
+{
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
+val b = { 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 } || somethinglong }
+}
+>>>
+{
+  val a =
+    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+      8 % 9
+    }
+  val b = {
+    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+      8 % 9
+    } || somethinglong
+  }
+}
+<<< 8.5: sequences of infix operations
+maxColumn = 75
+runner.optimizer.forceConfigStyleOnOffset = 1000
+===
+val strings = Seq(
+    "MetricEvaluatorResult:",
+    s"  # engine params evaluated: ${engineParamsScores.size}") ++
+    Seq(
+      "Optimal Engine Params:",
+      s"  $bestEPStr",
+      "Metrics:",
+      s"  $metricHeader: ${bestScore.score}") ++
+    otherMetricHeaders.zip(bestScore.otherScores).map {
+      case (h, s) => s"  $h: $s"
+    } ++
+    outputPath.toSeq.map { p =>
+      s"The best variant params can be found in $p"
+    }
+>>>
+val strings = Seq(
+  "MetricEvaluatorResult:",
+  s"  # engine params evaluated: ${engineParamsScores.size}"
+) ++
+  Seq(
+    "Optimal Engine Params:",
+    s"  $bestEPStr",
+    "Metrics:",
+    s"  $metricHeader: ${bestScore.score}"
+  ) ++
+  otherMetricHeaders.zip(bestScore.otherScores).map {
+    case (h, s) => s"  $h: $s"
+  } ++
+  outputPath.toSeq.map { p =>
+    s"The best variant params can be found in $p"
+  }
+<<< 8.6: assignment with short expression
+object a {
+  plugins(service.pluginType) += service.pluginName -> service
+}
+>>>
+object a {
+  plugins(
+    service.pluginType
+  ) += service.pluginName -> service
+}
+<<< 8.7
+maxColumn = 80
+===
+val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
+       ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
+       ("targetEntityId" -> data("itemId")) ~
+       ("eventTime" -> data("timestamp")) ~ ("properties" -> (("context" ->
+       (("ip" -> data("context[ip]")) ~ ("prop1" -> data("context[prop1]")
+         .toDouble) ~ ("prop2" -> data("context[prop2]")))) ~
+       ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+       ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
+>>>
+val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
+  ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
+  ("targetEntityId" -> data("itemId")) ~
+  ("eventTime" -> data("timestamp")) ~ ("properties" -> (("context" ->
+  (("ip" -> data("context[ip]")) ~ ("prop1" -> data(
+    "context[prop1]"
+  ).toDouble) ~ ("prop2" -> data("context[prop2]")))) ~
+  ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+  ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
+<<< 8.8
+maxColumn = 80
+===
+override def hashCode: Int = 41 + fields.hashCode
+>>>
+override def hashCode: Int = 41 + fields.hashCode
+<<< 8.9
+maxColumn = 80
+===
+object a {
+val fields = JField("engineVariant", JString(i.engineVariant)) ::
+   JField("engineFactory", JString(i.engineFactory)) ::
+     JField("batch", JString(i.batch)) ::
+     JField("env", Extraction.decompose(i.env)(DefaultFormats))
+}
+>>>
+object a {
+  val fields = JField("engineVariant", JString(i.engineVariant)) ::
+    JField("engineFactory", JString(i.engineFactory)) ::
+    JField("batch", JString(i.batch)) ::
+    JField("env", Extraction.decompose(i.env)(DefaultFormats))
+}
+<<< 8.10
+maxColumn = 80
+===
+object a {
+  def isReservedPrefix(name: String): Boolean =
+      name.startsWith("$") || name.startsWith("pio_")
+  def idWithAppid(appid: Int, id: String): String = appid + "_" + id
+}
+>>>
+object a {
+  def isReservedPrefix(name: String): Boolean =
+    name.startsWith("$") || name.startsWith("pio_")
+  def idWithAppid(appid: Int, id: String): String = appid + "_" + id
+}
+<<< 8.11
+maxColumn = 80
+===
+Some(
+  ("ip" -> data.get("context[ip]")) ~ (
+  "prop1" ->
+     data.get("context[prop1]").map(_.toDouble)
+))
+>>>
+Some(
+  ("ip" -> data.get("context[ip]")) ~ (
+    "prop1" ->
+      data.get("context[prop1]").map(_.toDouble)
+  )
+)
+<<< 8.12
+maxColumn = 80
+===
+val json = (estype -> ("properties" -> ("status" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("startTime" ->
+      ("type" -> "date")) ~ ("endTime" -> ("type" -> "date")) ~ ("engineId" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVersion" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVariant" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineFactory" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("batch" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("dataSourceParams" -> ("type" -> "string") ~ ("index" ->
+        "not_analyzed")) ~ ("preparatorParams" -> ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~ ("algorithmsParams" -> ("type" ->
+          "string") ~ ("index" -> "not_analyzed")) ~ ("servingParams" ->
+          ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
+          ("type" -> "string") ~ ("index" -> "not_analyzed"))))
+>>>
+val json = (estype -> ("properties" -> ("status" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("startTime" ->
+  ("type" -> "date")) ~ ("endTime" -> ("type" -> "date")) ~ ("engineId" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVersion" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVariant" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineFactory" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("batch" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+  ("dataSourceParams" -> ("type" -> "string") ~ ("index" ->
+    "not_analyzed")) ~ ("preparatorParams" -> ("type" -> "string") ~
+  ("index" -> "not_analyzed")) ~ ("algorithmsParams" -> ("type" ->
+  "string") ~ ("index" -> "not_analyzed")) ~ ("servingParams" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed"))))
+<<< 8.13
+val a = b match {
+  case i: EngineInstance =>
+    JObject(
+      JField("id", JString(i.id)) ::
+        JField("status", JString(i.status)) ::
+        JField("startTime", JString(i.startTime.toString)) ::
+        JField("endTime", JString(i.endTime.toString)) ::
+        JField("engineId", JString(i.engineId)) ::
+        JField("engineVersion", JString(i.engineVersion)) ::
+        JField("engineVariant", JString(i.engineVariant)) ::
+        JField("engineFactory", JString(i.engineFactory)) ::
+        JField("batch", JString(i.batch)) ::
+        JField("env", Extraction.decompose(i.env)(DefaultFormats)) ::
+        JField(
+          "sparkConf",
+          Extraction.decompose(i.sparkConf)(DefaultFormats)) ::
+        JField("dataSourceParams", JString(i.dataSourceParams)) ::
+        JField("preparatorParams", JString(i.preparatorParams)) ::
+        JField("algorithmsParams", JString(i.algorithmsParams)) ::
+        JField("servingParams", JString(i.servingParams)) ::
+        Nil)
+}
+>>>
+val a = b match {
+  case i: EngineInstance =>
+    JObject(
+      JField("id", JString(i.id)) ::
+        JField(
+          "status",
+          JString(i.status)
+        ) ::
+        JField(
+          "startTime",
+          JString(i.startTime.toString)
+        ) ::
+        JField(
+          "endTime",
+          JString(i.endTime.toString)
+        ) ::
+        JField(
+          "engineId",
+          JString(i.engineId)
+        ) ::
+        JField(
+          "engineVersion",
+          JString(i.engineVersion)
+        ) ::
+        JField(
+          "engineVariant",
+          JString(i.engineVariant)
+        ) ::
+        JField(
+          "engineFactory",
+          JString(i.engineFactory)
+        ) ::
+        JField(
+          "batch",
+          JString(i.batch)
+        ) ::
+        JField(
+          "env",
+          Extraction.decompose(i.env)(
+            DefaultFormats
+          )
+        ) ::
+        JField(
+          "sparkConf",
+          Extraction.decompose(
+            i.sparkConf
+          )(DefaultFormats)
+        ) ::
+        JField(
+          "dataSourceParams",
+          JString(i.dataSourceParams)
+        ) ::
+        JField(
+          "preparatorParams",
+          JString(i.preparatorParams)
+        ) ::
+        JField(
+          "algorithmsParams",
+          JString(i.algorithmsParams)
+        ) ::
+        JField(
+          "servingParams",
+          JString(i.servingParams)
+        ) ::
+        Nil
+    )
+}
+<<< 8.14
+private lazy val subNode: Parser[SubNode] = rep(' ') ~>
+  ((opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ {
+    name => AttrAppendSubNode(name)
+  }) |
+  (opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ {
+    name => AttrRemoveSubNode(name)
+  }) |    (opt('*') ~ '[' ~> attrName <~ ']' ^^ {
+     name => AttrSubNode(name)
+   }) |
+
+   ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+   ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
+   ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
+   ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
+   ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
+   ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
+   '*' ^^ (a => KidsSubNode()) |
+   '^' ~ '*' ^^ (a => SelectThisNode(true)) |
+   '^' ~ '^' ^^ (a => SelectThisNode(false)))
+>>>
+private lazy val subNode
+    : Parser[SubNode] = rep(' ') ~>
+  ((opt(
+    '*'
+  ) ~ '[' ~> attrName <~ '+' ~ ']' ^^ {
+    name =>
+      AttrAppendSubNode(name)
+  }) |
+    (opt(
+      '*'
+    ) ~ '[' ~> attrName <~ '!' ~ ']' ^^ {
+      name =>
+        AttrRemoveSubNode(name)
+    }) | (opt(
+    '*'
+  ) ~ '[' ~> attrName <~ ']' ^^ {
+    name =>
+      AttrSubNode(name)
+  }) |
+
+    ('!' ~ '!' ^^ (a =>
+      DontMergeAttributes
+    )) |
+    ('<' ~ '*' ~ '>') ^^ (a =>
+      SurroundKids()
+    ) |
+    ('-' ~ '*' ^^ (a =>
+      PrependKidsSubNode()
+    )) |
+    ('>' ~ '*' ^^ (a =>
+      PrependKidsSubNode()
+    )) |
+    ('*' ~ '+' ^^ (a =>
+      AppendKidsSubNode()
+    )) |
+    ('*' ~ '<' ^^ (a =>
+      AppendKidsSubNode()
+    )) |
+    '*' ^^ (a => KidsSubNode()) |
+    '^' ~ '*' ^^ (a =>
+      SelectThisNode(true)
+    ) |
+    '^' ~ '^' ^^ (a =>
+      SelectThisNode(false)
+    ))
+<<< 8.15
+maxColumn = 80
+===
+object a {
+  def toEventJson(common: Common, userAction: UserAction): JObject = {
+   import org.json4s.JsonDSL._
+    val json =
+      ("event" -> "subscribe") ~
+        ("entityType" -> "user") ~
+        ("entityId" -> data("data[id]")) ~
+        ("targetEntityType" -> "list") ~
+        ("targetEntityId" -> data("data[list_id]")) ~
+        ("eventTime" -> eventTime) ~
+        ("properties" -> (("email" -> data("data[email]")) ~
+          ("email_type" -> data("data[email_type]")) ~
+          ("merges" -> (("EMAIL" -> data("data[merges][EMAIL]")) ~
+            ("FNAME" -> data("data[merges][FNAME]"))) ~
+            ("LNAME" -> data("data[merges][LNAME]")) ~
+            ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+          ("ip_opt" -> data("data[ip_opt]")) ~
+          ("ip_signup" -> data("data[ip_signup]")))
+      json
+  }
+}
+>>>
+object a {
+  def toEventJson(common: Common, userAction: UserAction): JObject = {
+    import org.json4s.JsonDSL._
+    val json =
+      ("event" -> "subscribe") ~
+        ("entityType" -> "user") ~
+        ("entityId" -> data("data[id]")) ~
+        ("targetEntityType" -> "list") ~
+        ("targetEntityId" -> data("data[list_id]")) ~
+        ("eventTime" -> eventTime) ~
+        ("properties" -> (("email" -> data("data[email]")) ~
+          ("email_type" -> data("data[email_type]")) ~
+          ("merges" -> (("EMAIL" -> data("data[merges][EMAIL]")) ~
+            ("FNAME" -> data("data[merges][FNAME]"))) ~
+            ("LNAME" -> data("data[merges][LNAME]")) ~
+            ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+          ("ip_opt" -> data("data[ip_opt]")) ~
+          ("ip_signup" -> data("data[ip_signup]")))
+    json
+  }
+}
+<<< 8.16
+maxColumn = 80
+===
+override def preRestart(cause: Throwable, msg: Option[Any]) {
+       if (master ne null) {
+        master ! "failed with " + cause + " while processing " + msg
+       }
+       context stop self
+     }
+>>>
+override def preRestart(cause: Throwable, msg: Option[Any]) {
+  if (master ne null) {
+    master ! "failed with " + cause + " while processing " + msg
+  }
+  context stop self
+}
+<<< 8.17
+maxColumn = 80
+===
+object a {
+   def `media-range-def` =
+     rule {
+       "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+        ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+     }
+}
+>>>
+object a {
+  def `media-range-def` =
+    rule {
+      "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+          ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+    }
+}
+<<< 8.18
+maxColumn = 80
+===
+object a {
+  (people.map(p => (p.name, p.age))
+  // c1
+  returning people.map(_.id)
+  // c2
+  into ((nameAge, id) => Person(id, nameAge._1, nameAge._2))
+  )
+}
+>>>
+object a {
+  (people.map(p => (p.name, p.age))
+  // c1
+    returning people.map(_.id)
+  // c2
+    into ((nameAge, id) => Person(id, nameAge._1, nameAge._2)))
+}
+<<< 8.19
+maxColumn = 80
+===
+def `day-name` =
+     rule(
+       "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+        "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6))
+>>>
+def `day-name` =
+  rule(
+    "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+      "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6)
+  )
+<<< 8.20
+maxColumn = 80
+===
+HttpResponse(
+   StatusCodes.ServiceUnavailable,
+   entity = "The server was not able " +
+   "to produce a timely response to your request.\r\nPlease try again in a short while!"
+)
+>>>
+HttpResponse(
+  StatusCodes.ServiceUnavailable,
+  entity = "The server was not able " +
+    "to produce a timely response to your request.\r\nPlease try again in a short while!"
+)
+<<< 8.21
+maxColumn = 80
+===
+private val allParams: Map[String, String] = mandatoryParams +
+    (
+      "data-config" ->
+        dummyOptionalConfigPath,
+      "max-sales-mappers" ->
+        "10",
+      "overwrite" ->
+        null,
+      "keep" -> dummyOptionalMaxVersionCount
+    )
+>>>
+private val allParams: Map[String, String] = mandatoryParams +
+  (
+    "data-config" ->
+      dummyOptionalConfigPath,
+    "max-sales-mappers" ->
+      "10",
+    "overwrite" ->
+      null,
+    "keep" -> dummyOptionalMaxVersionCount
+)
+<<< 8.22
+maxColumn = 40
+===
+"Terminating(" + reason + ")" +
+                   (toDie.toSeq.sorted mkString
+                     (
+                      "\n" +
+                        indent +
+                        "   |    toDie: ", "\n" + indent + "   |           ", ""
+                     ))
+>>>
+"Terminating(" + reason + ")" +
+  (toDie.toSeq.sorted mkString
+    (
+      "\n" +
+        indent +
+        "   |    toDie: ", "\n" + indent + "   |           ", ""
+  ))
+<<< 8.23
+maxColumn = 80
+===
+val ret = (if (dailyStats.isEmpty)
+                   0
+                 else {
+                   val yestStats = dailyStats.last
+                   val yestNav = yestStats.nav
+                   (nav -
+                     yestNav) / nav - 1
+                 })
+>>>
+val ret =
+  (if (dailyStats.isEmpty)
+     0
+   else {
+     val yestStats = dailyStats.last
+     val yestNav = yestStats.nav
+     (nav -
+       yestNav) / nav - 1
+   })
+<<< 8.24
+maxColumn = 80
+===
+def isErrorEnabled(logClass: Class[_], logSource: String) =
+    (eventStream.logLevel >= ErrorLevel) &&
+      Logger(logClass, logSource).isErrorEnabled
+>>>
+def isErrorEnabled(logClass: Class[_], logSource: String) =
+  (eventStream.logLevel >= ErrorLevel) &&
+    Logger(logClass, logSource).isErrorEnabled
+<<< 8.25
+maxColumn = 80
+===
+def getShort(implicit byteOrder: ByteOrder): Short = {
+    if (byteOrder == ByteOrder.BIG_ENDIAN)
+      ((next() & 0xff) << 8 | (next() & 0xff) << 0).toShort
+    else if (byteOrder == ByteOrder.LITTLE_ENDIAN)
+      ((next() & 0xff) << 0 | (next() & 0xff) << 8).toShort
+     else throw new IllegalArgumentException("Unknown byte order " + byteOrder)
+   }
+>>>
+def getShort(implicit byteOrder: ByteOrder): Short = {
+  if (byteOrder == ByteOrder.BIG_ENDIAN)
+    ((next() & 0xff) << 8 | (next() & 0xff) << 0).toShort
+  else if (byteOrder == ByteOrder.LITTLE_ENDIAN)
+    ((next() & 0xff) << 0 | (next() & 0xff) << 8).toShort
+  else throw new IllegalArgumentException("Unknown byte order " + byteOrder)
+}
+<<< 8.26
+maxColumn = 80
+===
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
+  evt match {
+    case MemberUp(m) =>
+      if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
+  }
+>>>
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
+  evt match {
+    case MemberUp(m) =>
+      if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
+  }
+<<< 8.27
+maxColumn = 80
+===
+def insertAndDelete(eventClient: LEvents) = {
+  val resultAfter = eventClient.get(eventId, appId)
+
+  (resultBefore must beEqualTo(Some(expectedBefore))) and
+    (deleteStatus must beEqualTo(true)) and
+    (resultAfter must beEqualTo(None))
+}
+>>>
+def insertAndDelete(eventClient: LEvents) = {
+  val resultAfter = eventClient.get(eventId, appId)
+
+  (resultBefore must beEqualTo(Some(expectedBefore))) and
+    (deleteStatus must beEqualTo(true)) and
+    (resultAfter must beEqualTo(None))
+}
+<<< 8.28
+object a {
+  val b = qual1 op1 { 1 + 2 + 3 + 4 + 5 } op2
+    111 * 222 * 333 * 444 * 555 op3
+    { "1 / 2 / 3 / 4 / 5 / 6 / 7" }
+}
+>>>
+object a {
+  val b = qual1 op1 {
+    1 + 2 + 3 + 4 + 5
+  } op2
+    111 * 222 * 333 * 444 * 555 op3 {
+    "1 / 2 / 3 / 4 / 5 / 6 / 7"
+  }
+}
+<<< 8.29
+object a {
+  val a: Seq[(C, D, E[_, _, _, _], F)] =
+    (0 until c).map { x =>
+      // c1
+      x
+    }
+}
+>>>
+object a {
+  val a: Seq[(C, D, E[_, _, _, _], F)] =
+    (0 until c).map { x =>
+      // c1
+      x
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1536,3 +1536,566 @@ val a = new A {
 val a = new A {
   def f = b
 }
+<<< 8.1: infix with longer left ||
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op
+    7 map {
+      8 % 9
+    }
+>>>
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op
+    7 map { 8 % 9 }
+<<< 8.2: infix with shorter left ||
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
+>>>
+val a =
+  1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+    8 % 9
+  }
+<<< 8.3: infix with longer left ||, narrow
+maxColumn = 20
+===
+val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
+>>>
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+    8 % 9
+  }
+<<< 8.4: infix with shorter left ||, narrow
+maxColumn = 17
+===
+{
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
+val b = { 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 } || somethinglong }
+}
+>>>
+{
+  val a =
+    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+      8 % 9
+    }
+  val b = {
+    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+      8 % 9
+    } || somethinglong
+  }
+}
+<<< 8.5: sequences of infix operations
+maxColumn = 75
+runner.optimizer.forceConfigStyleOnOffset = 1000
+===
+val strings = Seq(
+    "MetricEvaluatorResult:",
+    s"  # engine params evaluated: ${engineParamsScores.size}") ++
+    Seq(
+      "Optimal Engine Params:",
+      s"  $bestEPStr",
+      "Metrics:",
+      s"  $metricHeader: ${bestScore.score}") ++
+    otherMetricHeaders.zip(bestScore.otherScores).map {
+      case (h, s) => s"  $h: $s"
+    } ++
+    outputPath.toSeq.map { p =>
+      s"The best variant params can be found in $p"
+    }
+>>>
+val strings = Seq(
+  "MetricEvaluatorResult:",
+  s"  # engine params evaluated: ${engineParamsScores.size}"
+) ++
+  Seq(
+    "Optimal Engine Params:",
+    s"  $bestEPStr",
+    "Metrics:",
+    s"  $metricHeader: ${bestScore.score}"
+  ) ++
+  otherMetricHeaders.zip(bestScore.otherScores).map {
+    case (h, s) => s"  $h: $s"
+  } ++
+  outputPath.toSeq.map { p =>
+    s"The best variant params can be found in $p"
+  }
+<<< 8.6: assignment with short expression
+object a {
+  plugins(service.pluginType) += service.pluginName -> service
+}
+>>>
+object a {
+  plugins(service.pluginType) += service
+    .pluginName -> service
+}
+<<< 8.7
+maxColumn = 80
+===
+val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
+       ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
+       ("targetEntityId" -> data("itemId")) ~
+       ("eventTime" -> data("timestamp")) ~ ("properties" -> (("context" ->
+       (("ip" -> data("context[ip]")) ~ ("prop1" -> data("context[prop1]")
+         .toDouble) ~ ("prop2" -> data("context[prop2]")))) ~
+       ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+       ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
+>>>
+val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
+  ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
+  ("targetEntityId" -> data("itemId")) ~
+  ("eventTime" -> data("timestamp")) ~ ("properties" -> (("context" ->
+  (("ip" -> data("context[ip]")) ~ ("prop1" -> data("context[prop1]")
+    .toDouble) ~ ("prop2" -> data("context[prop2]")))) ~
+  ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+  ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
+<<< 8.8
+maxColumn = 80
+===
+override def hashCode: Int = 41 + fields.hashCode
+>>>
+override def hashCode: Int = 41 + fields.hashCode
+<<< 8.9
+maxColumn = 80
+===
+object a {
+val fields = JField("engineVariant", JString(i.engineVariant)) ::
+   JField("engineFactory", JString(i.engineFactory)) ::
+     JField("batch", JString(i.batch)) ::
+     JField("env", Extraction.decompose(i.env)(DefaultFormats))
+}
+>>>
+object a {
+  val fields = JField("engineVariant", JString(i.engineVariant)) ::
+    JField("engineFactory", JString(i.engineFactory)) ::
+    JField("batch", JString(i.batch)) ::
+    JField("env", Extraction.decompose(i.env)(DefaultFormats))
+}
+<<< 8.10
+maxColumn = 80
+===
+object a {
+  def isReservedPrefix(name: String): Boolean =
+      name.startsWith("$") || name.startsWith("pio_")
+  def idWithAppid(appid: Int, id: String): String = appid + "_" + id
+}
+>>>
+object a {
+  def isReservedPrefix(name: String): Boolean =
+    name.startsWith("$") || name.startsWith("pio_")
+  def idWithAppid(appid: Int, id: String): String = appid + "_" + id
+}
+<<< 8.11
+maxColumn = 80
+===
+Some(
+  ("ip" -> data.get("context[ip]")) ~ (
+  "prop1" ->
+     data.get("context[prop1]").map(_.toDouble)
+))
+>>>
+Some(
+  ("ip" -> data.get("context[ip]")) ~ ("prop1" ->
+    data.get("context[prop1]").map(_.toDouble))
+)
+<<< 8.12
+maxColumn = 80
+===
+val json = (estype -> ("properties" -> ("status" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("startTime" ->
+      ("type" -> "date")) ~ ("endTime" -> ("type" -> "date")) ~ ("engineId" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVersion" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVariant" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineFactory" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("batch" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("dataSourceParams" -> ("type" -> "string") ~ ("index" ->
+        "not_analyzed")) ~ ("preparatorParams" -> ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~ ("algorithmsParams" -> ("type" ->
+          "string") ~ ("index" -> "not_analyzed")) ~ ("servingParams" ->
+          ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
+          ("type" -> "string") ~ ("index" -> "not_analyzed"))))
+>>>
+val json = (estype -> ("properties" -> ("status" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("startTime" ->
+  ("type" -> "date")) ~ ("endTime" -> ("type" -> "date")) ~ ("engineId" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVersion" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVariant" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineFactory" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("batch" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+  ("dataSourceParams" -> ("type" -> "string") ~ ("index" ->
+    "not_analyzed")) ~ ("preparatorParams" -> ("type" -> "string") ~
+  ("index" -> "not_analyzed")) ~ ("algorithmsParams" -> ("type" ->
+  "string") ~ ("index" -> "not_analyzed")) ~ ("servingParams" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed"))))
+<<< 8.13
+maxColumn = 80
+===
+val a = b match {
+  case i: EngineInstance =>
+    JObject(
+      JField("id", JString(i.id)) ::
+        JField("status", JString(i.status)) ::
+        JField("startTime", JString(i.startTime.toString)) ::
+        JField("endTime", JString(i.endTime.toString)) ::
+        JField("engineId", JString(i.engineId)) ::
+        JField("engineVersion", JString(i.engineVersion)) ::
+        JField("engineVariant", JString(i.engineVariant)) ::
+        JField("engineFactory", JString(i.engineFactory)) ::
+        JField("batch", JString(i.batch)) ::
+        JField("env", Extraction.decompose(i.env)(DefaultFormats)) ::
+        JField(
+          "sparkConf",
+          Extraction.decompose(i.sparkConf)(DefaultFormats)) ::
+        JField("dataSourceParams", JString(i.dataSourceParams)) ::
+        JField("preparatorParams", JString(i.preparatorParams)) ::
+        JField("algorithmsParams", JString(i.algorithmsParams)) ::
+        JField("servingParams", JString(i.servingParams)) ::
+        Nil)
+}
+>>>
+val a = b match {
+  case i: EngineInstance =>
+    JObject(
+      JField("id", JString(i.id)) ::
+        JField("status", JString(i.status)) ::
+        JField("startTime", JString(i.startTime.toString)) ::
+        JField("endTime", JString(i.endTime.toString)) ::
+        JField("engineId", JString(i.engineId)) ::
+        JField("engineVersion", JString(i.engineVersion)) ::
+        JField("engineVariant", JString(i.engineVariant)) ::
+        JField("engineFactory", JString(i.engineFactory)) ::
+        JField("batch", JString(i.batch)) ::
+        JField("env", Extraction.decompose(i.env)(DefaultFormats)) ::
+        JField(
+          "sparkConf",
+          Extraction.decompose(i.sparkConf)(DefaultFormats)
+        ) ::
+        JField("dataSourceParams", JString(i.dataSourceParams)) ::
+        JField("preparatorParams", JString(i.preparatorParams)) ::
+        JField("algorithmsParams", JString(i.algorithmsParams)) ::
+        JField("servingParams", JString(i.servingParams)) ::
+        Nil
+    )
+}
+<<< 8.14
+maxColumn = 80
+===
+private lazy val subNode: Parser[SubNode] = rep(' ') ~>
+  ((opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ {
+    name => AttrAppendSubNode(name)
+  }) |
+  (opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ {
+    name => AttrRemoveSubNode(name)
+  }) |    (opt('*') ~ '[' ~> attrName <~ ']' ^^ {
+     name => AttrSubNode(name)
+   }) |
+
+   ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+   ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
+   ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
+   ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
+   ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
+   ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
+   '*' ^^ (a => KidsSubNode()) |
+   '^' ~ '*' ^^ (a => SelectThisNode(true)) |
+   '^' ~ '^' ^^ (a => SelectThisNode(false)))
+>>>
+private lazy val subNode: Parser[SubNode] = rep(' ') ~>
+  ((opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ { name =>
+    AttrAppendSubNode(name)
+  }) |
+    (opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ { name =>
+      AttrRemoveSubNode(name)
+    }) | (opt('*') ~ '[' ~> attrName <~ ']' ^^ { name => AttrSubNode(name) }) |
+
+    ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+    ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
+    ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
+    ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
+    ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
+    ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
+    '*' ^^ (a => KidsSubNode()) |
+    '^' ~ '*' ^^ (a => SelectThisNode(true)) |
+    '^' ~ '^' ^^ (a => SelectThisNode(false)))
+<<< 8.15
+maxColumn = 80
+===
+object a {
+  def toEventJson(common: Common, userAction: UserAction): JObject = {
+   import org.json4s.JsonDSL._
+    val json =
+      ("event" -> "subscribe") ~
+        ("entityType" -> "user") ~
+        ("entityId" -> data("data[id]")) ~
+        ("targetEntityType" -> "list") ~
+        ("targetEntityId" -> data("data[list_id]")) ~
+        ("eventTime" -> eventTime) ~
+        ("properties" -> (("email" -> data("data[email]")) ~
+          ("email_type" -> data("data[email_type]")) ~
+          ("merges" -> (("EMAIL" -> data("data[merges][EMAIL]")) ~
+            ("FNAME" -> data("data[merges][FNAME]"))) ~
+            ("LNAME" -> data("data[merges][LNAME]")) ~
+            ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+          ("ip_opt" -> data("data[ip_opt]")) ~
+          ("ip_signup" -> data("data[ip_signup]")))
+      json
+  }
+}
+>>>
+object a {
+  def toEventJson(common: Common, userAction: UserAction): JObject = {
+    import org.json4s.JsonDSL._
+    val json =
+      ("event" -> "subscribe") ~
+        ("entityType" -> "user") ~
+        ("entityId" -> data("data[id]")) ~
+        ("targetEntityType" -> "list") ~
+        ("targetEntityId" -> data("data[list_id]")) ~
+        ("eventTime" -> eventTime) ~
+        ("properties" -> (("email" -> data("data[email]")) ~
+          ("email_type" -> data("data[email_type]")) ~
+          ("merges" -> (("EMAIL" -> data("data[merges][EMAIL]")) ~
+            ("FNAME" -> data("data[merges][FNAME]"))) ~
+            ("LNAME" -> data("data[merges][LNAME]")) ~
+            ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+          ("ip_opt" -> data("data[ip_opt]")) ~
+          ("ip_signup" -> data("data[ip_signup]")))
+    json
+  }
+}
+<<< 8.16
+maxColumn = 80
+===
+override def preRestart(cause: Throwable, msg: Option[Any]) {
+       if (master ne null) {
+        master ! "failed with " + cause + " while processing " + msg
+       }
+       context stop self
+     }
+>>>
+override def preRestart(cause: Throwable, msg: Option[Any]) {
+  if (master ne null) {
+    master ! "failed with " + cause + " while processing " + msg
+  }
+  context stop self
+}
+<<< 8.17
+maxColumn = 80
+===
+object a {
+   def `media-range-def` =
+     rule {
+       "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+        ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+     }
+}
+>>>
+object a {
+  def `media-range-def` =
+    rule {
+      "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+          ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+    }
+}
+<<< 8.18
+maxColumn = 80
+===
+object a {
+  (people.map(p => (p.name, p.age))
+  // c1
+  returning people.map(_.id)
+  // c2
+  into ((nameAge, id) => Person(id, nameAge._1, nameAge._2))
+  )
+}
+>>>
+object a {
+  (people.map(p => (p.name, p.age))
+  // c1
+    returning people.map(_.id)
+  // c2
+    into ((nameAge, id) => Person(id, nameAge._1, nameAge._2)))
+}
+<<< 8.19
+maxColumn = 80
+===
+def `day-name` =
+     rule(
+       "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+        "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6))
+>>>
+def `day-name` =
+  rule(
+    "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+      "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6)
+  )
+<<< 8.20
+maxColumn = 80
+===
+HttpResponse(
+   StatusCodes.ServiceUnavailable,
+   entity = "The server was not able " +
+   "to produce a timely response to your request.\r\nPlease try again in a short while!"
+)
+>>>
+HttpResponse(
+  StatusCodes.ServiceUnavailable,
+  entity = "The server was not able " +
+    "to produce a timely response to your request.\r\nPlease try again in a short while!"
+)
+<<< 8.21
+maxColumn = 80
+===
+private val allParams: Map[String, String] = mandatoryParams +
+    (
+      "data-config" ->
+        dummyOptionalConfigPath,
+      "max-sales-mappers" ->
+        "10",
+      "overwrite" ->
+        null,
+      "keep" -> dummyOptionalMaxVersionCount
+    )
+>>>
+private val allParams: Map[String, String] = mandatoryParams +
+  (
+    "data-config" ->
+      dummyOptionalConfigPath,
+    "max-sales-mappers" ->
+      "10",
+    "overwrite" ->
+      null,
+    "keep" -> dummyOptionalMaxVersionCount
+)
+<<< 8.22
+maxColumn = 40
+===
+"Terminating(" + reason + ")" +
+                   (toDie.toSeq.sorted mkString
+                     (
+                      "\n" +
+                        indent +
+                        "   |    toDie: ", "\n" + indent + "   |           ", ""
+                     ))
+>>>
+"Terminating(" + reason + ")" +
+  (toDie.toSeq.sorted mkString
+    (
+      "\n" +
+        indent +
+        "   |    toDie: ", "\n" + indent + "   |           ", ""
+  ))
+<<< 8.23
+maxColumn = 80
+===
+val ret = (if (dailyStats.isEmpty)
+                   0
+                 else {
+                   val yestStats = dailyStats.last
+                   val yestNav = yestStats.nav
+                   (nav -
+                     yestNav) / nav - 1
+                 })
+>>>
+val ret =
+  (if (dailyStats.isEmpty) 0
+   else {
+     val yestStats = dailyStats.last
+     val yestNav = yestStats.nav
+     (nav -
+       yestNav) / nav - 1
+   })
+<<< 8.24
+maxColumn = 80
+===
+def isErrorEnabled(logClass: Class[_], logSource: String) =
+    (eventStream.logLevel >= ErrorLevel) &&
+      Logger(logClass, logSource).isErrorEnabled
+>>>
+def isErrorEnabled(logClass: Class[_], logSource: String) =
+  (eventStream.logLevel >= ErrorLevel) &&
+    Logger(logClass, logSource).isErrorEnabled
+<<< 8.25
+maxColumn = 80
+===
+def getShort(implicit byteOrder: ByteOrder): Short = {
+    if (byteOrder == ByteOrder.BIG_ENDIAN)
+      ((next() & 0xff) << 8 | (next() & 0xff) << 0).toShort
+    else if (byteOrder == ByteOrder.LITTLE_ENDIAN)
+      ((next() & 0xff) << 0 | (next() & 0xff) << 8).toShort
+     else throw new IllegalArgumentException("Unknown byte order " + byteOrder)
+   }
+>>>
+def getShort(implicit byteOrder: ByteOrder): Short = {
+  if (byteOrder == ByteOrder.BIG_ENDIAN)
+    ((next() & 0xff) << 8 | (next() & 0xff) << 0).toShort
+  else if (byteOrder == ByteOrder.LITTLE_ENDIAN)
+    ((next() & 0xff) << 0 | (next() & 0xff) << 8).toShort
+  else throw new IllegalArgumentException("Unknown byte order " + byteOrder)
+}
+<<< 8.26
+maxColumn = 80
+===
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
+  evt match {
+    case MemberUp(m) =>
+      if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
+  }
+>>>
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
+  evt match {
+    case MemberUp(m) =>
+      if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
+  }
+<<< 8.27
+maxColumn = 80
+===
+def insertAndDelete(eventClient: LEvents) = {
+  val resultAfter = eventClient.get(eventId, appId)
+
+  (resultBefore must beEqualTo(Some(expectedBefore))) and
+    (deleteStatus must beEqualTo(true)) and
+    (resultAfter must beEqualTo(None))
+}
+>>>
+def insertAndDelete(eventClient: LEvents) = {
+  val resultAfter = eventClient.get(eventId, appId)
+
+  (resultBefore must beEqualTo(Some(expectedBefore))) and
+    (deleteStatus must beEqualTo(true)) and
+    (resultAfter must beEqualTo(None))
+}
+<<< 8.28
+object a {
+  val b = qual1 op1 { 1 + 2 + 3 + 4 + 5 } op2
+    111 * 222 * 333 * 444 * 555 op3
+    { "1 / 2 / 3 / 4 / 5 / 6 / 7" }
+}
+>>>
+object a {
+  val b = qual1 op1 {
+    1 + 2 + 3 + 4 + 5
+  } op2
+    111 * 222 * 333 * 444 * 555 op3 {
+    "1 / 2 / 3 / 4 / 5 / 6 / 7"
+  }
+}
+<<< 8.29
+object a {
+  val a: Seq[(C, D, E[_, _, _, _], F)] =
+    (0 until c).map { x =>
+      // c1
+      x
+    }
+}
+>>>
+object a {
+  val a: Seq[(C, D, E[_, _, _, _], F)] =
+    (0 until c).map { x =>
+      // c1
+      x
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -152,7 +152,8 @@ object a {
 object a {
   the[Exception] thrownBy {
     SizeUtils.calculate(segments, "user")
-  } should have message """Cannot resolve column name "user" among (segment_id);"""
+  } should have message
+    """Cannot resolve column name "user" among (segment_id);"""
 }
 <<< 1.d: if-else, no curlies
 if (a)
@@ -491,17 +492,12 @@ val augassign: P[Ast.operator] = P(
   )
 >>>
 val augassign: P[Ast.operator] = P(
-  "+=".!.map(_ => Ast.operator.Add) |
-    "-=".!.map(_ => Ast.operator.Sub) |
-    "*=".!.map(_ => Ast.operator.Mult) |
-    "/=".!.map(_ => Ast.operator.Div) |
-    "%=".!.map(_ => Ast.operator.Mod) |
-    "&=".!.map(_ => Ast.operator.BitAnd) |
-    "|=".!.map(_ => Ast.operator.BitOr) |
-    "^=".!.map(_ => Ast.operator.BitXor) |
+  "+=".!.map(_ => Ast.operator.Add) | "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) | "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) | "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) | "^=".!.map(_ => Ast.operator.BitXor) |
     "<<=".!.map(_ => Ast.operator.LShift) |
-    ">>=".!.map(_ => Ast.operator.RShift) |
-    "**=".!.map(_ => Ast.operator.Pow) |
+    ">>=".!.map(_ => Ast.operator.RShift) | "**=".!.map(_ => Ast.operator.Pow) |
     "//=".!.map(_ => Ast.operator.FloorDiv)
 )
 <<< 3.1: def non-config-style, long
@@ -588,11 +584,12 @@ object a {
 }
 >>>
 object a {
-  terminaters = Set() ++ (for (i ← 1 to n) yield {
-    val man = context.watch(context.system.actorOf(Props[Terminater]))
-    man ! "run"
-    man
-  })
+  terminaters = Set() ++
+    (for (i ← 1 to n) yield {
+      val man = context.watch(context.system.actorOf(Props[Terminater]))
+      man ! "run"
+      man
+    })
 }
 <<< 3.11 enclosed, by itself
 maxColumn = 80
@@ -714,8 +711,8 @@ object a {
 }
 >>>
 object a {
-  val a =
-    2 ++ (intercept[java.lang.IllegalStateException] { in.readObject }) ++ 3
+  val a = 2 ++ (intercept[java.lang.IllegalStateException] { in.readObject }) ++
+    3
 }
 <<< 3.18 enclosed, assignment, by itself, narrower
 maxColumn = 60
@@ -762,9 +759,10 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (intercept[java.lang.IllegalStateException] {
-    in.readObject
-  })
+  val a = 2 ++
+    (intercept[java.lang.IllegalStateException] {
+      in.readObject
+    })
 }
 <<< 3.21 enclosed, assignment, infix in middle, narrower
 maxColumn = 60
@@ -779,9 +777,10 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (intercept[java.lang.IllegalStateException] {
-    in.readObject
-  }) ++ 3
+  val a = 2 ++
+    (intercept[java.lang.IllegalStateException] {
+      in.readObject
+    }) ++ 3
 }
 <<< 3.22 enclosed, assignment, by itself, narrow
 maxColumn = 40
@@ -833,10 +832,11 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (intercept[
-    java.lang.IllegalStateException] {
-    in.readObject
-  })
+  val a = 2 ++
+    (intercept[
+      java.lang.IllegalStateException] {
+      in.readObject
+    })
 }
 <<< 3.25 enclosed, assignment, infix in middle, narrow
 maxColumn = 40
@@ -851,10 +851,11 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (intercept[
-    java.lang.IllegalStateException] {
-    in.readObject
-  }) ++ 3
+  val a = 2 ++
+    (intercept[
+      java.lang.IllegalStateException] {
+      in.readObject
+    }) ++ 3
 }
 <<< 3.26 enclosed, def, chain follows
 maxColumn = 80
@@ -1318,10 +1319,12 @@ created filter (ref ⇒
 }
 >>>
 object a {
-  created filter (ref ⇒
-    !ref.isTerminated && !ref.asInstanceOf[ActorRefWithCell].underlying
-      .isInstanceOf[UnstartedCell]
-  ) should ===(Seq.empty[ActorRef])
+  created filter
+    (ref ⇒
+      !ref.isTerminated &&
+        !ref.asInstanceOf[ActorRefWithCell].underlying
+          .isInstanceOf[UnstartedCell]
+    ) should ===(Seq.empty[ActorRef])
 }
 <<< 6.5: chain with delayed indent after break
 maxColumn = 70
@@ -1460,13 +1463,16 @@ object a {
   ).future2
 }
 <<< 7.7: for-yield enclosed in parens
+maxColumn = 40
+danglingParentheses = true
+===
 for {
   nu <- rand.gaussian(0, 1)
   y = nu * nu
   x = (mean
         + mean * mean * y * 0.5 / shape
         - 0.5 * mean / shape * math
-          .sqrt(4 * mean * shape * y + mean * mean * y * y)
+          .sqrt(4 * mean * shape * y + mean * mean * y * y) // c1
     )
   z <- rand.uniform
 } yield {
@@ -1479,11 +1485,14 @@ for {
 for {
   nu <- rand.gaussian(0, 1)
   y = nu * nu
-  x = (mean
-      + mean * mean * y * 0.5 / shape
-      - 0.5 * mean / shape * math.sqrt(
-        4 * mean * shape * y + mean * mean * y * y
-      ))
+  x =
+    (mean +
+      mean * mean * y * 0.5 / shape -
+      0.5 * mean / shape * math.sqrt(
+        4 * mean * shape * y +
+          mean * mean * y * y
+      ) // c1
+    )
   z <- rand.uniform
 } yield {
   if (z <= mean / (mean + x)) x
@@ -1544,24 +1553,23 @@ val a =
     }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op
-    7 map { 8 % 9 }
+  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+    8 % 9
+  }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
 >>>
-val a =
-  1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
-    8 % 9
-  }
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op
+  7 map { 8 % 9 }
 <<< 8.3: infix with longer left ||, narrow
 maxColumn = 20
 ===
 val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-    8 % 9
-  }
+  1 + 2 * 3 && 4 ^
+    5 || 6 op
+    7 map { 8 % 9 }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
 ===
@@ -1572,13 +1580,19 @@ val b = { 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 } || somethinglong }
 >>>
 {
   val a =
-    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
-      8 % 9
-    }
+    1 + 2 * 3 ||
+      4 ^
+      5 && 6 op
+      7 map {
+        8 % 9
+      }
   val b = {
-    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
-      8 % 9
-    } || somethinglong
+    1 + 2 * 3 ||
+    4 ^ 5 && 6 op
+      7 map {
+        8 % 9
+      } ||
+      somethinglong
   }
 }
 <<< 8.5: sequences of infix operations
@@ -1603,27 +1617,24 @@ val strings = Seq(
 val strings = Seq(
   "MetricEvaluatorResult:",
   s"  # engine params evaluated: ${engineParamsScores.size}"
-) ++
-  Seq(
-    "Optimal Engine Params:",
-    s"  $bestEPStr",
-    "Metrics:",
-    s"  $metricHeader: ${bestScore.score}"
-  ) ++
-  otherMetricHeaders.zip(bestScore.otherScores).map {
-    case (h, s) => s"  $h: $s"
-  } ++
-  outputPath.toSeq.map { p =>
-    s"The best variant params can be found in $p"
-  }
+) ++ Seq(
+  "Optimal Engine Params:",
+  s"  $bestEPStr",
+  "Metrics:",
+  s"  $metricHeader: ${bestScore.score}"
+) ++ otherMetricHeaders.zip(bestScore.otherScores).map {
+  case (h, s) => s"  $h: $s"
+} ++ outputPath.toSeq.map { p =>
+  s"The best variant params can be found in $p"
+}
 <<< 8.6: assignment with short expression
 object a {
   plugins(service.pluginType) += service.pluginName -> service
 }
 >>>
 object a {
-  plugins(service.pluginType) += service
-    .pluginName -> service
+  plugins(service.pluginType) +=
+    service.pluginName -> service
 }
 <<< 8.7
 maxColumn = 80
@@ -1637,14 +1648,20 @@ val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
        ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
        ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
 >>>
-val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
-  ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
-  ("targetEntityId" -> data("itemId")) ~
-  ("eventTime" -> data("timestamp")) ~ ("properties" -> (("context" ->
-  (("ip" -> data("context[ip]")) ~ ("prop1" -> data("context[prop1]")
-    .toDouble) ~ ("prop2" -> data("context[prop2]")))) ~
-  ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
-  ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
+val json =
+  ("event" -> data("event")) ~
+    ("entityType" -> "user") ~
+    ("entityId" -> data("userId")) ~
+    ("targetEntityType" -> "item") ~
+    ("targetEntityId" -> data("itemId")) ~
+    ("eventTime" -> data("timestamp")) ~
+    ("properties" ->
+      (("context" ->
+        (("ip" -> data("context[ip]")) ~
+          ("prop1" -> data("context[prop1]").toDouble) ~
+          ("prop2" -> data("context[prop2]")))) ~
+        ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+        ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
 <<< 8.8
 maxColumn = 80
 ===
@@ -1691,8 +1708,8 @@ Some(
 ))
 >>>
 Some(
-  ("ip" -> data.get("context[ip]")) ~ ("prop1" ->
-    data.get("context[prop1]").map(_.toDouble))
+  ("ip" -> data.get("context[ip]")) ~
+    ("prop1" -> data.get("context[prop1]").map(_.toDouble))
 )
 <<< 8.12
 maxColumn = 80
@@ -1712,28 +1729,32 @@ val json = (estype -> ("properties" -> ("status" ->
           ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
           ("type" -> "string") ~ ("index" -> "not_analyzed"))))
 >>>
-val json = (estype -> ("properties" -> ("status" ->
-  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("startTime" ->
-  ("type" -> "date")) ~ ("endTime" -> ("type" -> "date")) ~ ("engineId" ->
-  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVersion" ->
-  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVariant" ->
-  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineFactory" ->
-  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("batch" ->
-  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
-  ("dataSourceParams" -> ("type" -> "string") ~ ("index" ->
-    "not_analyzed")) ~ ("preparatorParams" -> ("type" -> "string") ~
-  ("index" -> "not_analyzed")) ~ ("algorithmsParams" -> ("type" ->
-  "string") ~ ("index" -> "not_analyzed")) ~ ("servingParams" ->
-  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
-  ("type" -> "string") ~ ("index" -> "not_analyzed"))))
+val json =
+  (estype ->
+    ("properties" ->
+      ("status" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("startTime" -> ("type" -> "date")) ~
+      ("endTime" -> ("type" -> "date")) ~
+      ("engineId" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("engineVersion" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("engineVariant" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("engineFactory" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("batch" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("dataSourceParams" -> ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~
+      ("preparatorParams" -> ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~
+      ("algorithmsParams" -> ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~
+      ("servingParams" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("status" -> ("type" -> "string") ~ ("index" -> "not_analyzed"))))
 <<< 8.13
 maxColumn = 80
 ===
 val a = b match {
   case i: EngineInstance =>
     JObject(
-      JField("id", JString(i.id)) ::
-        JField("status", JString(i.status)) ::
+      JField("id", JString(i.id)) :: JField("status", JString(i.status)) ::
         JField("startTime", JString(i.startTime.toString)) ::
         JField("endTime", JString(i.endTime.toString)) ::
         JField("engineId", JString(i.engineId)) ::
@@ -1741,11 +1762,10 @@ val a = b match {
         JField("engineVariant", JString(i.engineVariant)) ::
         JField("engineFactory", JString(i.engineFactory)) ::
         JField("batch", JString(i.batch)) ::
-        JField("env", Extraction.decompose(i.env)(DefaultFormats)) ::
-        JField(
+        JField("env", Extraction.decompose(i.env)(DefaultFormats)) :: JField(
           "sparkConf",
-          Extraction.decompose(i.sparkConf)(DefaultFormats)) ::
-        JField("dataSourceParams", JString(i.dataSourceParams)) ::
+          Extraction.decompose(i.sparkConf)(DefaultFormats)
+        ) :: JField("dataSourceParams", JString(i.dataSourceParams)) ::
         JField("preparatorParams", JString(i.preparatorParams)) ::
         JField("algorithmsParams", JString(i.algorithmsParams)) ::
         JField("servingParams", JString(i.servingParams)) ::
@@ -1755,8 +1775,7 @@ val a = b match {
 val a = b match {
   case i: EngineInstance =>
     JObject(
-      JField("id", JString(i.id)) ::
-        JField("status", JString(i.status)) ::
+      JField("id", JString(i.id)) :: JField("status", JString(i.status)) ::
         JField("startTime", JString(i.startTime.toString)) ::
         JField("endTime", JString(i.endTime.toString)) ::
         JField("engineId", JString(i.engineId)) ::
@@ -1768,12 +1787,10 @@ val a = b match {
         JField(
           "sparkConf",
           Extraction.decompose(i.sparkConf)(DefaultFormats)
-        ) ::
-        JField("dataSourceParams", JString(i.dataSourceParams)) ::
+        ) :: JField("dataSourceParams", JString(i.dataSourceParams)) ::
         JField("preparatorParams", JString(i.preparatorParams)) ::
         JField("algorithmsParams", JString(i.algorithmsParams)) ::
-        JField("servingParams", JString(i.servingParams)) ::
-        Nil
+        JField("servingParams", JString(i.servingParams)) :: Nil
     )
 }
 <<< 8.14
@@ -1805,17 +1822,21 @@ private lazy val subNode: Parser[SubNode] = rep(' ') ~>
   }) |
     (opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ { name =>
       AttrRemoveSubNode(name)
-    }) | (opt('*') ~ '[' ~> attrName <~ ']' ^^ { name => AttrSubNode(name) }) |
-
+    }) |
+    (opt('*') ~ '[' ~> attrName <~ ']' ^^ { name => AttrSubNode(name) }) |
     ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
-    ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
+    ('<' ~ '*' ~ '>') ^^
+    (a => SurroundKids()) |
     ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
     ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
     ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
     ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
-    '*' ^^ (a => KidsSubNode()) |
-    '^' ~ '*' ^^ (a => SelectThisNode(true)) |
-    '^' ~ '^' ^^ (a => SelectThisNode(false)))
+    '*' ^^
+    (a => KidsSubNode()) |
+    '^' ~ '*' ^^
+    (a => SelectThisNode(true)) |
+    '^' ~ '^' ^^
+    (a => SelectThisNode(false)))
 <<< 8.15
 maxColumn = 80
 ===
@@ -1851,12 +1872,14 @@ object a {
         ("targetEntityType" -> "list") ~
         ("targetEntityId" -> data("data[list_id]")) ~
         ("eventTime" -> eventTime) ~
-        ("properties" -> (("email" -> data("data[email]")) ~
-          ("email_type" -> data("data[email_type]")) ~
-          ("merges" -> (("EMAIL" -> data("data[merges][EMAIL]")) ~
-            ("FNAME" -> data("data[merges][FNAME]"))) ~
-            ("LNAME" -> data("data[merges][LNAME]")) ~
-            ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+        ("properties" ->
+          (("email" -> data("data[email]")) ~
+            ("email_type" -> data("data[email_type]")) ~
+            ("merges" ->
+              (("EMAIL" -> data("data[merges][EMAIL]")) ~
+                ("FNAME" -> data("data[merges][FNAME]"))) ~
+              ("LNAME" -> data("data[merges][LNAME]")) ~
+              ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
           ("ip_opt" -> data("data[ip_opt]")) ~
           ("ip_signup" -> data("data[ip_signup]")))
     json
@@ -1896,8 +1919,7 @@ object a {
     rule {
       "*/*" ~ push("*") ~ push("*") |
         `type` ~ '/' ~
-          ('*' ~ !tchar ~ push("*") | subtype) |
-        '*' ~ push("*") ~ push("*")
+        ('*' ~ !tchar ~ push("*") | subtype) | '*' ~ push("*") ~ push("*")
     }
 }
 <<< 8.18
@@ -1915,9 +1937,9 @@ object a {
 object a {
   (people.map(p => (p.name, p.age))
   // c1
-    returning people.map(_.id)
+  returning people.map(_.id)
   // c2
-    into ((nameAge, id) => Person(id, nameAge._1, nameAge._2)))
+  into ((nameAge, id) => Person(id, nameAge._1, nameAge._2)))
 }
 <<< 8.19
 maxColumn = 80
@@ -1962,14 +1984,11 @@ private val allParams: Map[String, String] = mandatoryParams +
 >>>
 private val allParams: Map[String, String] = mandatoryParams +
   (
-    "data-config" ->
-      dummyOptionalConfigPath,
-    "max-sales-mappers" ->
-      "10",
-    "overwrite" ->
-      null,
+    "data-config" -> dummyOptionalConfigPath,
+    "max-sales-mappers" -> "10",
+    "overwrite" -> null,
     "keep" -> dummyOptionalMaxVersionCount
-)
+  )
 <<< 8.22
 maxColumn = 40
 ===
@@ -1984,10 +2003,10 @@ maxColumn = 40
 "Terminating(" + reason + ")" +
   (toDie.toSeq.sorted mkString
     (
-      "\n" +
-        indent +
-        "   |    toDie: ", "\n" + indent + "   |           ", ""
-  ))
+      "\n" + indent + "   |    toDie: ",
+      "\n" + indent + "   |           ",
+      ""
+    ))
 <<< 8.23
 maxColumn = 80
 ===
@@ -2005,8 +2024,7 @@ val ret =
    else {
      val yestStats = dailyStats.last
      val yestNav = yestStats.nav
-     (nav -
-       yestNav) / nav - 1
+     (nav - yestNav) / nav - 1
    })
 <<< 8.24
 maxColumn = 80
@@ -2016,8 +2034,8 @@ def isErrorEnabled(logClass: Class[_], logSource: String) =
       Logger(logClass, logSource).isErrorEnabled
 >>>
 def isErrorEnabled(logClass: Class[_], logSource: String) =
-  (eventStream.logLevel >= ErrorLevel) &&
-    Logger(logClass, logSource).isErrorEnabled
+  (eventStream.logLevel >= ErrorLevel) && Logger(logClass, logSource)
+    .isErrorEnabled
 <<< 8.25
 maxColumn = 80
 ===
@@ -2065,8 +2083,7 @@ def insertAndDelete(eventClient: LEvents) = {
   val resultAfter = eventClient.get(eventId, appId)
 
   (resultBefore must beEqualTo(Some(expectedBefore))) and
-    (deleteStatus must beEqualTo(true)) and
-    (resultAfter must beEqualTo(None))
+    (deleteStatus must beEqualTo(true)) and (resultAfter must beEqualTo(None))
 }
 <<< 8.28
 object a {
@@ -2080,8 +2097,8 @@ object a {
     1 + 2 + 3 + 4 + 5
   } op2
     111 * 222 * 333 * 444 * 555 op3 {
-    "1 / 2 / 3 / 4 / 5 / 6 / 7"
-  }
+      "1 / 2 / 3 / 4 / 5 / 6 / 7"
+    }
 }
 <<< 8.29
 object a {
@@ -2098,4 +2115,16 @@ object a {
       // c1
       x
     }
+}
+<<< 8.30
+object a {
+  json should be(
+    """aaa bbb ccc ddd eee fff ggg"""
+  )
+}
+>>>
+object a {
+  json should be(
+    """aaa bbb ccc ddd eee fff ggg"""
+  )
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1603,3 +1603,618 @@ val foo = Bar { () =>
 val foo = Bar { () =>
   f(42)
 }
+<<< 8.1: infix with longer left ||
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op
+    7 map {
+      8 % 9
+    }
+>>>
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op
+    7 map {
+    8 % 9
+  }
+<<< 8.2: infix with shorter left ||
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
+>>>
+val a =
+  1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+    8 % 9
+  }
+<<< 8.3: infix with longer left ||, narrow
+maxColumn = 20
+===
+val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
+>>>
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+    8 % 9
+  }
+<<< 8.4: infix with shorter left ||, narrow
+maxColumn = 17
+===
+{
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
+val b = { 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 } || somethinglong }
+}
+>>>
+{
+  val a =
+    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+      8 % 9
+    }
+  val b = {
+    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+      8 % 9
+    } || somethinglong
+  }
+}
+<<< 8.5: sequences of infix operations
+maxColumn = 75
+runner.optimizer.forceConfigStyleOnOffset = 1000
+===
+val strings = Seq(
+    "MetricEvaluatorResult:",
+    s"  # engine params evaluated: ${engineParamsScores.size}") ++
+    Seq(
+      "Optimal Engine Params:",
+      s"  $bestEPStr",
+      "Metrics:",
+      s"  $metricHeader: ${bestScore.score}") ++
+    otherMetricHeaders.zip(bestScore.otherScores).map {
+      case (h, s) => s"  $h: $s"
+    } ++
+    outputPath.toSeq.map { p =>
+      s"The best variant params can be found in $p"
+    }
+>>>
+val strings = Seq(
+  "MetricEvaluatorResult:",
+  s"  # engine params evaluated: ${engineParamsScores.size}"
+) ++
+  Seq(
+    "Optimal Engine Params:",
+    s"  $bestEPStr",
+    "Metrics:",
+    s"  $metricHeader: ${bestScore.score}"
+  ) ++
+  otherMetricHeaders.zip(bestScore.otherScores).map {
+    case (h, s) => s"  $h: $s"
+  } ++
+  outputPath.toSeq.map { p =>
+    s"The best variant params can be found in $p"
+  }
+<<< 8.6: assignment with short expression
+object a {
+  plugins(service.pluginType) += service.pluginName -> service
+}
+>>>
+object a {
+  plugins(
+    service.pluginType
+  ) += service.pluginName -> service
+}
+<<< 8.7
+maxColumn = 80
+===
+val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
+       ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
+       ("targetEntityId" -> data("itemId")) ~
+       ("eventTime" -> data("timestamp")) ~ ("properties" -> (("context" ->
+       (("ip" -> data("context[ip]")) ~ ("prop1" -> data("context[prop1]")
+         .toDouble) ~ ("prop2" -> data("context[prop2]")))) ~
+       ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+       ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
+>>>
+val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
+  ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
+  ("targetEntityId" -> data("itemId")) ~
+  ("eventTime" -> data("timestamp")) ~ ("properties" -> (("context" ->
+  (("ip" -> data("context[ip]")) ~ ("prop1" -> data("context[prop1]")
+    .toDouble) ~ ("prop2" -> data("context[prop2]")))) ~
+  ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+  ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
+<<< 8.8
+maxColumn = 80
+===
+override def hashCode: Int = 41 + fields.hashCode
+>>>
+override def hashCode: Int = 41 + fields.hashCode
+<<< 8.9
+maxColumn = 80
+===
+object a {
+val fields = JField("engineVariant", JString(i.engineVariant)) ::
+   JField("engineFactory", JString(i.engineFactory)) ::
+     JField("batch", JString(i.batch)) ::
+     JField("env", Extraction.decompose(i.env)(DefaultFormats))
+}
+>>>
+object a {
+  val fields = JField("engineVariant", JString(i.engineVariant)) ::
+    JField("engineFactory", JString(i.engineFactory)) ::
+    JField("batch", JString(i.batch)) ::
+    JField("env", Extraction.decompose(i.env)(DefaultFormats))
+}
+<<< 8.10
+maxColumn = 80
+===
+object a {
+  def isReservedPrefix(name: String): Boolean =
+      name.startsWith("$") || name.startsWith("pio_")
+  def idWithAppid(appid: Int, id: String): String = appid + "_" + id
+}
+>>>
+object a {
+  def isReservedPrefix(name: String): Boolean =
+    name.startsWith("$") || name.startsWith("pio_")
+  def idWithAppid(appid: Int, id: String): String = appid + "_" + id
+}
+<<< 8.11
+maxColumn = 80
+===
+Some(
+  ("ip" -> data.get("context[ip]")) ~ (
+  "prop1" ->
+     data.get("context[prop1]").map(_.toDouble)
+))
+>>>
+Some(
+  ("ip" -> data.get("context[ip]")) ~ (
+    "prop1" ->
+      data.get("context[prop1]").map(_.toDouble)
+  )
+)
+<<< 8.12
+maxColumn = 80
+===
+val json = (estype -> ("properties" -> ("status" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("startTime" ->
+      ("type" -> "date")) ~ ("endTime" -> ("type" -> "date")) ~ ("engineId" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVersion" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVariant" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineFactory" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("batch" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("dataSourceParams" -> ("type" -> "string") ~ ("index" ->
+        "not_analyzed")) ~ ("preparatorParams" -> ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~ ("algorithmsParams" -> ("type" ->
+          "string") ~ ("index" -> "not_analyzed")) ~ ("servingParams" ->
+          ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
+          ("type" -> "string") ~ ("index" -> "not_analyzed"))))
+>>>
+val json = (estype -> ("properties" -> ("status" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("startTime" ->
+  ("type" -> "date")) ~ ("endTime" -> ("type" -> "date")) ~ ("engineId" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVersion" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVariant" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineFactory" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("batch" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+  ("dataSourceParams" -> ("type" -> "string") ~ ("index" ->
+    "not_analyzed")) ~ ("preparatorParams" -> ("type" -> "string") ~
+  ("index" -> "not_analyzed")) ~ ("algorithmsParams" -> ("type" ->
+  "string") ~ ("index" -> "not_analyzed")) ~ ("servingParams" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
+  ("type" -> "string") ~ ("index" -> "not_analyzed"))))
+<<< 8.13
+val a = b match {
+  case i: EngineInstance =>
+    JObject(
+      JField("id", JString(i.id)) ::
+        JField("status", JString(i.status)) ::
+        JField("startTime", JString(i.startTime.toString)) ::
+        JField("endTime", JString(i.endTime.toString)) ::
+        JField("engineId", JString(i.engineId)) ::
+        JField("engineVersion", JString(i.engineVersion)) ::
+        JField("engineVariant", JString(i.engineVariant)) ::
+        JField("engineFactory", JString(i.engineFactory)) ::
+        JField("batch", JString(i.batch)) ::
+        JField("env", Extraction.decompose(i.env)(DefaultFormats)) ::
+        JField(
+          "sparkConf",
+          Extraction.decompose(i.sparkConf)(DefaultFormats)) ::
+        JField("dataSourceParams", JString(i.dataSourceParams)) ::
+        JField("preparatorParams", JString(i.preparatorParams)) ::
+        JField("algorithmsParams", JString(i.algorithmsParams)) ::
+        JField("servingParams", JString(i.servingParams)) ::
+        Nil)
+}
+>>>
+val a = b match {
+  case i: EngineInstance =>
+    JObject(
+      JField("id", JString(i.id)) ::
+        JField(
+          "status",
+          JString(i.status)
+        ) ::
+        JField(
+          "startTime",
+          JString(i.startTime.toString)
+        ) ::
+        JField(
+          "endTime",
+          JString(i.endTime.toString)
+        ) ::
+        JField(
+          "engineId",
+          JString(i.engineId)
+        ) ::
+        JField(
+          "engineVersion",
+          JString(i.engineVersion)
+        ) ::
+        JField(
+          "engineVariant",
+          JString(i.engineVariant)
+        ) ::
+        JField(
+          "engineFactory",
+          JString(i.engineFactory)
+        ) ::
+        JField(
+          "batch",
+          JString(i.batch)
+        ) ::
+        JField(
+          "env",
+          Extraction.decompose(i.env)(
+            DefaultFormats
+          )
+        ) ::
+        JField(
+          "sparkConf",
+          Extraction.decompose(
+            i.sparkConf
+          )(DefaultFormats)
+        ) ::
+        JField(
+          "dataSourceParams",
+          JString(i.dataSourceParams)
+        ) ::
+        JField(
+          "preparatorParams",
+          JString(i.preparatorParams)
+        ) ::
+        JField(
+          "algorithmsParams",
+          JString(i.algorithmsParams)
+        ) ::
+        JField(
+          "servingParams",
+          JString(i.servingParams)
+        ) ::
+        Nil
+    )
+}
+<<< 8.14
+maxColumn = 80
+===
+private lazy val subNode: Parser[SubNode] = rep(' ') ~>
+  ((opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ {
+    name => AttrAppendSubNode(name)
+  }) |
+  (opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ {
+    name => AttrRemoveSubNode(name)
+  }) |    (opt('*') ~ '[' ~> attrName <~ ']' ^^ {
+     name => AttrSubNode(name)
+   }) |
+
+   ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+   ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
+   ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
+   ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
+   ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
+   ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
+   '*' ^^ (a => KidsSubNode()) |
+   '^' ~ '*' ^^ (a => SelectThisNode(true)) |
+   '^' ~ '^' ^^ (a => SelectThisNode(false)))
+>>>
+private lazy val subNode: Parser[SubNode] = rep(' ') ~>
+  ((opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ {
+    name =>
+      AttrAppendSubNode(name)
+  }) |
+    (opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ {
+      name =>
+        AttrRemoveSubNode(name)
+    }) | (opt('*') ~ '[' ~> attrName <~ ']' ^^ {
+    name =>
+      AttrSubNode(name)
+  }) |
+
+    ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+    ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
+    ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
+    ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
+    ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
+    ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
+    '*' ^^ (a => KidsSubNode()) |
+    '^' ~ '*' ^^ (a => SelectThisNode(true)) |
+    '^' ~ '^' ^^ (a => SelectThisNode(false)))
+<<< 8.15
+maxColumn = 80
+===
+object a {
+  def toEventJson(common: Common, userAction: UserAction): JObject = {
+   import org.json4s.JsonDSL._
+    val json =
+      ("event" -> "subscribe") ~
+        ("entityType" -> "user") ~
+        ("entityId" -> data("data[id]")) ~
+        ("targetEntityType" -> "list") ~
+        ("targetEntityId" -> data("data[list_id]")) ~
+        ("eventTime" -> eventTime) ~
+        ("properties" -> (("email" -> data("data[email]")) ~
+          ("email_type" -> data("data[email_type]")) ~
+          ("merges" -> (("EMAIL" -> data("data[merges][EMAIL]")) ~
+            ("FNAME" -> data("data[merges][FNAME]"))) ~
+            ("LNAME" -> data("data[merges][LNAME]")) ~
+            ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+          ("ip_opt" -> data("data[ip_opt]")) ~
+          ("ip_signup" -> data("data[ip_signup]")))
+      json
+  }
+}
+>>>
+object a {
+  def toEventJson(common: Common, userAction: UserAction): JObject = {
+    import org.json4s.JsonDSL._
+    val json =
+      ("event" -> "subscribe") ~
+        ("entityType" -> "user") ~
+        ("entityId" -> data("data[id]")) ~
+        ("targetEntityType" -> "list") ~
+        ("targetEntityId" -> data("data[list_id]")) ~
+        ("eventTime" -> eventTime) ~
+        ("properties" -> (("email" -> data("data[email]")) ~
+          ("email_type" -> data("data[email_type]")) ~
+          ("merges" -> (("EMAIL" -> data("data[merges][EMAIL]")) ~
+            ("FNAME" -> data("data[merges][FNAME]"))) ~
+            ("LNAME" -> data("data[merges][LNAME]")) ~
+            ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+          ("ip_opt" -> data("data[ip_opt]")) ~
+          ("ip_signup" -> data("data[ip_signup]")))
+    json
+  }
+}
+<<< 8.16
+maxColumn = 80
+===
+override def preRestart(cause: Throwable, msg: Option[Any]) {
+       if (master ne null) {
+        master ! "failed with " + cause + " while processing " + msg
+       }
+       context stop self
+     }
+>>>
+override def preRestart(cause: Throwable, msg: Option[Any]) {
+  if (master ne null) {
+    master ! "failed with " + cause + " while processing " + msg
+  }
+  context stop self
+}
+<<< 8.17
+maxColumn = 80
+===
+object a {
+   def `media-range-def` =
+     rule {
+       "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+        ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+     }
+}
+>>>
+object a {
+  def `media-range-def` =
+    rule {
+      "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+          ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+    }
+}
+<<< 8.18
+maxColumn = 80
+===
+object a {
+  (people.map(p => (p.name, p.age))
+  // c1
+  returning people.map(_.id)
+  // c2
+  into ((nameAge, id) => Person(id, nameAge._1, nameAge._2))
+  )
+}
+>>>
+object a {
+  (people.map(p => (p.name, p.age))
+  // c1
+    returning people.map(_.id)
+  // c2
+    into ((nameAge, id) => Person(id, nameAge._1, nameAge._2)))
+}
+<<< 8.19
+maxColumn = 80
+===
+def `day-name` =
+     rule(
+       "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+        "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6))
+>>>
+def `day-name` =
+  rule(
+    "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+      "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6)
+  )
+<<< 8.20
+maxColumn = 80
+===
+HttpResponse(
+   StatusCodes.ServiceUnavailable,
+   entity = "The server was not able " +
+   "to produce a timely response to your request.\r\nPlease try again in a short while!"
+)
+>>>
+HttpResponse(
+  StatusCodes.ServiceUnavailable,
+  entity = "The server was not able " +
+    "to produce a timely response to your request.\r\nPlease try again in a short while!"
+)
+<<< 8.21
+maxColumn = 80
+===
+private val allParams: Map[String, String] = mandatoryParams +
+    (
+      "data-config" ->
+        dummyOptionalConfigPath,
+      "max-sales-mappers" ->
+        "10",
+      "overwrite" ->
+        null,
+      "keep" -> dummyOptionalMaxVersionCount
+    )
+>>>
+private val allParams: Map[String, String] = mandatoryParams +
+  (
+    "data-config" ->
+      dummyOptionalConfigPath,
+    "max-sales-mappers" ->
+      "10",
+    "overwrite" ->
+      null,
+    "keep" -> dummyOptionalMaxVersionCount
+)
+<<< 8.22
+maxColumn = 40
+===
+"Terminating(" + reason + ")" +
+                   (toDie.toSeq.sorted mkString
+                     (
+                      "\n" +
+                        indent +
+                        "   |    toDie: ", "\n" + indent + "   |           ", ""
+                     ))
+>>>
+"Terminating(" + reason + ")" +
+  (toDie.toSeq.sorted mkString
+    (
+      "\n" +
+        indent +
+        "   |    toDie: ", "\n" + indent + "   |           ", ""
+  ))
+<<< 8.23
+maxColumn = 80
+===
+val ret = (if (dailyStats.isEmpty)
+                   0
+                 else {
+                   val yestStats = dailyStats.last
+                   val yestNav = yestStats.nav
+                   (nav -
+                     yestNav) / nav - 1
+                 })
+>>>
+val ret =
+  (if (dailyStats.isEmpty)
+     0
+   else {
+     val yestStats = dailyStats.last
+     val yestNav = yestStats.nav
+     (nav -
+       yestNav) / nav - 1
+   })
+<<< 8.24
+maxColumn = 80
+===
+def isErrorEnabled(logClass: Class[_], logSource: String) =
+    (eventStream.logLevel >= ErrorLevel) &&
+      Logger(logClass, logSource).isErrorEnabled
+>>>
+def isErrorEnabled(logClass: Class[_], logSource: String) =
+  (eventStream.logLevel >= ErrorLevel) &&
+    Logger(logClass, logSource).isErrorEnabled
+<<< 8.25
+maxColumn = 80
+===
+def getShort(implicit byteOrder: ByteOrder): Short = {
+    if (byteOrder == ByteOrder.BIG_ENDIAN)
+      ((next() & 0xff) << 8 | (next() & 0xff) << 0).toShort
+    else if (byteOrder == ByteOrder.LITTLE_ENDIAN)
+      ((next() & 0xff) << 0 | (next() & 0xff) << 8).toShort
+     else throw new IllegalArgumentException("Unknown byte order " + byteOrder)
+   }
+>>>
+def getShort(implicit byteOrder: ByteOrder): Short = {
+  if (byteOrder == ByteOrder.BIG_ENDIAN)
+    ((next() & 0xff) << 8 | (next() & 0xff) << 0).toShort
+  else if (byteOrder == ByteOrder.LITTLE_ENDIAN)
+    ((next() & 0xff) << 0 | (next() & 0xff) << 8).toShort
+  else throw new IllegalArgumentException("Unknown byte order " + byteOrder)
+}
+<<< 8.26
+maxColumn = 80
+===
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
+  evt match {
+    case MemberUp(m) =>
+      if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
+  }
+>>>
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
+  evt match {
+    case MemberUp(m) =>
+      if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
+  }
+<<< 8.27
+maxColumn = 80
+===
+def insertAndDelete(eventClient: LEvents) = {
+  val resultAfter = eventClient.get(eventId, appId)
+
+  (resultBefore must beEqualTo(Some(expectedBefore))) and
+    (deleteStatus must beEqualTo(true)) and
+    (resultAfter must beEqualTo(None))
+}
+>>>
+def insertAndDelete(eventClient: LEvents) = {
+  val resultAfter = eventClient.get(eventId, appId)
+
+  (resultBefore must beEqualTo(Some(expectedBefore))) and
+    (deleteStatus must beEqualTo(true)) and
+    (resultAfter must beEqualTo(None))
+}
+<<< 8.28
+object a {
+  val b = qual1 op1 { 1 + 2 + 3 + 4 + 5 } op2
+    111 * 222 * 333 * 444 * 555 op3
+    { "1 / 2 / 3 / 4 / 5 / 6 / 7" }
+}
+>>>
+object a {
+  val b = qual1 op1 {
+    1 + 2 + 3 + 4 + 5
+  } op2
+    111 * 222 * 333 * 444 * 555 op3 {
+    "1 / 2 / 3 / 4 / 5 / 6 / 7"
+  }
+}
+<<< 8.29
+object a {
+  val a: Seq[(C, D, E[_, _, _, _], F)] =
+    (0 until c).map { x =>
+      // c1
+      x
+    }
+}
+>>>
+object a {
+  val a: Seq[(C, D, E[_, _, _, _], F)] =
+    (0 until c).map { x =>
+      // c1
+      x
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1748,3 +1748,639 @@ val foo = Bar { () =>
 val foo = Bar { () =>
   f(42)
 }
+<<< 8.1: infix with longer left ||
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op
+    7 map {
+      8 % 9
+    }
+>>>
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op
+    7 map {
+    8 % 9
+  }
+<<< 8.2: infix with shorter left ||
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
+>>>
+val a =
+  1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+    8 % 9
+  }
+<<< 8.3: infix with longer left ||, narrow
+maxColumn = 20
+===
+val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
+>>>
+val a =
+  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+    8 % 9
+  }
+<<< 8.4: infix with shorter left ||, narrow
+maxColumn = 17
+===
+{
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
+val b = { 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 } || somethinglong }
+}
+>>>
+{
+  val a =
+    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+      8 % 9
+    }
+  val b = {
+    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+      8 % 9
+    } || somethinglong
+  }
+}
+<<< 8.5: sequences of infix operations
+maxColumn = 75
+runner.optimizer.forceConfigStyleOnOffset = 1000
+===
+val strings = Seq(
+    "MetricEvaluatorResult:",
+    s"  # engine params evaluated: ${engineParamsScores.size}") ++
+    Seq(
+      "Optimal Engine Params:",
+      s"  $bestEPStr",
+      "Metrics:",
+      s"  $metricHeader: ${bestScore.score}") ++
+    otherMetricHeaders.zip(bestScore.otherScores).map {
+      case (h, s) => s"  $h: $s"
+    } ++
+    outputPath.toSeq.map { p =>
+      s"The best variant params can be found in $p"
+    }
+>>>
+val strings = Seq(
+  "MetricEvaluatorResult:",
+  s"  # engine params evaluated: ${engineParamsScores.size}"
+) ++
+  Seq(
+    "Optimal Engine Params:",
+    s"  $bestEPStr",
+    "Metrics:",
+    s"  $metricHeader: ${bestScore.score}"
+  ) ++
+  otherMetricHeaders
+    .zip(bestScore.otherScores)
+    .map {
+      case (h, s) =>
+        s"  $h: $s"
+    } ++
+  outputPath
+    .toSeq
+    .map { p =>
+      s"The best variant params can be found in $p"
+    }
+<<< 8.6: assignment with short expression
+object a {
+  plugins(service.pluginType) += service.pluginName -> service
+}
+>>>
+object a {
+  plugins(service.pluginType) += service
+    .pluginName -> service
+}
+<<< 8.7
+maxColumn = 80
+===
+val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
+       ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
+       ("targetEntityId" -> data("itemId")) ~
+       ("eventTime" -> data("timestamp")) ~ ("properties" -> (("context" ->
+       (("ip" -> data("context[ip]")) ~ ("prop1" -> data("context[prop1]")
+         .toDouble) ~ ("prop2" -> data("context[prop2]")))) ~
+       ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+       ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
+>>>
+val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
+  ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
+  ("targetEntityId" -> data("itemId")) ~
+  ("eventTime" -> data("timestamp")) ~ (
+  "properties" -> (
+    (
+      "context" ->
+        (
+          ("ip" -> data("context[ip]")) ~ (
+            "prop1" -> data("context[prop1]").toDouble
+          ) ~ ("prop2" -> data("context[prop2]"))
+        )
+    ) ~
+      ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+      ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))
+  )
+)
+<<< 8.8
+maxColumn = 80
+===
+override def hashCode: Int = 41 + fields.hashCode
+>>>
+override def hashCode: Int = 41 + fields.hashCode
+<<< 8.9
+maxColumn = 80
+===
+object a {
+val fields = JField("engineVariant", JString(i.engineVariant)) ::
+   JField("engineFactory", JString(i.engineFactory)) ::
+     JField("batch", JString(i.batch)) ::
+     JField("env", Extraction.decompose(i.env)(DefaultFormats))
+}
+>>>
+object a {
+  val fields = JField("engineVariant", JString(i.engineVariant)) ::
+    JField("engineFactory", JString(i.engineFactory)) ::
+    JField("batch", JString(i.batch)) ::
+    JField("env", Extraction.decompose(i.env)(DefaultFormats))
+}
+<<< 8.10
+maxColumn = 80
+===
+object a {
+  def isReservedPrefix(name: String): Boolean =
+      name.startsWith("$") || name.startsWith("pio_")
+  def idWithAppid(appid: Int, id: String): String = appid + "_" + id
+}
+>>>
+object a {
+  def isReservedPrefix(name: String): Boolean =
+    name.startsWith("$") || name.startsWith("pio_")
+  def idWithAppid(appid: Int, id: String): String = appid + "_" + id
+}
+<<< 8.11
+maxColumn = 80
+===
+Some(
+  ("ip" -> data.get("context[ip]")) ~ (
+  "prop1" ->
+     data.get("context[prop1]").map(_.toDouble)
+))
+>>>
+Some(
+  ("ip" -> data.get("context[ip]")) ~ (
+    "prop1" ->
+      data.get("context[prop1]").map(_.toDouble)
+  )
+)
+<<< 8.12
+maxColumn = 80
+===
+val json = (estype -> ("properties" -> ("status" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("startTime" ->
+      ("type" -> "date")) ~ ("endTime" -> ("type" -> "date")) ~ ("engineId" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVersion" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineVariant" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("engineFactory" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("batch" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("dataSourceParams" -> ("type" -> "string") ~ ("index" ->
+        "not_analyzed")) ~ ("preparatorParams" -> ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~ ("algorithmsParams" -> ("type" ->
+          "string") ~ ("index" -> "not_analyzed")) ~ ("servingParams" ->
+          ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
+          ("type" -> "string") ~ ("index" -> "not_analyzed"))))
+>>>
+val json = (estype -> (
+  "properties" -> (
+    "status" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")
+  ) ~ (
+    "startTime" ->
+      ("type" -> "date")
+  ) ~ ("endTime" -> ("type" -> "date")) ~ (
+    "engineId" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")
+  ) ~ (
+    "engineVersion" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")
+  ) ~ (
+    "engineVariant" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")
+  ) ~ (
+    "engineFactory" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")
+  ) ~ (
+    "batch" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")
+  ) ~
+    (
+      "dataSourceParams" -> ("type" -> "string") ~ (
+        "index" ->
+          "not_analyzed"
+      )
+    ) ~ (
+    "preparatorParams" -> ("type" -> "string") ~
+      ("index" -> "not_analyzed")
+  ) ~ (
+    "algorithmsParams" -> (
+      "type" ->
+        "string"
+    ) ~ ("index" -> "not_analyzed")
+  ) ~ (
+    "servingParams" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")
+  ) ~ (
+    "status" ->
+      ("type" -> "string") ~ ("index" -> "not_analyzed")
+  )
+))
+<<< 8.13
+maxColumn = 80
+===
+val a = b match {
+  case i: EngineInstance =>
+    JObject(
+      JField("id", JString(i.id)) ::
+        JField("status", JString(i.status)) ::
+        JField("startTime", JString(i.startTime.toString)) ::
+        JField("endTime", JString(i.endTime.toString)) ::
+        JField("engineId", JString(i.engineId)) ::
+        JField("engineVersion", JString(i.engineVersion)) ::
+        JField("engineVariant", JString(i.engineVariant)) ::
+        JField("engineFactory", JString(i.engineFactory)) ::
+        JField("batch", JString(i.batch1)) ::
+        JField("env", Extraction.decompose(i.env)(DefaultFormats)) ::
+        JField(
+          "sparkConf",
+          Extraction.decompose(i.sparkConf)(DefaultFormats)) ::
+        JField("dataSourceParams", JString(i.dataSourceParams)) ::
+        JField("preparatorParams", JString(i.preparatorParams)) ::
+        JField("algorithmsParams", JString(i.algorithmsParams)) ::
+        JField("servingParams", JString(i.servingParams)) ::
+        Nil)
+}
+>>>
+val a =
+  b match {
+    case i: EngineInstance =>
+      JObject(
+        JField("id", JString(i.id)) ::
+          JField("status", JString(i.status)) ::
+          JField("startTime", JString(i.startTime.toString)) ::
+          JField("endTime", JString(i.endTime.toString)) ::
+          JField("engineId", JString(i.engineId)) ::
+          JField("engineVersion", JString(i.engineVersion)) ::
+          JField("engineVariant", JString(i.engineVariant)) ::
+          JField("engineFactory", JString(i.engineFactory)) ::
+          JField("batch", JString(i.batch1)) ::
+          JField("env", Extraction.decompose(i.env)(DefaultFormats)) ::
+          JField(
+            "sparkConf",
+            Extraction.decompose(i.sparkConf)(DefaultFormats)
+          ) ::
+          JField("dataSourceParams", JString(i.dataSourceParams)) ::
+          JField("preparatorParams", JString(i.preparatorParams)) ::
+          JField("algorithmsParams", JString(i.algorithmsParams)) ::
+          JField("servingParams", JString(i.servingParams)) ::
+          Nil
+      )
+  }
+<<< 8.14
+maxColumn = 80
+===
+private lazy val subNode: Parser[SubNode] = rep(' ') ~>
+  ((opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ {
+    name => AttrAppendSubNode(name)
+  }) |
+  (opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ {
+    name => AttrRemoveSubNode(name)
+  }) |    (opt('*') ~ '[' ~> attrName <~ ']' ^^ {
+     name => AttrSubNode(name)
+   }) |
+
+   ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+   ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
+   ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
+   ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
+   ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
+   ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
+   '*' ^^ (a => KidsSubNode()) |
+   '^' ~ '*' ^^ (a => SelectThisNode(true)) |
+   '^' ~ '^' ^^ (a => SelectThisNode(false)))
+>>>
+private lazy val subNode: Parser[SubNode] = rep(' ') ~>
+  (
+    (
+      opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ { name =>
+        AttrAppendSubNode(name)
+      }
+    ) |
+      (
+        opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ { name =>
+          AttrRemoveSubNode(name)
+        }
+      ) | (
+      opt('*') ~ '[' ~> attrName <~ ']' ^^ { name =>
+        AttrSubNode(name)
+      }
+    ) |
+
+      ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+      ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
+      ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
+      ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
+      ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
+      ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
+      '*' ^^ (a => KidsSubNode()) |
+      '^' ~ '*' ^^ (a => SelectThisNode(true)) |
+      '^' ~ '^' ^^ (a => SelectThisNode(false))
+  )
+<<< 8.15
+maxColumn = 80
+===
+object a {
+  def toEventJson(common: Common, userAction: UserAction): JObject = {
+   import org.json4s.JsonDSL._
+    val json =
+      ("event" -> "subscribe") ~
+        ("entityType" -> "user") ~
+        ("entityId" -> data("data[id]")) ~
+        ("targetEntityType" -> "list") ~
+        ("targetEntityId" -> data("data[list_id]")) ~
+        ("eventTime" -> eventTime) ~
+        ("properties" -> (("email" -> data("data[email]")) ~
+          ("email_type" -> data("data[email_type]")) ~
+          ("merges" -> (("EMAIL" -> data("data[merges][EMAIL]")) ~
+            ("FNAME" -> data("data[merges][FNAME]"))) ~
+            ("LNAME" -> data("data[merges][LNAME]")) ~
+            ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+          ("ip_opt" -> data("data[ip_opt]")) ~
+          ("ip_signup" -> data("data[ip_signup]")))
+      json
+  }
+}
+>>>
+object a {
+  def toEventJson(common: Common, userAction: UserAction): JObject = {
+    import org.json4s.JsonDSL._
+    val json =
+      ("event" -> "subscribe") ~
+        ("entityType" -> "user") ~
+        ("entityId" -> data("data[id]")) ~
+        ("targetEntityType" -> "list") ~
+        ("targetEntityId" -> data("data[list_id]")) ~
+        ("eventTime" -> eventTime) ~
+        (
+          "properties" -> (
+            ("email" -> data("data[email]")) ~
+              ("email_type" -> data("data[email_type]")) ~
+              (
+                "merges" -> (
+                  ("EMAIL" -> data("data[merges][EMAIL]")) ~
+                    ("FNAME" -> data("data[merges][FNAME]"))
+                ) ~
+                  ("LNAME" -> data("data[merges][LNAME]")) ~
+                  ("INTERESTS" -> data.get("data[merges][INTERESTS]"))
+              )
+          ) ~
+            ("ip_opt" -> data("data[ip_opt]")) ~
+            ("ip_signup" -> data("data[ip_signup]"))
+        )
+    json
+  }
+}
+<<< 8.16
+maxColumn = 80
+===
+override def preRestart(cause: Throwable, msg: Option[Any]) {
+       if (master ne null) {
+        master ! "failed with " + cause + " while processing " + msg
+       }
+       context stop self
+     }
+>>>
+override def preRestart(cause: Throwable, msg: Option[Any]) {
+  if (master ne null) {
+    master ! "failed with " + cause + " while processing " + msg
+  }
+  context stop self
+}
+<<< 8.17
+maxColumn = 80
+===
+object a {
+   def `media-range-def` =
+     rule {
+       "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+        ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+     }
+}
+>>>
+object a {
+  def `media-range-def` =
+    rule {
+      "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+          ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+    }
+}
+<<< 8.18
+maxColumn = 80
+===
+object a {
+  (people.map(p => (p.name, p.age))
+  // c1
+  returning people.map(_.id)
+  // c2
+  into ((nameAge, id) => Person(id, nameAge._1, nameAge._2))
+  )
+}
+>>>
+object a {
+  (people.map(p => (p.name, p.age))
+  // c1
+    returning people.map(_.id)
+  // c2
+    into ((nameAge, id) => Person(id, nameAge._1, nameAge._2)))
+}
+<<< 8.19
+maxColumn = 80
+===
+def `day-name` =
+     rule(
+       "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+        "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6))
+>>>
+def `day-name` =
+  rule(
+    "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+      "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6)
+  )
+<<< 8.20
+maxColumn = 80
+===
+HttpResponse(
+   StatusCodes.ServiceUnavailable,
+   entity = "The server was not able " +
+   "to produce a timely response to your request.\r\nPlease try again in a short while!"
+)
+>>>
+HttpResponse(
+  StatusCodes.ServiceUnavailable,
+  entity = "The server was not able " +
+    "to produce a timely response to your request.\r\nPlease try again in a short while!"
+)
+<<< 8.21
+maxColumn = 80
+===
+private val allParams: Map[String, String] = mandatoryParams +
+    (
+      "data-config" ->
+        dummyOptionalConfigPath,
+      "max-sales-mappers" ->
+        "10",
+      "overwrite" ->
+        null,
+      "keep" -> dummyOptionalMaxVersionCount
+    )
+>>>
+private val allParams: Map[String, String] = mandatoryParams +
+  (
+    "data-config" ->
+      dummyOptionalConfigPath,
+    "max-sales-mappers" ->
+      "10",
+    "overwrite" ->
+      null,
+    "keep" -> dummyOptionalMaxVersionCount
+)
+<<< 8.22
+maxColumn = 40
+===
+"Terminating(" + reason + ")" +
+                   (toDie.toSeq.sorted mkString
+                     (
+                      "\n" +
+                        indent +
+                        "   |    toDie: ", "\n" + indent + "   |           ", ""
+                     ))
+>>>
+"Terminating(" + reason + ")" +
+  (
+    toDie.toSeq.sorted mkString
+      (
+        "\n" +
+          indent +
+          "   |    toDie: ", "\n" + indent + "   |           ", ""
+    )
+  )
+<<< 8.23
+maxColumn = 80
+===
+val ret = (if (dailyStats.isEmpty)
+                   0
+                 else {
+                   val yestStats = dailyStats.last
+                   val yestNav = yestStats.nav
+                   (nav -
+                     yestNav) / nav - 1
+                 })
+>>>
+val ret = (if (dailyStats.isEmpty)
+             0
+           else {
+             val yestStats = dailyStats.last
+             val yestNav = yestStats.nav
+             (
+               nav -
+                 yestNav
+             ) / nav - 1
+           })
+<<< 8.24
+maxColumn = 80
+===
+def isErrorEnabled(logClass: Class[_], logSource: String) =
+    (eventStream.logLevel >= ErrorLevel) &&
+      Logger(logClass, logSource).isErrorEnabled
+>>>
+def isErrorEnabled(logClass: Class[_], logSource: String) =
+  (eventStream.logLevel >= ErrorLevel) &&
+    Logger(logClass, logSource).isErrorEnabled
+<<< 8.25
+maxColumn = 80
+===
+def getShort(implicit byteOrder: ByteOrder): Short = {
+    if (byteOrder == ByteOrder.BIG_ENDIAN)
+      ((next() & 0xff) << 8 | (next() & 0xff) << 0).toShort
+    else if (byteOrder == ByteOrder.LITTLE_ENDIAN)
+      ((next() & 0xff) << 0 | (next() & 0xff) << 8).toShort
+     else throw new IllegalArgumentException("Unknown byte order " + byteOrder)
+   }
+>>>
+def getShort(implicit byteOrder: ByteOrder): Short = {
+  if (byteOrder == ByteOrder.BIG_ENDIAN)
+    ((next() & 0xff) << 8 | (next() & 0xff) << 0).toShort
+  else if (byteOrder == ByteOrder.LITTLE_ENDIAN)
+    ((next() & 0xff) << 0 | (next() & 0xff) << 8).toShort
+  else
+    throw new IllegalArgumentException("Unknown byte order " + byteOrder)
+}
+<<< 8.26
+maxColumn = 80
+===
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
+  evt match {
+    case MemberUp(m) =>
+      if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
+  }
+>>>
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
+  evt match {
+    case MemberUp(m) =>
+      if (matchingRole(m))
+        changeMembers(membersByAge - m + m) // replace
+  }
+<<< 8.27
+maxColumn = 80
+===
+def insertAndDelete(eventClient: LEvents) = {
+  val resultAfter = eventClient.get(eventId, appId)
+
+  (resultBefore must beEqualTo(Some(expectedBefore))) and
+    (deleteStatus must beEqualTo(true)) and
+    (resultAfter must beEqualTo(None))
+}
+>>>
+def insertAndDelete(eventClient: LEvents) = {
+  val resultAfter = eventClient.get(eventId, appId)
+
+  (resultBefore must beEqualTo(Some(expectedBefore))) and
+    (deleteStatus must beEqualTo(true)) and
+    (resultAfter must beEqualTo(None))
+}
+<<< 8.28
+object a {
+  val b = qual1 op1 { 1 + 2 + 3 + 4 + 5 } op2
+    111 * 222 * 333 * 444 * 555 op3
+    { "1 / 2 / 3 / 4 / 5 / 6 / 7" }
+}
+>>>
+object a {
+  val b = qual1 op1 {
+    1 + 2 + 3 + 4 + 5
+  } op2
+    111 * 222 * 333 * 444 * 555 op3 {
+    "1 / 2 / 3 / 4 / 5 / 6 / 7"
+  }
+}
+<<< 8.29
+object a {
+  val a: Seq[(C, D, E[_, _, _, _], F)] =
+    (0 until c).map { x =>
+      // c1
+      x
+    }
+}
+>>>
+object a {
+  val a: Seq[(C, D, E[_, _, _, _], F)] =
+    (0 until c).map { x =>
+      // c1
+      x
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -178,7 +178,8 @@ object a {
 object a {
   the[Exception] thrownBy {
     SizeUtils.calculate(segments, "user")
-  } should have message """Cannot resolve column name "user" among (segment_id);"""
+  } should have message
+    """Cannot resolve column name "user" among (segment_id);"""
 }
 <<< 1.d: if-else, no curlies
 if (a)
@@ -594,17 +595,12 @@ val augassign: P[Ast.operator] = P(
   )
 >>>
 val augassign: P[Ast.operator] = P(
-  "+=".!.map(_ => Ast.operator.Add) |
-    "-=".!.map(_ => Ast.operator.Sub) |
-    "*=".!.map(_ => Ast.operator.Mult) |
-    "/=".!.map(_ => Ast.operator.Div) |
-    "%=".!.map(_ => Ast.operator.Mod) |
-    "&=".!.map(_ => Ast.operator.BitAnd) |
-    "|=".!.map(_ => Ast.operator.BitOr) |
-    "^=".!.map(_ => Ast.operator.BitXor) |
+  "+=".!.map(_ => Ast.operator.Add) | "-=".!.map(_ => Ast.operator.Sub) |
+    "*=".!.map(_ => Ast.operator.Mult) | "/=".!.map(_ => Ast.operator.Div) |
+    "%=".!.map(_ => Ast.operator.Mod) | "&=".!.map(_ => Ast.operator.BitAnd) |
+    "|=".!.map(_ => Ast.operator.BitOr) | "^=".!.map(_ => Ast.operator.BitXor) |
     "<<=".!.map(_ => Ast.operator.LShift) |
-    ">>=".!.map(_ => Ast.operator.RShift) |
-    "**=".!.map(_ => Ast.operator.Pow) |
+    ">>=".!.map(_ => Ast.operator.RShift) | "**=".!.map(_ => Ast.operator.Pow) |
     "//=".!.map(_ => Ast.operator.FloorDiv)
 )
 <<< 3.1: def non-config-style, long
@@ -693,14 +689,13 @@ object a {
 }
 >>>
 object a {
-  terminaters = Set() ++ (
-    for (i ← 1 to n)
+  terminaters = Set() ++
+    (for (i ← 1 to n)
       yield {
         val man = context.watch(context.system.actorOf(Props[Terminater]))
         man ! "run"
         man
-      }
-  )
+      })
 }
 <<< 3.11 enclosed, by itself
 maxColumn = 80
@@ -770,9 +765,10 @@ object a {
     intercept[java.lang.IllegalStateException] {
       in.readObject
     }
-  ).getMessage should ===(
-    "Trying to deserialize a serialized ActorRef without an ActorSystem in scope." +
-      " Use 'akka.serialization.Serialization.currentSystem.withValue(system) { ... }'")
+  ).getMessage should
+    ===(
+      "Trying to deserialize a serialized ActorRef without an ActorSystem in scope." +
+        " Use 'akka.serialization.Serialization.currentSystem.withValue(system) { ... }'")
 }
 <<< 3.14 enclosed, assignment, by itself
 maxColumn = 80
@@ -804,11 +800,9 @@ object a {
 }
 >>>
 object a {
-  val a = (
-    intercept[java.lang.IllegalStateException] {
-      in.readObject
-    }
-  ) ++ 2
+  val a = (intercept[java.lang.IllegalStateException] {
+    in.readObject
+  }) ++ 2
 }
 <<< 3.16 enclosed, assignment, infix on right
 maxColumn = 80
@@ -823,11 +817,10 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (
-    intercept[java.lang.IllegalStateException] {
+  val a = 2 ++
+    (intercept[java.lang.IllegalStateException] {
       in.readObject
-    }
-  )
+    })
 }
 <<< 3.17 enclosed, assignment, infix in middle
 maxColumn = 80
@@ -842,11 +835,10 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (
-    intercept[java.lang.IllegalStateException] {
+  val a = 2 ++
+    (intercept[java.lang.IllegalStateException] {
       in.readObject
-    }
-  ) ++ 3
+    }) ++ 3
 }
 <<< 3.18 enclosed, assignment, by itself, narrower
 maxColumn = 60
@@ -876,11 +868,9 @@ object a {
 }
 >>>
 object a {
-  val a = (
-    intercept[java.lang.IllegalStateException] {
-      in.readObject
-    }
-  ) ++ 2
+  val a = (intercept[java.lang.IllegalStateException] {
+    in.readObject
+  }) ++ 2
 }
 <<< 3.20 enclosed, assignment, infix on right, narrower
 maxColumn = 60
@@ -895,11 +885,10 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (
-    intercept[java.lang.IllegalStateException] {
+  val a = 2 ++
+    (intercept[java.lang.IllegalStateException] {
       in.readObject
-    }
-  )
+    })
 }
 <<< 3.21 enclosed, assignment, infix in middle, narrower
 maxColumn = 60
@@ -914,11 +903,10 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (
-    intercept[java.lang.IllegalStateException] {
+  val a = 2 ++
+    (intercept[java.lang.IllegalStateException] {
       in.readObject
-    }
-  ) ++ 3
+    }) ++ 3
 }
 <<< 3.22 enclosed, assignment, by itself, narrow
 maxColumn = 40
@@ -951,12 +939,10 @@ object a {
 }
 >>>
 object a {
-  val a = (
-    intercept[
-      java.lang.IllegalStateException] {
-      in.readObject
-    }
-  ) ++ 2
+  val a = (intercept[
+    java.lang.IllegalStateException] {
+    in.readObject
+  }) ++ 2
 }
 <<< 3.24 enclosed, assignment, infix on right, narrow
 maxColumn = 40
@@ -971,12 +957,11 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (
-    intercept[
+  val a = 2 ++
+    (intercept[
       java.lang.IllegalStateException] {
       in.readObject
-    }
-  )
+    })
 }
 <<< 3.25 enclosed, assignment, infix in middle, narrow
 maxColumn = 40
@@ -991,12 +976,11 @@ object a {
 }
 >>>
 object a {
-  val a = 2 ++ (
-    intercept[
+  val a = 2 ++
+    (intercept[
       java.lang.IllegalStateException] {
       in.readObject
-    }
-  ) ++ 3
+    }) ++ 3
 }
 <<< 3.26 enclosed, def, chain follows
 maxColumn = 80
@@ -1519,12 +1503,14 @@ created filter (ref ⇒
 }
 >>>
 object a {
-  created filter (ref ⇒
-    !ref.isTerminated && !ref
-      .asInstanceOf[ActorRefWithCell]
-      .underlying
-      .isInstanceOf[UnstartedCell]
-  ) should ===(Seq.empty[ActorRef])
+  created filter
+    (ref ⇒
+      !ref.isTerminated &&
+        !ref
+          .asInstanceOf[ActorRefWithCell]
+          .underlying
+          .isInstanceOf[UnstartedCell]
+    ) should ===(Seq.empty[ActorRef])
 }
 <<< 6.5: chain with delayed indent after break
 maxColumn = 70
@@ -1589,8 +1575,8 @@ object a {
   ): List[Int] =
     for {
       a <- b
-      if (b ++ b)
-        .length >= 2
+      if (b ++ b).length >=
+        2
     } yield a
 }
 <<< 7.3: enumerator and guard short, for short
@@ -1702,13 +1688,16 @@ for {
 for {
   nu <- rand.gaussian(0, 1)
   y = nu * nu
-  x = (
-      mean
-        + mean * mean * y * 0.5 / shape
-        - 0.5 * mean / shape * math.sqrt(
-          4 * mean * shape * y + mean * mean * y * y
+  x =
+    (
+      mean +
+        mean * mean * y * 0.5 / shape -
+        0.5 * mean / shape *
+        math.sqrt(
+          4 * mean * shape * y +
+            mean * mean * y * y
         )
-  )
+    )
   z <- rand.uniform
 } yield {
   if (z <= mean / (mean + x))
@@ -1756,8 +1745,7 @@ val a =
     }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op
-    7 map {
+  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
     8 % 9
   }
 <<< 8.2: infix with shorter left ||
@@ -1773,9 +1761,11 @@ maxColumn = 20
 val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-    8 % 9
-  }
+  1 + 2 * 3 && 4 ^
+    5 || 6 op
+    7 map {
+      8 % 9
+    }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
 ===
@@ -1786,13 +1776,19 @@ val b = { 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 } || somethinglong }
 >>>
 {
   val a =
-    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
-      8 % 9
-    }
+    1 + 2 * 3 ||
+      4 ^
+      5 && 6 op
+      7 map {
+        8 % 9
+      }
   val b = {
-    1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
-      8 % 9
-    } || somethinglong
+    1 + 2 * 3 ||
+    4 ^ 5 && 6 op
+      7 map {
+        8 % 9
+      } ||
+      somethinglong
   }
 }
 <<< 8.5: sequences of infix operations
@@ -1841,8 +1837,8 @@ object a {
 }
 >>>
 object a {
-  plugins(service.pluginType) += service
-    .pluginName -> service
+  plugins(service.pluginType) +=
+    service.pluginName -> service
 }
 <<< 8.7
 maxColumn = 80
@@ -1856,23 +1852,20 @@ val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
        ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
        ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
 >>>
-val json = ("event" -> data("event")) ~ ("entityType" -> "user") ~
-  ("entityId" -> data("userId")) ~ ("targetEntityType" -> "item") ~
-  ("targetEntityId" -> data("itemId")) ~
-  ("eventTime" -> data("timestamp")) ~ (
-  "properties" -> (
-    (
-      "context" ->
-        (
-          ("ip" -> data("context[ip]")) ~ (
-            "prop1" -> data("context[prop1]").toDouble
-          ) ~ ("prop2" -> data("context[prop2]"))
-        )
-    ) ~
-      ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
-      ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))
-  )
-)
+val json =
+  ("event" -> data("event")) ~
+    ("entityType" -> "user") ~
+    ("entityId" -> data("userId")) ~
+    ("targetEntityType" -> "item") ~
+    ("targetEntityId" -> data("itemId")) ~
+    ("eventTime" -> data("timestamp")) ~
+    ("properties" ->
+      (("context" ->
+        (("ip" -> data("context[ip]")) ~
+          ("prop1" -> data("context[prop1]").toDouble) ~
+          ("prop2" -> data("context[prop2]")))) ~
+        ("anotherPropertyA" -> data.get("anotherPropertyA").map(_.toDouble)) ~
+        ("anotherPropertyB" -> data.get("anotherPropertyB").map(_.toBoolean))))
 <<< 8.8
 maxColumn = 80
 ===
@@ -1919,10 +1912,8 @@ Some(
 ))
 >>>
 Some(
-  ("ip" -> data.get("context[ip]")) ~ (
-    "prop1" ->
-      data.get("context[prop1]").map(_.toDouble)
-  )
+  ("ip" -> data.get("context[ip]")) ~
+    ("prop1" -> data.get("context[prop1]").map(_.toDouble))
 )
 <<< 8.12
 maxColumn = 80
@@ -1942,50 +1933,28 @@ val json = (estype -> ("properties" -> ("status" ->
           ("type" -> "string") ~ ("index" -> "not_analyzed")) ~ ("status" ->
           ("type" -> "string") ~ ("index" -> "not_analyzed"))))
 >>>
-val json = (estype -> (
-  "properties" -> (
-    "status" ->
-      ("type" -> "string") ~ ("index" -> "not_analyzed")
-  ) ~ (
-    "startTime" ->
-      ("type" -> "date")
-  ) ~ ("endTime" -> ("type" -> "date")) ~ (
-    "engineId" ->
-      ("type" -> "string") ~ ("index" -> "not_analyzed")
-  ) ~ (
-    "engineVersion" ->
-      ("type" -> "string") ~ ("index" -> "not_analyzed")
-  ) ~ (
-    "engineVariant" ->
-      ("type" -> "string") ~ ("index" -> "not_analyzed")
-  ) ~ (
-    "engineFactory" ->
-      ("type" -> "string") ~ ("index" -> "not_analyzed")
-  ) ~ (
-    "batch" ->
-      ("type" -> "string") ~ ("index" -> "not_analyzed")
-  ) ~
-    (
-      "dataSourceParams" -> ("type" -> "string") ~ (
-        "index" ->
-          "not_analyzed"
-      )
-    ) ~ (
-    "preparatorParams" -> ("type" -> "string") ~
-      ("index" -> "not_analyzed")
-  ) ~ (
-    "algorithmsParams" -> (
-      "type" ->
-        "string"
-    ) ~ ("index" -> "not_analyzed")
-  ) ~ (
-    "servingParams" ->
-      ("type" -> "string") ~ ("index" -> "not_analyzed")
-  ) ~ (
-    "status" ->
-      ("type" -> "string") ~ ("index" -> "not_analyzed")
-  )
-))
+val json =
+  (estype ->
+    ("properties" ->
+      ("status" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("startTime" -> ("type" -> "date")) ~
+      ("endTime" -> ("type" -> "date")) ~
+      ("engineId" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("engineVersion" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("engineVariant" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("engineFactory" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("batch" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("dataSourceParams" ->
+        ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~
+      ("preparatorParams" ->
+        ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~
+      ("algorithmsParams" ->
+        ("type" -> "string") ~
+        ("index" -> "not_analyzed")) ~
+      ("servingParams" -> ("type" -> "string") ~ ("index" -> "not_analyzed")) ~
+      ("status" -> ("type" -> "string") ~ ("index" -> "not_analyzed"))))
 <<< 8.13
 maxColumn = 80
 ===
@@ -2016,8 +1985,7 @@ val a =
   b match {
     case i: EngineInstance =>
       JObject(
-        JField("id", JString(i.id)) ::
-          JField("status", JString(i.status)) ::
+        JField("id", JString(i.id)) :: JField("status", JString(i.status)) ::
           JField("startTime", JString(i.startTime.toString)) ::
           JField("endTime", JString(i.endTime.toString)) ::
           JField("engineId", JString(i.engineId)) ::
@@ -2029,12 +1997,10 @@ val a =
           JField(
             "sparkConf",
             Extraction.decompose(i.sparkConf)(DefaultFormats)
-          ) ::
-          JField("dataSourceParams", JString(i.dataSourceParams)) ::
+          ) :: JField("dataSourceParams", JString(i.dataSourceParams)) ::
           JField("preparatorParams", JString(i.preparatorParams)) ::
           JField("algorithmsParams", JString(i.algorithmsParams)) ::
-          JField("servingParams", JString(i.servingParams)) ::
-          Nil
+          JField("servingParams", JString(i.servingParams)) :: Nil
       )
   }
 <<< 8.14
@@ -2061,32 +2027,28 @@ private lazy val subNode: Parser[SubNode] = rep(' ') ~>
    '^' ~ '^' ^^ (a => SelectThisNode(false)))
 >>>
 private lazy val subNode: Parser[SubNode] = rep(' ') ~>
-  (
-    (
-      opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ { name =>
-        AttrAppendSubNode(name)
-      }
-    ) |
-      (
-        opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ { name =>
-          AttrRemoveSubNode(name)
-        }
-      ) | (
-      opt('*') ~ '[' ~> attrName <~ ']' ^^ { name =>
-        AttrSubNode(name)
-      }
-    ) |
-
-      ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
-      ('<' ~ '*' ~ '>') ^^ (a => SurroundKids()) |
-      ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
-      ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
-      ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
-      ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
-      '*' ^^ (a => KidsSubNode()) |
-      '^' ~ '*' ^^ (a => SelectThisNode(true)) |
-      '^' ~ '^' ^^ (a => SelectThisNode(false))
-  )
+  ((opt('*') ~ '[' ~> attrName <~ '+' ~ ']' ^^ { name =>
+    AttrAppendSubNode(name)
+  }) |
+    (opt('*') ~ '[' ~> attrName <~ '!' ~ ']' ^^ { name =>
+      AttrRemoveSubNode(name)
+    }) |
+    (opt('*') ~ '[' ~> attrName <~ ']' ^^ { name =>
+      AttrSubNode(name)
+    }) |
+    ('!' ~ '!' ^^ (a => DontMergeAttributes)) |
+    ('<' ~ '*' ~ '>') ^^
+    (a => SurroundKids()) |
+    ('-' ~ '*' ^^ (a => PrependKidsSubNode())) |
+    ('>' ~ '*' ^^ (a => PrependKidsSubNode())) |
+    ('*' ~ '+' ^^ (a => AppendKidsSubNode())) |
+    ('*' ~ '<' ^^ (a => AppendKidsSubNode())) |
+    '*' ^^
+    (a => KidsSubNode()) |
+    '^' ~ '*' ^^
+    (a => SelectThisNode(true)) |
+    '^' ~ '^' ^^
+    (a => SelectThisNode(false)))
 <<< 8.15
 maxColumn = 80
 ===
@@ -2122,22 +2084,16 @@ object a {
         ("targetEntityType" -> "list") ~
         ("targetEntityId" -> data("data[list_id]")) ~
         ("eventTime" -> eventTime) ~
-        (
-          "properties" -> (
-            ("email" -> data("data[email]")) ~
-              ("email_type" -> data("data[email_type]")) ~
-              (
-                "merges" -> (
-                  ("EMAIL" -> data("data[merges][EMAIL]")) ~
-                    ("FNAME" -> data("data[merges][FNAME]"))
-                ) ~
-                  ("LNAME" -> data("data[merges][LNAME]")) ~
-                  ("INTERESTS" -> data.get("data[merges][INTERESTS]"))
-              )
-          ) ~
-            ("ip_opt" -> data("data[ip_opt]")) ~
-            ("ip_signup" -> data("data[ip_signup]"))
-        )
+        ("properties" ->
+          (("email" -> data("data[email]")) ~
+            ("email_type" -> data("data[email_type]")) ~
+            ("merges" ->
+              (("EMAIL" -> data("data[merges][EMAIL]")) ~
+                ("FNAME" -> data("data[merges][FNAME]"))) ~
+              ("LNAME" -> data("data[merges][LNAME]")) ~
+              ("INTERESTS" -> data.get("data[merges][INTERESTS]")))) ~
+          ("ip_opt" -> data("data[ip_opt]")) ~
+          ("ip_signup" -> data("data[ip_signup]")))
     json
   }
 }
@@ -2175,8 +2131,7 @@ object a {
     rule {
       "*/*" ~ push("*") ~ push("*") |
         `type` ~ '/' ~
-          ('*' ~ !tchar ~ push("*") | subtype) |
-        '*' ~ push("*") ~ push("*")
+        ('*' ~ !tchar ~ push("*") | subtype) | '*' ~ push("*") ~ push("*")
     }
 }
 <<< 8.18
@@ -2194,9 +2149,10 @@ object a {
 object a {
   (people.map(p => (p.name, p.age))
   // c1
-    returning people.map(_.id)
+  returning people.map(_.id)
   // c2
-    into ((nameAge, id) => Person(id, nameAge._1, nameAge._2)))
+  into
+    ((nameAge, id) => Person(id, nameAge._1, nameAge._2)))
 }
 <<< 8.19
 maxColumn = 80
@@ -2241,14 +2197,11 @@ private val allParams: Map[String, String] = mandatoryParams +
 >>>
 private val allParams: Map[String, String] = mandatoryParams +
   (
-    "data-config" ->
-      dummyOptionalConfigPath,
-    "max-sales-mappers" ->
-      "10",
-    "overwrite" ->
-      null,
+    "data-config" -> dummyOptionalConfigPath,
+    "max-sales-mappers" -> "10",
+    "overwrite" -> null,
     "keep" -> dummyOptionalMaxVersionCount
-)
+  )
 <<< 8.22
 maxColumn = 40
 ===
@@ -2261,14 +2214,12 @@ maxColumn = 40
                      ))
 >>>
 "Terminating(" + reason + ")" +
-  (
-    toDie.toSeq.sorted mkString
-      (
-        "\n" +
-          indent +
-          "   |    toDie: ", "\n" + indent + "   |           ", ""
-    )
-  )
+  (toDie.toSeq.sorted mkString
+    (
+      "\n" + indent + "   |    toDie: ",
+      "\n" + indent + "   |           ",
+      ""
+    ))
 <<< 8.23
 maxColumn = 80
 ===
@@ -2286,10 +2237,7 @@ val ret = (if (dailyStats.isEmpty)
            else {
              val yestStats = dailyStats.last
              val yestNav = yestStats.nav
-             (
-               nav -
-                 yestNav
-             ) / nav - 1
+             (nav - yestNav) / nav - 1
            })
 <<< 8.24
 maxColumn = 80
@@ -2365,8 +2313,8 @@ object a {
     1 + 2 + 3 + 4 + 5
   } op2
     111 * 222 * 333 * 444 * 555 op3 {
-    "1 / 2 / 3 / 4 / 5 / 6 / 7"
-  }
+      "1 / 2 / 3 / 4 / 5 / 6 / 7"
+    }
 }
 <<< 8.29
 object a {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1,6 +1,7 @@
 rewrite.rules = [RedundantBraces]
 rewrite.redundantBraces.maxLines = 1
 rewrite.redundantBraces.generalExpressions = true
+newlines.afterInfix = some
 <<< basic
 object a {
   def x(i: Int): Int = {
@@ -321,6 +322,8 @@ object a {
   b.c(d => e => { f; g })
 }
 <<< #1027 2.1: parens to braces no
+newlines.afterInfix = keep
+===
 object a {
   b.c (d =>
     e
@@ -607,9 +610,7 @@ object a {
 }
 >>>
 object a {
-  1 + {
-    2
-  } + 3
+  1 + 2 + 3
 }
 <<< #1633 4.2: infix with literal and no break before
 object a {
@@ -618,8 +619,7 @@ object a {
 }
 >>>
 object a {
-  1 +
-    2 + 3
+  1 + 2 + 3
 }
 <<< #1633 4.3: infix with literal and comment
 object a {

--- a/scalafmt-tests/src/test/resources/test/DynamicStyle.stat
+++ b/scalafmt-tests/src/test/resources/test/DynamicStyle.stat
@@ -41,11 +41,13 @@ function(
 <<< infix types #500
 type Row =
   AlertEvent :+:
+  TestEvent :+:
   InteractionEvent
 >>>
 type Row =
   AlertEvent :+:
-  InteractionEvent
+    TestEvent :+:
+    InteractionEvent
 <<< base config is preseverd
 {
   // scalafmt: { maxColumn = 40 }


### PR DESCRIPTION
Add the `newlines.afterInfix` parameter to allow formatting of infix expressions and optionally breaking lines after an infix operation (which appears to be always safe, unlike before it); enable it for `newlines.source=fold,unfold`. The behaviour and specific parameters/values will be defined in a separate PR containing the documentation.

Helps with #1627.

`scala-repos` diffs:
* Infix bugfix: handle Type.ApplyInfix correctly
  * `unfold`: https://github.com/kitbellew/scala-repos/commit/6377998f6d7f4c3b05d7b9dbb8486e5adba8b9a0
  * rest unchanged
* FormatOps: ignore line breaks in infix expressions
  * `fold`: https://github.com/kitbellew/scala-repos/commit/1a055b5d397d1f745b016813ea5c6f611a74ddaf
  * `unfold`: https://github.com/kitbellew/scala-repos/commit/edbae8c98e30637849da986dd281f1d800423887
  * rest: unchanged