### PR TITLE
Add new rewrite rule:  CamelCaseVariableNaming

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -865,6 +865,20 @@ rewrite.rules = [AsciiSortImports]
 import foo.{~>, `symbol`, bar, Random}
 ```
 
+### `CamelCaseVariableNaming`
+
+Convert snake case variable naming style to camel case
+
+```scala mdoc:scalafmt
+rewrite.rules = [CamelCaseVariableNaming]
+---
+class A {
+  val student_name = "wang"
+  val student_age = 12
+}
+```  
+
+
 ### Trailing commas
 
 > See [SIP](https://docs.scala-lang.org/sips/trailing-commas.html)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -876,8 +876,7 @@ class A {
   val student_name = "wang"
   val student_age = 12
 }
-```  
-
+```
 
 ### Trailing commas
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.3.9

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.9
+sbt.version=1.3.8

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/CamelCaseVariableNaming.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/CamelCaseVariableNaming.scala
@@ -1,0 +1,39 @@
+package org.scalafmt.rewrite
+
+import scala.meta.{Pat, Term, Tree}
+
+
+object VariableNaming extends Rewrite {
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    new VariableNaming
+}
+
+class VariableNaming(implicit ctx: RewriteCtx) extends RewriteSession {
+
+  def isSnakeCaseNaming(str: String): Boolean = {
+    str.contains('_')
+  }
+
+  def toCamelCaseNaming(str: String): String = {
+    str.split('_') match {
+      case Array(head) => head
+      case Array(head, tail @ _*) => head + tail
+          .map(s => s.charAt(0).toUpper + s.slice(1, s.length))
+        .reduce( _ + _)
+    }
+  }
+
+  def rewriteCamelCaseNaming(t: Tree): Unit = {
+    t.tokens.headOption.filter(p => isSnakeCaseNaming(p.text)).foreach(
+      snakeCase => {
+        ctx.addPatchSet(Seq(TokenPatch.Replace(snakeCase, toCamelCaseNaming(snakeCase.text))): _*)
+      }
+    )
+  }
+
+  override def rewrite(tree: Tree): Unit =
+    tree match {
+      case t: Pat.Var => rewriteCamelCaseNaming(t)
+      case _ =>
+    }
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/CamelCaseVariableNaming.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/CamelCaseVariableNaming.scala
@@ -1,34 +1,35 @@
 package org.scalafmt.rewrite
 
-import scala.meta.{Pat, Term, Tree}
+import scala.meta.{Pat, Tree}
 
-
-object VariableNaming extends Rewrite {
+object CamelCaseVariableNaming extends Rewrite {
   override def create(implicit ctx: RewriteCtx): RewriteSession =
-    new VariableNaming
+    new CamelCaseVariableNaming
 }
 
-class VariableNaming(implicit ctx: RewriteCtx) extends RewriteSession {
-
-  def isSnakeCaseNaming(str: String): Boolean = {
-    str.contains('_')
-  }
+class CamelCaseVariableNaming(implicit ctx: RewriteCtx) extends RewriteSession {
 
   def toCamelCaseNaming(str: String): String = {
     str.split('_') match {
       case Array(head) => head
-      case Array(head, tail @ _*) => head + tail
+      case Array(head, tail @ _*) =>
+        head + tail
           .map(s => s.charAt(0).toUpper + s.slice(1, s.length))
-        .reduce( _ + _)
+          .reduce(_ + _)
     }
   }
 
   def rewriteCamelCaseNaming(t: Tree): Unit = {
-    t.tokens.headOption.filter(p => isSnakeCaseNaming(p.text)).foreach(
-      snakeCase => {
-        ctx.addPatchSet(Seq(TokenPatch.Replace(snakeCase, toCamelCaseNaming(snakeCase.text))): _*)
-      }
-    )
+    t.tokens.headOption
+      .filter(p => p.text.contains('_'))
+      .foreach(snakeCase => {
+        ctx
+          .addPatchSet(
+            Seq(
+              TokenPatch.Replace(snakeCase, toCamelCaseNaming(snakeCase.text))
+            ): _*
+          )
+      })
   }
 
   override def rewrite(tree: Tree): Unit =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -81,6 +81,7 @@ object Rewrite {
 
   private val rewrites = Seq[sourcecode.Text[Rewrite]](
     RedundantBraces,
+    CamelCaseVariableNaming,
     RedundantParens,
     SortImports,
     AsciiSortImports,

--- a/scalafmt-tests/src/test/resources/rewrite/CamelCaseVariableNaming.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/CamelCaseVariableNaming.stat
@@ -1,0 +1,16 @@
+rewrite.rules = [CamelCaseVariableNaming]
+
+<<< Only basic
+class A {
+  val student_name = "wang"
+  val student_age = 12
+  val studentSex = "male"
+}
+>>>
+class A {
+  val studentName = "wang"
+  val studentAge = 12
+  val studentSex = "male"
+}
+
+


### PR DESCRIPTION
Different developers have different variable naming styles, the most common is:

1.  SnakeCase  ```val student_name = "xxx" ```
2. CamelCase ```val studentName = "xxx" ```

Add new rewrite rule **CamelCaseVariableNaming** to unify variable naming style, here is a example :

```scala
class A {
  val student_name = "wang"
  val studentAge = 22
}

// after formatting
// rewrite.rules = [CamelCaseVariableNaming]
class A {
  val studentName = "wang"
  val studentAge = 22
}

```