### PR TITLE
ScalafmtConfig: allow overriding per file pattern

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1302,7 +1302,7 @@ newlines.implicitParamListModifier = [before,after]
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
 
-## Disabling Formatting
+## Disabling or customizing formatting
 
 <!-- TODO: document dynamic configuration: https://github.com/scalameta/scalafmt/pull/464 -->
 
@@ -1338,6 +1338,32 @@ project.includeFilters = [
   regex2
 ]
 ```
+
+### `fileOverride`
+
+> Since v2.5.0.
+
+Allows specifying an additional subset of parameters for each file matching
+a [PathMatcher](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-)
+pattern. For instance,
+
+```
+align = none
+fileOverride {
+  "glob:*.sbt" {
+    align = most
+  }
+  "glob:**/src/test/scala/**/*.scala" {
+    maxColumn = 120
+    binPack.unsafeCallSite = true
+  }
+}
+```
+
+uses `align=none` for all files except `.sbt` for which `align=most` will apply.
+It will also use different parameters for test suites.
+
+> This parameter does not modify which files are formatted.
 
 ## Miscellaneous
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -23,6 +23,7 @@ object Scalafmt {
 
   private val WindowsLineEnding = "\r\n"
   private val UnixLineEnding = "\n"
+  private val defaultFilename = "<input>"
 
   // XXX: don't modify signature, scalafmt-dynamic expects it via reflection
   /**
@@ -50,12 +51,15 @@ object Scalafmt {
 
   private[scalafmt] def formatCode(
       code: String,
-      style: ScalafmtConfig = ScalafmtConfig.default,
+      baseStyle: ScalafmtConfig = ScalafmtConfig.default,
       range: Set[Range] = Set.empty,
-      filename: String = "<input>"
+      filename: String = defaultFilename
   ): Formatted = {
+    val style =
+      if (filename == defaultFilename) baseStyle
+      else baseStyle.getConfigFor(filename) // might throw for invalid conf
+    val runner = style.runner
     try {
-      val runner = style.runner
       if (code.matches("\\s*")) Formatted.Success(System.lineSeparator())
       else {
         val isWindows = containsWindowsLineEndings(code)


### PR DESCRIPTION
For instance, we might want to use a slightly different configuration
for `*.sbt` files, or those under `src/test/scala`.