### PR TITLE
Presets: automatically decode all config builtins

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ using [HOCON](https://github.com/lightbend/config) syntax.
 Here is an example `.scalafmt.conf`:
 
 ```scala config
-align = more    // For pretty alignment.
+align.preset = more    // For pretty alignment.
 maxColumn = 100 // For my wide 30" display.
 ```
 
@@ -108,6 +108,50 @@ val example2 =
   |""".stripMargin
 ```
 
+## Presets
+
+Some sections provide preset values to set multiple parameters at once.
+These are always accessed via the `preset` key of the appropriate section,
+including top-level.
+
+### Top-level presets
+
+- `preset=default`: this preset is implicit and sets all values to their defaults.
+- `preset=IntelliJ`: this preset is defined as
+
+```
+    preset = default
+    continuationIndent.defnSite = 2
+    optIn.configStyleArguments = false
+```
+
+- `preset=defaultWithAlign`: this preset is defined as
+
+```
+    preset = default
+    align.preset = more
+```
+
+- `preset=Scala.js`: this preset is defined as
+
+```
+    preset = default
+    binPack.preset = true
+    align.ifWhileOpenParen = false
+    continuationIndent.callSite = 4
+    docstrings = JavaDoc
+    importSelectors = binPack
+    newlines {
+      neverInResultType = true
+      neverBeforeJsNative = true
+      sometimesBeforeColonInMethodReturnType = false
+    )
+    runner.optimizer {
+      forceConfigStyleOnOffset = 500
+      forceConfigStyleMinArgCount = 5
+    }
+```
+
 ## Indentation
 
 ### `continuationIndent.callSite`
@@ -152,10 +196,10 @@ four possible presets: none, some, more, & most.
 
 ### `align`
 
-#### `align=none`
+#### `align.preset=none`
 
 ```scala mdoc:scalafmt
-align = none
+align.preset = none
 ---
 x match { // false for case arrows
   case 2  => 22 // also comments!
@@ -169,13 +213,13 @@ x match { // false for case arrows
 > rebasing.
 
 > Starting with the introduction of `align.stripMargin` parameter in v2.5.0,
-> one must explicitly enable it to get earlier behaviour of `align=none`.
+> one must explicitly enable it to get earlier behaviour of `align.preset=none`.
 > See [assumeStandardLibraryStripMargin](#assumestandardlibrarystripmargin).
 
-#### `align=some`
+#### `align.preset=some`
 
 ```scala mdoc:scalafmt
-align = some
+align.preset = some
 ---
 x match { // true for case arrows
   case 2 => 22
@@ -189,10 +233,10 @@ case object B extends A // false for `extends`
 case object BB extends A
 ```
 
-#### `align=more`
+#### `align.preset=more`
 
 ```scala mdoc:scalafmt
-align = more
+align.preset = more
 ---
 val x = 2 // true for assignment
 val xx = 22
@@ -229,10 +273,10 @@ libraryDependencies ++= Seq(
 )
 ```
 
-#### `align=most`
+#### `align.preset=most`
 
 ```scala mdoc:scalafmt
-align = most
+align.preset = most
 ---
 for {
   // align <- with =
@@ -401,7 +445,7 @@ See [assumeStandardLibraryStripMargin](#assumestandardlibrarystripmargin).
 align.stripMargin
 ```
 
-This functionality is enabled in all presets except `align=none` where it was
+This functionality is enabled in all presets except `align.preset=none` where it was
 disabled since the parameter's introduction in v2.5.0.
 
 ## Newlines
@@ -1307,12 +1351,12 @@ There is a possibility to override scalafmt config for a specific code with
 
 ```scala mdoc:scalafmt
 ---
-// scalafmt: { align = most, danglingParentheses = false }
+// scalafmt: { align.preset = most, danglingParentheses.preset = false }
 libraryDependencies ++= Seq(
   "org.scalameta" %% "scalameta" % scalametaV,
   "org.scalacheck" %% "scalacheck" % scalacheckV)
 
-// scalafmt: { align = some, danglingParentheses = true } (back to defaults)
+// scalafmt: { align.preset = some, danglingParentheses.preset = true } (back to defaults)
 libraryDependencies ++= Seq(
   "org.scalameta" %% "scalameta" % scalametaV,
   "org.scalacheck" %% "scalacheck" % scalacheckV)
@@ -1360,10 +1404,10 @@ a [PathMatcher](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSyst
 pattern. For instance,
 
 ```
-align = none
+align.preset = none
 fileOverride {
   "glob:**/*.sbt" {
-    align = most
+    align.preset = most
   }
   "glob:**/src/test/scala/**/*.scala" {
     maxColumn = 120
@@ -1372,8 +1416,8 @@ fileOverride {
 }
 ```
 
-uses `align=none` for all files except `.sbt` for which `align=most` will apply.
-It will also use different parameters for test suites.
+uses `align.preset=none` for all files except `.sbt` for which `align.preset=most`
+will apply. It will also use different parameters for test suites.
 
 > This parameter does not modify which files are formatted.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,10 +50,10 @@ it, considering
 
 ## Which configuration options minimize diffs/conflicts in version control?}
 
-- `align=none` If alignment is enabled a renaming of one entity can impact the
+- `align.preset=none` If alignment is enabled a renaming of one entity can impact the
   indentation of other entities.
 
-- `danglingParentheses=true` Having the closing parentheses on the same line as
+- `danglingParentheses.preset=true` Having the closing parentheses on the same line as
   the last argument makes the diff line include the parentheses and everything
   following it in case that argument is renamed. So, technically this does not
   reduce the number of diff lines, but the length of them.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -29,7 +29,7 @@ import metaconfig.generic.Surface
   *
   *               Pro tip. if you use for example
   *
-  *               style = defaultWithAlign
+  *               preset = defaultWithAlign
   *
   *               and want to add one extra token (for example "|>") to align by, write
   *
@@ -78,9 +78,10 @@ case class Align(
       "Enumerator.Generator" -> "for",
       "Enumerator.Val" -> "for"
     )
-) {
-  implicit val reader: ConfDecoder[Align] = generic.deriveDecoder(this).noTypos
-  implicit val alignReader: ConfDecoder[Seq[AlignToken]] =
+) extends Decodable[Align] {
+  override protected[config] def baseDecoder =
+    generic.deriveDecoder(this).noTypos
+  implicit def alignReader: ConfDecoder[Seq[AlignToken]] =
     Align.alignTokenReader(tokens)
 }
 
@@ -120,11 +121,6 @@ object Align {
     case Conf.Str("more") | Conf.Bool(true) => Align.more
     case Conf.Str("most") => Align.most
   }
-
-  def alignReader(base: ConfDecoder[Align]): ConfDecoder[Align] =
-    ConfDecoder.instance[Align] {
-      case c => preset.lift(c).fold(base.read(c))(Configured.ok)
-    }
 
   def alignTokenReader(
       initTokens: Seq[AlignToken]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
@@ -37,8 +37,9 @@ case class BinPack(
     literalsMinArgCount: Int = 5,
     literalsInclude: Seq[String] = Seq(".*"),
     literalsExclude: Seq[String] = Seq("String", "Term.Name")
-) {
-  val reader: ConfDecoder[BinPack] = generic.deriveDecoder(this).noTypos
+) extends Decodable[BinPack] {
+  override protected[config] def baseDecoder =
+    generic.deriveDecoder(this).noTypos
   def literalsRegex: FilterMatcher =
     FilterMatcher(literalsInclude, literalsExclude)
 }
@@ -46,4 +47,15 @@ object BinPack {
   implicit lazy val surface: generic.Surface[BinPack] =
     generic.deriveSurface[BinPack]
   implicit lazy val encoder: ConfEncoder[BinPack] = generic.deriveEncoder
+
+  val enabled = BinPack(
+    unsafeDefnSite = true,
+    unsafeCallSite = true,
+    parentConstructors = true
+  )
+  implicit val preset: PartialFunction[Conf, BinPack] = {
+    case Conf.Bool(true) => enabled
+    case Conf.Bool(false) => BinPack()
+  }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
@@ -66,7 +66,7 @@ object Config {
               ConfError.typeMismatch("Conf.Obj", x).notOk
           }
       }
-      ScalafmtConfig.configReader(default).read(next)
+      default.decoder.read(next)
     }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
@@ -6,8 +6,8 @@ case class DanglingParentheses(
     callSite: Boolean,
     defnSite: Boolean,
     exclude: List[DanglingParentheses.Exclude] = Nil
-) {
-  val decoder: ConfDecoder[DanglingParentheses] =
+) extends Decodable[DanglingParentheses] {
+  override protected[config] def baseDecoder =
     generic.deriveDecoder(this).noTypos
 }
 
@@ -20,11 +20,6 @@ object DanglingParentheses {
 
   implicit lazy val surface: generic.Surface[DanglingParentheses] =
     generic.deriveSurface
-
-  implicit val decoder: ConfDecoder[DanglingParentheses] =
-    ConfDecoder.instance[DanglingParentheses] {
-      case c => preset.lift(c).fold(default.decoder.read(c))(Configured.ok)
-    }
 
   implicit val encoder: ConfEncoder[DanglingParentheses] =
     generic.deriveEncoder

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
@@ -23,13 +23,16 @@ object DanglingParentheses {
 
   implicit val decoder: ConfDecoder[DanglingParentheses] =
     ConfDecoder.instance[DanglingParentheses] {
-      case Conf.Bool(true) => Configured.Ok(shortcutTrue)
-      case Conf.Bool(false) => Configured.Ok(shortcutFalse)
-      case els => default.decoder.read(els)
+      case c => preset.lift(c).fold(default.decoder.read(c))(Configured.ok)
     }
 
   implicit val encoder: ConfEncoder[DanglingParentheses] =
     generic.deriveEncoder
+
+  implicit val preset: PartialFunction[Conf, DanglingParentheses] = {
+    case Conf.Bool(true) => shortcutTrue
+    case Conf.Bool(false) => shortcutFalse
+  }
 
   sealed abstract class Exclude
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Decodable.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Decodable.scala
@@ -1,0 +1,58 @@
+package org.scalafmt.config
+
+import metaconfig._
+
+object Decodable {
+
+  val presetKey = "preset"
+
+}
+
+abstract class Decodable[A] { self: A =>
+  type T = A
+  protected[config] def baseDecoder: ConfDecoder[A]
+
+  implicit final def decoder(implicit
+      presets: PartialFunction[Conf, A]
+  ): ConfDecoder[A] =
+    new ConfDecoder[A] {
+      override def read(conf: Conf): Configured[A] = {
+        decodePresets(conf, presets) match {
+          case Some(x: Configured.NotOk) => x
+          case Some(Configured.Ok((obj, null))) => Configured.ok(obj)
+          case Some(Configured.Ok((obj, cfg))) =>
+            obj.asInstanceOf[Decodable[A]].baseDecoder.read(cfg)
+          case _ => self.baseDecoder.read(conf)
+        }
+      }
+    }
+
+  protected def decodePresets(
+      conf: Conf,
+      presets: PartialFunction[Conf, A]
+  ): Option[Configured[(A, Conf)]] = {
+    def me = getClass.getSimpleName
+    object presetsMatch {
+      def unapply(conf: Conf): Option[A] = presets.lift(conf)
+    }
+    conf match {
+      case Conf.Obj(v) =>
+        v.collectFirst { case (Decodable.presetKey, x) => x }.map {
+          case presetsMatch(x) =>
+            val filtered = v.filter(_._1 != Decodable.presetKey)
+            val newConf = if (filtered.isEmpty) null else Conf.Obj(filtered)
+            Configured.ok((x, newConf))
+          case x =>
+            ConfError.message(s"$me: unsupported preset: $x").notOk
+        }
+      case presetsMatch(x) =>
+        Console.err.println(
+          s"$me: top-level presets deprecated; " +
+            s"use '${Decodable.presetKey}' subsection"
+        )
+        Some(Configured.ok(x, null))
+      case _ => None
+    }
+  }
+
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ImportSelectors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ImportSelectors.scala
@@ -60,10 +60,13 @@ object ImportSelectors {
   // to ScalafmtConfig
   implicit val backwardsCompatibleReader: ConfDecoder[ImportSelectors] =
     ConfDecoder.instance[ImportSelectors] {
-      case Conf.Bool(true) => Ok(ImportSelectors.binPack)
-      case Conf.Bool(false) => Ok(ImportSelectors.noBinPack)
-      case els => reader.read(els)
+      case c => preset.lift(c).fold(reader.read(c))(Configured.ok)
     }
+
+  implicit val preset: PartialFunction[Conf, ImportSelectors] = {
+    case Conf.Bool(true) => ImportSelectors.binPack
+    case Conf.Bool(false) => ImportSelectors.noBinPack
+  }
 
   case object noBinPack extends ImportSelectors
   case object binPack extends ImportSelectors

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ImportSelectors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ImportSelectors.scala
@@ -1,6 +1,5 @@
 package org.scalafmt.config
 
-import metaconfig.Configured.Ok
 import metaconfig._
 
 /**
@@ -41,7 +40,9 @@ import metaconfig._
   * }}}
   *
   */
-sealed abstract class ImportSelectors
+sealed abstract class ImportSelectors extends Decodable[ImportSelectors] {
+  override protected[config] def baseDecoder = ImportSelectors.reader
+}
 
 object ImportSelectors {
 
@@ -58,11 +59,6 @@ object ImportSelectors {
   // limitations in the current version of scalameta/paradise, but these will
   // likely be fixed in the future, at which point this reader could be moved
   // to ScalafmtConfig
-  implicit val backwardsCompatibleReader: ConfDecoder[ImportSelectors] =
-    ConfDecoder.instance[ImportSelectors] {
-      case c => preset.lift(c).fold(reader.read(c))(Configured.ok)
-    }
-
   implicit val preset: PartialFunction[Conf, ImportSelectors] = {
     case Conf.Bool(true) => ImportSelectors.binPack
     case Conf.Bool(false) => ImportSelectors.noBinPack

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -32,8 +32,9 @@ import metaconfig._
 case class IndentOperator(
     include: String = ".*",
     exclude: String = "^(&&|\\|\\|)$"
-) {
-  val reader: ConfDecoder[IndentOperator] = generic.deriveDecoder(this).noTypos
+) extends Decodable[IndentOperator] {
+  override protected[config] def baseDecoder =
+    generic.deriveDecoder(this).noTypos
 
   private val includeRegexp = include.r.pattern
   private val excludeRegexp = exclude.r.pattern
@@ -50,10 +51,6 @@ object IndentOperator {
     generic.deriveSurface
   implicit lazy val encoder: ConfEncoder[IndentOperator] =
     generic.deriveEncoder
-  implicit val IndentOperatorDecoder: ConfDecoder[IndentOperator] =
-    ConfDecoder.instance[IndentOperator] {
-      case c => preset.lift(c).fold(default.reader.read(c))(Configured.ok)
-    }
 
   implicit val preset: PartialFunction[Conf, IndentOperator] = {
     case Conf.Str("spray" | "akka" | "akka-http") => IndentOperator.akka

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -1,6 +1,5 @@
 package org.scalafmt.config
 
-import metaconfig.Configured.Ok
 import metaconfig._
 
 /**
@@ -53,8 +52,11 @@ object IndentOperator {
     generic.deriveEncoder
   implicit val IndentOperatorDecoder: ConfDecoder[IndentOperator] =
     ConfDecoder.instance[IndentOperator] {
-      case Conf.Str("spray" | "akka" | "akka-http") => Ok(IndentOperator.akka)
-      case Conf.Str("default") => Ok(IndentOperator.default)
-      case els => default.reader.read(els)
+      case c => preset.lift(c).fold(default.reader.read(c))(Configured.ok)
     }
+
+  implicit val preset: PartialFunction[Conf, IndentOperator] = {
+    case Conf.Str("spray" | "akka" | "akka-http") => IndentOperator.akka
+    case Conf.Str("default") => IndentOperator.default
+  }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -333,17 +333,6 @@ object ScalafmtConfig {
       )
     )
 
-  def oneOf[T](m: Map[String, T])(input: String): Configured[T] =
-    m.get(input.toLowerCase()) match {
-      case Some(x) => Ok(x)
-      case None =>
-        val available = m.keys.mkString(", ")
-        val msg =
-          s"Unknown line endings type $input. Expected one of $available"
-        ConfError.message(msg).notOk
-
-    }
-
   def configReader(baseReader: ScalafmtConfig): ConfDecoder[ScalafmtConfig] =
     ConfDecoder.instance[ScalafmtConfig] {
       case conf @ Conf.Obj(values) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -192,7 +192,7 @@ case class ScalafmtConfig(
   private implicit val optInReader = optIn.reader
   private implicit val verticalMultilineReader = verticalMultiline.reader
   implicit val alignDecoder: ConfDecoder[Align] =
-    ScalafmtConfig.alignReader(align.reader)
+    Align.alignReader(align.reader)
   lazy val alignMap: Map[String, Regex] =
     align.tokens.map(x => x.code -> x.owner.r).toMap
   private implicit val confObjReader = ScalafmtConfig.confObjReader
@@ -367,20 +367,4 @@ object ScalafmtConfig {
         }
     }
 
-  def alignReader(base: ConfDecoder[Align]): ConfDecoder[Align] =
-    ConfDecoder.instance[Align] {
-      case Align.Builtin(a) => Ok(a)
-      case els => base.read(els)
-    }
-  def alignTokenReader(
-      initTokens: Seq[AlignToken]
-  ): ConfDecoder[Seq[AlignToken]] = {
-    val baseReader = ConfDecoder[Seq[AlignToken]]
-    ConfDecoder.instance[Seq[AlignToken]] {
-      case Conf.Obj(("add", conf) :: Nil) =>
-        baseReader.read(conf).map(initTokens ++ _)
-      case Align.Builtin(a) => Ok(a.tokens)
-      case els => baseReader.read(els)
-    }
-  }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SpaceBeforeContextBound.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SpaceBeforeContextBound.scala
@@ -3,7 +3,10 @@ package org.scalafmt.config
 import metaconfig._
 import org.scalafmt.config.SpaceBeforeContextBound.{Always, IfMultipleBounds}
 
-sealed trait SpaceBeforeContextBound {
+sealed abstract class SpaceBeforeContextBound
+    extends Decodable[SpaceBeforeContextBound] {
+  override protected[config] def baseDecoder = SpaceBeforeContextBound.decoder
+
   def isIfMultipleBounds = this == IfMultipleBounds
   def isAlways = this == Always
 }
@@ -14,10 +17,7 @@ object SpaceBeforeContextBound {
     ReaderUtil.oneOf[SpaceBeforeContextBound](Always, Never, IfMultipleBounds)
 
   implicit val encoder: ConfEncoder[SpaceBeforeContextBound] = codec
-  implicit val reader: ConfDecoder[SpaceBeforeContextBound] =
-    ConfDecoder.instance[SpaceBeforeContextBound] {
-      case c => preset.lift(c).fold(codec.read(c))(Configured.ok)
-    }
+  implicit val decoder: ConfDecoder[SpaceBeforeContextBound] = codec
 
   implicit val preset: PartialFunction[Conf, SpaceBeforeContextBound] = {
     case Conf.Bool(true) => Always

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SpaceBeforeContextBound.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SpaceBeforeContextBound.scala
@@ -1,9 +1,6 @@
 package org.scalafmt.config
 
-import metaconfig.ConfCodec
-import metaconfig.ConfEncoder
-import metaconfig.Configured.Ok
-import metaconfig.{Conf, ConfDecoder}
+import metaconfig._
 import org.scalafmt.config.SpaceBeforeContextBound.{Always, IfMultipleBounds}
 
 sealed trait SpaceBeforeContextBound {
@@ -19,10 +16,13 @@ object SpaceBeforeContextBound {
   implicit val encoder: ConfEncoder[SpaceBeforeContextBound] = codec
   implicit val reader: ConfDecoder[SpaceBeforeContextBound] =
     ConfDecoder.instance[SpaceBeforeContextBound] {
-      case Conf.Bool(true) => Ok(Always)
-      case Conf.Bool(false) => Ok(Never)
-      case x => codec.read(x)
+      case c => preset.lift(c).fold(codec.read(c))(Configured.ok)
     }
+
+  implicit val preset: PartialFunction[Conf, SpaceBeforeContextBound] = {
+    case Conf.Bool(true) => Always
+    case Conf.Bool(false) => Never
+  }
 
   case object Always extends SpaceBeforeContextBound
   case object Never extends SpaceBeforeContextBound

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
@@ -35,8 +35,10 @@ case class Spaces(
     inByNameTypes: Boolean = true,
     afterSymbolicDefs: Boolean = false
 ) {
+  implicit val spaceBeforeContextBoundReader = beforeContextBoundColon.decoder
   implicit val reader: ConfDecoder[Spaces] = generic.deriveDecoder(this).noTypos
 }
+
 object Spaces {
   implicit lazy val surface: generic.Surface[Spaces] = generic.deriveSurface
   implicit lazy val encoder: ConfEncoder[Spaces] = generic.deriveEncoder

--- a/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
+++ b/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
@@ -1,4 +1,4 @@
-align=most
+align.preset = most
 <<< Align = with <-
 for {
   _ <- f1

--- a/scalafmt-tests/src/test/resources/align/ArrayIndexOutOfBounds800.source
+++ b/scalafmt-tests/src/test/resources/align/ArrayIndexOutOfBounds800.source
@@ -1,8 +1,8 @@
-style = defaultWithAlign
+preset = defaultWithAlign
 edition = 2019-10
 onTestFailure = "Search state"
-align = most
-danglingParentheses = false
+align.preset = most
+danglingParentheses.preset = false
 <<< #800
 object Test {
   Some(Files.newInputStream(inFile)) match {

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -1,4 +1,4 @@
-align = more
+align.preset = more
 <<< => with comment
 x match {
   case 1 => 2 // this is a comment
@@ -530,7 +530,7 @@ val iovec = CStruct2[
   CSize
 ](a) // iov_len
 <<< #1720 no align
-align = none
+align.preset = none
 ===
 type iovec = CStruct2[Ptr[Byte], // iov_base
                         CSize] // iov_len

--- a/scalafmt-tests/src/test/resources/align/MixedTokens.stat
+++ b/scalafmt-tests/src/test/resources/align/MixedTokens.stat
@@ -1,4 +1,4 @@
-style = defaultWithAlign
+preset = defaultWithAlign
 align.tokenCategory {
   Equals = Assign
   LeftArrow = Assign

--- a/scalafmt-tests/src/test/resources/align/TrollAlignment.stat
+++ b/scalafmt-tests/src/test/resources/align/TrollAlignment.stat
@@ -1,4 +1,4 @@
-style = defaultWithAlign
+preset = defaultWithAlign
 align.treeCategory {
   Case: Assign
   "Enumerator.Generator": Assign

--- a/scalafmt-tests/src/test/resources/align/addSbtPlugin.source
+++ b/scalafmt-tests/src/test/resources/align/addSbtPlugin.source
@@ -1,4 +1,4 @@
-style = defaultWithAlign
+preset = defaultWithAlign
 runner.dialect = Sbt0137
 <<< align addSbtPlugin
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M14")

--- a/scalafmt-tests/src/test/resources/align/comment-wrapping.source
+++ b/scalafmt-tests/src/test/resources/align/comment-wrapping.source
@@ -1,7 +1,7 @@
-style = defaultWithAlign
+preset = defaultWithAlign
 runner.dialect = Sbt0137
 align.openParenCallSite = true
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< wrap with inline comment
 lazy val ivyProj = (project in file("ivy"))
   .dependsOn(interfaceProj,

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -680,13 +680,13 @@ val a = b(
     /* comment */ arg1,
     arg2)
 <<< init with multiple curried parameters and comment, long
-align = none
+align.preset = none
 ===
 val a = new b(/*c1*/c => d)(/*c2*/e => f, g => h)
 >>>
 val a = new b( /*c1*/ c => d)( /*c2*/ e => f, g => h)
 <<< init with multiple curried parameters and comment, short
-align = none
+align.preset = none
 maxColumn = 30
 ===
 val a = new b(/*c1*/c => dddddddd)(/*c2*/e => f, g => h)
@@ -712,7 +712,7 @@ object ThreadPoolConfigDispatcherBuilder {
     opt map fun
 }
 <<< implicit with single argument
-align = none
+align.preset = none
 ===
   def apply(throughput: Int)(implicit context: ExecutionContext)
       : SerializedSuspendableExecutionContext =

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -159,7 +159,7 @@ final class TypedArrayBufferOps[ // scalastyle:ignore
   ???
 }
 <<< #1362 1: single implict, long line
-danglingParentheses = true
+danglingParentheses.preset = true
 align.openParenCallSite = false
 align.openParenDefnSite = false
 ===
@@ -200,7 +200,7 @@ case class Foo(
 }
 <<< #1362 2: single implicit, short line
 maxColumn = 40
-danglingParentheses = true
+danglingParentheses.preset = true
 align.openParenCallSite = false
 align.openParenDefnSite = false
 ===
@@ -241,7 +241,7 @@ case class Foo(
 }
 <<< #1362 3: multiple implicits, short line
 maxColumn = 30
-danglingParentheses = true
+danglingParentheses.preset = true
 align.openParenCallSite = false
 align.openParenDefnSite = false
 ===
@@ -284,7 +284,7 @@ case class Foo(
 }
 <<< #1362 4: multiple implicits, long line
 maxColumn = 60
-danglingParentheses = true
+danglingParentheses.preset = true
 align.openParenCallSite = false
 align.openParenDefnSite = false
 ===

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -312,7 +312,7 @@ trait Test[A] {
   def <=>[B](that: Test[B]): Int
 }
 <<< #1787
-danglingParentheses = true
+danglingParentheses.preset = true
 ===
 object a {
   private def getTopN[T](s: Iterable[T], n: Int)(

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -83,7 +83,7 @@ for ((l, r) ← /* c1 */ (/* c2 */ Seq(
        ) // test Java API
      )) checkOne(looker, l, r)
 <<< multiline for with paren, no align
-align = none
+align.preset = none
 ===
 for ((l, r) ← /* c1 */ ( /* c2 */Seq(
     SelectString("a/b/c") -> None,

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -194,7 +194,7 @@ val add = (x: Int) => x + 2
 >>>
 val add = (x: Int) => x + 2
 <<< #965
-style = defaultWithAlign
+preset = defaultWithAlign
 maxColumn = 120
 newlines.sometimesBeforeColonInMethodReturnType = false
 align.openParenCallSite = false
@@ -321,9 +321,9 @@ testAsync("Resource.make is equivalent to a partially applied bracket") {
     }
 }
 <<< #1714 2
-align = none
+align.preset = none
 maxColumn = 120
-danglingParentheses = true
+danglingParentheses.preset = true
 ===
 testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
     check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]) =>
@@ -337,9 +337,9 @@ testAsync("Resource.make is equivalent to a partially applied bracket") { implic
   }
 }
 <<< #1714 3
-align = none
+align.preset = none
 maxColumn = 120
-danglingParentheses = true
+danglingParentheses.preset = true
 ===
 testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
     check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]/* c1 */)/* c2 */=>
@@ -354,9 +354,9 @@ testAsync("Resource.make is equivalent to a partially applied bracket") { implic
   }
 }
 <<< #1714 4
-align = none
+align.preset = none
 maxColumn = 120
-danglingParentheses = true
+danglingParentheses.preset = true
 ===
 testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
     check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]/* c1 */)/* c2 */=>
@@ -371,9 +371,9 @@ testAsync("Resource.make is equivalent to a partially applied bracket") { implic
   }
 }
 <<< #1714 5
-align = none
+align.preset = none
 maxColumn = 120
-danglingParentheses = true
+danglingParentheses.preset = true
 ===
 testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
     check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String]/* c1 */)/* c2 */=>
@@ -412,7 +412,7 @@ object Foo {
   }
 }
 <<< #1485
-style = IntelliJ
+preset = IntelliJ
 maxColumn = 120
 ===
 class A {

--- a/scalafmt-tests/src/test/resources/default/Trait.stat
+++ b/scalafmt-tests/src/test/resources/default/Trait.stat
@@ -104,7 +104,7 @@ abstract class Quantity[A <: Quantity[A]]
   println(1)
 }
 <<< trait with multiple complex type params
-align = none
+align.preset = none
 ===
  trait CounterLike[
     K, V, +M <: scala.collection.mutable.Map[K, V], +This <: Counter[K, V]]

--- a/scalafmt-tests/src/test/resources/default/Val.stat
+++ b/scalafmt-tests/src/test/resources/default/Val.stat
@@ -287,7 +287,7 @@ val currentName = currentNameOption | info.hasSimul
   )
   .name
 <<< apply with optimal token inside, no dangle
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 val currentName = currentNameOption | info.hasSimul
   .fold(
@@ -303,7 +303,7 @@ val currentName = currentNameOption | info.hasSimul
   )
   .name
 <<< apply with optimal token inside, and comment, no dangle
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 val currentName = currentNameOption | info.hasSimul
   .fold(

--- a/scalafmt-tests/src/test/resources/newdefault/CaseNoAlign.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/CaseNoAlign.stat
@@ -1,6 +1,6 @@
-style = default
+preset = default
 maxColumn = 80
-align = none
+align.preset = none
 <<< Route partial function
 val Route: PartialFunction[Decision, Decision] = {
   case FormatToken(_: Ident | _: `this` | _: `_ ` | _: `(`, _: `.` | _: `#`, _) =>

--- a/scalafmt-tests/src/test/resources/newdefault/ColumnWidth.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/ColumnWidth.stat
@@ -1,4 +1,4 @@
-style = default
+preset = default
 <<< n-th column is OK, #975
 object Wat {
   val a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
@@ -1,4 +1,4 @@
-style = default
+preset = default
 <<< forAll
 forAll(table)(
   (reqProto, headReq, reqCH, resProto, resCH, resCD, renCH, close) ⇒

--- a/scalafmt-tests/src/test/resources/newlines/OffByOneParameterlessMethod.stat
+++ b/scalafmt-tests/src/test/resources/newlines/OffByOneParameterlessMethod.stat
@@ -1,7 +1,7 @@
-style = defaultWithAlign
+preset = defaultWithAlign
 newlines.sometimesBeforeColonInMethodReturnType = false
 maxColumn = 32
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< equals is at column + 1
 object Test {
 //-----------------------------|

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaAlways.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaAlways.stat
@@ -1,4 +1,4 @@
-style = default
+preset = default
 newlines.afterCurlyLambda = always
 
 <<< Preserve (when always) newline in lambda call

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaNever.stat
@@ -1,4 +1,4 @@
-style = default
+preset = default
 newlines.afterCurlyLambda = never
 
 <<< Remove newline in lambda call

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
@@ -1,4 +1,4 @@
-style = default
+preset = default
 newlines.afterCurlyLambda = preserve
 
 <<< Preserve newline in lambda call

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeElseAfterCurlyIf.stat
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeElseAfterCurlyIf.stat
@@ -1,4 +1,4 @@
-style = default
+preset = default
 newlines.alwaysBeforeElseAfterCurlyIf = true
 
 <<< Insert line break between curly if and else

--- a/scalafmt-tests/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/src/test/resources/newlines/source.source
@@ -23,7 +23,7 @@ object a {
 <<< complex infix source, fold
 runner.optimizer.maxVisitsPerToken = 2000
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 newlines.source = fold
 ===
 /**

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1,4 +1,4 @@
-align = none
+align.preset = none
 maxColumn = 40
 # newlines.source = classic
 runner.optimizer.forceConfigStyleOnOffset = 50
@@ -455,7 +455,7 @@ object a {
     )
 }
 <<< 2.16 val with apply and comment
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 val a =
   Set(
@@ -631,7 +631,7 @@ a.b(foo {
 })
 <<< 3.10 enclosed, infix on the right
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   terminaters = Set() ++ (for (i ← 1 to n)
@@ -652,7 +652,7 @@ object a {
 }
 <<< 3.11 enclosed, by itself
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (for (i ← 1 to n)
@@ -673,7 +673,7 @@ object a {
 }
 <<< 3.12 enclosed, followed by select
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (intercept[java.lang.IllegalStateException] {
@@ -696,7 +696,7 @@ object a {
 }
 <<< 3.13 enclosed, followed by select and infix
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (intercept[java.lang.IllegalStateException] {
@@ -715,7 +715,7 @@ object a {
 }
 <<< 3.14 enclosed, assignment, by itself
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -734,7 +734,7 @@ object a {
 }
 <<< 3.15 enclosed, assignment, infix on left
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -753,7 +753,7 @@ object a {
 }
 <<< 3.16 enclosed, assignment, infix on right
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -772,7 +772,7 @@ object a {
 }
 <<< 3.17 enclosed, assignment, infix in middle
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -791,7 +791,7 @@ object a {
 }
 <<< 3.18 enclosed, assignment, by itself, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (intercept[java.lang.IllegalStateException] {
@@ -806,7 +806,7 @@ object a {
 }
 <<< 3.19 enclosed, assignment, infix on left, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -825,7 +825,7 @@ object a {
 }
 <<< 3.20 enclosed, assignment, infix on right, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -844,7 +844,7 @@ object a {
 }
 <<< 3.21 enclosed, assignment, infix in middle, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -863,7 +863,7 @@ object a {
 }
 <<< 3.22 enclosed, assignment, by itself, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -883,7 +883,7 @@ object a {
 }
 <<< 3.23 enclosed, assignment, infix on left, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -903,7 +903,7 @@ object a {
 }
 <<< 3.24 enclosed, assignment, infix on right, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -923,7 +923,7 @@ object a {
 }
 <<< 3.25 enclosed, assignment, infix in middle, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -988,7 +988,7 @@ def activationFutureFor(
   })
 <<< 3.28 apply with optimal token
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 case class AttributeInfo(symbol : Symbol, typeRef : Type, value : Option[Any],
   values : Seq[String ~ Any]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1,4 +1,4 @@
-align = none
+align.preset = none
 maxColumn = 40
 newlines.source = fold
 newlines.afterCurlyLambda = squash
@@ -415,7 +415,7 @@ object a {
   )
 }
 <<< 2.16 val with apply and comment
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 val a = Set(
   "b" // ...
@@ -572,7 +572,7 @@ a.b(foo {
 })
 <<< 3.10 enclosed, infix on the right
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   terminaters = Set() ++ (for (i ← 1 to n)
@@ -593,7 +593,7 @@ object a {
 }
 <<< 3.11 enclosed, by itself
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (for (i ← 1 to n)
@@ -613,7 +613,7 @@ object a {
 }
 <<< 3.12 enclosed, followed by select
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (intercept[java.lang.IllegalStateException] {
@@ -637,7 +637,7 @@ object a {
 }
 <<< 3.13 enclosed, followed by select and infix
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (intercept[java.lang.IllegalStateException] {
@@ -655,7 +655,7 @@ object a {
 }
 <<< 3.14 enclosed, assignment, by itself
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -670,7 +670,7 @@ object a {
 }
 <<< 3.15 enclosed, assignment, infix on left
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -685,7 +685,7 @@ object a {
 }
 <<< 3.16 enclosed, assignment, infix on right
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -700,7 +700,7 @@ object a {
 }
 <<< 3.17 enclosed, assignment, infix in middle
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -716,7 +716,7 @@ object a {
 }
 <<< 3.18 enclosed, assignment, by itself, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (intercept[java.lang.IllegalStateException] {
@@ -731,7 +731,7 @@ object a {
 }
 <<< 3.19 enclosed, assignment, infix on left, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -748,7 +748,7 @@ object a {
 }
 <<< 3.20 enclosed, assignment, infix on right, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -766,7 +766,7 @@ object a {
 }
 <<< 3.21 enclosed, assignment, infix in middle, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -784,7 +784,7 @@ object a {
 }
 <<< 3.22 enclosed, assignment, by itself, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -803,7 +803,7 @@ object a {
 }
 <<< 3.23 enclosed, assignment, infix on left, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -821,7 +821,7 @@ object a {
 }
 <<< 3.24 enclosed, assignment, infix on right, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -840,7 +840,7 @@ object a {
 }
 <<< 3.25 enclosed, assignment, infix in middle, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -900,7 +900,7 @@ def activationFutureFor(
 })
 <<< 3.28 apply with optimal token
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 case class AttributeInfo(symbol : Symbol, typeRef : Type, value : Option[Any],
   values : Seq[String ~ Any]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}
@@ -1464,7 +1464,7 @@ object a {
 }
 <<< 7.7: for-yield enclosed in parens
 maxColumn = 40
-danglingParentheses = true
+danglingParentheses.preset = true
 ===
 for {
   nu <- rand.gaussian(0, 1)

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1,4 +1,4 @@
-align = none
+align.preset = none
 maxColumn = 40
 newlines.source = keep
 runner.optimizer.forceConfigStyleOnOffset = 50
@@ -454,7 +454,7 @@ object a {
     )
 }
 <<< 2.16 val with apply and comment
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 val a =
   Set(
@@ -628,7 +628,7 @@ a.b(foo {
 })
 <<< 3.10 enclosed, infix on the right
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   terminaters = Set() ++ (for (i ← 1 to n)
@@ -649,7 +649,7 @@ object a {
 }
 <<< 3.11 enclosed, by itself
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (for (i ← 1 to n) yield {
@@ -668,7 +668,7 @@ object a {
 }
 <<< 3.12 enclosed, followed by select
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (intercept[java.lang.IllegalStateException] {
@@ -691,7 +691,7 @@ object a {
 }
 <<< 3.13 enclosed, followed by select and infix
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (intercept[java.lang.IllegalStateException] { in.readObject
@@ -709,7 +709,7 @@ object a {
 }
 <<< 3.14 enclosed, assignment, by itself
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (intercept[java.lang.IllegalStateException] {
@@ -723,7 +723,7 @@ object a {
 }
 <<< 3.15 enclosed, assignment, infix on left
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -739,7 +739,7 @@ object a {
 }
 <<< 3.16 enclosed, assignment, infix on right
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (intercept[java.lang.IllegalStateException] { in.readObject
@@ -751,7 +751,7 @@ object a {
 }
 <<< 3.17 enclosed, assignment, infix in middle
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (intercept[java.lang.IllegalStateException] { in.readObject }) ++ 3
@@ -763,7 +763,7 @@ object a {
 }
 <<< 3.18 enclosed, assignment, by itself, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (intercept[java.lang.IllegalStateException] {
@@ -778,7 +778,7 @@ object a {
 }
 <<< 3.19 enclosed, assignment, infix on left, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (intercept[java.lang.IllegalStateException] {
@@ -794,7 +794,7 @@ object a {
 }
 <<< 3.20 enclosed, assignment, infix on right, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -810,7 +810,7 @@ object a {
 }
 <<< 3.21 enclosed, assignment, infix in middle, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -826,7 +826,7 @@ object a {
 }
 <<< 3.22 enclosed, assignment, by itself, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (intercept[java.lang.IllegalStateException] {
@@ -843,7 +843,7 @@ object a {
 }
 <<< 3.23 enclosed, assignment, infix on left, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -861,7 +861,7 @@ object a {
 }
 <<< 3.24 enclosed, assignment, infix on right, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (intercept[java.lang.IllegalStateException] { in.readObject }
@@ -876,7 +876,7 @@ object a {
 }
 <<< 3.25 enclosed, assignment, infix in middle, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (intercept[java.lang.IllegalStateException] {
@@ -937,7 +937,7 @@ def activationFutureFor(
   })
 <<< 3.28 apply with optimal token
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 case class AttributeInfo(symbol : Symbol, typeRef : Type, value : Option[Any],
   values : Seq[String ~ Any]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1,4 +1,4 @@
-align = none
+align.preset = none
 maxColumn = 40
 newlines.source = unfold
 runner.optimizer.forceConfigStyleOnOffset = 50
@@ -515,7 +515,7 @@ object a {
   )
 }
 <<< 2.16 val with apply and comment
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 val a = Set("b" // ...
 )
@@ -677,7 +677,7 @@ a.b(
 )
 <<< 3.10 enclosed, infix on the right
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   terminaters = Set() ++ (for (i ← 1 to n)
@@ -699,7 +699,7 @@ object a {
 }
 <<< 3.11 enclosed, by itself
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (for (i ← 1 to n)
@@ -720,7 +720,7 @@ object a {
 }
 <<< 3.12 enclosed, followed by select
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (intercept[java.lang.IllegalStateException] {
@@ -750,7 +750,7 @@ object a {
 }
 <<< 3.13 enclosed, followed by select and infix
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   (intercept[java.lang.IllegalStateException] {
@@ -772,7 +772,7 @@ object a {
 }
 <<< 3.14 enclosed, assignment, by itself
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -789,7 +789,7 @@ object a {
 }
 <<< 3.15 enclosed, assignment, infix on left
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -806,7 +806,7 @@ object a {
 }
 <<< 3.16 enclosed, assignment, infix on right
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -824,7 +824,7 @@ object a {
 }
 <<< 3.17 enclosed, assignment, infix in middle
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -842,7 +842,7 @@ object a {
 }
 <<< 3.18 enclosed, assignment, by itself, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (intercept[java.lang.IllegalStateException] {
@@ -857,7 +857,7 @@ object a {
 }
 <<< 3.19 enclosed, assignment, infix on left, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -874,7 +874,7 @@ object a {
 }
 <<< 3.20 enclosed, assignment, infix on right, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -892,7 +892,7 @@ object a {
 }
 <<< 3.21 enclosed, assignment, infix in middle, narrower
 maxColumn = 60
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -910,7 +910,7 @@ object a {
 }
 <<< 3.22 enclosed, assignment, by itself, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -928,7 +928,7 @@ object a {
 }
 <<< 3.23 enclosed, assignment, infix on left, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = (
@@ -946,7 +946,7 @@ object a {
 }
 <<< 3.24 enclosed, assignment, infix on right, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -965,7 +965,7 @@ object a {
 }
 <<< 3.25 enclosed, assignment, infix in middle, narrow
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 object a {
   val a = 2 ++ (
@@ -1029,7 +1029,7 @@ def activationFutureFor(
 })
 <<< 3.28 apply with optimal token
 maxColumn = 80
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 case class AttributeInfo(symbol : Symbol, typeRef : Type, value : Option[Any],
   values : Seq[String ~ Any]) // sym_Ref info_Ref {constant_Ref} {nameRef constantRef}

--- a/scalafmt-tests/src/test/resources/optIn/Annotation.stat
+++ b/scalafmt-tests/src/test/resources/optIn/Annotation.stat
@@ -1,5 +1,5 @@
 optIn.annotationNewlines = true
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< keep lines of annotations unchanged
 object WrapperToHaveStatTestCaseParserWorking {
   @annot   @deprecated   class B(@annot @deprecated x: Int) extends A {

--- a/scalafmt-tests/src/test/resources/optIn/SelectChains.stat
+++ b/scalafmt-tests/src/test/resources/optIn/SelectChains.stat
@@ -1,5 +1,5 @@
 optIn.breaksInsideChains = true
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< airframe
 val design: Design =
   newDesign                      // Create an empty design

--- a/scalafmt-tests/src/test/resources/optIn/forceBlankLineBeforeDocstring.stat
+++ b/scalafmt-tests/src/test/resources/optIn/forceBlankLineBeforeDocstring.stat
@@ -1,4 +1,4 @@
-style = default
+preset = default
 <<< docstring does not force line break
 optIn.forceBlankLineBeforeDocstring = false
 ===

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-ParenLambdas.stat
@@ -173,7 +173,7 @@ def a(b: B): C[D] =
 def a(b: B): C[D] =
   C[String].contramap[D]((i: D, j: Int) => b.format(i))
 <<< #1708
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 val a = b[IO](
 { c: Int => if (d) e else f }, g)

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -345,7 +345,7 @@ object a {
   b.c({ d => e + f })
 }
 <<< #1027 3.1: with align
-align = more
+align.preset = more
 ===
 object a {
   val b = c(d => {e}) // comment1
@@ -357,7 +357,7 @@ object a {
   val bb = cc(dd => ee) // comment2
 }
 <<< #1027 3.2: with align
-align = more
+align.preset = more
 ===
 object a {
   val b = c(d => {e}) // comment1
@@ -369,7 +369,7 @@ object a {
   val bb = cc(dd => ee) // comment2
 }
 <<< #1027 3.3: with align
-align = more
+align.preset = more
 ===
 object a {
   val b = c(d => {e})(d => {e}) // comment1
@@ -381,7 +381,7 @@ object a {
   val bb = cc(dd => ee)(dd => ee) // comment2
 }
 <<< #1027 3.4: with align
-align = more
+align.preset = more
 ===
 object a {
   val b = c(d => {e})(d => {e}) // comment1
@@ -393,7 +393,7 @@ object a {
   val bb = cc(dd => ee)(dd => ee) // comment2
 }
 <<< #1027 3.5: with align
-align = more
+align.preset = more
 ===
 object a {
   val b = c(d => e)(d => e) // comment1
@@ -406,7 +406,7 @@ object a {
 }
 <<< #1027 3.6: with align, no redundant braces
 rewrite.rules = []
-align = more
+align.preset = more
 ===
 object a {
   val b  = c(d => e)(d => e) // comment1

--- a/scalafmt-tests/src/test/resources/spaces/BeforeContextBoundColonTrue.stat
+++ b/scalafmt-tests/src/test/resources/spaces/BeforeContextBoundColonTrue.stat
@@ -1,4 +1,4 @@
-spaces.beforeContextBoundColon = true
+spaces.beforeContextBoundColon.preset = true
 <<< space before colon #180
 def map[T: Class](f: N => T): S[T]
 >>>

--- a/scalafmt-tests/src/test/resources/spaces/InParentheses.stat
+++ b/scalafmt-tests/src/test/resources/spaces/InParentheses.stat
@@ -1,6 +1,6 @@
 spaces.inParentheses = true
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< Spaces in parentheses
 function(a, b, c)
 >>>

--- a/scalafmt-tests/src/test/resources/test/BlocksInSingleArg.stat
+++ b/scalafmt-tests/src/test/resources/test/BlocksInSingleArg.stat
@@ -1,4 +1,4 @@
-style = IntelliJ
+preset = IntelliJ
 optIn.configStyleArguments = true
 <<< single arg with curly
   println(

--- a/scalafmt-tests/src/test/resources/test/ContinuationIndentNoDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/test/ContinuationIndentNoDanglingParens.stat
@@ -1,7 +1,7 @@
 continuationIndent.callSite   = 2
 continuationIndent.defnSite   = 4
 continuationIndent.extendSite = 4
-danglingParentheses = false
+danglingParentheses.preset = false
 maxColumn = 50
 <<< Type Annotation Site
 def doAThingFunction(extremelyLongNamedParameterNumberOne: Int, extremelyLongNamedParameterNumberTwo: Int): ExtremelyLongNameForAReturnValueType

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -1,4 +1,4 @@
-style = intellij
+preset = intellij
 maxColumn = 40
 continuationIndent.callSite = 4
 <<< single line still works

--- a/scalafmt-tests/src/test/resources/test/DynamicStyle.stat
+++ b/scalafmt-tests/src/test/resources/test/DynamicStyle.stat
@@ -1,9 +1,9 @@
 maxColumn = 100 # comment
-style = defaultWithAlign
+preset = defaultWithAlign
 unindentTopLevelOperators = true
 indentOperator.exclude = ":\\+:"
 align.tokens.add = [foo]
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< dynamic
 // scalafmt: { maxColumn = 20 }
 function(aaaaaaaaaaa, bbbbbbb)
@@ -61,14 +61,14 @@ type Row =
   val xx = 22 + foo
 }
 <<< override align it is none originally
-align=none
+align.preset = none
 ===
 object a {
   for {
     x <- "asd"
     xxxx <- "bb"
   } yield x
-  // scalafmt: { align = most }
+  // scalafmt: { align.preset = most }
   for {
     x <- "asd"
     xxxx <- "bb"
@@ -80,7 +80,7 @@ object a {
     x <- "asd"
     xxxx <- "bb"
   } yield x
-  // scalafmt: { align = most }
+  // scalafmt: { align.preset = most }
   for {
     x    <- "asd"
     xxxx <- "bb"

--- a/scalafmt-tests/src/test/resources/test/NoAlign.stat
+++ b/scalafmt-tests/src/test/resources/test/NoAlign.stat
@@ -1,7 +1,7 @@
 maxColumn = 40
 align.openParenDefnSite = true
 align.openParenCallSite = false
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< single line still works
 function(aaaaaaaa, bbbbbbbb)
 >>>

--- a/scalafmt-tests/src/test/resources/test/OperatorSpray.stat
+++ b/scalafmt-tests/src/test/resources/test/OperatorSpray.stat
@@ -2,7 +2,7 @@
 // but uses the default unindentTopLevelOperators = false
 // Tests have been updated to match expected output
 unindentTopLevelOperators = false
-indentOperator = spray
+indentOperator.preset = spray
 <<< Indent operators
 object TestRoutes {
   def routes = {

--- a/scalafmt-tests/src/test/resources/test/Type747.stat
+++ b/scalafmt-tests/src/test/resources/test/Type747.stat
@@ -1,5 +1,5 @@
 align.openParenDefnSite = false
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< #747
 type MyTypeWithVeryLongName = (A,
                                Int,

--- a/scalafmt-tests/src/test/resources/test/UnindentTopLevelOperatorsOperatorSpray.stat
+++ b/scalafmt-tests/src/test/resources/test/UnindentTopLevelOperatorsOperatorSpray.stat
@@ -1,5 +1,5 @@
 unindentTopLevelOperators = true
-indentOperator = spray
+indentOperator.preset = spray
 <<< Indent operators
 object TestRoutes {
   def routes = {

--- a/scalafmt-tests/src/test/resources/test/i1116.stat
+++ b/scalafmt-tests/src/test/resources/test/i1116.stat
@@ -1,4 +1,4 @@
-style = default
+preset = default
 <<< #1116
 val x: A#   !
 >>>

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -1,6 +1,6 @@
 maxColumn = 30
 trailingCommas = always
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< should add a trailing comma on the last argument
 def method(
     a: String,

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysAlignMore.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysAlignMore.stat
@@ -1,6 +1,6 @@
 maxColumn = 30
 trailingCommas = always
-align = more
+align.preset = more
 <<< should consider comments with extra whitespace when adding trailing commas align more
 def method(
     abc: String, // abc comment

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -1,6 +1,6 @@
 maxColumn = 30
-danglingParentheses = true
-align = none
+danglingParentheses.preset = true
+align.preset = none
 trailingCommas = always
 
 <<< should add a trailing comma on the last argument

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultiple.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultiple.stat
@@ -1,6 +1,6 @@
 maxColumn = 30
 trailingCommas = multiple
-danglingParentheses = false
+danglingParentheses.preset = false
 <<< should add a trailing comma on the last argument
 def method(
     a: String,

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleAlignMore.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleAlignMore.stat
@@ -1,6 +1,6 @@
 maxColumn = 30
 trailingCommas = multiple
-align = more
+align.preset = more
 <<< should consider comments with extra whitespace when adding trailing commas align more
 def method(
     abc: String, // abc comment

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleDanglingParens.stat
@@ -1,6 +1,6 @@
 maxColumn = 30
-danglingParentheses = true
-align = none
+danglingParentheses.preset = true
+align.preset = none
 trailingCommas = multiple
 
 <<< should add a trailing comma on the last argument

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNeverCommentsAlignMore.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNeverCommentsAlignMore.stat
@@ -1,6 +1,6 @@
 maxColumn = 30
 trailingCommas = never
-align = more
+align.preset = more
 
 <<< should consider comments when removing trailing commas while align comment
 def method(

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
@@ -1,6 +1,6 @@
 maxColumn = 30
-align = none
-danglingParentheses = true
+align.preset = none
+danglingParentheses.preset = true
 trailingCommas = preserve
 
 <<< should preserve the lack of trailing commas
@@ -40,7 +40,7 @@ def a(b: Int,
 def a(b: Int, c: Int)
 <<< should remove trailing comma when folding, with comment
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 def a(b: Int, c: Int,
  /* comment */ )
@@ -57,7 +57,7 @@ def a( b: Int, c: Int )
 <<< should remove trailing comma when folding, with spaces and comment
 spaces.inParentheses = true
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 def a(b: Int, c: Int,
  /* comment */ )

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -105,7 +105,7 @@ implicit def pairEncoder[A, B](implicit
   bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]
 <<< #1362 1: single implict, long line
-danglingParentheses = true
+danglingParentheses.preset = true
 align.openParenCallSite = false
 align.openParenDefnSite = false
 ===
@@ -145,7 +145,7 @@ case class Foo(
 }
 <<< #1362 2: single implicit, short line
 maxColumn = 40
-danglingParentheses = true
+danglingParentheses.preset = true
 align.openParenCallSite = false
 align.openParenDefnSite = false
 ===
@@ -185,7 +185,7 @@ case class Foo(
 }
 <<< #1362 3: multiple implicits, short line
 maxColumn = 30
-danglingParentheses = true
+danglingParentheses.preset = true
 align.openParenCallSite = false
 align.openParenDefnSite = false
 ===
@@ -227,7 +227,7 @@ case class Foo(
 }
 <<< #1362 4: multiple implicits, long line
 maxColumn = 60
-danglingParentheses = true
+danglingParentheses.preset = true
 align.openParenCallSite = false
 align.openParenDefnSite = false
 ===
@@ -269,7 +269,7 @@ case class Foo(
 }
 <<< #1539 1: config style, no dangling
 optIn.configStyleArguments = true
-danglingParentheses = false
+danglingParentheses.preset = false
 ===
 class Abc(
   x: Int,
@@ -281,7 +281,7 @@ class Abc(
   b: Int)
 <<< #1539 2: config style, dangling
 optIn.configStyleArguments = true
-danglingParentheses = true
+danglingParentheses.preset = true
 verticalMultiline.excludeDanglingParens = []
 ===
 class Abc(

--- a/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
@@ -82,7 +82,7 @@ def getListing(
 }
 <<< with many implicits (non-vm)
 verticalMultiline.atDefnSite = false
-danglingParentheses = true
+danglingParentheses.preset = true
 ===
 def getListing(
   a: String,
@@ -102,7 +102,7 @@ def getListing(a: String, b: String, c: String, d: String)(implicit
 }
 <<< with many implicits (non-vm, with exclude)
 verticalMultiline.atDefnSite = false
-danglingParentheses = true
+danglingParentheses.preset = true
 danglingParentheses.exclude = [def]
 ===
 def getListing(

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDefnSiteNoDangling.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDefnSiteNoDangling.stat
@@ -1,5 +1,5 @@
 maxColumn = 40
-danglingParentheses = false
+danglingParentheses.preset = false
 verticalMultiline.atDefnSite = true
 <<< handles comment correctly
 case class Example(

--- a/scalafmt-tests/src/test/scala/org/scalafmt/ScalafmtConfigTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/ScalafmtConfigTest.scala
@@ -1,5 +1,6 @@
 package org.scalafmt
 
+import org.scalafmt.config.Align
 import org.scalafmt.config.Newlines
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -42,6 +43,23 @@ class ScalafmtConfigTest extends AnyFunSuite {
     assert(nlCfg2.source == Newlines.unfold)
     assert(nlCfg1.topLevelStatements == Seq(Newlines.before, Newlines.after))
     assert(nlCfg2.topLevelStatements == Seq.empty)
+  }
+
+  test("align preset no override") {
+    val config = Scalafmt.parseHoconConfig("""
+      |align = none
+      |align.stripMargin = true
+      """.stripMargin).get
+    // none was ignored
+    assert(config.align == Align(stripMargin = true))
+  }
+
+  test("align preset with override") {
+    val config = Scalafmt.parseHoconConfig("""
+      |align.preset = none
+      |align.stripMargin = true
+      """.stripMargin).get
+    assert(config.align == Align.none.copy(stripMargin = true))
   }
 
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -11,28 +11,29 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class CliOptionsTest extends AnyFunSuite {
 
-  test("style = ...") {
+  test("preset = ...") {
     import org.scalafmt.config.Config
-    val NotOk(err) = Config.fromHoconString("style = foobar")
+    val NotOk(err) = Config.fromHoconString("preset = foobar")
     assert(
-      "Unknown style name foobar. Expected one of: Scala.js, IntelliJ, default, defaultWithAlign" == err.msg
+      "Unknown style \"foobar\". Expected one of: " +
+        "Scala.js, IntelliJ, default, defaultWithAlign" == err.msg
     )
 
-    val overrideOne = Config.fromHoconString("""|style = defaultWithAlign
+    val overrideOne = Config.fromHoconString("""|preset = defaultWithAlign
       |maxColumn = 100
       |""".stripMargin)
     assert(
       Ok(ScalafmtConfig.defaultWithAlign.copy(maxColumn = 100)) == overrideOne
     )
     assert(
-      Ok(ScalafmtConfig.intellij) == Config.fromHoconString("style = intellij")
+      Ok(ScalafmtConfig.intellij) == Config.fromHoconString("preset = intellij")
     )
     assert(
-      Ok(ScalafmtConfig.scalaJs) == Config.fromHoconString("style = Scala.js")
+      Ok(ScalafmtConfig.scalaJs) == Config.fromHoconString("preset = Scala.js")
     )
     assert(
       Ok(ScalafmtConfig.defaultWithAlign) == Config
-        .fromHoconString("style = defaultWithAlign")
+        .fromHoconString("preset = defaultWithAlign")
     )
   }
 


### PR DESCRIPTION
For each, check the `preset` subkey as well. We should deprecate the top-level presets as they don't allow overrides.

For instance, currently, the pre-2.5.0 behaviour of `align = none` can't be achieved because one of the parameters was added which changed default behaviour. With this change, one can use
```
align.preset = none
align.stripMargin = true
```

this also standardizes that all presets are accessible via `preset` key (including the full-config presets which were historically available via `style`). however, previous ways of using presets are still supported albeit not encouraged.