### PR TITLE
Newlines: allow break after top-level statements

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -527,36 +527,117 @@ def other(a: String, b: String)(c: String, d: String) = a + b + c
 other(a, b)(c, d)
 ```
 
-### `newlines.alwaysBeforeTopLevelStatements`
+### `newlines.topLevelStatements`
+
+> Since v2.5.0.
 
 ```scala mdoc:defaults
-newlines.alwaysBeforeTopLevelStatements
+newlines.topLevelStatements
 ```
 
 ```scala mdoc:scalafmt
-newlines.alwaysBeforeTopLevelStatements = false
+newlines.topLevelStatements = []
 ---
 import org.scalafmt
 package core { // no newline added here
+  class C1 {}
   object O { // nor here
     val x1 = 1
     val x2 = 2
     def A = "A"
     def B = "B"
+  } // nor here
+  class C2 {}
+}
+```
+
+```scala mdoc:scalafmt
+newlines.topLevelStatements = [before]
+---
+import org.scalafmt
+package core {
+  class C1 {}
+  object O {
+    val x1 = 1
+    val x2 = 2
+    def A = "A"
+    def B = "B"
+  }
+  class C2 {}
+}
+```
+
+```scala mdoc:scalafmt
+newlines.topLevelStatements = [after]
+---
+import org.scalafmt
+package core {
+  class C1 {}
+  object O {
+    val x1 = 1
+    val x2 = 2
+    def A = "A"
+    def B = "B"
+  }
+  class C2 {}
+}
+```
+
+```scala mdoc:scalafmt
+newlines.topLevelStatements = [before,after]
+---
+import org.scalafmt
+package core {
+  class C1 {}
+  object O {
+    val x1 = 1
+    val x2 = 2
+    def A = "A"
+    def B = "B"
+  }
+  class C2 {}
+}
+```
+
+### `newlines.topLevelStatementsMinBreaks`
+
+> Since v2.5.0.
+
+```scala mdoc:defaults
+newlines.topLevelStatementsMinBreaks
+```
+
+```scala mdoc:scalafmt
+newlines.topLevelStatements = [before,after]
+newlines.topLevelStatementsMinBreaks = 0
+---
+package core {
+  object O {
+    val x1 = 1
+    val x2 = 2
+    def A =
+      "A"
+    def B = {
+      "B"
+    }
   }
 }
 ```
 
 ```scala mdoc:scalafmt
