### PR TITLE
Fixed alignment overriding

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -559,7 +559,11 @@ class FormatWriter(formatOps: FormatOps) {
   def alignmentTokens(
       locations: Array[FormatLocation]
   ): Map[TokenHash, Int] = {
-    if (initStyle.align.tokens.isEmpty || locations.length != tokens.length)
+    lazy val noAlignTokens = locations.forall { floc =>
+      styleMap.at(floc.formatToken).align.tokens.isEmpty
+    }
+
+    if (locations.length != tokens.length || noAlignTokens)
       Map.empty[TokenHash, Int]
     else {
       var columnShift = 0

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -559,10 +559,8 @@ class FormatWriter(formatOps: FormatOps) {
   def alignmentTokens(
       locations: Array[FormatLocation]
   ): Map[TokenHash, Int] = {
-    lazy val noAlignTokens = locations.forall { floc =>
-      styleMap.at(floc.formatToken).align.tokens.isEmpty
-    }
-
+    lazy val noAlignTokens = initStyle.align.tokens.isEmpty &&
+      styleMap.tok2style.values.forall(_.align.tokens.isEmpty)
     if (locations.length != tokens.length || noAlignTokens)
       Map.empty[TokenHash, Int]
     else {

--- a/scalafmt-tests/src/test/resources/test/DynamicStyle.stat
+++ b/scalafmt-tests/src/test/resources/test/DynamicStyle.stat
@@ -60,7 +60,7 @@ type Row =
   val x  = 2 +  foo
   val xx = 22 + foo
 }
-<<< ONLY override align it is none originally
+<<< override align it is none originally
 align=none
 ===
 object a {

--- a/scalafmt-tests/src/test/resources/test/DynamicStyle.stat
+++ b/scalafmt-tests/src/test/resources/test/DynamicStyle.stat
@@ -60,3 +60,29 @@ type Row =
   val x  = 2 +  foo
   val xx = 22 + foo
 }
+<<< ONLY override align it is none originally
+align=none
+===
+object a {
+  for {
+    x <- "asd"
+    xxxx <- "bb"
+  } yield x
+  // scalafmt: { align = most }
+  for {
+    x <- "asd"
+    xxxx <- "bb"
+  } yield x
+}
+>>>
+object a {
+  for {
+    x <- "asd"
+    xxxx <- "bb"
+  } yield x
+  // scalafmt: { align = most }
+  for {
+    x    <- "asd"
+    xxxx <- "bb"
+  } yield x
+}


### PR DESCRIPTION
Fixes #1861 

Fixed for alignment. But global problem is still here:
1. every contributor and code-reviewer can forgot the `styleMap` and look at the `initStyle`;
2. There is no documentation about what configs can't be overridden.

File override looks like more reliable and simple mechanism. What do you think, should we continue to support config overrides for code blocks or deprecate it in favor of file override?