### PR TITLE
Newlines: implicitParamListModifier to replace two

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -648,18 +648,20 @@ something.map { x => f(x) }
 
 ### Newlines around `implicit` parameter list modifier
 
+> Since v2.5.0.
+
+```scala mdoc:defaults
+newlines.implicitParamListModifier
+```
+
 #### Before
 
 > If set, forces newline before `implicit`. Otherwise, newline can still be
 > added if the keyword would overflow the line.
 
-```scala mdoc:defaults
-newlines.beforeImplicitParamListModifier
-```
-
 ```scala mdoc:scalafmt
 maxColumn = 60
-newlines.beforeImplicitParamListModifier = true
+newlines.implicitParamListModifier = [before]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -670,13 +672,9 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 > unless `before` is true, or the entire implicit parameter list fits on a line,
 > or config style is false.
 
-```scala mdoc:defaults
-newlines.afterImplicitParamListModifier
-```
-
 ```scala mdoc:scalafmt
 maxColumn = 60
-newlines.afterImplicitParamListModifier = true
+newlines.implicitParamListModifier = [after]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -685,8 +683,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 
 ```scala mdoc:scalafmt
 maxColumn = 60
-newlines.afterImplicitParamListModifier = true
-newlines.beforeImplicitParamListModifier = true
+newlines.implicitParamListModifier = [before,after]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -695,8 +692,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 
 ```scala mdoc:scalafmt
 maxColumn = 60
-newlines.afterImplicitParamListModifier = false
-newlines.beforeImplicitParamListModifier = false
+newlines.implicitParamListModifier = []
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -706,7 +702,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```scala mdoc:scalafmt
 maxColumn = 60
 optIn.configStyleArguments = true
-newlines.afterImplicitParamListModifier = true
+newlines.implicitParamListModifier = [after]
 ---
 def format(code: String, age: Int)(
    implicit ev: Parser, c: Context
@@ -1200,7 +1196,7 @@ other(a, b)(c, d)
 ```scala mdoc:scalafmt
 maxColumn = 60
 verticalMultiline.atDefnSite = true
-newlines.beforeImplicitParamListModifier = true
+newlines.implicitParamListModifier = [before]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -1210,7 +1206,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```scala mdoc:scalafmt
 maxColumn = 60
 verticalMultiline.atDefnSite = true
-newlines.afterImplicitParamListModifier = true
+newlines.implicitParamListModifier = [after]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -1220,8 +1216,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```scala mdoc:scalafmt
 maxColumn = 60
 verticalMultiline.atDefnSite = true
-newlines.beforeImplicitParamListModifier = true
-newlines.afterImplicitParamListModifier = true
+newlines.implicitParamListModifier = [before,after]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -216,6 +216,13 @@ object Newlines {
       ReaderUtil.oneOf[AfterInfix](keep, some, many)
   }
 