-newlines.alwaysBeforeTopLevelStatements = true
+newlines.topLevelStatements = [before,after]
+newlines.topLevelStatementsMinBreaks = 2
 ---
 import org.scalafmt
 package core {
   object O {
     val x1 = 1
     val x2 = 2
-    def A = "A"
-    def B = "B"
+    def A =
+      "A"
+    def B = {
+      "B"
+    }
   }
 }
 ```

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -129,6 +129,11 @@ import metaconfig.generic.Surface
   *   Switch to `many` for a given expression (possibly nested) if the
   *   number of operations in that expression exceeds this value AND
   *   `afterInfix` had been set to `some`.
+  * @param topLevelStatements
+  *   Forces a blank line before and/or after a top-level statement.
+  * @param topLevelStatementsMinBreaks
+  *   Minimum span (number of line breaks between first and last line)
+  *   to start forcing blank lines.
   */
 case class Newlines(
     source: Newlines.SourceHints = Newlines.classic,
@@ -137,6 +142,13 @@ case class Newlines(
     sometimesBeforeColonInMethodReturnType: Boolean = true,
     penalizeSingleSelectMultiArgList: Boolean = true,
     alwaysBeforeCurlyBraceLambdaParams: Boolean = false,
+    topLevelStatementsMinBreaks: Int = 1,
+    topLevelStatements: Seq[Newlines.BeforeAfter] = Seq.empty,
+    @annotation.DeprecatedName(
+      "alwaysBeforeTopLevelStatements",
+      "Use newlines.topLevelStatements instead",
+      "2.5.0"
+    )
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
     implicitParamListModifier: Seq[Newlines.BeforeAfter] = Seq.empty,
@@ -185,6 +197,12 @@ case class Newlines(
     implicitParamListModifier.contains(Newlines.before)
   lazy val afterImplicitParamListModifier: Boolean =
     implicitParamListModifier.contains(Newlines.after)
+
+  lazy val forceBlankBeforeMultilineTopLevelStmt: Boolean =
+    topLevelStatements.contains(Newlines.before) ||
+      alwaysBeforeTopLevelStatements
+  lazy val forceBlankAfterMultilineTopLevelStmt: Boolean =
+    topLevelStatements.contains(Newlines.after)
 }
 
 object Newlines {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1271,10 +1271,10 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   }
 
   // Returns leading comment, if there exists one, otherwise formatToken.right
-  final def leadingComment(formatToken: FormatToken): Token =
+  final def leadingComment(formatToken: FormatToken): FormatToken =
     findToken(formatToken, prev) { formatToken =>
       formatToken.hasBlankLine || !formatToken.left.is[T.Comment]
-    }.fold(_.left, _.right)
+    }.fold(identity, identity)
 
   def xmlSpace(owner: Tree): Modification = owner match {
     case _: Term.Xml | _: Pat.Xml => NoSplit

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -10,11 +10,10 @@ import org.scalafmt.util.{TreeOps, LiteralOps}
 import scala.annotation.tailrec
 import scala.collection.IndexedSeq
 import scala.collection.mutable
-import scala.meta.Type
 import scala.meta.tokens.Token
 import scala.meta.tokens.{Token => T}
 import scala.meta.transversers.Traverser
-import scala.meta.{Importer, Mod, Pkg, Term, Tree}
+import scala.meta.{Importer, Mod, Pkg, Template, Term, Tree, Type}
 
 /**
   * Produces formatted output from sequence of splits.
@@ -412,8 +411,8 @@ class FormatWriter(formatOps: FormatOps) {
     val buffer = List.newBuilder[TokenHash]
     val trav = new Traverser {
       override def apply(tree: Tree): Unit = tree match {
-        case Term.Block(_) =>
-          ()
+        case _: Term.Block =>
+        case t: Template => super.apply(t.stats) // skip inits
         case TreeOps.MaybeTopLevelStat(t) =>
           val result = leadingComment(tokens(t.tokens.head, -1))
           val hashed = hash(result)

--- a/scalafmt-tests/src/test/resources/default/Trait.stat
+++ b/scalafmt-tests/src/test/resources/default/Trait.stat
@@ -55,6 +55,8 @@ trait AllSyntax
     with EitherSyntax
     with EqSyntax
 <<< nested with
+newlines.topLevelStatements = [before]
+===
 trait Grouped[K, +V]
   extends KeyedListLike[K, V, UnsortedGrouped]
   with HashJoinable[K, V]
@@ -67,6 +69,7 @@ trait Grouped[K, +V]
     with HashJoinable[K, V]
     with Sortable[V,
                   ({
+
                     type t[+x] =
                       SortedGrouped[K, x] with Reversible[SortedGrouped[K, x]]
                   })#t]

--- a/scalafmt-tests/src/test/resources/default/Trait.stat
+++ b/scalafmt-tests/src/test/resources/default/Trait.stat
@@ -69,7 +69,6 @@ trait Grouped[K, +V]
     with HashJoinable[K, V]
     with Sortable[V,
                   ({
-
                     type t[+x] =
                       SortedGrouped[K, x] with Reversible[SortedGrouped[K, x]]
                   })#t]

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.source
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.source
@@ -152,14 +152,18 @@ object a {
     def b = {
       "multiline"
     }
+
     def c = "single"
   }
+
   object a {
     def c = "single"
     def b = {
       "multiline"
     }
+
   }
+
 }
 <<< #1653 both
 maxColumn = 25
@@ -183,6 +187,7 @@ object a {
     def b = {
       "multiline"
     }
+
     def c = "single"
   }
 
@@ -192,5 +197,7 @@ object a {
     def b = {
       "multiline"
     }
+
   }
+
 }

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.source
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.source
@@ -1,5 +1,5 @@
 maxColumn = 80
-newlines.alwaysBeforeTopLevelStatements = true
+newlines.topLevelStatements = [before]
 
 <<< #1069 1
 package a
@@ -69,4 +69,128 @@ import g.h.i.j
 package k.l.m {
   import n.o.p
   class q {}
+}
+<<< #1653 none
+maxColumn = 25
+newlines.topLevelStatements = []
+===
+object a {
+  object a {
+    def b = { "multiline" }
+    def c = "single"
+  }
+  object a {
+    def c = "single"
+    def b = { "multiline" }
+  }
+}
+>>>
+object a {
+  object a {
+    def b = {
+      "multiline"
+    }
+    def c = "single"
+  }
+  object a {
+    def c = "single"
+    def b = {
+      "multiline"
+    }
+  }
+}
+<<< #1653 before
+maxColumn = 25
+newlines.topLevelStatements = [before]
+===
+object a {
+  object a {
+    def b = { "multiline" }
+    def c = "single"
+  }
+  object a {
+    def c = "single"
+    def b = { "multiline" }
+  }
+}
+>>>
+object a {
+
+  object a {
+
+    def b = {
+      "multiline"
+    }
+    def c = "single"
+  }
+
+  object a {
+    def c = "single"
+
+    def b = {
+      "multiline"
+    }
+  }
+}
+<<< #1653 after
+maxColumn = 25
+newlines.topLevelStatements = [after]
+===
+object a {
+  object a {
+    def b = { "multiline" }
+    def c = "single"
+  }
+  object a {
+    def c = "single"
+    def b = { "multiline" }
+  }
+}
+>>>
+object a {
+  object a {
+    def b = {
+      "multiline"
+    }
+    def c = "single"
+  }
+  object a {
+    def c = "single"
+    def b = {
+      "multiline"
+    }
+  }
+}
+<<< #1653 both
+maxColumn = 25
+newlines.topLevelStatements = [before,after]
+===
+object a {
+  object a {
+    def b = { "multiline" }
+    def c = "single"
+  }
+  object a {
+    def c = "single"
+    def b = { "multiline" }
+  }
+}
+>>>
+object a {
+
+  object a {
+
+    def b = {
+      "multiline"
+    }
+    def c = "single"
+  }
+
+  object a {
+    def c = "single"
+
+    def b = {
+      "multiline"
+    }
+  }
 }


### PR DESCRIPTION
When writing newlines before a token, check whether the previous token ended a multi-line top-level statement and optionally add a double.

Fixes #1653.