### PR TITLE
CLI: add explicit flag --reportError to exit 1 on malformatted code

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -126,7 +126,8 @@ object Cli {
       runner: ScalafmtRunner
   ): ExitCode = {
     val termDisplayMessage =
-      if (options.testing) "Looking for unformatted files..."
+      if (options.writeMode == WriteMode.Test)
+        "Looking for unformatted files..."
       else "Reformatting..."
     options.common.debug.println(
       "Working directory: " + options.common.workingDirectory.jfile.getPath
@@ -134,7 +135,7 @@ object Cli {
 
     val exit = runner.run(options, termDisplayMessage)
 
-    if (options.testing) {
+    if (options.writeMode == WriteMode.Test) {
       if (exit.isOk) {
         options.common.out.println("All files are formatted with scalafmt :)")
       } else if (exit.is(ExitCode.TestError)) {
@@ -146,7 +147,7 @@ object Cli {
         options.common.out.println(s"error: $exit")
       }
     }
-    if (options.testing &&
+    if (options.writeMode == WriteMode.Test &&
       !options.fatalWarnings &&
       !exit.is(ExitCode.TestError)) {
       // Ignore parse errors etc.

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -87,13 +87,13 @@ object CliArgParser {
         )
 
       opt[Unit]('i', "in-place")
-        .action((opt, c) => c.copy(writeMode = Override))
+        .action((_, c) => c.copy(writeMode = WriteMode.Override))
         .hidden() // this option isn't needed anymore. Simply don't pass
         // --stdout. Keeping for backwards compatibility
         .text("format files in-place (default)")
 
       opt[Unit]("stdout")
-        .action((opt, c) => c.copy(writeMode = Stdout))
+        .action((_, c) => c.copy(writeMode = WriteMode.Stdout))
         .text("write formatted files to stdout")
 
       opt[Boolean]("git")
@@ -123,12 +123,14 @@ object CliArgParser {
           "when using --stdin, use --assume-filename to hint to scalafmt that the input is an .sbt file."
         )
       opt[Unit]("test")
-        .action((_, c) => c.copy(testing = true))
-        .text("test for mis-formatted code, exits with status 1 on failure.")
-      opt[Unit]("check")
-        .action((_, c) => c.copy(check = true))
+        .action((_, c) => c.copy(writeMode = WriteMode.Test))
         .text(
-          "test for mis-formatted code, exits with status 1 on first failure."
+          "test for mis-formatted code only, exits with status 1 on failure."
+        )
+      opt[Unit]("check")
+        .action((_, c) => c.copy(writeMode = WriteMode.Test, check = true))
+        .text(
+          "test for mis-formatted code only, exits with status 1 on first failure."
         )
       opt[File]("migrate2hocon")
         .action((file, c) =>
@@ -176,7 +178,7 @@ object CliArgParser {
         .action((_, c) => c.copy(nonInteractive = true))
         .text("disable fancy progress bar, useful in ci or sbt plugin.")
       opt[Unit]("list")
-        .action((_, c) => c.copy(list = true))
+        .action((_, c) => c.copy(writeMode = WriteMode.List))
         .text("list files that are different from scalafmt formatting")
       opt[(Int, Int)]("range")
         .hidden()

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -122,13 +122,18 @@ object CliArgParser {
         .text(
           "when using --stdin, use --assume-filename to hint to scalafmt that the input is an .sbt file."
         )
+      opt[Unit]("reportError")
+        .action((_, c) => c.copy(error = true))
+        .text("exit with status 1 if any mis-formatted code found.")
       opt[Unit]("test")
-        .action((_, c) => writeMode(c, WriteMode.Test))
+        .action((_, c) => writeMode(c, WriteMode.Test).copy(error = true))
         .text(
           "test for mis-formatted code only, exits with status 1 on failure."
         )
       opt[Unit]("check")
-        .action((_, c) => writeMode(c, WriteMode.Test).copy(check = true))
+        .action((_, c) =>
+          writeMode(c, WriteMode.Test).copy(error = true, check = true)
+        )
         .text(
           "test for mis-formatted code only, exits with status 1 on first failure."
         )
@@ -174,7 +179,7 @@ object CliArgParser {
         .action((_, c) => c.copy(nonInteractive = true))
         .text("disable fancy progress bar, useful in ci or sbt plugin.")
       opt[Unit]("list")
-        .action((_, c) => writeMode(c, WriteMode.List))
+        .action((_, c) => writeMode(c, WriteMode.List).copy(error = true))
         .text("list files that are different from scalafmt formatting")
       opt[(Int, Int)]("range")
         .hidden()

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -122,6 +122,7 @@ case class CliOptions(
     quiet: Boolean = false,
     stdIn: Boolean = false,
     noStdErr: Boolean = false,
+    error: Boolean = false,
     check: Boolean = false
 ) {
   lazy val writeMode: WriteMode = writeModeOpt.getOrElse(WriteMode.Override)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -41,7 +41,8 @@ object CliOptions {
     }
 
     val auxOut =
-      if (parsed.noStdErr || (!parsed.stdIn && parsed.writeMode != WriteMode.Stdout))
+      if (parsed.noStdErr ||
+        !(parsed.stdIn || parsed.writeMode == WriteMode.Stdout))
         parsed.common.out
       else parsed.common.err
 
@@ -116,13 +117,15 @@ case class CliOptions(
     migrate: Option[AbsoluteFile] = None,
     common: CommonOptions = CommonOptions(),
     gitOpsConstructor: AbsoluteFile => GitOps = x => new GitOpsImpl(x),
-    writeMode: WriteMode = WriteMode.Override,
+    writeModeOpt: Option[WriteMode] = None,
     debug: Boolean = false,
     quiet: Boolean = false,
     stdIn: Boolean = false,
     noStdErr: Boolean = false,
     check: Boolean = false
 ) {
+  lazy val writeMode: WriteMode = writeModeOpt.getOrElse(WriteMode.Override)
+
   // These default values are copied from here.
   // https://github.com/scalameta/scalafmt/blob/f2154330afa0bc4a0a556598adeb116eafecb8e3/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala#L127-L162
   private[this] val DefaultGit = false

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -48,10 +48,9 @@ object InputMethod {
         options: CliOptions
     ): ExitCode = {
       val codeChanged = formatted != original
-      if (options.writeMode == WriteMode.Stdout) {
+      if (options.writeMode == WriteMode.Stdout)
         options.common.out.print(formatted)
-        ExitCode.Ok
-      } else if (codeChanged)
+      else if (codeChanged)
         options.writeMode match {
           case WriteMode.Test =>
             throw MisformattedFile(
@@ -60,18 +59,15 @@ object InputMethod {
             )
           case WriteMode.Override =>
             FileOps.writeFile(filename, formatted)(options.encoding)
-            ExitCode.Ok
           case WriteMode.List =>
             options.common.out.println(
               options.common.workingDirectory.jfile
                 .toURI()
                 .relativize(file.jfile.toURI())
             )
-            ExitCode.TestError
-          case _ => ExitCode.TestError
+          case _ =>
         }
-      else
-        ExitCode.Ok
+      if (options.error && codeChanged) ExitCode.TestError else ExitCode.Ok
     }
   }
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -17,11 +17,9 @@ trait ScalafmtRunner {
   ): TermDisplay = {
     val termDisplay = new TermDisplay(
       new OutputStreamWriter(options.common.info),
-      fallbackMode =
-        options.nonInteractive ||
-          TermDisplay.defaultFallbackMode
+      fallbackMode = options.nonInteractive || TermDisplay.defaultFallbackMode
     )
-    if ((options.inPlace || options.testing) && inputMethods.length > 5) {
+    if (options.writeMode != WriteMode.Stdout && inputMethods.length > 5) {
       termDisplay.init()
       termDisplay.startTask(msg, options.common.workingDirectory.jfile)
       termDisplay.taskLength(msg, inputMethods.length, 0)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/WriteMode.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/WriteMode.scala
@@ -8,5 +8,13 @@ package org.scalafmt.cli
   */
 sealed trait WriteMode
 
-case object Override extends WriteMode
-case object Stdout extends WriteMode
+object WriteMode {
+
+  case object Override extends WriteMode
+
+  case object Stdout extends WriteMode
+
+  case object List extends WriteMode
+
+  case object Test extends WriteMode
+}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -84,8 +84,8 @@ abstract class AbstractCliTest extends AnyFunSuite with DiffAssertions {
       assertExit(exit)
       val obtained = dir2string(input)
       assertNoDiff(obtained, expected)
-      val configTest = Cli.getConfig(Array("--test"), config).get
-      Cli.run(configTest)
+      val testConfig = config.copy(writeModeOpt = None)
+      Cli.run(Cli.getConfig(Array("--test"), testConfig).get)
       assertOut(out.toString())
     }
 


### PR DESCRIPTION
This will allow returning a non-zero exit code not just for `--test` mode.

Also:
* verify conflicting options aren't used (`--test` or `--check` vs `--list` vs `--in-place`)
* fail fast in core runner when `--check` is used (only dynamic runner used to do it)

Fixes #928 #1291.