### PR TITLE
Self formatting with 2.5.0-RC1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=2.4.2
+version=2.5.0-RC1
 project.git = true
 project.excludeFilters = [
   scalafmt-benchmarks/src/resources,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,10 +6,10 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV = "4.3.7"
-  val scalatestV = "3.1.1"
+  val scalametaV  = "4.3.7"
+  val scalatestV  = "3.1.1"
   val scalacheckV = "1.14.3"
-  val coursier = "1.0.3"
+  val coursier    = "1.0.3"
 
   val scalapb = Def.setting {
     ExclusionRule(
@@ -20,8 +20,8 @@ object Dependencies {
 
   val scalametaTestkit = "org.scalameta" %% "testkit" % scalametaV
 
-  val scalacheck = "org.scalacheck" %% "scalacheck" % scalacheckV
-  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % scalatestV)
+  val scalacheck = "org.scalacheck"             %% "scalacheck" % scalacheckV
+  val scalatest  = Def.setting("org.scalatest" %%% "scalatest"  % scalatestV)
   val scalameta = Def.setting {
     scalaBinaryVersion.value match {
       case "2.11" =>
@@ -38,8 +38,8 @@ object Dependencies {
         "org.scalameta" %%% "scalameta" % scalametaV excludeAll scalapb.value
     }
   }
-  val metaconfig = Def.setting("com.geirsson" %%% "metaconfig-core" % metaconfigV)
+  val metaconfig         = Def.setting("com.geirsson" %%% "metaconfig-core"            % metaconfigV)
   val metaconfigTypesafe = Def.setting("com.geirsson" %%% "metaconfig-typesafe-config" % metaconfigV)
-  val metaconfigHocon = Def.setting("com.geirsson" %%% "metaconfig-hocon" % metaconfigV)
+  val metaconfigHocon    = Def.setting("com.geirsson" %%% "metaconfig-hocon"           % metaconfigV)
 
 }

--- a/readme/src/main/scala/org/scalafmt/readme/Adopters.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Adopters.scala
@@ -8,10 +8,11 @@ case class Adopter(
     description: Option[String] = None
 ) {
   import scalatags.Text.all._
-  def bullet: TypedTag[String] = li(
-    a(href := url, name),
-    description.fold("")(x => s": $x")
-  )
+  def bullet: TypedTag[String] =
+    li(
+      a(href := url, name),
+      description.fold("")(x => s": $x")
+    )
 }
 object Adopters {
 

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -21,14 +21,15 @@ object hl extends scalatex.site.Highlighter
 
 object Readme {
 
-  def gitter = a(
-    href := "https://gitter.im/scalameta/scalafmt",
-    img(
-      src := "https://camo.githubusercontent.com/da2edb525cde1455a622c58c0effc3a90b9a181c/68747470733a2f2f6261646765732e6769747465722e696d2f4a6f696e253230436861742e737667",
-      alt := "Join the chat at https://gitter.im/scalameta/scalameta",
-      maxWidth := "100%;"
+  def gitter =
+    a(
+      href := "https://gitter.im/scalameta/scalafmt",
+      img(
+        src := "https://camo.githubusercontent.com/da2edb525cde1455a622c58c0effc3a90b9a181c/68747470733a2f2f6261646765732e6769747465722e696d2f4a6f696e253230436861742e737667",
+        alt := "Join the chat at https://gitter.im/scalameta/scalameta",
+        maxWidth := "100%;"
+      )
     )
-  )
 
   val eval = new Eval()
   implicit def bool2frag(boolean: Boolean): StringFrag =
@@ -54,12 +55,12 @@ object Readme {
     val output = evaluated match {
       case s: String =>
         s"""
-           |"$s"""".stripMargin
+          |"$s"""".stripMargin
       case x => x.toString
     }
     val result = s"""${expressions
-                      .map(x => s"scala> ${x.toString().trim}")
-                      .mkString("\n")}
+        .map(x => s"scala> ${x.toString().trim}")
+        .mkString("\n")}
                     |res0: ${evaluated.getClass.getName} = $output
                     |""".stripMargin
     hl.scala(result)
@@ -344,9 +345,10 @@ object Readme {
     val formatted = Scalafmt.format(code, style).get
     hl.scala(formatted)
   }
-  def image(url: String) = img(
-    src := url,
-    width := "100%",
-    textAlign := "center"
-  )
+  def image(url: String) =
+    img(
+      src := url,
+      width := "100%",
+      textAlign := "center"
+    )
 }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -104,16 +104,16 @@ object Cli {
         } else if (isNativeImage) {
           Left(
             s"""error: invalid Scalafmt version.
-               |
-               |This Scalafmt installation has version '${Versions.version}' and the version configured in '${options.configPath}' is '${v}'.
-               |To fix this problem, add the following line to .scalafmt.conf:
-               |```
-               |version = '${Versions.version}'
-               |```
-               |
-               |NOTE: this error happens only when running a native Scalafmt binary.
-               |Scalafmt automatically installs and invokes the correct version of Scalafmt when running on the JVM.
-               |""".stripMargin
+              |
+              |This Scalafmt installation has version '${Versions.version}' and the version configured in '${options.configPath}' is '${v}'.
+              |To fix this problem, add the following line to .scalafmt.conf:
+              |```
+              |version = '${Versions.version}'
+              |```
+              |
+              |NOTE: this error happens only when running a native Scalafmt binary.
+              |Scalafmt automatically installs and invokes the correct version of Scalafmt when running on the JVM.
+              |""".stripMargin
           )
         } else {
           Right(ScalafmtDynamicRunner)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -11,20 +11,20 @@ object CliArgParser {
 
   val usageExamples: String =
     """|scalafmt # Format all files in the current project, configuration is determined in this order:
-       |         # 1. .scalafmt.conf file in current directory
-       |         # 2. .scalafmt.conf inside root directory of current git repo
-       |         # 3. no configuration, default style
-       |scalafmt --test # throw exception on mis-formatted files, won't write to files.
-       |scalafmt --mode diff # Format all files that were edited in git diff against master branch.
-       |scalafmt --mode changed # Format files listed in `git status` (latest changes against previous commit.
-       |scalafmt --diff-branch 2.x # same as --diff, except against branch 2.x
-       |scalafmt --stdin # read from stdin and print to stdout
-       |scalafmt --stdin --assume-filename foo.sbt < foo.sbt # required when using --stdin to format .sbt files.
-       |scalafmt Code1.scala A.scala       # write formatted contents to file.
-       |scalafmt --stdout Code.scala       # print formatted contents to stdout.
-       |scalafmt --exclude target          # format all files in directory excluding target
-       |scalafmt --config .scalafmt.conf   # read custom style from file.
-       |scalafmt --config-str "style=IntelliJ" # define custom style as a flag, must be quoted.""".stripMargin
+      |         # 1. .scalafmt.conf file in current directory
+      |         # 2. .scalafmt.conf inside root directory of current git repo
+      |         # 3. no configuration, default style
+      |scalafmt --test # throw exception on mis-formatted files, won't write to files.
+      |scalafmt --mode diff # Format all files that were edited in git diff against master branch.
+      |scalafmt --mode changed # Format files listed in `git status` (latest changes against previous commit.
+      |scalafmt --diff-branch 2.x # same as --diff, except against branch 2.x
+      |scalafmt --stdin # read from stdin and print to stdout
+      |scalafmt --stdin --assume-filename foo.sbt < foo.sbt # required when using --stdin to format .sbt files.
+      |scalafmt Code1.scala A.scala       # write formatted contents to file.
+      |scalafmt --stdout Code.scala       # print formatted contents to stdout.
+      |scalafmt --exclude target          # format all files in directory excluding target
+      |scalafmt --config .scalafmt.conf   # read custom style from file.
+      |scalafmt --config-str "style=IntelliJ" # define custom style as a flag, must be quoted.""".stripMargin
 
   val scoptParser: OptionParser[CliOptions] =
     new scopt.OptionParser[CliOptions]("scalafmt") {
@@ -151,15 +151,15 @@ object CliArgParser {
         .action((_, c) => c.copy(mode = Option(DiffFiles("master"))))
         .text(
           s"""Format files listed in `git diff` against master.
-             |Deprecated: use --mode diff instead""".stripMargin
+            |Deprecated: use --mode diff instead""".stripMargin
         )
       opt[FileFetchMode]("mode")
         .action((m, c) => c.copy(mode = Option(m)))
         .text(
           s"""Sets the files to be formatted fetching mode.
-             |Options:
-             |        diff - format files listed in `git diff` against master
-             |        changed - format files listed in `git status` (latest changes against previous commit)""".stripMargin
+            |Options:
+            |        diff - format files listed in `git diff` against master
+            |        changed - format files listed in `git status` (latest changes against previous commit)""".stripMargin
         )
       opt[String]("diff-branch")
         .action((branch, c) => c.copy(mode = Option(DiffFiles(branch))))
@@ -191,13 +191,13 @@ object CliArgParser {
         .text("(experimental) only format line range from=to")
 
       note(s"""|Examples:
-               |$usageExamples
-               |Please file bugs to https://github.com/scalameta/scalafmt/issues
+        |$usageExamples
+        |Please file bugs to https://github.com/scalameta/scalafmt/issues
       """.stripMargin)
     }
   def buildInfo =
     s"""build commit: ${Versions.commit}
-       |build time: ${new Date(Versions.timestamp.toLong)}""".stripMargin
+      |build time: ${new Date(Versions.timestamp.toLong)}""".stripMargin
 
   private def writeMode(c: CliOptions, writeMode: WriteMode): CliOptions =
     c.writeModeOpt.fold {

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -151,13 +151,14 @@ case class CliOptions(
     *
     * @return A path to a configuration file
     */
-  def configPath: Path = tempConfigPath match {
-    case Some(tempConf) => tempConf
-    case None =>
-      config.getOrElse(
-        (common.workingDirectory / ".scalafmt.conf").jfile.toPath
-      )
-  }
+  def configPath: Path =
+    tempConfigPath match {
+      case Some(tempConf) => tempConf
+      case None =>
+        config.getOrElse(
+          (common.workingDirectory / ".scalafmt.conf").jfile.toPath
+        )
+    }
 
   /** Parse the scalafmt configuration and try to encode it to `ScalafmtConfig`.
     * If `--config-str` is specified, this will parse the configuration string specified by `--config-str`.

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/TermDisplay.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/TermDisplay.scala
@@ -291,7 +291,9 @@ object TermDisplay {
 
           val extra0 =
             if (extra.length > baseExtraWidth)
-              extra.take((baseExtraWidth max (extra.length - overflow)) - 1) + "…"
+              extra.take(
+                (baseExtraWidth max (extra.length - overflow)) - 1
+              ) + "…"
             else
               extra
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
@@ -43,12 +43,12 @@ object Error {
 
   case class FormatterChangedAST(diff: String, output: String)
       extends Error(s"""Formatter changed AST
-                       |=====================
-                       |$diff
-                       |=====================
-                       |${output.linesIterator.toVector.take(10).mkString("\n")}
-                       |=====================
-                       |Formatter changed AST
+        |=====================
+        |$diff
+        |=====================
+        |${output.linesIterator.toVector.take(10).mkString("\n")}
+        |=====================
+        |Formatter changed AST
       """.stripMargin)
 
   case class FormatterOutputDoesNotParse(msg: String, line: Int)
@@ -56,7 +56,7 @@ object Error {
 
   case class UnexpectedTree[Expected <: Tree: ClassTag](obtained: Tree)
       extends Error(s"""Expected: ${classTag[Expected].runtimeClass.getClass}
-                       |Obtained: ${log(obtained)}""".stripMargin)
+        |Obtained: ${log(obtained)}""".stripMargin)
 
   case class CantFormatFile(msg: String)
       extends Error("scalafmt cannot format this file:\n" + msg)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Formatted.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Formatted.scala
@@ -2,15 +2,17 @@ package org.scalafmt
 
 sealed abstract class Formatted {
 
-  def toEither: Either[Throwable, String] = this match {
-    case Formatted.Success(s) => Right(s)
-    case Formatted.Failure(e) => Left(e)
-  }
+  def toEither: Either[Throwable, String] =
+    this match {
+      case Formatted.Success(s) => Right(s)
+      case Formatted.Failure(e) => Left(e)
+    }
 
-  def get: String = this match {
-    case Formatted.Success(code) => code
-    case Formatted.Failure(e) => throw e
-  }
+  def get: String =
+    this match {
+      case Formatted.Success(code) => code
+      case Formatted.Failure(e) => throw e
+    }
 }
 
 object Formatted {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -115,11 +115,12 @@ object Align {
   val allValues = List(default, none, some, most)
 
   object Builtin {
-    def unapply(conf: Conf): Option[Align] = Option(conf).collect {
-      case Conf.Str("none") | Conf.Bool(false) => Align.none
-      case Conf.Str("some" | "default") => Align.some
-      case Conf.Str("more") | Conf.Bool(true) => Align.more
-      case Conf.Str("most") => Align.most
-    }
+    def unapply(conf: Conf): Option[Align] =
+      Option(conf).collect {
+        case Conf.Str("none") | Conf.Bool(false) => Align.none
+        case Conf.Str("some" | "default") => Align.some
+        case Conf.Str("more") | Conf.Bool(true) => Align.more
+        case Conf.Str("most") => Align.most
+      }
   }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Case.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Case.scala
@@ -4,11 +4,12 @@ import metaconfig.ConfCodec
 
 sealed abstract class Case {
   import Case._
-  def process(str: String): String = this match {
-    case Unchanged => str
-    case Lower => str.toLowerCase()
-    case Upper => str.toUpperCase()
-  }
+  def process(str: String): String =
+    this match {
+      case Unchanged => str
+      case Lower => str.toLowerCase()
+      case Upper => str.toUpperCase()
+    }
 }
 
 object Case {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -269,11 +269,12 @@ object ScalafmtConfig {
     danglingParentheses = DanglingParentheses(true, true)
   )
 
-  def addAlign(style: ScalafmtConfig): ScalafmtConfig = style.copy(
-    align = style.align.copy(
-      tokens = AlignToken.default
+  def addAlign(style: ScalafmtConfig): ScalafmtConfig =
+    style.copy(
+      align = style.align.copy(
+        tokens = AlignToken.default
+      )
     )
-  )
 
   val defaultWithAlign: ScalafmtConfig = addAlign(default)
 
@@ -327,13 +328,14 @@ object ScalafmtConfig {
     )
   }.map { case (k, v) => k.toLowerCase -> v }
 
-  def conservativeRunner: ScalafmtRunner = default.runner.copy(
-    optimizer = default.runner.optimizer.copy(
-      // The tests were not written in this style
-      forceConfigStyleOnOffset = 500,
-      forceConfigStyleMinArgCount = 5
+  def conservativeRunner: ScalafmtRunner =
+    default.runner.copy(
+      optimizer = default.runner.optimizer.copy(
+        // The tests were not written in this style
+        forceConfigStyleOnOffset = 500,
+        forceConfigStyleMinArgCount = 5
+      )
     )
-  )
 
   def oneOf[T](m: Map[String, T])(input: String): Configured[T] =
     m.get(input.toLowerCase()) match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -311,15 +311,15 @@ private class BestFirstSearch private (
       val splitsAfterPolicy =
         deepestYet.policy.execute(Decision(tok, nextSplits))
       val msg = s"""UNABLE TO FORMAT,
-                   |tok=$tok
-                   |toks.length=${tokens.length}
-                   |deepestYet.length=${deepestYet.depth}
-                   |policies=${deepestYet.policy.policies}
-                   |nextSplits=$nextSplits
-                   |splitsAfterPolicy=$splitsAfterPolicy""".stripMargin
+        |tok=$tok
+        |toks.length=${tokens.length}
+        |deepestYet.length=${deepestYet.depth}
+        |policies=${deepestYet.policy.policies}
+        |nextSplits=$nextSplits
+        |splitsAfterPolicy=$splitsAfterPolicy""".stripMargin
       if (runner.debug) {
         logger.debug(s"""Failed to format
-                        |$msg""".stripMargin)
+          |$msg""".stripMargin)
       }
       complete(deepestYet)
       SearchResult(deepestYet, reachedEOF = false)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -264,7 +264,9 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   def isJsNative(jsToken: Token): Boolean = {
     initStyle.newlines.neverBeforeJsNative && jsToken.syntax == "js" &&
     owners(jsToken).parent.exists(
-      _.show[Structure].trim == """Term.Select(Term.Name("js"), Term.Name("native"))"""
+      _.show[
+        Structure
+      ].trim == """Term.Select(Term.Name("js"), Term.Name("native"))"""
     )
   }
 
@@ -313,8 +315,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     else None
   }.toSet
 
-  def insideBlockRanges[A](start: FormatToken, end: Token)(
-      implicit classifier: Classifier[Token, A]
+  def insideBlockRanges[A](start: FormatToken, end: Token)(implicit
+      classifier: Classifier[Token, A]
   ): Set[Range] =
     insideBlockRanges(start, end, classifyOnRight(classifier))
 
@@ -325,8 +327,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   ): Set[Range] =
     insideBlock(start, end, matches).map((matchingParensRange _).tupled).toSet
 
-  def insideBlock[A](start: FormatToken, end: Token)(
-      implicit classifier: Classifier[Token, A]
+  def insideBlock[A](start: FormatToken, end: Token)(implicit
+      classifier: Classifier[Token, A]
   ): Map[Token, Token] =
     insideBlock(start, end, classifyOnRight(classifier))
 
@@ -381,8 +383,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   }.getOrElse(tree.tokens.last)
 
   @inline
-  def OneArgOneLineSplit(tok: FormatToken)(
-      implicit line: sourcecode.Line,
+  def OneArgOneLineSplit(tok: FormatToken)(implicit
+      line: sourcecode.Line,
       style: ScalafmtConfig
   ): Policy =
     if (style.poorMansTrailingCommasInConfigStyle)
@@ -390,8 +392,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     else
       splitOneArgPerLineAfterComma(tok)
 
-  def splitOneArgPerLineBeforeComma(tok: FormatToken)(
-      implicit line: sourcecode.Line,
+  def splitOneArgPerLineBeforeComma(tok: FormatToken)(implicit
+      line: sourcecode.Line,
       style: ScalafmtConfig
   ): Policy = {
     val owner = tok.meta.leftOwner
@@ -413,8 +415,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     }
   }
 
-  def splitOneArgPerLineAfterComma(tok: FormatToken)(
-      implicit line: sourcecode.Line,
+  def splitOneArgPerLineAfterComma(tok: FormatToken)(implicit
+      line: sourcecode.Line,
       style: ScalafmtConfig
   ): Policy = {
     val owner = tok.meta.leftOwner
@@ -464,8 +466,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
         }
     }
 
-  def penalizeNewlineByNesting(from: Token, to: Token)(
-      implicit line: sourcecode.Line
+  def penalizeNewlineByNesting(from: Token, to: Token)(implicit
+      line: sourcecode.Line
   ): Policy = {
     val range = Range(from.start, to.end).inclusive
     Policy(to) {
@@ -524,7 +526,11 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     */
   def getSelectsLastToken(dot: T.Dot): FormatToken = {
     var curr = tokens(dot, 1)
-    while (isOpenApply(curr.right, includeCurly = true, includeNoParens = true) &&
+    while (isOpenApply(
+        curr.right,
+        includeCurly = true,
+        includeNoParens = true
+      ) &&
       !statementStarts.contains(hash(curr.right))) {
       if (curr.right.is[T.Dot]) {
         curr = tokens(curr, 2)
@@ -802,10 +808,11 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     singleLineSplits ++ spaceSplits ++ otherSplits
   }
 
-  def getSingleLineInfixPolicy(end: Token) = Policy(end) {
-    case Decision(t: FormatToken, s) if isInfixOp(t.meta.leftOwner) =>
-      SplitTag.InfixChainNoNL.activateOnly(s)
-  }
+  def getSingleLineInfixPolicy(end: Token) =
+    Policy(end) {
+      case Decision(t: FormatToken, s) if isInfixOp(t.meta.leftOwner) =>
+        SplitTag.InfixChainNoNL.activateOnly(s)
+    }
 
   def getMidInfixToken(app: InfixApp): Token = {
     val opToken = app.op.tokens.head
@@ -878,14 +885,15 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     maxPrecedence
   }
 
-  def isEmptyFunctionBody(tree: Tree): Boolean = tree match {
-    case function: Term.Function =>
-      function.body match {
-        case b: Term.Block => b.stats.isEmpty
-        case _ => false
-      }
-    case _ => false
-  }
+  def isEmptyFunctionBody(tree: Tree): Boolean =
+    tree match {
+      case function: Term.Function =>
+        function.body match {
+          case b: Term.Block => b.stats.isEmpty
+          case _ => false
+        }
+      case _ => false
+    }
 
   def functionExpire(function: Term.Function): (Token, ExpiresOn) = {
     def dropWS(rtoks: Seq[Token]): Seq[Token] =
@@ -1056,8 +1064,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     else onBreakPolicy.copy(f = { case OnBreakDecision(d) => d })
   }
 
-  def newlinesOnlyBeforeClosePolicy(close: Token)(
-      implicit line: sourcecode.Line
+  def newlinesOnlyBeforeClosePolicy(close: Token)(implicit
+      line: sourcecode.Line
   ): Policy =
     Policy.map(decideNewlinesOnlyBeforeClose(Split(Newline, 0)))(close)
 
@@ -1115,8 +1123,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   /**
     * Implementation for `verticalMultiline`
     */
-  def verticalMultiline(owner: Tree, ft: FormatToken)(
-      implicit style: ScalafmtConfig
+  def verticalMultiline(owner: Tree, ft: FormatToken)(implicit
+      style: ScalafmtConfig
   ): Seq[Split] = {
 
     val FormatToken(open, r, _) = ft
@@ -1243,14 +1251,16 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       if (isBracket) close // If we can fit the type params, make it so
       else lastParen // If we can fit all in one block, make it so
 
-    def maxArity = valueParamsOwner match {
-      case d: Decl.Def if d.paramss.nonEmpty => d.paramss.map(_.size).max
-      case d: Defn.Def if d.paramss.nonEmpty => d.paramss.map(_.size).max
-      case m: Defn.Macro if m.paramss.nonEmpty => m.paramss.map(_.size).max
-      case c: Ctor.Primary if c.paramss.nonEmpty => c.paramss.map(_.size).max
-      case c: Ctor.Secondary if c.paramss.nonEmpty => c.paramss.map(_.size).max
-      case _ => 0
-    }
+    def maxArity =
+      valueParamsOwner match {
+        case d: Decl.Def if d.paramss.nonEmpty => d.paramss.map(_.size).max
+        case d: Defn.Def if d.paramss.nonEmpty => d.paramss.map(_.size).max
+        case m: Defn.Macro if m.paramss.nonEmpty => m.paramss.map(_.size).max
+        case c: Ctor.Primary if c.paramss.nonEmpty => c.paramss.map(_.size).max
+        case c: Ctor.Secondary if c.paramss.nonEmpty =>
+          c.paramss.map(_.size).max
+        case _ => 0
+      }
 
     def configStyle =
       style.optIn.configStyleArguments &&
@@ -1276,10 +1286,11 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       formatToken.hasBlankLine || !formatToken.left.is[T.Comment]
     }.fold(identity, identity)
 
-  def xmlSpace(owner: Tree): Modification = owner match {
-    case _: Term.Xml | _: Pat.Xml => NoSplit
-    case _ => Space
-  }
+  def xmlSpace(owner: Tree): Modification =
+    owner match {
+      case _: Term.Xml | _: Pat.Xml => NoSplit
+      case _ => Space
+    }
 
   def getSpaceAndNewlineAfterCurlyLambda(
       newlines: Int
@@ -1330,13 +1341,14 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   def findArgsFor[A <: Tree](
       token: Token,
       argss: Seq[Seq[A]]
-  ): Option[Seq[A]] = matchingOpt(token).flatMap { other =>
-    // find the arg group starting with given format token
-    val beg = math.min(token.start, other.start)
-    argss
-      .find(_.headOption.exists(_.tokens.head.start >= beg))
-      .filter(_.head.tokens.head.start <= math.max(token.end, other.end))
-  }
+  ): Option[Seq[A]] =
+    matchingOpt(token).flatMap { other =>
+      // find the arg group starting with given format token
+      val beg = math.min(token.start, other.start)
+      argss
+        .find(_.headOption.exists(_.tokens.head.start >= beg))
+        .filter(_.head.tokens.head.start <= math.max(token.end, other.end))
+    }
 
   // look for arrow before body, if any, else after params
   def getFuncArrow(term: Term.Function): Option[FormatToken] =
@@ -1387,8 +1399,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
         }
       case _ =>
         logger.debug(s"""Unknown tree
-                        |${log(owner.parent.get)}
-                        |${isDefnSite(owner)}""".stripMargin)
+          |${log(owner.parent.get)}
+          |${isDefnSite(owner)}""".stripMargin)
         throw UnexpectedTree[Term.Apply](owner)
     }
   }
@@ -1418,12 +1430,13 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     getClosingIfEnclosedInMatching(tree).isDefined
 
   @tailrec
-  final def findPrevSelect(tree: Tree): Option[Term.Select] = tree match {
-    case t: Term.Select => Some(t)
-    case t @ SplitCallIntoParts(fun, _) if t ne fun =>
-      if (isEnclosedInMatching(t)) None else findPrevSelect(fun)
-    case _ => None
-  }
+  final def findPrevSelect(tree: Tree): Option[Term.Select] =
+    tree match {
+      case t: Term.Select => Some(t)
+      case t @ SplitCallIntoParts(fun, _) if t ne fun =>
+        if (isEnclosedInMatching(t)) None else findPrevSelect(fun)
+      case _ => None
+    }
   def findPrevSelect(tree: Term.Select): Option[Term.Select] =
     findPrevSelect(tree.qual)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -352,15 +352,16 @@ class FormatWriter(formatOps: FormatOps) {
           // try to add them in the TrainingCommas.always branch.
 
           // skip empty parens/braces/brackets
-          def rightIsCloseDelim = right match {
-            case _: T.RightBrace =>
-              !tok.left.is[T.LeftBrace] && owner.is[Importer]
-            case _: T.RightParen =>
-              !tok.left.is[T.LeftParen] && TreeOps.isDefnOrCallSite(owner)
-            case _: T.RightBracket =>
-              !tok.left.is[T.LeftBracket] && TreeOps.isDefnOrCallSite(owner)
-            case _ => false
-          }
+          def rightIsCloseDelim =
+            right match {
+              case _: T.RightBrace =>
+                !tok.left.is[T.LeftBrace] && owner.is[Importer]
+              case _: T.RightParen =>
+                !tok.left.is[T.LeftParen] && TreeOps.isDefnOrCallSite(owner)
+              case _: T.RightBracket =>
+                !tok.left.is[T.LeftBracket] && TreeOps.isDefnOrCallSite(owner)
+              case _ => false
+            }
 
           val ok = rightIsCloseDelim && expectedNewline == isNewline
           if (ok) Some(nextNonCommentTok) else None
@@ -416,18 +417,19 @@ class FormatWriter(formatOps: FormatOps) {
     val headBuffer = Set.newBuilder[Int]
     val lastBuffer = Map.newBuilder[Int, Int]
     val trav = new Traverser {
-      override def apply(tree: Tree): Unit = tree match {
-        case _: Term.Block =>
-        case t: Template => super.apply(t.stats) // skip inits
-        case TreeOps.MaybeTopLevelStat(t) =>
-          val leading = leadingComment(tokens(t.tokens.head, -1)).meta.idx
-          val trailing = tokens(t.tokens.last).meta.idx
-          headBuffer += leading
-          lastBuffer += trailing -> leading
-          super.apply(tree)
-        case _ =>
-          super.apply(tree)
-      }
+      override def apply(tree: Tree): Unit =
+        tree match {
+          case _: Term.Block =>
+          case t: Template => super.apply(t.stats) // skip inits
+          case TreeOps.MaybeTopLevelStat(t) =>
+            val leading = leadingComment(tokens(t.tokens.head, -1)).meta.idx
+            val trailing = tokens(t.tokens.last).meta.idx
+            headBuffer += leading
+            lastBuffer += trailing -> leading
+            super.apply(tree)
+          case _ =>
+            super.apply(tree)
+        }
     }
 
     trav(tree)
@@ -460,7 +462,9 @@ class FormatWriter(formatOps: FormatOps) {
 
             // package a.b.c
             case select: Term.Select =>
-              select.parent.collect { case pkg: Pkg => pkg.stats.headOption }.flatten
+              select.parent.collect {
+                case pkg: Pkg => pkg.stats.headOption
+              }.flatten
           }
           .flatten
           .map {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -67,12 +67,12 @@ object Policy {
     override def toString: String = "NoPolicy"
   }
 
-  def empty(token: Token)(
-      implicit line: sourcecode.Line
+  def empty(token: Token)(implicit
+      line: sourcecode.Line
   ): Policy = Policy(token)(emptyPf)
 
-  def map(func: Token => Pf)(token: Token)(
-      implicit line: sourcecode.Line
+  def map(func: Token => Pf)(token: Token)(implicit
+      line: sourcecode.Line
   ): Policy = Policy(token)(func(token))
 
   def apply(token: Token)(f: Pf)(implicit line: sourcecode.Line): Policy =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -45,11 +45,12 @@ case class Split(
 )(implicit val line: sourcecode.Line) {
   import TokenOps._
 
-  def adapt(formatToken: FormatToken): Split = modification match {
-    case n: NewlineT if !n.noIndent && rhsIsCommentedOut(formatToken) =>
-      copy(modification = NewlineT(n.isDouble, noIndent = true))
-    case _ => this
-  }
+  def adapt(formatToken: FormatToken): Split =
+    modification match {
+      case n: NewlineT if !n.noIndent && rhsIsCommentedOut(formatToken) =>
+        copy(modification = NewlineT(n.isDouble, noIndent = true))
+      case _ => this
+    }
 
   val indentation = indents.mkString("[", ", ", "]")
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SyntacticGroupOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SyntacticGroupOps.scala
@@ -60,42 +60,43 @@ object SyntacticGroupOps {
       outerGroup: SyntacticGroup,
       innerGroup: SyntacticGroup,
       side: Side
-  ): Boolean = (outerGroup, innerGroup) match {
-    case (g.Term.InfixExpr(outerOperator), g.Term.InfixExpr(innerOperator)) =>
-      operatorNeedsParenthesis(
-        outerOperator,
-        innerOperator,
-        customAssociativity = true,
-        customPrecedence = true,
-        side,
-        forceRight = true
-      )
-    case (g.Type.InfixTyp(outerOperator), g.Type.InfixTyp(innerOperator)) =>
-      operatorNeedsParenthesis(
-        outerOperator,
-        innerOperator,
-        customAssociativity = true,
-        customPrecedence = false,
-        side
-      )
-    case (g.Pat.Pattern3(outerOperator), g.Pat.Pattern3(innerOperator)) =>
-      operatorNeedsParenthesis(
-        outerOperator,
-        innerOperator,
-        customAssociativity = true,
-        customPrecedence = true,
-        side
-      )
+  ): Boolean =
+    (outerGroup, innerGroup) match {
+      case (g.Term.InfixExpr(outerOperator), g.Term.InfixExpr(innerOperator)) =>
+        operatorNeedsParenthesis(
+          outerOperator,
+          innerOperator,
+          customAssociativity = true,
+          customPrecedence = true,
+          side,
+          forceRight = true
+        )
+      case (g.Type.InfixTyp(outerOperator), g.Type.InfixTyp(innerOperator)) =>
+        operatorNeedsParenthesis(
+          outerOperator,
+          innerOperator,
+          customAssociativity = true,
+          customPrecedence = false,
+          side
+        )
+      case (g.Pat.Pattern3(outerOperator), g.Pat.Pattern3(innerOperator)) =>
+        operatorNeedsParenthesis(
+          outerOperator,
+          innerOperator,
+          customAssociativity = true,
+          customPrecedence = true,
+          side
+        )
 
-    case (_: g.Term.PrefixExpr, g.Term.PrefixArg(_, _: g.Term.PrefixExpr)) =>
-      true
+      case (_: g.Term.PrefixExpr, g.Term.PrefixArg(_, _: g.Term.PrefixExpr)) =>
+        true
 
-    case (g.Term.PrefixExpr("-"), g.Term.PrefixArg(Term.Select(tree, _), _))
-        if startsWithNumericLiteral(tree) =>
-      true
+      case (g.Term.PrefixExpr("-"), g.Term.PrefixArg(Term.Select(tree, _), _))
+          if startsWithNumericLiteral(tree) =>
+        true
 
-    case _ =>
-      outerGroup.precedence > innerGroup.precedence
-  }
+      case _ =>
+        outerGroup.precedence > innerGroup.precedence
+    }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/TreeSyntacticGroup.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/TreeSyntacticGroup.scala
@@ -8,77 +8,78 @@ import scala.meta.Type
 import org.scalafmt.internal.{SyntacticGroup => g}
 
 object TreeSyntacticGroup {
-  def apply(tree: Tree): SyntacticGroup = tree match {
-    case _: Lit => g.Literal
-    // Term
-    case _: Term.Name => g.Path
-    case _: Term.Select => g.Path
-    case _: Term.Interpolate => g.Term.SimpleExpr1
-    case _: Term.Xml => g.Term.SimpleExpr1
-    case _: Term.Apply => g.Term.SimpleExpr1
-    case _: Term.ApplyType => g.Term.SimpleExpr1
-    case t: Term.ApplyInfix => g.Term.InfixExpr(t.op.value)
-    case t: Term.ApplyUnary => g.Term.PrefixExpr(t.op.value)
-    case _: Term.Assign => g.Term.Expr1
-    case _: Term.Return => g.Term.Expr1
-    case _: Term.Throw => g.Term.Expr1
-    case _: Term.Ascribe => g.Term.Expr1
-    case _: Term.Annotate => g.Term.Expr1
-    case _: Term.Block => g.Term.SimpleExpr1
-    case _: Term.Tuple => g.Term.SimpleExpr1 // ???, breaks a op ((b, c))
+  def apply(tree: Tree): SyntacticGroup =
+    tree match {
+      case _: Lit => g.Literal
+      // Term
+      case _: Term.Name => g.Path
+      case _: Term.Select => g.Path
+      case _: Term.Interpolate => g.Term.SimpleExpr1
+      case _: Term.Xml => g.Term.SimpleExpr1
+      case _: Term.Apply => g.Term.SimpleExpr1
+      case _: Term.ApplyType => g.Term.SimpleExpr1
+      case t: Term.ApplyInfix => g.Term.InfixExpr(t.op.value)
+      case t: Term.ApplyUnary => g.Term.PrefixExpr(t.op.value)
+      case _: Term.Assign => g.Term.Expr1
+      case _: Term.Return => g.Term.Expr1
+      case _: Term.Throw => g.Term.Expr1
+      case _: Term.Ascribe => g.Term.Expr1
+      case _: Term.Annotate => g.Term.Expr1
+      case _: Term.Block => g.Term.SimpleExpr1
+      case _: Term.Tuple => g.Term.SimpleExpr1 // ???, breaks a op ((b, c))
 //    case _: Term.Tuple => g.Term.Expr1 // ??? Was SimpleExpr1, which is buggy for `a op ((b, c))
-    case _: Term.If => g.Term.Expr1
-    case _: Term.Match => g.Term.Expr1
-    case _: Term.Try => g.Term.Expr1
-    case _: Term.TryWithHandler => g.Term.Expr1
-    case _: Term.Function => g.Term.Expr
-    case _: Term.PartialFunction => g.Term.SimpleExpr
-    case _: Term.While => g.Term.Expr1
-    case _: Term.Do => g.Term.Expr1
-    case _: Term.For => g.Term.Expr1
-    case _: Term.ForYield => g.Term.Expr1
-    case _: Term.New => g.Term.SimpleExpr
-    case _: Term.Placeholder => g.Term.SimpleExpr1
-    case _: Term.Eta => g.Term.SimpleExpr
-    case _: Term.Repeated => g.Term.PostfixExpr
-    case _: Term.Param => g.Path // ???
-    // Type
-    case _: Type.Name => g.Path
-    case _: Type.Select => g.Type.SimpleTyp
-    case _: Type.Project => g.Type.SimpleTyp
-    case _: Type.Singleton => g.Type.SimpleTyp
-    case _: Type.Apply => g.Type.SimpleTyp
-    case t: Type.ApplyInfix => g.Type.InfixTyp(t.op.value)
-    case _: Type.Function => g.Type.Typ
-    case _: Type.Tuple => g.Type.SimpleTyp
-    case _: Type.With => g.Type.WithTyp
-    case _: Type.And => g.Type.InfixTyp("&")
-    case _: Type.Or => g.Type.InfixTyp("|")
-    case _: Type.Refine => g.Type.RefineTyp
-    case _: Type.Existential => g.Type.Typ
-    case _: Type.Annotate => g.Type.AnnotTyp
-    case _: Type.Lambda => g.Type.Typ
-    case _: Type.Method => g.Type.Typ
-    case _: Type.Placeholder => g.Type.SimpleTyp
-    case _: Type.Bounds => g.Path // ???
-    case _: Type.Repeated => g.Type.ParamTyp
-    case _: Type.ByName => g.Type.ParamTyp
-    case _: Type.Var => g.Type.ParamTyp
-    case _: Type.Param => g.Path // ???
-    // Pat
-    case _: Pat.Var => g.Pat.SimplePattern
-    case _: Pat.Wildcard => g.Pat.SimplePattern
-    case _: Pat.SeqWildcard => g.Pat.SimplePattern
-    case _: Pat.Bind => g.Pat.Pattern2
-    case _: Pat.Alternative => g.Pat.Pattern
-    case _: Pat.Tuple => g.Pat.SimplePattern
-    case _: Pat.Extract => g.Pat.SimplePattern
-    case t: Pat.ExtractInfix => g.Pat.Pattern3(t.op.value)
-    case _: Pat.Interpolate => g.Pat.SimplePattern
-    case _: Pat.Xml => g.Pat.SimplePattern
-    case _: Pat.Typed => g.Pat.Pattern1
+      case _: Term.If => g.Term.Expr1
+      case _: Term.Match => g.Term.Expr1
+      case _: Term.Try => g.Term.Expr1
+      case _: Term.TryWithHandler => g.Term.Expr1
+      case _: Term.Function => g.Term.Expr
+      case _: Term.PartialFunction => g.Term.SimpleExpr
+      case _: Term.While => g.Term.Expr1
+      case _: Term.Do => g.Term.Expr1
+      case _: Term.For => g.Term.Expr1
+      case _: Term.ForYield => g.Term.Expr1
+      case _: Term.New => g.Term.SimpleExpr
+      case _: Term.Placeholder => g.Term.SimpleExpr1
+      case _: Term.Eta => g.Term.SimpleExpr
+      case _: Term.Repeated => g.Term.PostfixExpr
+      case _: Term.Param => g.Path // ???
+      // Type
+      case _: Type.Name => g.Path
+      case _: Type.Select => g.Type.SimpleTyp
+      case _: Type.Project => g.Type.SimpleTyp
+      case _: Type.Singleton => g.Type.SimpleTyp
+      case _: Type.Apply => g.Type.SimpleTyp
+      case t: Type.ApplyInfix => g.Type.InfixTyp(t.op.value)
+      case _: Type.Function => g.Type.Typ
+      case _: Type.Tuple => g.Type.SimpleTyp
+      case _: Type.With => g.Type.WithTyp
+      case _: Type.And => g.Type.InfixTyp("&")
+      case _: Type.Or => g.Type.InfixTyp("|")
+      case _: Type.Refine => g.Type.RefineTyp
+      case _: Type.Existential => g.Type.Typ
+      case _: Type.Annotate => g.Type.AnnotTyp
+      case _: Type.Lambda => g.Type.Typ
+      case _: Type.Method => g.Type.Typ
+      case _: Type.Placeholder => g.Type.SimpleTyp
+      case _: Type.Bounds => g.Path // ???
+      case _: Type.Repeated => g.Type.ParamTyp
+      case _: Type.ByName => g.Type.ParamTyp
+      case _: Type.Var => g.Type.ParamTyp
+      case _: Type.Param => g.Path // ???
+      // Pat
+      case _: Pat.Var => g.Pat.SimplePattern
+      case _: Pat.Wildcard => g.Pat.SimplePattern
+      case _: Pat.SeqWildcard => g.Pat.SimplePattern
+      case _: Pat.Bind => g.Pat.Pattern2
+      case _: Pat.Alternative => g.Pat.Pattern
+      case _: Pat.Tuple => g.Pat.SimplePattern
+      case _: Pat.Extract => g.Pat.SimplePattern
+      case t: Pat.ExtractInfix => g.Pat.Pattern3(t.op.value)
+      case _: Pat.Interpolate => g.Pat.SimplePattern
+      case _: Pat.Xml => g.Pat.SimplePattern
+      case _: Pat.Typed => g.Pat.Pattern1
 
-    // Misc
-    case _ => g.Path
-  }
+      // Misc
+      case _ => g.Path
+    }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -13,22 +13,23 @@ object AvoidInfix extends Rewrite {
     val queue = new mutable.Queue[Tree]
     queue += tree
     @tailrec
-    def iter: Boolean = queue.nonEmpty && {
-      queue.dequeue() match {
-        case _: Term.Placeholder => true
-        case t: Term.ApplyInfix =>
-          queue ++= (t.lhs +: t.args)
-          iter
-        case t: Term.Apply =>
-          queue += t.fun
-          iter
-        case t: Term.Select =>
-          queue += t.qual
-          iter
-        case _ =>
-          iter
+    def iter: Boolean =
+      queue.nonEmpty && {
+        queue.dequeue() match {
+          case _: Term.Placeholder => true
+          case t: Term.ApplyInfix =>
+            queue ++= (t.lhs +: t.args)
+            iter
+          case t: Term.Apply =>
+            queue += t.fun
+            iter
+          case t: Term.Select =>
+            queue += t.qual
+            iter
+          case _ =>
+            iter
+        }
       }
-    }
     iter
   }
 
@@ -45,60 +46,65 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
   // and be done with it. However, until transform becomes token aware (see https://github.com/scalameta/scalameta/pull/457)
   // we will do these dangerous rewritings by hand.
 
-  override def rewrite(tree: Tree): Unit = tree match {
-    case Term.ApplyInfix(lhs, op, _, args) if matcher.matches(op.value) =>
-      val builder = Seq.newBuilder[TokenPatch]
+  override def rewrite(tree: Tree): Unit =
+    tree match {
+      case Term.ApplyInfix(lhs, op, _, args) if matcher.matches(op.value) =>
+        val builder = Seq.newBuilder[TokenPatch]
 
-      val opHead = op.tokens.head
-      builder += TokenPatch.AddLeft(opHead, ".", keepTok = true)
+        val opHead = op.tokens.head
+        builder += TokenPatch.AddLeft(opHead, ".", keepTok = true)
 
-      if (args.lengthCompare(1) == 0) { // otherwise, definitely enclosed
-        val rhs = args.head
-        rhs.tokens.headOption.foreach { head =>
-          val last = args.head.tokens.last
-          val opLast = op.tokens.last
-          if (!ctx.isMatching(head, last)) {
-            if (AvoidInfix.hasPlaceholder(args.head)) return
-            builder += TokenPatch.AddRight(opLast, "(", keepTok = true)
-            builder += TokenPatch.AddRight(last, ")", keepTok = true)
-          } else if (ctx.tokenTraverser.nextToken(opLast) ne head) {
-            // has comments: move delimiter
-            builder += TokenPatch.AddRight(opLast, head.syntax, keepTok = true)
-            builder += TokenPatch.Remove(head)
+        if (args.lengthCompare(1) == 0) { // otherwise, definitely enclosed
+          val rhs = args.head
+          rhs.tokens.headOption.foreach { head =>
+            val last = args.head.tokens.last
+            val opLast = op.tokens.last
+            if (!ctx.isMatching(head, last)) {
+              if (AvoidInfix.hasPlaceholder(args.head)) return
+              builder += TokenPatch.AddRight(opLast, "(", keepTok = true)
+              builder += TokenPatch.AddRight(last, ")", keepTok = true)
+            } else if (ctx.tokenTraverser.nextToken(opLast) ne head) {
+              // has comments: move delimiter
+              builder += TokenPatch.AddRight(
+                opLast,
+                head.syntax,
+                keepTok = true
+              )
+              builder += TokenPatch.Remove(head)
+            }
           }
         }
-      }
 
-      val shouldWrapLhs = lhs match {
-        case Term.ApplyInfix(_, o, _, _)
-            if !matcher.matches(o.value) && !lhs.tokens.head.is[LeftParen] =>
-          if (AvoidInfix.hasPlaceholder(lhs)) return
-          true
-        case _: Term.Eta => true // foo _ compose bar => (foo _).compose(bar)
-        case _ => false
-      }
-      if (shouldWrapLhs) {
-        builder += TokenPatch.AddLeft(lhs.tokens.head, "(", keepTok = true)
-        builder += TokenPatch.AddRight(lhs.tokens.last, ")", keepTok = true)
-      }
+        val shouldWrapLhs = lhs match {
+          case Term.ApplyInfix(_, o, _, _)
+              if !matcher.matches(o.value) && !lhs.tokens.head.is[LeftParen] =>
+            if (AvoidInfix.hasPlaceholder(lhs)) return
+            true
+          case _: Term.Eta => true // foo _ compose bar => (foo _).compose(bar)
+          case _ => false
+        }
+        if (shouldWrapLhs) {
+          builder += TokenPatch.AddLeft(lhs.tokens.head, "(", keepTok = true)
+          builder += TokenPatch.AddRight(lhs.tokens.last, ")", keepTok = true)
+        }
 
-      // remove parens if enclosed
-      for {
-        parent <- tree.parent
-        if !parent.is[Term.ApplyInfix] && !parent.is[Term.Apply]
-        if ctx.style.rewrite.rules.contains(RedundantParens)
-        infixTokens = tree.tokens
-        head <- infixTokens.headOption if head.is[LeftParen]
-        last <- infixTokens.lastOption if last.is[RightParen]
-        if ctx.isMatching(head, last)
-      } yield {
-        builder += TokenPatch.Remove(head)
-        builder += TokenPatch.Remove(last)
-      }
+        // remove parens if enclosed
+        for {
+          parent <- tree.parent
+          if !parent.is[Term.ApplyInfix] && !parent.is[Term.Apply]
+          if ctx.style.rewrite.rules.contains(RedundantParens)
+          infixTokens = tree.tokens
+          head <- infixTokens.headOption if head.is[LeftParen]
+          last <- infixTokens.lastOption if last.is[RightParen]
+          if ctx.isMatching(head, last)
+        } yield {
+          builder += TokenPatch.Remove(head)
+          builder += TokenPatch.Remove(last)
+        }
 
-      ctx.addPatchSet(builder.result(): _*)
+        ctx.addPatchSet(builder.result(): _*)
 
-    case _ =>
-  }
+      case _ =>
+    }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ExpandImportSelectors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ExpandImportSelectors.scala
@@ -19,46 +19,47 @@ class ExpandImportSelectors(implicit ctx: RewriteCtx) extends RewriteSession {
 
   import ExpandImportSelectors.Group
 
-  override def rewrite(tree: Tree): Unit = tree match {
-    case q"import ..$imports" =>
-      val groupedPatches = mutable.Map.empty[Token, Group]
-      imports.foreach { `import` =>
-        val parentTokens = `import`.parent.get.tokens
-        val group =
-          groupedPatches.getOrElseUpdate(parentTokens.head, new Group)
-        parentTokens.tail.foreach(x => group.patches += TokenPatch.Remove(x))
+  override def rewrite(tree: Tree): Unit =
+    tree match {
+      case q"import ..$imports" =>
+        val groupedPatches = mutable.Map.empty[Token, Group]
+        imports.foreach { `import` =>
+          val parentTokens = `import`.parent.get.tokens
+          val group =
+            groupedPatches.getOrElseUpdate(parentTokens.head, new Group)
+          parentTokens.tail.foreach(x => group.patches += TokenPatch.Remove(x))
 
-        `import`.traverse {
-          case importer @ Importer(path, importees) =>
-            val hasRenamesOrUnimports = importees.exists(importee =>
-              importee.is[Importee.Rename] || importee.is[Importee.Unimport]
-            )
+          `import`.traverse {
+            case importer @ Importer(path, importees) =>
+              val hasRenamesOrUnimports = importees.exists(importee =>
+                importee.is[Importee.Rename] || importee.is[Importee.Unimport]
+              )
 
-            val hasWildcards = importees.exists(_.is[Importee.Wildcard])
+              val hasWildcards = importees.exists(_.is[Importee.Wildcard])
 
-            if (hasWildcards && hasRenamesOrUnimports)
-              group.imports += s"import ${importer.syntax}"
-            else
-              importees.foreach { importee =>
-                val importString = importee.toString
-                val replacement =
-                  if (importString.contains("=>"))
-                    s"import $path.{$importString}"
-                  else
-                    s"import $path.$importString"
-                group.imports += replacement
-              }
+              if (hasWildcards && hasRenamesOrUnimports)
+                group.imports += s"import ${importer.syntax}"
+              else
+                importees.foreach { importee =>
+                  val importString = importee.toString
+                  val replacement =
+                    if (importString.contains("=>"))
+                      s"import $path.{$importString}"
+                    else
+                      s"import $path.$importString"
+                  group.imports += replacement
+                }
+          }
         }
-      }
 
-      groupedPatches.foreach {
-        case (tok, group) =>
-          group.patches +=
-            TokenPatch.AddRight(tok, group.imports.mkString("\n"))
-          ctx.addPatchSet(group.patches.result(): _*)
-      }
+        groupedPatches.foreach {
+          case (tok, group) =>
+            group.patches +=
+              TokenPatch.AddRight(tok, group.imports.mkString("\n"))
+            ctx.addPatchSet(group.patches.result(): _*)
+        }
 
-    case _ =>
-  }
+      case _ =>
+    }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Patch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Patch.scala
@@ -34,21 +34,22 @@ object TokenPatch {
 }
 
 object Patch {
-  def merge(a: TokenPatch, b: TokenPatch): TokenPatch = (a, b) match {
-    case (add1: Add, add2: Add) =>
-      Add(
-        add1.tok,
-        add1.addLeft + add2.addLeft,
-        add1.addRight + add2.addRight,
-        add1.keepTok && add2.keepTok
-      )
-    case (_: Remove, add: Add) => add.copy(keepTok = false)
-    case (add: Add, _: Remove) => add.copy(keepTok = false)
-    case (rem: Remove, _: Remove) => rem
-    case _ =>
-      sys.error(s"""Can't merge token patches:
-                   |1. $a
-                   |2. $b""".stripMargin)
-  }
+  def merge(a: TokenPatch, b: TokenPatch): TokenPatch =
+    (a, b) match {
+      case (add1: Add, add2: Add) =>
+        Add(
+          add1.tok,
+          add1.addLeft + add2.addLeft,
+          add1.addRight + add2.addRight,
+          add1.keepTok && add2.keepTok
+        )
+      case (_: Remove, add: Add) => add.copy(keepTok = false)
+      case (add: Add, _: Remove) => add.copy(keepTok = false)
+      case (rem: Remove, _: Remove) => rem
+      case _ =>
+        sys.error(s"""Can't merge token patches:
+          |1. $a
+          |2. $b""".stripMargin)
+    }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
@@ -45,10 +45,11 @@ class PreferCurlyFors(implicit ctx: RewriteCtx) extends RewriteSession {
   private def findForSemiColons(forEnumerators: Seq[Enumerator]): Seq[Token] =
     for {
       enumerator <- forEnumerators
-      token <- enumerator
-        .tokens(ctx.style.runner.dialect)
-        .headOption
-        .toIterable
+      token <-
+        enumerator
+          .tokens(ctx.style.runner.dialect)
+          .headOption
+          .toIterable
       semicolon <- findBefore(token) {
         case _: Token.Semicolon => Some(true)
         case Whitespace() => None
@@ -82,12 +83,13 @@ class PreferCurlyFors(implicit ctx: RewriteCtx) extends RewriteSession {
   ): Boolean =
     forEnumerators.count(_.is[Enumerator.Generator]) > 1
 
-  override def rewrite(tree: Tree): Unit = tree match {
-    case fy: Term.ForYield if hasMoreThanOneGenerator(fy.enums) =>
-      ctx.addPatchSet(rewriteFor(fy.tokens, fy.enums): _*)
-    case f: Term.For if hasMoreThanOneGenerator(f.enums) =>
-      ctx.addPatchSet(rewriteFor(f.tokens, f.enums): _*)
-    case _ =>
-  }
+  override def rewrite(tree: Tree): Unit =
+    tree match {
+      case fy: Term.ForYield if hasMoreThanOneGenerator(fy.enums) =>
+        ctx.addPatchSet(rewriteFor(fy.tokens, fy.enums): _*)
+      case f: Term.For if hasMoreThanOneGenerator(f.enums) =>
+        ctx.addPatchSet(rewriteFor(f.tokens, f.enums): _*)
+      case _ =>
+    }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -15,39 +15,40 @@ class RedundantParens(implicit ctx: RewriteCtx) extends RewriteSession {
   def isWrappedInParens(tokens: Tokens): Boolean =
     tokens.nonEmpty && tokens.head.is[LeftParen] && tokens.last.is[RightParen]
 
-  override def rewrite(tree: Tree): Unit = tree match {
-    case g: Enumerator.Guard =>
-      val tokens: Tokens = g.cond.tokens
-      if (isWrappedInParens(tokens)) {
-        val openParensCount = tokens.segmentLength(_.is[LeftParen], 0)
-        val closeParensCount =
-          tokens.reverse.segmentLength(_.is[RightParen], 0)
-        val parensToRemoveCount = Math.min(openParensCount, closeParensCount)
-        val leftSegment: Tokens = tokens.slice(0, parensToRemoveCount)
-        val rightSegment: Tokens =
-          tokens.slice(tokens.length - parensToRemoveCount, tokens.length)
-        leftSegment.zip(rightSegment.reverse).foreach {
-          case (left, right) if ctx.isMatching(left, right) =>
-            ctx.addPatchSet(TokenPatch.Remove(left), TokenPatch.Remove(right))
-          case _ =>
+  override def rewrite(tree: Tree): Unit =
+    tree match {
+      case g: Enumerator.Guard =>
+        val tokens: Tokens = g.cond.tokens
+        if (isWrappedInParens(tokens)) {
+          val openParensCount = tokens.segmentLength(_.is[LeftParen], 0)
+          val closeParensCount =
+            tokens.reverse.segmentLength(_.is[RightParen], 0)
+          val parensToRemoveCount = Math.min(openParensCount, closeParensCount)
+          val leftSegment: Tokens = tokens.slice(0, parensToRemoveCount)
+          val rightSegment: Tokens =
+            tokens.slice(tokens.length - parensToRemoveCount, tokens.length)
+          leftSegment.zip(rightSegment.reverse).foreach {
+            case (left, right) if ctx.isMatching(left, right) =>
+              ctx.addPatchSet(TokenPatch.Remove(left), TokenPatch.Remove(right))
+            case _ =>
+          }
         }
-      }
 
-    case t @ Term.Apply(_, List(b: Term.Block))
-        if ctx.style.activeForEdition_2020_01 &&
-          b.tokens.headOption.exists(_.is[Token.LeftBrace]) =>
-      t.tokens.lastOption.filter(_.is[RightParen]).foreach { rparen =>
-        ctx.getMatchingOpt(rparen).foreach { lparen =>
-          implicit val builder = Seq.newBuilder[TokenPatch]
-          builder += TokenPatch.Remove(lparen)
-          builder += TokenPatch.Remove(rparen)
-          ctx.removeLFToAvoidEmptyLine(lparen)
-          ctx.removeLFToAvoidEmptyLine(rparen)
-          ctx.addPatchSet(builder.result(): _*)
+      case t @ Term.Apply(_, List(b: Term.Block))
+          if ctx.style.activeForEdition_2020_01 &&
+            b.tokens.headOption.exists(_.is[Token.LeftBrace]) =>
+        t.tokens.lastOption.filter(_.is[RightParen]).foreach { rparen =>
+          ctx.getMatchingOpt(rparen).foreach { lparen =>
+            implicit val builder = Seq.newBuilder[TokenPatch]
+            builder += TokenPatch.Remove(lparen)
+            builder += TokenPatch.Remove(rparen)
+            ctx.removeLFToAvoidEmptyLine(lparen)
+            ctx.removeLFToAvoidEmptyLine(rparen)
+            ctx.addPatchSet(builder.result(): _*)
+          }
         }
-      }
 
-    case _ =>
-  }
+      case _ =>
+    }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -113,11 +113,12 @@ object Rewrite {
 
   val default: Seq[Rewrite] = name2rewrite.values.toSeq
 
-  private def incompatibleRewrites: List[(Rewrite, Rewrite)] = List(
-    SortImports -> ExpandImportSelectors,
-    SortImports -> AsciiSortImports,
-    AsciiSortImports -> ExpandImportSelectors
-  )
+  private def incompatibleRewrites: List[(Rewrite, Rewrite)] =
+    List(
+      SortImports -> ExpandImportSelectors,
+      SortImports -> AsciiSortImports,
+      AsciiSortImports -> ExpandImportSelectors
+    )
 
   def validateRewrites(rewrites: Seq[Rewrite]): Seq[String] = {
     incompatibleRewrites.flatMap {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
@@ -18,25 +18,26 @@ class RewriteTrailingCommas(implicit ctx: RewriteCtx) extends RewriteSession {
    * commas here, to avoid any idempotence problems caused by an extra comma,
    * with a different AST, in a subsequent runs; in FormatWriter, we'll add
    * them back if there is a newline before the closing bracket/paren/brace */
-  override def rewrite(tree: Tree): Unit = tree match {
-    case t: Importer =>
-      t.tokens.lastOption match {
-        case Some(close: Token.RightBrace) => before(close)
-        case _ =>
-      }
+  override def rewrite(tree: Tree): Unit =
+    tree match {
+      case t: Importer =>
+        t.tokens.lastOption match {
+          case Some(close: Token.RightBrace) => before(close)
+          case _ =>
+        }
 
-    case TreeOps.SplitDefnIntoParts(_, _, tparams, paramss) =>
-      afterTParams(tparams)
-      afterEachArgs(paramss)
+      case TreeOps.SplitDefnIntoParts(_, _, tparams, paramss) =>
+        afterTParams(tparams)
+        afterEachArgs(paramss)
 
-    case TreeOps.SplitCallIntoParts(_, either) =>
-      either match {
-        case Left(args) => afterArgs(args)
-        case Right(argss) => afterEachArgs(argss)
-      }
+      case TreeOps.SplitCallIntoParts(_, either) =>
+        either match {
+          case Left(args) => afterArgs(args)
+          case Right(argss) => afterEachArgs(argss)
+        }
 
-    case _ =>
-  }
+      case _ =>
+    }
 
   private def patch(token: Token): Unit =
     ctx.addPatchSet(TokenPatch.Remove(token))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortImports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortImports.scala
@@ -23,29 +23,30 @@ sealed abstract class SortImports(implicit ctx: RewriteCtx)
     */
   protected def sorted(str: Seq[String]): IndexedSeq[String]
 
-  override def rewrite(tree: Tree): Unit = tree match {
-    case Import(imports) =>
-      val builder = Seq.newBuilder[TokenPatch]
-      imports.foreach { `import` =>
-        val importees = `import`.importees
-        if (!importees.exists(!_.is[Importee.Name])) {
-          // Do nothing if an importee has for example rename
-          // import a.{d, b => c}
-          // I think we are safe to sort these, just want to convince myself
-          // it's 100% safe first.
-          val sortedImportees = sorted(importees.map(_.tokens.mkString))
-          var i = 0
-          importees.foreach { importee =>
-            builder +=
-              TokenPatch.AddRight(importee.tokens.head, sortedImportees(i))
-            i += 1
+  override def rewrite(tree: Tree): Unit =
+    tree match {
+      case Import(imports) =>
+        val builder = Seq.newBuilder[TokenPatch]
+        imports.foreach { `import` =>
+          val importees = `import`.importees
+          if (!importees.exists(!_.is[Importee.Name])) {
+            // Do nothing if an importee has for example rename
+            // import a.{d, b => c}
+            // I think we are safe to sort these, just want to convince myself
+            // it's 100% safe first.
+            val sortedImportees = sorted(importees.map(_.tokens.mkString))
+            var i = 0
+            importees.foreach { importee =>
+              builder +=
+                TokenPatch.AddRight(importee.tokens.head, sortedImportees(i))
+              i += 1
+            }
           }
         }
-      }
-      ctx.addPatchSet(builder.result(): _*)
+        ctx.addPatchSet(builder.result(): _*)
 
-    case _ =>
-  }
+      case _ =>
+    }
 }
 
 /**

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -14,36 +14,37 @@ class SortModifiers(implicit ctx: RewriteCtx) extends RewriteSession {
 
   private implicit val order = ctx.style.rewrite.sortModifiers.order
 
-  override def rewrite(tree: Tree): Unit = tree match {
+  override def rewrite(tree: Tree): Unit =
+    tree match {
 
-    /*
-     * in the case of Class, Object, and of class constructor parameters
-     * some Mods are immovable, e.g. 'case' in "case class X".
-     *
-     * The case of parameters is a bit more curious because there the
-     * "val" or "var" in, say:
-     * {{{
-     *   class Test(private final val x: Int)
-     * }}}
-     * are considered Mods, instead of being similar to `Defn.Val`, or `Defn.Var`.
-     */
-    case d: Decl.Def => sortMods(d.mods)
-    case v: Decl.Val => sortMods(v.mods)
-    case v: Decl.Var => sortMods(v.mods)
-    case t: Decl.Type => sortMods(t.mods)
-    case d: Defn.Def => sortMods(d.mods)
-    case v: Defn.Val => sortMods(v.mods)
-    case v: Defn.Var => sortMods(v.mods)
-    case t: Defn.Type => sortMods(t.mods)
-    case c: Defn.Class => sortMods(c.mods.filterNot(_.is[Mod.Case]))
-    case o: Defn.Object => sortMods(o.mods.filterNot(_.is[Mod.Case]))
-    case t: Defn.Trait => sortMods(t.mods)
-    case p: Term.Param =>
-      sortMods(
-        p.mods.filterNot(m => m.is[Mod.ValParam] || m.is[Mod.VarParam])
-      )
-    case _ =>
-  }
+      /*
+       * in the case of Class, Object, and of class constructor parameters
+       * some Mods are immovable, e.g. 'case' in "case class X".
+       *
+       * The case of parameters is a bit more curious because there the
+       * "val" or "var" in, say:
+       * {{{
+       *   class Test(private final val x: Int)
+       * }}}
+       * are considered Mods, instead of being similar to `Defn.Val`, or `Defn.Var`.
+       */
+      case d: Decl.Def => sortMods(d.mods)
+      case v: Decl.Val => sortMods(v.mods)
+      case v: Decl.Var => sortMods(v.mods)
+      case t: Decl.Type => sortMods(t.mods)
+      case d: Defn.Def => sortMods(d.mods)
+      case v: Defn.Val => sortMods(v.mods)
+      case v: Defn.Var => sortMods(v.mods)
+      case t: Defn.Type => sortMods(t.mods)
+      case c: Defn.Class => sortMods(c.mods.filterNot(_.is[Mod.Case]))
+      case o: Defn.Object => sortMods(o.mods.filterNot(_.is[Mod.Case]))
+      case t: Defn.Trait => sortMods(t.mods)
+      case p: Term.Param =>
+        sortMods(
+          p.mods.filterNot(m => m.is[Mod.ValParam] || m.is[Mod.VarParam])
+        )
+      case _ =>
+    }
 
   private def sortMods(oldMods: Seq[Mod]): Unit = {
     if (oldMods.nonEmpty) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/FileOps.scala
@@ -62,8 +62,8 @@ object FileOps {
     new File(path.mkString(File.separator))
   }
 
-  def writeFile(file: AbsoluteFile, content: String)(
-      implicit codec: Codec
+  def writeFile(file: AbsoluteFile, content: String)(implicit
+      codec: Codec
   ): Unit = {
     writeFile(file.jfile, content)
   }
@@ -77,8 +77,8 @@ object FileOps {
     Files.write(path, bytes)
   }
 
-  def writeFile(filename: String, content: String)(
-      implicit codec: Codec
+  def writeFile(filename: String, content: String)(implicit
+      codec: Codec
   ): Unit = {
     writeFile(Paths.get(filename), content)
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -30,8 +30,8 @@ object LoggerOps {
 
   def log(formatToken: FormatToken): String =
     s"""${log(formatToken.left)}
-       |${log(formatToken.between: _*)}
-       |${log(formatToken.right)}""".stripMargin
+      |${log(formatToken.between: _*)}
+      |${log(formatToken.right)}""".stripMargin
 
   def log2(formatToken: FormatToken): String = formatToken.toString
 
@@ -41,11 +41,12 @@ object LoggerOps {
 
   def log(tokens: Token*): String = tokens.map(log).mkString("\n")
 
-  def cleanup(token: Token): String = token match {
-    case Literal() | Interpolation.Part(_) =>
-      escape(token.syntax).stripPrefix("\"").stripSuffix("\"")
-    case _ => token.syntax.replace("\n", "")
-  }
+  def cleanup(token: Token): String =
+    token match {
+      case Literal() | Interpolation.Part(_) =>
+        escape(token.syntax).stripPrefix("\"").stripSuffix("\"")
+      case _ => token.syntax.replace("\n", "")
+    }
 
   def log(tokens: Tokens): String = tokens.map(log).mkString("\n")
 
@@ -60,10 +61,10 @@ object LoggerOps {
       s"TOKENS: ${t.tokens.map(x => reveal(x.syntax)).mkString(",")}"
     if (tokensOnly) tokens
     else s"""TYPE: ${t.getClass.getName.stripPrefix("scala.meta.")}
-            |SOURCE: $t
-            |STRUCTURE: ${t.show[Structure]}
-            |$tokens
-            |""".stripMargin
+      |SOURCE: $t
+      |STRUCTURE: ${t.show[Structure]}
+      |$tokens
+      |""".stripMargin
   }
 
   def logOpt(t: Option[Tree], tokensOnly: Boolean = false): String =
@@ -71,11 +72,12 @@ object LoggerOps {
 
   def stripTrailingSpace(s: String): String = s.replaceAll("\\s+\n", "\n")
 
-  def reveal(s: String): String = s.map {
-    case '\n' => '¶'
-    case ' ' => '∙'
-    case ch => ch
-  }
+  def reveal(s: String): String =
+    s.map {
+      case '\n' => '¶'
+      case ' ' => '∙'
+      case ch => ch
+    }
 
   def header[T](t: T): String = {
     val line = s"=" * (t.toString.length + 3)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -41,7 +41,7 @@ class StyleMap(
               empty = false
               curr = style
             case Configured.NotOk(
-                e
+                  e
                 ) => // TODO(olafur) report error via callback
               logger.elem(e)
           }
@@ -71,16 +71,17 @@ class StyleMap(
       )
     )
 
-  private def isLiteral(tree: Tree): Boolean = tree match {
-    case lit @ Lit(value: Any) =>
-      val syntax = lit.tokens.mkString
-      val strName =
-        if (syntax.startsWith("0x")) "Byte"
-        else value.getClass.getName
-      literalR.matches(strName)
-    case x @ Term.Name(_) => literalR.matches(x.productPrefix)
-    case _ => false
-  }
+  private def isLiteral(tree: Tree): Boolean =
+    tree match {
+      case lit @ Lit(value: Any) =>
+        val syntax = lit.tokens.mkString
+        val strName =
+          if (syntax.startsWith("0x")) "Byte"
+          else value.getClass.getName
+        literalR.matches(strName)
+      case x @ Term.Name(_) => literalR.matches(x.productPrefix)
+      case _ => false
+    }
 
   private def isLiteralArgumentList(open: LeftParen): Boolean =
     owners(hash(open)) match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -140,10 +140,11 @@ object TokenOps {
   def isSingleLineComment(c: Token.Comment): Boolean =
     c.syntax.startsWith("//")
 
-  def isSingleLineComment(token: Token): Boolean = token match {
-    case c: Comment => isSingleLineComment(c)
-    case _ => false
-  }
+  def isSingleLineComment(token: Token): Boolean =
+    token match {
+      case c: Comment => isSingleLineComment(c)
+      case _ => false
+    }
 
   private def getModByNL(nl: Int, noIndent: => Boolean): Modification =
     if (FormatToken.noBreak(nl)) Space
@@ -164,61 +165,69 @@ object TokenOps {
   def isAttachedSingleLineComment(ft: FormatToken) =
     isSingleLineComment(ft.right) && ft.noBreak
 
-  def defnTemplate(tree: Tree): Option[Template] = tree match {
-    case t: Defn.Object => Some(t.templ)
-    case t: Defn.Class => Some(t.templ)
-    case t: Defn.Trait => Some(t.templ)
-    case t: Pkg.Object => Some(t.templ)
-    case t: Template => Some(t)
-    case _ => None
-  }
+  def defnTemplate(tree: Tree): Option[Template] =
+    tree match {
+      case t: Defn.Object => Some(t.templ)
+      case t: Defn.Class => Some(t.templ)
+      case t: Defn.Trait => Some(t.templ)
+      case t: Pkg.Object => Some(t.templ)
+      case t: Template => Some(t)
+      case _ => None
+    }
 
-  def tokenLength(token: Token): Int = token match {
-    case lit: Constant.String =>
-      // Even if the literal is not strip margined, we use the longest line
-      // excluding margins. The will only affect is multiline string literals
-      // with a short first line but long lines inside, example:
-      //
-      // val x = """short
-      //  Long aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      // """
-      //
-      // In this case, we would put a newline before """short and indent by
-      // two.
-      //
-      // Predef.augmentString = work around scala/bug#11125 on JDK 11
-      augmentString(lit.syntax).lines.map(_.replaceFirst(" *|", "").length).max
-    case _ =>
-      val tokenSyntax = token.syntax
-      val firstNewline = tokenSyntax.indexOf('\n')
-      if (firstNewline == -1) tokenSyntax.length
-      else firstNewline
-  }
+  def tokenLength(token: Token): Int =
+    token match {
+      case lit: Constant.String =>
+        // Even if the literal is not strip margined, we use the longest line
+        // excluding margins. The will only affect is multiline string literals
+        // with a short first line but long lines inside, example:
+        //
+        // val x = """short
+        //  Long aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        // """
+        //
+        // In this case, we would put a newline before """short and indent by
+        // two.
+        //
+        // Predef.augmentString = work around scala/bug#11125 on JDK 11
+        augmentString(lit.syntax).lines
+          .map(_.replaceFirst(" *|", "").length)
+          .max
+      case _ =>
+        val tokenSyntax = token.syntax
+        val firstNewline = tokenSyntax.indexOf('\n')
+        if (firstNewline == -1) tokenSyntax.length
+        else firstNewline
+    }
 
-  def isFormatOn(token: Token): Boolean = token match {
-    case c: Comment if formatOnCode.contains(c.syntax.toLowerCase) => true
-    case _ => false
-  }
+  def isFormatOn(token: Token): Boolean =
+    token match {
+      case c: Comment if formatOnCode.contains(c.syntax.toLowerCase) => true
+      case _ => false
+    }
 
-  def isFormatOff(token: Token): Boolean = token match {
-    case c: Comment if formatOffCode.contains(c.syntax.toLowerCase) => true
-    case _ => false
-  }
+  def isFormatOff(token: Token): Boolean =
+    token match {
+      case c: Comment if formatOffCode.contains(c.syntax.toLowerCase) => true
+      case _ => false
+    }
 
   val formatOffCode = Set(
     "// @formatter:off", // IntelliJ
     "// format: off" // scalariform
   )
 
-  def endsWithSymbolIdent(tok: Token): Boolean = tok match {
-    case Ident(name) => !name.last.isLetterOrDigit
-    case _ => false
-  }
+  def endsWithSymbolIdent(tok: Token): Boolean =
+    tok match {
+      case Ident(name) => !name.last.isLetterOrDigit
+      case _ => false
+    }
 
-  def isSymbolicIdent(tok: Token): Boolean = tok match {
-    case Ident(name) => isSymbolicName(name)
-    case _ => false
-  }
+  def isSymbolicIdent(tok: Token): Boolean =
+    tok match {
+      case Ident(name) => isSymbolicName(name)
+      case _ => false
+    }
 
   def isSymbolicName(name: String): Boolean = {
     val head = name.head

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -28,12 +28,13 @@ case class InfixApp(lhs: Tree, op: Name, rhs: Seq[Tree], all: Tree) {
 
 object InfixApp {
 
-  def unapply(tree: Tree): Option[InfixApp] = tree match {
-    case t: Type.ApplyInfix => Some(InfixApp(t.lhs, t.op, Seq(t.rhs), t))
-    case t: Term.ApplyInfix => Some(InfixApp(t.lhs, t.op, t.args, t))
-    case t: Pat.ExtractInfix => Some(InfixApp(t.lhs, t.op, t.rhs, t))
-    case _ => None
-  }
+  def unapply(tree: Tree): Option[InfixApp] =
+    tree match {
+      case t: Type.ApplyInfix => Some(InfixApp(t.lhs, t.op, Seq(t.rhs), t))
+      case t: Term.ApplyInfix => Some(InfixApp(t.lhs, t.op, t.args, t))
+      case t: Pat.ExtractInfix => Some(InfixApp(t.lhs, t.op, t.rhs, t))
+      case _ => None
+    }
 
   // https://scala-lang.org/files/archive/spec/2.11/06-expressions.html#infix-operations
   private val infixOpPrecedence: Map[Char, Int] = {
@@ -79,11 +80,12 @@ object InfixApp {
   * alphabetic characters
   */
 object `:parent:` {
-  def unapply(tree: Tree): Option[(Tree, Tree)] = tree.parent match {
-    case Some(parent) =>
-      Some(tree -> parent)
-    case _ => None
-  }
+  def unapply(tree: Tree): Option[(Tree, Tree)] =
+    tree.parent match {
+      case Some(parent) =>
+        Some(tree -> parent)
+      case _ => None
+    }
 }
 
 object WithChain {
@@ -91,7 +93,7 @@ object WithChain {
     TreeOps.topTypeWith(t) match {
       // self types, params, val/def/var/type definitions or declarations
       case (top: Type.With) `:parent:`
-            (_: Defn | _: Decl | _: Term.Param | _: Self) =>
+          (_: Defn | _: Decl | _: Term.Param | _: Self) =>
         Some(top)
       case _ =>
         None

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -36,15 +36,17 @@ object TreeOps {
   import TokenOps._
 
   @tailrec
-  def topTypeWith(typeWith: Type.With): Type.With = typeWith.parent match {
-    case Some(t: Type.With) => topTypeWith(t)
-    case _ => typeWith
-  }
+  def topTypeWith(typeWith: Type.With): Type.With =
+    typeWith.parent match {
+      case Some(t: Type.With) => topTypeWith(t)
+      case _ => typeWith
+    }
 
-  def withChain(top: Tree): Seq[Type.With] = top match {
-    case t: Type.With => t +: withChain(t.lhs)
-    case _ => Nil
-  }
+  def withChain(top: Tree): Seq[Type.With] =
+    top match {
+      case t: Type.With => t +: withChain(t.lhs)
+      case _ => Nil
+    }
 
   def getEnumStatements(enums: Seq[Enumerator]): Seq[Enumerator] = {
     val ret = Seq.newBuilder[Enumerator]
@@ -74,22 +76,23 @@ object TreeOps {
       case _ => false
     }
 
-  def extractStatementsIfAny(tree: Tree): Seq[Tree] = tree match {
-    case b: Term.Block => b.stats
-    case b: Term.Function if isBlockFunction(b) => b.body :: Nil
-    case t: Pkg => t.stats
-    // TODO(olafur) would be nice to have an abstract "For" superclass.
-    case t: Term.For => getEnumStatements(t.enums)
-    case t: Term.ForYield => getEnumStatements(t.enums)
-    case t: Term.Match => t.cases
-    case t: Term.PartialFunction => t.cases
-    case t: Term.Try => t.catchp
-    case t: Type.Refine => t.stats
-    case t: scala.meta.Source => t.stats
-    case t: Template => t.stats
-    case t: Case if t.body.tokens.nonEmpty => Seq(t.body)
-    case _ => Seq.empty[Tree]
-  }
+  def extractStatementsIfAny(tree: Tree): Seq[Tree] =
+    tree match {
+      case b: Term.Block => b.stats
+      case b: Term.Function if isBlockFunction(b) => b.body :: Nil
+      case t: Pkg => t.stats
+      // TODO(olafur) would be nice to have an abstract "For" superclass.
+      case t: Term.For => getEnumStatements(t.enums)
+      case t: Term.ForYield => getEnumStatements(t.enums)
+      case t: Term.Match => t.cases
+      case t: Term.PartialFunction => t.cases
+      case t: Term.Try => t.catchp
+      case t: Type.Refine => t.stats
+      case t: scala.meta.Source => t.stats
+      case t: Template => t.stats
+      case t: Case if t.body.tokens.nonEmpty => Seq(t.body)
+      case _ => Seq.empty[Tree]
+    }
 
   def getDequeueSpots(tree: Tree): Set[TokenHash] = {
     val ret = Set.newBuilder[TokenHash]
@@ -245,8 +248,8 @@ object TreeOps {
   /**
     * Returns first ancestor with a parent of a given type.
     */
-  def findTreeWithParentOfType[A <: Tree](tree: Tree)(
-      implicit classifier: Classifier[Tree, A]
+  def findTreeWithParentOfType[A <: Tree](tree: Tree)(implicit
+      classifier: Classifier[Tree, A]
   ): Option[Tree] =
     findTreeWithParentSimple(tree)(classifier.apply)
 
@@ -259,39 +262,43 @@ object TreeOps {
   )(implicit classifier: Classifier[Tree, A]): Boolean =
     findTreeWithParentOfType[A](tree).isDefined
 
-  def isTopLevel(tree: Tree): Boolean = tree match {
-    case _: Pkg | _: Source => true
-    case _ => false
-  }
+  def isTopLevel(tree: Tree): Boolean =
+    tree match {
+      case _: Pkg | _: Source => true
+      case _ => false
+    }
 
-  def isDefDef(tree: Tree): Boolean = tree match {
-    case _: Decl.Def | _: Defn.Def => true
-    case _ => false
-  }
+  def isDefDef(tree: Tree): Boolean =
+    tree match {
+      case _: Decl.Def | _: Defn.Def => true
+      case _ => false
+    }
 
-  def defDefReturnType(tree: Tree): Option[Type] = tree match {
-    case d: Decl.Def => Some(d.decltpe)
-    case d: Defn.Def => d.decltpe
-    case d: Defn.Val => d.decltpe
-    case d: Defn.Var => d.decltpe
-    case pat: Pat.Var => pat.parent.flatMap(defDefReturnType)
-    case name: Term.Name => name.parent.flatMap(defDefReturnType)
-    case _ => None
-  }
+  def defDefReturnType(tree: Tree): Option[Type] =
+    tree match {
+      case d: Decl.Def => Some(d.decltpe)
+      case d: Defn.Def => d.decltpe
+      case d: Defn.Val => d.decltpe
+      case d: Defn.Var => d.decltpe
+      case pat: Pat.Var => pat.parent.flatMap(defDefReturnType)
+      case name: Term.Name => name.parent.flatMap(defDefReturnType)
+      case _ => None
+    }
 
   /**
     * Returns `true` if the `scala.meta.Tree` is a class, trait or def
     *
     * For classes this includes primary and secondary Ctors.
     */
-  def isDefnSiteWithParams(tree: Tree): Boolean = tree match {
-    case _: Decl.Def | _: Defn.Def | _: Defn.Macro | _: Defn.Class |
-        _: Defn.Trait | _: Ctor.Secondary =>
-      true
-    case x: Ctor.Primary =>
-      x.parent.exists(isDefnSiteWithParams)
-    case _ => false
-  }
+  def isDefnSiteWithParams(tree: Tree): Boolean =
+    tree match {
+      case _: Decl.Def | _: Defn.Def | _: Defn.Macro | _: Defn.Class |
+          _: Defn.Trait | _: Ctor.Secondary =>
+        true
+      case x: Ctor.Primary =>
+        x.parent.exists(isDefnSiteWithParams)
+      case _ => false
+    }
 
   /**
     * Returns `true` if the `scala.meta.Tree` is a definition site
@@ -299,15 +306,16 @@ object TreeOps {
     * Currently, this includes everything from classes and defs to type
     * applications
     */
-  def isDefnSite(tree: Tree): Boolean = tree match {
-    case _: Decl.Def | _: Defn.Def | _: Defn.Macro | _: Defn.Class |
-        _: Defn.Trait | _: Ctor.Secondary | _: Decl.Type | _: Defn.Type |
-        _: Type.Apply | _: Type.Param | _: Type.Tuple =>
-      true
-    case _: Term.Function | _: Type.Function => true
-    case x: Ctor.Primary => x.parent.exists(isDefnSite)
-    case _ => false
-  }
+  def isDefnSite(tree: Tree): Boolean =
+    tree match {
+      case _: Decl.Def | _: Defn.Def | _: Defn.Macro | _: Defn.Class |
+          _: Defn.Trait | _: Ctor.Secondary | _: Decl.Type | _: Defn.Type |
+          _: Type.Apply | _: Type.Param | _: Type.Tuple =>
+        true
+      case _: Term.Function | _: Type.Function => true
+      case x: Ctor.Primary => x.parent.exists(isDefnSite)
+      case _ => false
+    }
 
   /**
     * Returns true if open is "unnecessary".
@@ -339,10 +347,11 @@ object TreeOps {
       case _ => false
     }
 
-  def isTuple(tree: Tree): Boolean = tree match {
-    case _: Pat.Tuple | _: Term.Tuple | _: Type.Tuple => true
-    case _ => false
-  }
+  def isTuple(tree: Tree): Boolean =
+    tree match {
+      case _: Pat.Tuple | _: Term.Tuple | _: Type.Tuple => true
+      case _ => false
+    }
 
   def isDefnOrCallSite(tree: Tree)(implicit style: ScalafmtConfig): Boolean =
     isDefnSite(tree) || isCallSite(tree)
@@ -352,15 +361,17 @@ object TreeOps {
   )(implicit style: ScalafmtConfig): Boolean =
     !isTuple(tree) && isDefnOrCallSite(tree)
 
-  def isModPrivateProtected(tree: Tree): Boolean = tree match {
-    case _: Mod.Private | _: Mod.Protected => true
-    case _ => false
-  }
+  def isModPrivateProtected(tree: Tree): Boolean =
+    tree match {
+      case _: Mod.Private | _: Mod.Protected => true
+      case _ => false
+    }
 
-  def isTypeVariant(tree: Tree): Boolean = tree match {
-    case _: Mod.Contravariant | _: Mod.Covariant => true
-    case _ => false
-  }
+  def isTypeVariant(tree: Tree): Boolean =
+    tree match {
+      case _: Mod.Contravariant | _: Mod.Covariant => true
+      case _ => false
+    }
 
   type CallParts = (Tree, Either[Seq[Tree], Seq[Seq[Tree]]])
   val splitCallIntoParts: PartialFunction[Tree, CallParts] = {
@@ -418,12 +429,13 @@ object TreeOps {
     }
   }
 
-  def startsSelectChain(tree: Tree): Boolean = tree match {
-    case select: Term.Select =>
-      !(existsChild(_.is[Term.Select])(select) &&
-        existsChild(splitCallIntoParts.isDefinedAt)(select))
-    case _ => false
-  }
+  def startsSelectChain(tree: Tree): Boolean =
+    tree match {
+      case select: Term.Select =>
+        !(existsChild(_.is[Term.Select])(select) &&
+          existsChild(splitCallIntoParts.isDefinedAt)(select))
+      case _ => false
+    }
 
   /**
     * Returns true tree has a child for which f(child) is true.
@@ -435,10 +447,11 @@ object TreeOps {
   /**
     * How many parents of tree are Term.Apply?
     */
-  def nestedApplies(tree: Tree): Int = numParents(tree) {
-    case _: Term.Apply | _: Term.ApplyInfix | _: Type.Apply => true
-    case _ => false
-  }
+  def nestedApplies(tree: Tree): Int =
+    numParents(tree) {
+      case _: Term.Apply | _: Term.ApplyInfix | _: Type.Apply => true
+      case _ => false
+    }
 
   def nestedSelect(tree: Tree): Int = numParents(tree)(_.is[Term.Select])
 
@@ -477,12 +490,13 @@ object TreeOps {
     if (tree.children.isEmpty) 0
     else 1 + tree.children.map(treeDepth).max
 
-  def defBody(tree: Tree): Option[Tree] = tree match {
-    case t: Defn.Def => Some(t.body)
-    case t: Defn.Macro => Some(t.body)
-    case t: Ctor.Secondary => Some(t.init)
-    case _ => None
-  }
+  def defBody(tree: Tree): Option[Tree] =
+    tree match {
+      case t: Defn.Def => Some(t.body)
+      case t: Defn.Macro => Some(t.body)
+      case t: Ctor.Secondary => Some(t.init)
+      case _ => None
+    }
 
   @tailrec
   final def lastLambda(first: Term.Function): Term.Function =
@@ -546,17 +560,19 @@ object TreeOps {
 
   // matches tree nodes that can be considered "top-level statement": package/object/trait/def/val
   object MaybeTopLevelStat {
-    def unapply(tree: Tree): Option[Tree] = tree match {
-      case _: Pkg | _: Defn | _: Decl => Some(tree)
-      case _ => None
-    }
+    def unapply(tree: Tree): Option[Tree] =
+      tree match {
+        case _: Pkg | _: Defn | _: Decl => Some(tree)
+        case _ => None
+      }
   }
 
-  def isXmlBrace(owner: Tree): Boolean = owner match {
-    case _: Term.Xml | _: Pat.Xml => true
-    case b: Term.Block => b.parent.exists(_.isInstanceOf[Term.Xml])
-    case _ => false
-  }
+  def isXmlBrace(owner: Tree): Boolean =
+    owner match {
+      case _: Term.Xml | _: Pat.Xml => true
+      case b: Term.Block => b.parent.exists(_.isInstanceOf[Term.Xml])
+      case _ => false
+    }
 
   def getAssignAtSingleArgCallSite(tree: Tree): Option[Term.Assign] =
     tree match {
@@ -570,10 +586,11 @@ object TreeOps {
   def getBlockSingleStat(b: Term.Block): Option[Stat] =
     if (b.stats.lengthCompare(1) != 0) None else Some(b.stats.head)
 
-  def getTermSingleStat(t: Term): Option[Tree] = t match {
-    case b: Term.Block => getBlockSingleStat(b)
-    case _ => Some(t)
-  }
+  def getTermSingleStat(t: Term): Option[Tree] =
+    t match {
+      case b: Term.Block => getBlockSingleStat(b)
+      case _ => Some(t)
+    }
 
   def getTermLineSpan(b: Tree): Int =
     if (b.tokens.isEmpty) 0

--- a/scalafmt-dynamic/src/main/scala-2.11/org/scalafmt/dynamic/package.scala
+++ b/scalafmt-dynamic/src/main/scala-2.11/org/scalafmt/dynamic/package.scala
@@ -10,11 +10,12 @@ package object dynamic {
         case _ => target.asInstanceOf[Either[A1, B1]]
       }
 
-    def map[B1](f: B => B1): Either[A, B1] = target match {
-      case Right(b) => Right(f(b))
-      case _ =>
-        target.asInstanceOf[Either[A, B1]]
-    }
+    def map[B1](f: B => B1): Either[A, B1] =
+      target match {
+        case Right(b) => Right(f(b))
+        case _ =>
+          target.asInstanceOf[Either[A, B1]]
+      }
   }
 
   implicit class TryOps[T](val target: Try[T]) extends AnyVal {

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
@@ -29,16 +29,17 @@ final case class ScalafmtDynamic(
     ]]
 ) extends Scalafmt {
 
-  def this() = this(
-    ConsoleScalafmtReporter,
-    Nil,
-    true,
-    true,
-    BuildInfo.stable,
-    ReentrantCache(),
-    true,
-    ReentrantCache()
-  )
+  def this() =
+    this(
+      ConsoleScalafmtReporter,
+      Nil,
+      true,
+      true,
+      BuildInfo.stable,
+      ReentrantCache(),
+      true,
+      ReentrantCache()
+    )
 
   override def clear(): Unit =
     formatCache

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicDownloader.scala
@@ -51,18 +51,19 @@ class ScalafmtDynamicDownloader(
     }
   }
 
-  private def dependencies(version: ScalafmtVersion): List[Dependency] = List(
-    Dependency.of(
-      organization(version),
-      s"scalafmt-cli_${scalaBinaryVersion(version)}",
-      version.toString
-    ),
-    Dependency.of(
-      "org.scala-lang",
-      "scala-reflect",
-      scalaVersion(version)
+  private def dependencies(version: ScalafmtVersion): List[Dependency] =
+    List(
+      Dependency.of(
+        organization(version),
+        s"scalafmt-cli_${scalaBinaryVersion(version)}",
+        version.toString
+      ),
+      Dependency.of(
+        "org.scala-lang",
+        "scala-reflect",
+        scalaVersion(version)
+      )
     )
-  )
 
   @inline
   private def scalaBinaryVersion(version: ScalafmtVersion): String =

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/exceptions/ReflectionException.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/exceptions/ReflectionException.scala
@@ -3,8 +3,9 @@ package org.scalafmt.dynamic.exceptions
 import java.lang.reflect.InvocationTargetException
 
 object ReflectionException {
-  def unapply(e: Throwable): Option[Throwable] = e match {
-    case e: InvocationTargetException => Some(e.getCause)
-    case _ => Some(e)
-  }
+  def unapply(e: Throwable): Option[Throwable] =
+    e match {
+      case e: InvocationTargetException => Some(e.getCause)
+      case _ => Some(e)
+    }
 }

--- a/scalafmt-tests/src/main/scala/org/scalafmt/util/DiffAssertions.scala
+++ b/scalafmt-tests/src/main/scala/org/scalafmt/util/DiffAssertions.scala
@@ -40,12 +40,12 @@ trait DiffAssertions extends AnyFunSuiteLike {
   def error2message(obtained: String, diff: String): String = {
     val sb = new StringBuilder
     if (obtained.length < 1000) sb.append(s"""
-         #${header("Obtained")}
-         #${trailingSpace(obtained)}
+      #${header("Obtained")}
+      #${trailingSpace(obtained)}
          """.stripMargin('#'))
     sb.append(s"""
-         #${header("Diff")}
-         #${trailingSpace(diff)}
+      #${header("Diff")}
+      #${trailingSpace(diff)}
          """.stripMargin('#'))
     sb.toString()
   }
@@ -83,8 +83,8 @@ trait DiffAssertions extends AnyFunSuiteLike {
     )
   }
 
-  def assertNoDiff(file: AbsoluteFile, expected: String)(
-      implicit pos: Position
+  def assertNoDiff(file: AbsoluteFile, expected: String)(implicit
+      pos: Position
   ): Unit =
     assertNoDiff(FileOps.readFile(file.jfile), expected)
 

--- a/scalafmt-tests/src/main/scala/org/scalafmt/util/ScalaFile.scala
+++ b/scalafmt-tests/src/main/scala/org/scalafmt/util/ScalaFile.scala
@@ -25,10 +25,10 @@ case class ScalaFile(filename: String, projectUrl: String, commit: String) {
   def user = userRepo.split("/")(0)
 
   override def toString: String = s"""ScalaFile(
-                                     |    project: $user
-                                     |    github: $githubUrl
-                                     |    raw: $rawUrl
-                                     |)""".stripMargin
+    |    project: $user
+    |    github: $githubUrl
+    |    raw: $rawUrl
+    |)""".stripMargin
 }
 
 object ScalaFile {
@@ -44,9 +44,9 @@ object ScalaFile {
     val files = Option(repos.listFiles()).getOrElse {
       throw new IllegalStateException(
         s"""${repos.getAbsolutePath} is not a directory, run:
-           |* wget $reposTarballUrl
-           |* tar xvf $tarballNameWithExt
-           |""".stripMargin
+          |* wget $reposTarballUrl
+          |* tar xvf $tarballNameWithExt
+          |""".stripMargin
       )
     }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
@@ -10,37 +10,37 @@ class CommentTest extends AnyFunSuite with DiffAssertions {
   test("remove trailing space in comments") {
     val trailingSpace = "   "
     val original = s"""object a {
-                      |  // inline comment$trailingSpace
-                      |/**$trailingSpace
-                      |  * Y is cool$trailingSpace
-                      |  */
-                      |/*$trailingSpace
-                      |  * X is cool$trailingSpace
-                      |  */
-                      |/*
-                      |    I have blank lines.
-                      |
-                      |    Please preserve them.
-                      |  */
-                      |val y = 2
-                      |}
+      |  // inline comment$trailingSpace
+      |/**$trailingSpace
+      |  * Y is cool$trailingSpace
+      |  */
+      |/*$trailingSpace
+      |  * X is cool$trailingSpace
+      |  */
+      |/*
+      |    I have blank lines.
+      |
+      |    Please preserve them.
+      |  */
+      |val y = 2
+      |}
                    """.stripMargin
     val expected = """object a {
-                     |  // inline comment
-                     |  /**
-                     |   * Y is cool
-                     |   */
-                     |  /*
-                     |   * X is cool
-                     |   */
-                     |  /*
-                     |    I have blank lines.
-                     |
-                     |    Please preserve them.
-                     |   */
-                     |  val y = 2
-                     |}
-                     |""".stripMargin
+      |  // inline comment
+      |  /**
+      |   * Y is cool
+      |   */
+      |  /*
+      |   * X is cool
+      |   */
+      |  /*
+      |    I have blank lines.
+      |
+      |    Please preserve them.
+      |   */
+      |  val y = 2
+      |}
+      |""".stripMargin
     val obtained = Scalafmt.format(original, javadocStyle).get
     assertNoDiff(obtained, expected)
   }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/EditionTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/EditionTest.scala
@@ -38,9 +38,9 @@ class EditionTest extends AnyFunSuite with DiffAssertions {
   checkError(
     "2019-invalid",
     """|Type mismatch;
-       |  found    : String (value: "2019-invalid")
-       |  expected : '$year-$month', for example '2019-08'
-       |""".stripMargin.trim
+      |  found    : String (value: "2019-invalid")
+      |  expected : '$year-$month', for example '2019-08'
+      |""".stripMargin.trim
   )
   checkActiveFor("2019-09", "2019-09")
   checkActiveFor("2019-09", "2019-10")

--- a/scalafmt-tests/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/RangeTest.scala
@@ -6,14 +6,14 @@ import org.scalafmt.util.{DiffAssertions, HasTests}
 class RangeTest extends AnyFunSuite with DiffAssertions {
   test("range preserves indent") {
     val original = """object a {
-                     |val x = 1
-                     |val y = 2
-                     |}
+      |val x = 1
+      |val y = 2
+      |}
       """.stripMargin
     val expected = """object a {
-                     |val x = 1
-                     |  val y = 2
-                     |}
+      |val x = 1
+      |  val y = 2
+      |}
       """.stripMargin
     val obtained = Scalafmt
       .format(

--- a/scalafmt-tests/src/test/scala/org/scalafmt/ScalafmtProps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/ScalafmtProps.scala
@@ -91,8 +91,8 @@ class ScalafmtProps extends AnyFunSuite with FormatAssertions {
         .mkString("\n")
     val report =
       s"""|$summary
-          |
-          |$table """.stripMargin
+        |
+        |$table """.stripMargin
     logger.elem(summary)
     logger.elem(report)
     logger.elem(summary)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/ScalafmtTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/ScalafmtTest.scala
@@ -24,34 +24,34 @@ class ScalafmtTest extends AnyFunSuite {
       |// comment
       """.stripMargin,
     """|object A { println("HELLO!") }
-       |
-       |// comment
-       |""".stripMargin
+      |
+      |// comment
+      |""".stripMargin
   )
   check(
     """|object A {
-       |  val x = 2
-       |  val xx = 3
-       |}
+      |  val x = 2
+      |  val xx = 3
+      |}
     """.stripMargin,
     """|object A {
-       |  val x  = 2
-       |  val xx = 3
-       |}
-       |""".stripMargin,
+      |  val x  = 2
+      |  val xx = 3
+      |}
+      |""".stripMargin,
     config.ScalafmtConfig.defaultWithAlign
   )
   check(
     """|object A { function(aaaaaaaa, bbbbbbbbbb, ddddd(eeeeeeeeee, fffffff, gggggggg)) }
     """.stripMargin,
     """|object A {
-       |  function(
-       |    aaaaaaaa,
-       |    bbbbbbbbbb,
-       |    ddddd(eeeeeeeeee, fffffff, gggggggg)
-       |  )
-       |}
-       |""".stripMargin,
+      |  function(
+      |    aaaaaaaa,
+      |    bbbbbbbbbb,
+      |    ddddd(eeeeeeeeee, fffffff, gggggggg)
+      |  )
+      |}
+      |""".stripMargin,
     config.ScalafmtConfig.default40
   )
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/UnitTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/UnitTests.scala
@@ -28,7 +28,7 @@ object UnitTests extends HasTests {
       if (sys.env.contains("CI") && test.only) {
         sys.error(
           s"""Please remove ONLY from test '${test.name}' in file '$filename'.
-             |Tests with ONLY will not be merged, this feature is only meant to be used for local development.
+            |Tests with ONLY will not be merged, this feature is only meant to be used for local development.
            """.stripMargin
         )
       }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -19,8 +19,8 @@ class CliOptionsTest extends AnyFunSuite {
     )
 
     val overrideOne = Config.fromHoconString("""|style = defaultWithAlign
-                                                |maxColumn = 100
-                                                |""".stripMargin)
+      |maxColumn = 100
+      |""".stripMargin)
     assert(
       Ok(ScalafmtConfig.defaultWithAlign.copy(maxColumn = 100)) == overrideOne
     )
@@ -83,10 +83,10 @@ class CliOptionsTest extends AnyFunSuite {
     val expected = "foo bar"
     val configPath = Files.createTempFile(".scalafmt", ".conf")
     val config = s"""
-                    |version="${Versions.version}"
-                    |maxColumn=100
-                    |onTestFailure="$expected"
-                    |""".stripMargin
+      |version="${Versions.version}"
+      |maxColumn=100
+      |onTestFailure="$expected"
+      |""".stripMargin
     Files.write(configPath, config.getBytes)
 
     val opt = baseCliOptions.copy(config = Some(configPath))

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -34,37 +34,37 @@ abstract class AbstractCliTest extends AnyFunSuite with DiffAssertions {
   }
 
   val unformatted = """
-                      |object a    extends   App {
-                      |pr("h")
-                      |}
+    |object a    extends   App {
+    |pr("h")
+    |}
                     """.stripMargin
   // Using maxColumn 10 just to see the CLI uses the custom style.
   val expected10 = """|object a
-                      |    extends App {
-                      |  pr(
-                      |    "h"
-                      |  )
-                      |}
-                      |""".stripMargin
+    |    extends App {
+    |  pr(
+    |    "h"
+    |  )
+    |}
+    |""".stripMargin
   val formatted = """|object a extends App {
-                     |  pr("h")
-                     |}
-                     |""".stripMargin
+    |  pr("h")
+    |}
+    |""".stripMargin
   val customConfig =
     """
       |maxColumn   = 2
       """.stripMargin
   val sbtOriginal =
     """|lazy val x = project
-       |   lazy val y    = project
-       |   """.stripMargin
+      |   lazy val y    = project
+      |   """.stripMargin
 
   val sbtExpected =
     """|lazy val x =
-       |  project
-       |lazy val y =
-       |  project
-       |""".stripMargin
+      |  project
+      |lazy val y =
+      |  project
+      |""".stripMargin
 
   def gimmeConfig(string: String): ScalafmtConfig =
     Config.fromHoconString(string).get
@@ -101,9 +101,9 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val originalTmpFile2 = Files.createTempFile("prefix2", ".scala")
       val scalafmtConfig = Files.createTempFile("scalafmtConfig", ".scala")
       val config = s"""
-                      |version="$version"
-                      |maxColumn=7
-                      |style=IntelliJ
+        |version="$version"
+        |maxColumn=7
+        |style=IntelliJ
     """.stripMargin
       Files.write(originalTmpFile, unformatted.getBytes)
       Files.write(originalTmpFile2, unformatted.getBytes)
@@ -146,9 +146,9 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"scalafmt --stdin --assume-filename: $label") {
       val scalafmtConfig = Files.createTempFile(".scalafmt", ".conf")
       val config = s"""
-                      |version="$version"
-                      |maxColumn=7
-                      |style=IntelliJ
+        |version="$version"
+        |maxColumn=7
+        |style=IntelliJ
     """.stripMargin
       Files.write(scalafmtConfig, config.getBytes)
 
@@ -209,23 +209,23 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"handles .scala, .sbt, and .sc files: $label") {
       val input = string2dir(
         s"""|/foobar.scala
-            |object    A {  }
-            |/foo.sbt
-            |lazy   val x   = project
-            |/foo.sc
-            |lazy   val x   = project
-            |""".stripMargin
+          |object    A {  }
+          |/foo.sbt
+          |lazy   val x   = project
+          |/foo.sc
+          |lazy   val x   = project
+          |""".stripMargin
       )
       val expected =
         s"""|/foo.sbt
-            |lazy val x = project
-            |
-            |/foo.sc
-            |lazy val x = project
-            |
-            |/foobar.scala
-            |object A {}
-            |""".stripMargin
+          |lazy val x = project
+          |
+          |/foo.sc
+          |lazy val x = project
+          |
+          |/foobar.scala
+          |object A {}
+          |""".stripMargin
       val options = getConfig(
         Array(
           input.path,
@@ -241,37 +241,37 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"excludefilters are respected: $label") {
       val input = string2dir(
         s"""|/foo.sbt
-            |lazy   val x   = project
-            |
-            |/target/FormatMe.scala
-            |object    PleaseFormatMeOtherwiseIWillBeReallySad   {  }
-            |
-            |/target/nested/DoNotFormatMe.scala
-            |object    AAAAAAIgnoreME   {  }
-            |
-            |/target/nested/nested2/DoNotFormatMeToo.scala
-            |object    BBBBBBIgnoreME   {  }
-            |
-            |/target/nested3/DoNotFormatMe.scala
-            |object    CIgnoreME   {  }
-            |""".stripMargin
+          |lazy   val x   = project
+          |
+          |/target/FormatMe.scala
+          |object    PleaseFormatMeOtherwiseIWillBeReallySad   {  }
+          |
+          |/target/nested/DoNotFormatMe.scala
+          |object    AAAAAAIgnoreME   {  }
+          |
+          |/target/nested/nested2/DoNotFormatMeToo.scala
+          |object    BBBBBBIgnoreME   {  }
+          |
+          |/target/nested3/DoNotFormatMe.scala
+          |object    CIgnoreME   {  }
+          |""".stripMargin
       )
       val expected =
         s"""|/foo.sbt
-            |lazy val x = project
-            |
-            |/target/FormatMe.scala
-            |object PleaseFormatMeOtherwiseIWillBeReallySad {}
-            |
-            |/target/nested/DoNotFormatMe.scala
-            |object    AAAAAAIgnoreME   {  }
-            |
-            |/target/nested/nested2/DoNotFormatMeToo.scala
-            |object    BBBBBBIgnoreME   {  }
-            |
-            |/target/nested3/DoNotFormatMe.scala
-            |object    CIgnoreME   {  }
-            |""".stripMargin
+          |lazy val x = project
+          |
+          |/target/FormatMe.scala
+          |object PleaseFormatMeOtherwiseIWillBeReallySad {}
+          |
+          |/target/nested/DoNotFormatMe.scala
+          |object    AAAAAAIgnoreME   {  }
+          |
+          |/target/nested/nested2/DoNotFormatMeToo.scala
+          |object    BBBBBBIgnoreME   {  }
+          |
+          |/target/nested3/DoNotFormatMe.scala
+          |object    CIgnoreME   {  }
+          |""".stripMargin
       val options = getConfig(
         Array(
           "--config-str",
@@ -305,7 +305,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"scalafmt (no matching files) throws error: $label") {
       val scalafmtConfig: Path = Files.createTempFile(".scalafmt", ".conf")
       val config: String = s"""
-                              |version="$version"
+        |version="$version"
                """.stripMargin
       Files.write(scalafmtConfig, config.getBytes)
       val options = baseCliOptions.copy(config = Some(scalafmtConfig))
@@ -341,34 +341,34 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"scalafmt (no arg) read config from git repo: $label") {
       val input = string2dir(
         s"""|/foo.scala
-            |object    FormatMe {
-            |  val x = 1
-            |}
-            |/target/foo.scala
-            |object A   { }
-            |
-            |/.scalafmt.conf
-            |version = "$version"
-            |maxColumn = 2
-            |project.excludeFilters = [target]
-            |""".stripMargin
+          |object    FormatMe {
+          |  val x = 1
+          |}
+          |/target/foo.scala
+          |object A   { }
+          |
+          |/.scalafmt.conf
+          |version = "$version"
+          |maxColumn = 2
+          |project.excludeFilters = [target]
+          |""".stripMargin
       )
 
       val expected =
         s"""|/.scalafmt.conf
-            |version = "$version"
-            |maxColumn = 2
-            |project.excludeFilters = [target]
-            |
-            |/foo.scala
-            |object FormatMe {
-            |  val x =
-            |    1
-            |}
-            |
-            |/target/foo.scala
-            |object A   { }
-            |""".stripMargin
+          |version = "$version"
+          |maxColumn = 2
+          |project.excludeFilters = [target]
+          |
+          |/foo.scala
+          |object FormatMe {
+          |  val x =
+          |    1
+          |}
+          |
+          |/target/foo.scala
+          |object A   { }
+          |""".stripMargin
       noArgTest(
         input,
         expected,
@@ -380,17 +380,17 @@ trait CliTestBehavior { this: AbstractCliTest =>
       noArgTest(
         string2dir(
           """|/foo.scala
-             |object    FormatMe
-             |/foo.sc
-             |object    FormatMe
-             |""".stripMargin
+            |object    FormatMe
+            |/foo.sc
+            |object    FormatMe
+            |""".stripMargin
         ),
         """|/foo.sc
-           |object FormatMe
-           |
-           |/foo.scala
-           |object FormatMe
-           |""".stripMargin,
+          |object FormatMe
+          |
+          |/foo.scala
+          |object FormatMe
+          |""".stripMargin,
         Seq(
           Array("--config-str", s"""{version="$version"}""")
         )
@@ -401,17 +401,17 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val original = "object a { val x = 1 }"
       val expected =
         """|object a {
-           |  val x =
-           |    1
-           |}
-           |""".stripMargin
+          |  val x =
+          |    1
+          |}
+          |""".stripMargin
       val input = string2dir(
         s"""|/nested/foo.scala
-            |$original
-            |/.scalafmt.conf
-            |version="$version"
-            |maxColumn = 2
-            |""".stripMargin
+          |$original
+          |/.scalafmt.conf
+          |version="$version"
+          |maxColumn = 2
+          |""".stripMargin
       )
       val workingDir = input / "nested"
       val options: CliOptions = {
@@ -430,17 +430,17 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val root =
         string2dir(
           s"""
-             |/scalafmt.conf
-             |style = default
-             |version="$version"
-             |/scalafile.scala
-             |$unformatted
-             |/scalatex.scalatex
-             |$unformatted
-             |/sbt.sbt
-             |$sbtOriginal
-             |/sbt.sbtfile
-             |$sbtOriginal""".stripMargin
+            |/scalafmt.conf
+            |style = default
+            |version="$version"
+            |/scalafile.scala
+            |$unformatted
+            |/scalatex.scalatex
+            |$unformatted
+            |/sbt.sbt
+            |$sbtOriginal
+            |/sbt.sbtfile
+            |$sbtOriginal""".stripMargin
         )
 
       val config = root / "scalafmt.conf"
@@ -456,8 +456,8 @@ trait CliTestBehavior { this: AbstractCliTest =>
       assertNoDiff(root / "scalafile.scala", formatted)
       val sbtFormatted =
         """|lazy val x = project
-           |lazy val y = project
-           |""".stripMargin
+          |lazy val y = project
+          |""".stripMargin
       assertNoDiff(root / "sbt.sbt", sbtFormatted)
     }
 
@@ -467,12 +467,12 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val root =
         string2dir(
           s"""
-             |/inner/file1.scala
-             |$unformatted
-             |/inner2/file2.scalahala
-             |$unformatted
-             |/inner2/file3.scalahala
-             |$unformatted""".stripMargin
+            |/inner/file1.scala
+            |$unformatted
+            |/inner2/file2.scalahala
+            |$unformatted
+            |/inner2/file3.scalahala
+            |$unformatted""".stripMargin
         )
       val inner1 = root / "inner"
       val inner2 = root / "inner2"
@@ -491,10 +491,10 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"--config accepts absolute paths: $label") {
       val root = string2dir(
         s"""/scalafmt.conf
-           |version = "$version"
-           |style = intellij
-           |/foo.scala
-           |object    A
+          |version = "$version"
+          |style = intellij
+          |/foo.scala
+          |object    A
       """.stripMargin
       )
       val config = (root / "scalafmt.conf").path
@@ -538,8 +538,8 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"parse error is formatted nicely: $label") {
       val input =
         """|/foo.scala
-           |object    A { foo( }
-           |""".stripMargin
+          |object    A { foo( }
+          |""".stripMargin
       noArgTest(
         string2dir(input),
         input,
@@ -573,12 +573,12 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"--test failure prints out unified diff: $label") {
       val input =
         s"""|/.scalafmt.conf
-            |onTestFailure = "To fix this ..."
-            |version = "$version"
-            |
-            |/foo.scala
-            |object    A { }
-            |""".stripMargin
+          |onTestFailure = "To fix this ..."
+          |version = "$version"
+          |
+          |/foo.scala
+          |object    A { }
+          |""".stripMargin
       noArgTest(
         string2dir(input),
         input,
@@ -588,11 +588,11 @@ trait CliTestBehavior { this: AbstractCliTest =>
           assert(
             out.contains(
               """|foo.scala-formatted
-                 |@@ -1,1 +1,1 @@
-                 |-object    A { }
-                 |+object A {}
-                 |error: --test failed
-                 |To fix this ...""".stripMargin
+                |@@ -1,1 +1,1 @@
+                |-object    A { }
+                |+object A {}
+                |error: --test failed
+                |To fix this ...""".stripMargin
             )
           )
         }
@@ -602,8 +602,8 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"--test succeeds even with parse error: $label") {
       val input =
         """|/foo.scala
-           |object A {
-           |""".stripMargin
+          |object A {
+          |""".stripMargin
       noArgTest(
         string2dir(input),
         input,
@@ -626,11 +626,11 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"--test fails with parse error if fatalWarnings=true: $label") {
       val input =
         s"""|/.scalafmt.conf
-            |runner.fatalWarnings = true
-            |version = "$version"
-            |/foo.scala
-            |object A {
-            |""".stripMargin
+          |runner.fatalWarnings = true
+          |version = "$version"
+          |/foo.scala
+          |object A {
+          |""".stripMargin
       noArgTest(
         string2dir(input),
         input,
@@ -651,10 +651,10 @@ trait CliTestBehavior { this: AbstractCliTest =>
     test(s"exception is thrown on invalid .scalafmt.conf: $label") {
       val input =
         s"""/.scalafmt.conf
-           |version="$version"
-           |blah = intellij
-           |/foo.scala
-           |object A {}
+          |version="$version"
+          |blah = intellij
+          |/foo.scala
+          |object A {}
       """.stripMargin
       noArgTest(
         string2dir(input),
@@ -685,12 +685,12 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val unexpected = "This message should not be shown"
       val input =
         s"""|/.scalafmt.conf
-            |onTestFailure = "$unexpected"
-            |version = "$version"
-            |
-            |/foo.scala
-            |object      A { }
-            |""".stripMargin
+          |onTestFailure = "$unexpected"
+          |version = "$version"
+          |
+          |/foo.scala
+          |object      A { }
+          |""".stripMargin
       noArgTest(
         string2dir(input),
         input,
@@ -716,17 +716,17 @@ trait CliTestBehavior { this: AbstractCliTest =>
     ) {
       val input =
         s"""|/.scalafmt.conf
-            |version = "$version"
-            |
-            |/bar.scala
-            |object    A { }
-            |
-            |/baz.scala
-            |object A {}
-            |
-            |/dir/foo.scala
-            |object   A { }
-            |""".stripMargin
+          |version = "$version"
+          |
+          |/bar.scala
+          |object    A { }
+          |
+          |/baz.scala
+          |object A {}
+          |
+          |/dir/foo.scala
+          |object   A { }
+          |""".stripMargin
       val dir = string2dir(input)
       noArgTest(
         dir,
@@ -749,11 +749,13 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
   testCli("1.6.0-RC4") // test for runDynamic
   testCli(Versions.version) // test for runScalafmt
 
-  test("Running pre-resolved version of scalafmt if .scalafmt.conf is missing.") {
+  test(
+    "Running pre-resolved version of scalafmt if .scalafmt.conf is missing."
+  ) {
     val input =
       s"""|/foo.scala
-          |object A {}
-          |""".stripMargin
+        |object A {}
+        |""".stripMargin
     noArgTest(
       string2dir(input),
       input,
@@ -774,11 +776,11 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
   ) {
     val input =
       s"""|/.scalafmt.conf
-          |maxColumn = 10
-          |
-          |/foo.scala
-          |object A {}
-          |""".stripMargin
+        |maxColumn = 10
+        |
+        |/foo.scala
+        |object A {}
+        |""".stripMargin
     noArgTest(
       string2dir(input),
       input,

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FileTestOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FileTestOps.scala
@@ -40,7 +40,7 @@ object FileTestOps {
       .map { path =>
         val contents = FileOps.readFile(path)
         s"""|${path.stripPrefix(file.jfile.getPath)}
-            |$contents""".stripMargin
+          |$contents""".stripMargin
       }
       .mkString("\n")
       .replace(File.separator, "/") // ensure original separators

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -28,22 +28,23 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
       new ConsoleScalafmtReporter(new PrintStream(out)) {
         override def downloadWriter(): PrintWriter = new PrintWriter(download)
 
-        override def error(file: Path, e: Throwable): Unit = e match {
-          case p: PositionException =>
-            val input = m.Input.VirtualFile(file.toString, p.code)
-            val pos =
-              m.Position.Range(
-                input,
-                p.startLine,
-                p.startCharacter,
-                p.endLine,
-                p.endCharacter
-              )
-            val formattedMessage = pos.formatMessage("error", p.shortMessage)
-            out.write(formattedMessage.getBytes(StandardCharsets.UTF_8))
-          case _ =>
-            super.error(file, e)
-        }
+        override def error(file: Path, e: Throwable): Unit =
+          e match {
+            case p: PositionException =>
+              val input = m.Input.VirtualFile(file.toString, p.code)
+              val pos =
+                m.Position.Range(
+                  input,
+                  p.startLine,
+                  p.startCharacter,
+                  p.endLine,
+                  p.endCharacter
+                )
+              val formattedMessage = pos.formatMessage("error", p.shortMessage)
+              out.write(formattedMessage.getBytes(StandardCharsets.UTF_8))
+            case _ =>
+              super.error(file, e)
+          }
         override def missingVersion(
             config: Path,
             defaultVersion: String
@@ -146,8 +147,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
     def assertError(expected: String)(implicit pos: Position): Unit = {
       assertError("object A  {  }", expected)
     }
-    def assertError(code: String, expected: String)(
-        implicit pos: Position
+    def assertError(code: String, expected: String)(implicit
+        pos: Position
     ): Unit = {
       out.reset()
       val obtained = dynamic.format(config, filename, code)
@@ -193,7 +194,7 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
     check(s"v$version") { f =>
       f.setConfig(
         s"""|version=$version
-            |""".stripMargin
+          |""".stripMargin
       )
       f.assertFormat("object A  {  }", "object A {}\n")
     }
@@ -209,8 +210,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
       f.assertError(
         "object object A",
         """|parse-error.scala:1:8: error: identifier expected but object found
-           |object object A
-           |       ^^^^^^""".stripMargin
+          |object object A
+          |       ^^^^^^""".stripMargin
       )
     }
     f.setVersion(latest)
@@ -276,12 +277,12 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
   check("config-error") { f =>
     f.setConfig(
       s"""max=70
-         |version=$latest
-         |""".stripMargin
+        |version=$latest
+        |""".stripMargin
     )
     f.assertError(
       """|error: path/.scalafmt.conf: Invalid field: max. Expected one of version, maxColumn, docstrings, optIn, binPack, continuationIndent, align, spaces, literals, lineEndings, rewriteTokens, rewrite, indentOperator, newlines, runner, indentYieldKeyword, importSelectors, unindentTopLevelOperators, includeCurlyBraceInSelectChains, includeNoParensInSelectChains, assumeStandardLibraryStripMargin, danglingParentheses, poorMansTrailingCommasInConfigStyle, trailingCommas, verticalMultilineAtDefinitionSite, verticalMultilineAtDefinitionSiteArityThreshold, verticalMultiline, onTestFailure, encoding, project
-         |""".stripMargin
+        |""".stripMargin
     )
   }
 
@@ -296,8 +297,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
 
     f.setConfig(
       s"""version=$latest
-         |maxColumn = 40
-         |""".stripMargin
+        |maxColumn = 40
+        |""".stripMargin
     )
     f.assertFormat()
     assert(f.parsedCount == 2, f.parsed)
@@ -321,8 +322,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
     f.setVersion("1.0")
     f.assertError(
       """|error: path/.scalafmt.conf: org.scalafmt.dynamic.exceptions.ScalafmtException: failed to resolve Scalafmt version '1.0'
-         |Caused by: org.scalafmt.dynamic.ScalafmtVersion$InvalidVersionException: Invalid scalafmt version 1.0
-         |""".stripMargin
+        |Caused by: org.scalafmt.dynamic.ScalafmtVersion$InvalidVersionException: Invalid scalafmt version 1.0
+        |""".stripMargin
     )
     assert(f.downloadLogs.isEmpty)
   }
@@ -338,14 +339,14 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
         f.assertError(
           "lazy   val   x =  project",
           """|sbt.scala:1:1: error: classes cannot be lazy
-             |lazy   val   x =  project
-             |^^^^""".stripMargin
+            |lazy   val   x =  project
+            |^^^^""".stripMargin
         )
       }
     }
     f.setConfig(
       """|project.includeFilters = [ ".*" ]
-         |""".stripMargin
+        |""".stripMargin
     )
     f.setVersion(latest)
     check()
@@ -356,7 +357,7 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
   check("no-config") { f =>
     Files.delete(f.config)
     f.assertError("""|error: path/.scalafmt.conf: file does not exist
-                     |""".stripMargin)
+      |""".stripMargin)
   }
 
   check("intellij-default-config") { f: Format =>
@@ -372,8 +373,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
   checkExhaustive("continuation-indent-callSite-and-defnSite") { (f, version) =>
     f.setConfig(
       s"""version=$version
-         |continuationIndent.callSite = 5
-         |continuationIndent.defnSite = 3
+        |continuationIndent.callSite = 5
+        |continuationIndent.defnSite = 3
       """.stripMargin
     )
     val original =
@@ -406,7 +407,7 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
   checkExhaustive("hasRewriteRules-and-withoutRewriteRules") { (f, version) =>
     f.setConfig(
       s"""version=$version
-         |rewrite.rules = [RedundantBraces]
+        |rewrite.rules = [RedundantBraces]
         """.stripMargin
     )
     f.assertFormat()

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/PositionSyntax.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/PositionSyntax.scala
@@ -42,12 +42,13 @@ object PositionSyntax {
     def rangeNumber: String =
       s"${pos.startLine + 1}:${pos.startColumn + 1}..${pos.endLine + 1}:${pos.endColumn + 1}"
 
-    def rangeText: String = pos match {
-      case Position.None => ""
-      case _ =>
-        if (pos.startLine != pos.endLine) multilines
-        else lineTextAndCaret
-    }
+    def rangeText: String =
+      pos match {
+        case Position.None => ""
+        case _ =>
+          if (pos.startLine != pos.endLine) multilines
+          else lineTextAndCaret
+      }
     def lineTextAndCaret: String = {
       new StringBuilder()
         .append("\n")
@@ -78,16 +79,17 @@ object PositionSyntax {
       }
       sb.toString()
     }
-    def lineCaret: String = pos match {
-      case Position.None =>
-        ""
-      case _ =>
-        val caret =
-          if (pos.start == pos.end) "^"
-          else if (pos.startLine == pos.endLine) "^" * (pos.end - pos.start)
-          else "^"
-        (" " * pos.startColumn) + caret
-    }
+    def lineCaret: String =
+      pos match {
+        case Position.None =>
+          ""
+        case _ =>
+          val caret =
+            if (pos.start == pos.end) "^"
+            else if (pos.startLine == pos.endLine) "^" * (pos.end - pos.start)
+            else "^"
+          (" " * pos.startColumn) + caret
+      }
 
     private def lineContent(
         line: Int,
@@ -102,11 +104,12 @@ object PositionSyntax {
         endColumn = endColumn
       )
 
-    private def lineContent: String = pos match {
-      case Position.None => ""
-      case range: Position.Range =>
-        lineContent(range.startLine).text
-    }
+    private def lineContent: String =
+      pos match {
+        case Position.None => ""
+        case range: Position.Range =>
+          lineContent(range.startLine).text
+      }
   }
 
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/stats/GitInfo.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/stats/GitInfo.scala
@@ -23,9 +23,10 @@ object GitInfo {
     GitInfo("CI", "CI", currentBranch, currentCommit)
   }
 
-  def apply(): GitInfo = travis.getOrElse {
-    GitInfo(user, email, currentBranch, currentCommit)
-  }
+  def apply(): GitInfo =
+    travis.getOrElse {
+      GitInfo(user, email, currentBranch, currentCommit)
+    }
 
   def currentCommit = exec("git", "rev-parse", "HEAD")
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/FormatAssertions.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/FormatAssertions.scala
@@ -72,10 +72,10 @@ trait FormatAssertions extends DiffAssertions {
     val lines = augmentString(obtained).lines.toVector
     val arrow = (" " * (e.pos.startColumn - 2)) + "^"
     s"""${lines.slice(i - range, i + 1).mkString("\n")}
-       |$arrow
-       |${e.getMessage}
-       |${lines.slice(i + 1, i + range).mkString("\n")}
-       |$obtained
-       |""".stripMargin
+      |$arrow
+      |${e.getMessage}
+      |${lines.slice(i + 1, i + range).mkString("\n")}
+      |$obtained
+      |""".stripMargin
   }
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -56,8 +56,8 @@ class GitOpsTest extends funsuite.FixtureAnyFunSuite {
     link
   }
 
-  def mv(f: AbsoluteFile, dir: Option[AbsoluteFile] = None)(
-      implicit ops: GitOpsImpl
+  def mv(f: AbsoluteFile, dir: Option[AbsoluteFile] = None)(implicit
+      ops: GitOpsImpl
   ): AbsoluteFile = {
     val destDir = Files.createTempDirectory(
       dir.orElse(ops.rootDir).get.jfile.toPath,

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -27,21 +27,24 @@ import org.scalactic.source.Position
 trait HasTests extends FormatAssertions {
   import LoggerOps._
 
-  def scalafmtRunner(sr: ScalafmtRunner, dg: Debug): ScalafmtRunner = sr.copy(
-    debug = true,
-    maxStateVisits = 150000,
-    eventCallback = {
-      case CreateFormatOps(ops) => dg.formatOps = ops
-      case explored: Explored if explored.n % 10000 == 0 =>
-        logger.elem(explored)
-      case Enqueue(split) => dg.enqueued(split)
-      case evt: CompleteFormat => dg.completed(evt)
-      case _ =>
-    }
-  )
+  def scalafmtRunner(sr: ScalafmtRunner, dg: Debug): ScalafmtRunner =
+    sr.copy(
+      debug = true,
+      maxStateVisits = 150000,
+      eventCallback = {
+        case CreateFormatOps(ops) => dg.formatOps = ops
+        case explored: Explored if explored.n % 10000 == 0 =>
+          logger.elem(explored)
+        case Enqueue(split) => dg.enqueued(split)
+        case evt: CompleteFormat => dg.completed(evt)
+        case _ =>
+      }
+    )
 
   lazy val debugResults = mutable.ArrayBuilder.make[Result]
-  val testDir = new File(getClass.getClassLoader.getResource("test").toURI).getParent
+  val testDir = new File(
+    getClass.getClassLoader.getResource("test").toURI
+  ).getParent
 
   def tests: Seq[DiffTest]
 
@@ -85,8 +88,8 @@ trait HasTests extends FormatAssertions {
         case Configured.NotOk(c) =>
           throw new IllegalArgumentException(
             s"""Failed to parse filename $filename:
-               |$content
-               |$c""".stripMargin
+              |$content
+              |$c""".stripMargin
           )
       }
     val style: ScalafmtConfig = {

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/Report.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/Report.scala
@@ -58,9 +58,9 @@ object Report {
   def explanation =
     div(
       p("""Formatting output from scalafmt's test suite.
-          |The formatter uses Dijkstra's shortest path to determine the
-          |formatting with the "cheapest" cost. The red regions are
-          |tokens the formatter visits often.
+        |The formatter uses Dijkstra's shortest path to determine the
+        |formatting with the "cheapest" cost. The red regions are
+        |tokens the formatter visits often.
         """.stripMargin),
       ul(
         li("Declaration arguments: bin packed"),

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/Tabulator.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/Tabulator.scala
@@ -8,19 +8,20 @@ object Tabulator {
 
   def csv(table: Seq[Seq[Any]]) = table.map(_.mkString(",")).mkString("\n")
 
-  def format(table: Seq[Seq[Any]]) = table match {
-    case Seq() => ""
-    case _ =>
-      val sizes =
-        for (row <- table)
-          yield (for (cell <- row)
-            yield
-              if (cell == null) 0
-              else cell.toString.length)
-      val colSizes = for (col <- sizes.transpose) yield col.max
-      val rows = for (row <- table) yield formatRow(row, colSizes)
-      formatRows(rowSeparator(colSizes), rows)
-  }
+  def format(table: Seq[Seq[Any]]) =
+    table match {
+      case Seq() => ""
+      case _ =>
+        val sizes =
+          for (row <- table)
+            yield (for (cell <- row)
+              yield
+                if (cell == null) 0
+                else cell.toString.length)
+        val colSizes = for (col <- sizes.transpose) yield col.max
+        val rows = for (row <- table) yield formatRow(row, colSizes)
+        formatRows(rowSeparator(colSizes), rows)
+    }
 
   def formatRows(rowSeparator: String, rows: Seq[String]): String =
     (rowSeparator :: rows.head :: rowSeparator :: rows.tail.toList ::: rowSeparator :: List(


### PR DESCRIPTION
2.5.0-RC1 is available on Maven Central.

@kitbellew I see a lot of changes about `stripMargin` align. Is it intended by default? Diff in [CliArgParser](https://github.com/scalameta/scalafmt/compare/master...poslegm:self-formatting-2.5.0-rc1?expand=1#diff-90fa12de3f330db9b5e3bc1b91ec6055) looks weird a little.
![Screen Shot 2020-04-15 at 6 40 42 PM](https://user-images.githubusercontent.com/4687050/79357480-c3593e00-7f48-11ea-85ac-2de72ff7ec7d.png)