+  sealed abstract class BeforeAfter
+  case object before extends BeforeAfter
+  case object after extends BeforeAfter
+
+  implicit val beforeAfterReader: ConfCodec[BeforeAfter] =
+    ReaderUtil.oneOf[BeforeAfter](before, after)
+
 }
 
 sealed abstract class NewlineCurlyLambda

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -139,8 +139,7 @@ case class Newlines(
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
-    afterImplicitParamListModifier: Boolean = false,
-    beforeImplicitParamListModifier: Boolean = false,
+    implicitParamListModifier: Seq[Newlines.BeforeAfter] = Seq.empty,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
     afterInfix: Option[AfterInfix] = None,
@@ -182,6 +181,10 @@ case class Newlines(
     else copy(afterInfix = Some(needAfterInfix))
   }
 
+  lazy val beforeImplicitParamListModifier: Boolean =
+    implicitParamListModifier.contains(Newlines.before)
+  lazy val afterImplicitParamListModifier: Boolean =
+    implicitParamListModifier.contains(Newlines.after)
 }
 
 object Newlines {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -10,13 +10,13 @@ case class VerticalMultiline(
     arityThreshold: Int = 100,
     @annotation.DeprecatedName(
       "newlineBeforeImplicitKW",
-      "Use newlines.beforeImplicitParamListModifier instead",
+      "Use newlines.implicitParamListModifier=[before] instead",
       "2.5.0"
     )
     newlineBeforeImplicitKW: Boolean = false,
     @annotation.DeprecatedName(
       "newlineAfterImplicitKW",
-      "Use newlines.afterImplicitParamListModifier instead",
+      "Use newlines.implicitParamListModifier=[after] instead",
       "2.5.0"
     )
     newlineAfterImplicitKW: Boolean = false,

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -1,5 +1,5 @@
 maxColumn = 80
-newlines.afterImplicitParamListModifier = true
+newlines.implicitParamListModifier = [after]
 verticalMultiline.atDefnSite = true
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 0
@@ -80,7 +80,7 @@ implicit def pairEncoder[A, B](
 ): CsvEncoder[(A, B)]
 <<< should work without explicit parameter groups (non-vm, before=T)
 verticalMultiline.atDefnSite = false
-newlines.beforeImplicitParamListModifier = true
+newlines.implicitParamListModifier = [before,after]
 ===
 implicit def pairEncoder[A, B](
     implicit aEncoder: CsvEncoder[A],
@@ -94,7 +94,6 @@ implicit def pairEncoder[A, B](
 ): CsvEncoder[(A, B)]
 <<< should work without explicit parameter groups (non-vm, before=F)
 verticalMultiline.atDefnSite = false
-newlines.beforeImplicitParamListModifier = false
 ===
 implicit def pairEncoder[A, B](
     implicit aEncoder: CsvEncoder[A],

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -1,6 +1,5 @@
 maxColumn = 80
-newlines.beforeImplicitParamListModifier = true
-newlines.afterImplicitParamListModifier = true
+newlines.implicitParamListModifier = [before,after]
 verticalMultiline.atDefnSite = true
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 0

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -2,6 +2,7 @@ package org.scalafmt.util
 
 import scala.meta._
 
+import org.scalafmt.config.Newlines
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.FormatOps
 import org.scalatest.funsuite.AnyFunSuite
@@ -54,6 +55,38 @@ class StyleMapTest extends AnyFunSuite {
     val newPrintlnConfig = newFormatOps.styleMap.at(printlnToken)
     assert(printlnConfig.alignMap("=").regex == overrideEquals)
     assert(newPrintlnConfig.alignMap("=").regex == overrideEquals)
+  }
+
+  test("newlines.implicitParamListModifier") {
+    val code =
+      """object a {
+        |  // scalafmt: { newlines.implicitParamListModifier = [after] }
+        |  println(1)
+        |}
+      """.stripMargin.parse[Source].get
+    val formatOps = new FormatOps(
+      code,
+      ScalafmtConfig(newlines =
+        Newlines(implicitParamListModifier = List(Newlines.before))
+      )
+    )
+    val headToken = formatOps.tokens.head
+    val printlnToken = formatOps.tokens.find(_.left.syntax == "println").get
+
+    val defaultValue = List(Newlines.before)
+    val overrideValue = List(Newlines.after)
+
+    val headConfig = formatOps.styleMap.at(headToken)
+    val printlnConfig = formatOps.styleMap.at(printlnToken)
+    val newFormatOps = new FormatOps(code, printlnConfig)
+
+    val newHeadConfig = newFormatOps.styleMap.at(headToken)
+    assert(headConfig.newlines.implicitParamListModifier == defaultValue)
+    assert(newHeadConfig.newlines.implicitParamListModifier == overrideValue)
+
+    val newPrintlnConfig = newFormatOps.styleMap.at(printlnToken)
+    assert(printlnConfig.newlines.implicitParamListModifier == overrideValue)
+    assert(newPrintlnConfig.newlines.implicitParamListModifier == overrideValue)
   }
 
 }


### PR DESCRIPTION
As these parameters haven't yet been released, let's consolidate these two into a single multi-valued parameter. There are other, unrelated parameters which also follow the same before/after logic.