### PR TITLE
Router: fix strip margin in interpolated strings

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -270,7 +270,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
 
   def isTripleQuote(token: Token): Boolean = token.syntax.startsWith("\"\"\"")
 
-  def getStripMarginChar(token: Token): Option[Char] = {
+  def getStripMarginChar(ft: FormatToken): Option[Char] = {
     def getChar(ft: FormatToken): Option[Char] =
       if (!ft.left.is[T.Dot] || ft.right.syntax != "stripMargin") None
       else
@@ -279,11 +279,11 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
             Some(r.value)
           case _ => Some('|')
         }
-    token match {
-      case start @ T.Interpolation.Start() =>
+    ft.left match {
+      case start: T.Interpolation.Start =>
         getChar(tokens(matching(start), 1))
       case string: T.Constant.String if isTripleQuote(string) =>
-        getChar(tokens(string, 1))
+        getChar(next(ft))
       case _ => None
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -2,15 +2,22 @@ package org.scalafmt.internal
 
 sealed abstract class Modification {
   val newlines: Int
+  val length: Int
   @inline final def isNewline: Boolean = newlines != 0
 }
 
 case class Provided(code: String) extends Modification {
   override lazy val newlines: Int = code.count(_ == '\n')
+  override lazy val length: Int = {
+    val firstLine = code.indexOf('\n')
+    if (firstLine == -1) code.length
+    else firstLine
+  }
 }
 
 case object NoSplit extends Modification {
   override val newlines: Int = 0
+  override val length: Int = 0
   def orNL(flag: Boolean): Modification = if (flag) this else Newline
 }
 
@@ -36,6 +43,7 @@ case class NewlineT(
     double + indent + "Newline"
   }
   override val newlines: Int = if (isDouble) 2 else 1
+  override val length: Int = 0
 }
 
 object Newline extends NewlineT {
@@ -50,6 +58,7 @@ object Newline2xNoIndent extends NewlineT(isDouble = true, noIndent = true)
 
 object Space extends Modification {
   override val newlines: Int = 0
+  override val length: Int = 1
   override def toString = "Space"
 
   def apply(flag: Boolean): Modification = if (flag) this else NoSplit

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -81,23 +81,23 @@ class Router(formatOps: FormatOps) {
         Seq(
           Split(Newline, 0) // End files with trailing newline
         )
-      case FormatToken(start @ T.Interpolation.Start(), _, _) =>
+      case FormatToken(start: T.Interpolation.Start, _, _) =>
         val end = matching(start)
         val policy =
           if (isTripleQuote(start)) NoPolicy
           else penalizeAllNewlines(end, BreakSingleLineInterpolatedString)
         val split = Split(NoSplit, 0).withPolicy(policy)
         Seq(
-          // statecolumn - 1 because of margin characters |
-          if (style.align.stripMargin && getStripMarginChar(start).isDefined)
+          if (getStripMarginChar(formatToken).isEmpty) split
+          else if (!style.align.stripMargin) split.withIndent(2, end, After)
+          else // statecolumn - 1 because of margin characters |
             split
               .withIndent(StateColumn, end, After)
               .withIndent(-1, end, After)
-          else split
         )
       case FormatToken(
-          T.Interpolation.Id(_) | T.Interpolation.Part(_) |
-          T.Interpolation.Start() | T.Interpolation.SpliceStart(),
+          _: T.Interpolation.Id | _: T.Interpolation.Part |
+          _: T.Interpolation.Start | _: T.Interpolation.SpliceStart,
           _,
           _
           ) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -53,15 +53,8 @@ case class Split(
 
   val indentation = indents.mkString("[", ", ", "]")
 
-  def length: Int = modification match {
-    case m if m.isNewline => 0
-    case NoSplit => 0
-    case Space => 1
-    case Provided(code) =>
-      val firstLine = code.indexOf("\n")
-      if (firstLine == -1) code.length
-      else firstLine
-  }
+  @inline
+  def length: Int = modification.length
 
   @inline
   def isIgnored: Boolean = tag eq SplitTag.Ignored

--- a/scalafmt-tests/src/test/resources/default/Comment.stat
+++ b/scalafmt-tests/src/test/resources/default/Comment.stat
@@ -136,9 +136,9 @@ object a {
   /*
 
    /**
- * comment
- */
+   * comment
+   */
 
   def undefined = ???
- */
+   */
 }

--- a/scalafmt-tests/src/test/resources/default/Comment.stat
+++ b/scalafmt-tests/src/test/resources/default/Comment.stat
@@ -120,3 +120,25 @@ object Primes {
 **                                                                      **
 \*                                                                      */
 trait A
+<<< docstring within commented-out code
+object a {
+  /*
+
+   /**
+     * comment
+     */
+
+  def undefined = ???
+  */
+}
+>>>
+object a {
+  /*
+
+   /**
+ * comment
+ */
+
+  def undefined = ???
+ */
+}

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -53,8 +53,8 @@ val x = """Formatter changed AST
 val x = """Formatter changed AST
       |=====================
       |$diff
-    ?=====================
-    ?$diff
+  ?=====================
+  ?$diff
         """
   .stripMargin('?')
 <<< No rewrite | margin 1, different char

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -85,10 +85,10 @@ val x = s"""Formatter changed AST
         .stripMargin('?')
 >>>
 val x = s"""Formatter changed AST
-           |=====================
-           |$diff
-      ?=====================
-      ?$diff
+      |=====================
+      |$diff
+           ?=====================
+           ?$diff
         """
   .stripMargin('?')
 <<< No align | margin 1 | interpolate, different char
@@ -103,10 +103,10 @@ val x = f"""Formatter changed AST
         .stripMargin('?')
 >>>
 val x = f"""Formatter changed AST
-|=====================
-|$diff
-      ?=====================
-      ?$diff
+      |=====================
+      |$diff
+  ?=====================
+  ?$diff
         """
   .stripMargin('?')
 <<< No rewrite | margin 1 | interpolate, different char

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -57,6 +57,76 @@ val x = """Formatter changed AST
     ?$diff
         """
   .stripMargin('?')
+<<< No rewrite | margin 1, different char
+assumeStandardLibraryStripMargin = false
+===
+val x = """Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+        .stripMargin('?')
+>>>
+val x = """Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+  .stripMargin('?')
+<<< Align | margin 1 | interpolate, different char
+val x = s"""Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+        .stripMargin('?')
+>>>
+val x = s"""Formatter changed AST
+           |=====================
+           |$diff
+      ?=====================
+      ?$diff
+        """
+  .stripMargin('?')
+<<< No align | margin 1 | interpolate, different char
+align.stripMargin = false
+===
+val x = f"""Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+        .stripMargin('?')
+>>>
+val x = f"""Formatter changed AST
+|=====================
+|$diff
+      ?=====================
+      ?$diff
+        """
+  .stripMargin('?')
+<<< No rewrite | margin 1 | interpolate, different char
+assumeStandardLibraryStripMargin = false
+===
+val x = f"""Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+        .stripMargin('?')
+>>>
+val x = f"""Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+  .stripMargin('?')
 <<< Align | margin 2
 {
   val x = 1


### PR DESCRIPTION
`align.stripMargin=false` incorrectly handled interpolated strings:
* strip margin character was incorrectly determined (`|` was always assumed);
* strip-margin lines were not indented at all.

As a side effect of this fix, we are also fixing the bug with nested comments which were incorrectly formatted.

Follow-on to #1837.