### PR TITLE
Router: indent comments in the middle of a select

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1211,8 +1211,9 @@ class Router(formatOps: FormatOps) {
 
         // trigger indent only on the first newline
         val indent = Indent(Num(2), expire, After)
+        val mustIndent = nextNonCommentSameLine(tokens(formatToken, 2)).hasBreak
         val splits = baseSplits.map { s =>
-          if (s.modification.isNewline) s.withIndent(indent)
+          if (mustIndent || s.modification.isNewline) s.withIndent(indent)
           else s.andThenPolicyOpt(delayedBreakPolicy)
         }
 

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2252,3 +2252,107 @@ object a {
       x
     }
 }
+<<< #1334 1: continue chain indent after a comment
+class Foo {
+  val vv = v.aaa //
+  //
+.bbb
+.ccc()
+  val vv = v.aaa //
+  val vv = v.aaa
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+  //
+  .bbb
+    .ccc()
+  val vv = v.aaa //
+  val vv = v.aaa
+}
+<<< #1334 2: continue chain indent after a comment, a bit longer
+class Foo {
+  val vv = v.aaa //
+  .bbb //
+  //
+  .ccc //
+  .ddd
+  .eee()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+  .bbb //
+  //
+  .ccc //
+  .ddd
+    .eee()
+}
+<<< #1334 3: continue chain indent after a comment with apply
+class Foo {
+  val vv = v.aaa //
+  .bbb() //
+  //
+  .ccc //
+  .ddd()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+    .bbb() //
+    //
+    .ccc //
+    .ddd()
+}
+<<< #1334 4: continue chain indent after a comment with apply, longer
+class Foo {
+  val vv = v.aaa //
+  .bbb() //
+  .ccc() //
+  .ddd()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+    .bbb() //
+    .ccc() //
+    .ddd()
+}
+<<< #1334 5: select and a block apply after a comment
+     val a: Vector[Array[Double]] = b.c
+     // similarUserFeatures may not contain the requested user
+   .map { x =>
+       similarUserFeatures.get(x)
+     }.flatten
+     // another comment
+     .map { foo =>
+       bar
+       }
+       .tail
+>>>
+val a: Vector[Array[Double]] = b.c
+// similarUserFeatures may not contain the requested user
+  .map { x =>
+    similarUserFeatures.get(x)
+  }
+  .flatten
+  // another comment
+  .map { foo =>
+    bar
+  }
+  .tail
+<<< #1334 6: multiple select and a match after a comment
+val a: Vector[Array[Double]] = b.c
+       // Only handle first case, others will be fixed on the next pass.
+  .headOption
+  .a match {
+ case None =>
+ case _ =>
+}
+>>>
+val a: Vector[Array[Double]] = b.c
+// Only handle first case, others will be fixed on the next pass.
+.headOption.a match {
+  case None =>
+  case _ =>
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2128,3 +2128,101 @@ object a {
     """aaa bbb ccc ddd eee fff ggg"""
   )
 }
+<<< #1334 1: continue chain indent after a comment
+class Foo {
+  val vv = v.aaa //
+  //
+.bbb
+.ccc()
+  val vv = v.aaa //
+  val vv = v.aaa
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+  //
+    .bbb.ccc()
+  val vv = v.aaa //
+  val vv = v.aaa
+}
+<<< #1334 2: continue chain indent after a comment, a bit longer
+class Foo {
+  val vv = v.aaa //
+  .bbb //
+  //
+  .ccc //
+  .ddd
+  .eee()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+    .bbb //
+    //
+    .ccc //
+    .ddd.eee()
+}
+<<< #1334 3: continue chain indent after a comment with apply
+class Foo {
+  val vv = v.aaa //
+  .bbb() //
+  //
+  .ccc //
+  .ddd()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+    .bbb() //
+    //
+    .ccc //
+    .ddd()
+}
+<<< #1334 4: continue chain indent after a comment with apply, longer
+class Foo {
+  val vv = v.aaa //
+  .bbb() //
+  .ccc() //
+  .ddd()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+    .bbb() //
+    .ccc() //
+    .ddd()
+}
+<<< #1334 5: select and a block apply after a comment
+     val a: Vector[Array[Double]] = b.c
+     // similarUserFeatures may not contain the requested user
+   .map { x =>
+       similarUserFeatures.get(x)
+     }.flatten
+     // another comment
+     .map { foo =>
+       bar
+       }
+       .tail
+>>>
+val a: Vector[Array[Double]] = b.c
+// similarUserFeatures may not contain the requested user
+  .map { x =>
+    similarUserFeatures.get(x)
+  }.flatten
+  // another comment
+  .map { foo => bar }.tail
+<<< #1334 6: multiple select and a match after a comment
+val a: Vector[Array[Double]] = b.c
+       // Only handle first case, others will be fixed on the next pass.
+  .headOption
+  .a match {
+ case None =>
+ case _ =>
+}
+>>>
+val a: Vector[Array[Double]] = b.c
+// Only handle first case, others will be fixed on the next pass.
+  .headOption.a match {
+  case None =>
+  case _ =>
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2140,7 +2140,7 @@ class Foo {
 >>>
 class Foo {
   val vv = v.aaa //
-  //
+    //
     .bbb.ccc()
   val vv = v.aaa //
   val vv = v.aaa
@@ -2205,7 +2205,7 @@ class Foo {
        .tail
 >>>
 val a: Vector[Array[Double]] = b.c
-// similarUserFeatures may not contain the requested user
+  // similarUserFeatures may not contain the requested user
   .map { x =>
     similarUserFeatures.get(x)
   }.flatten
@@ -2221,7 +2221,7 @@ val a: Vector[Array[Double]] = b.c
 }
 >>>
 val a: Vector[Array[Double]] = b.c
-// Only handle first case, others will be fixed on the next pass.
+  // Only handle first case, others will be fixed on the next pass.
   .headOption.a match {
   case None =>
   case _ =>

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2230,7 +2230,7 @@ class Foo {
 >>>
 class Foo {
   val vv = v.aaa //
-  //
+    //
     .bbb
     .ccc()
   val vv = v.aaa //
@@ -2297,7 +2297,7 @@ class Foo {
        .tail
 >>>
 val a: Vector[Array[Double]] = b.c
-// similarUserFeatures may not contain the requested user
+  // similarUserFeatures may not contain the requested user
   .map { x =>
     similarUserFeatures.get(x)
   }.flatten
@@ -2316,7 +2316,7 @@ val a: Vector[Array[Double]] = b.c
 }
 >>>
 val a: Vector[Array[Double]] = b.c
-// Only handle first case, others will be fixed on the next pass.
+  // Only handle first case, others will be fixed on the next pass.
   .headOption
   .a match {
   case None =>

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2218,3 +2218,107 @@ object a {
       x
     }
 }
+<<< #1334 1: continue chain indent after a comment
+class Foo {
+  val vv = v.aaa //
+  //
+.bbb
+.ccc()
+  val vv = v.aaa //
+  val vv = v.aaa
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+  //
+    .bbb
+    .ccc()
+  val vv = v.aaa //
+  val vv = v.aaa
+}
+<<< #1334 2: continue chain indent after a comment, a bit longer
+class Foo {
+  val vv = v.aaa //
+  .bbb //
+  //
+  .ccc //
+  .ddd
+  .eee()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+    .bbb //
+    //
+    .ccc //
+    .ddd
+    .eee()
+}
+<<< #1334 3: continue chain indent after a comment with apply
+class Foo {
+  val vv = v.aaa //
+  .bbb() //
+  //
+  .ccc //
+  .ddd()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+    .bbb() //
+    //
+    .ccc //
+    .ddd()
+}
+<<< #1334 4: continue chain indent after a comment with apply, longer
+class Foo {
+  val vv = v.aaa //
+  .bbb() //
+  .ccc() //
+  .ddd()
+}
+>>>
+class Foo {
+  val vv = v.aaa //
+    .bbb() //
+    .ccc() //
+    .ddd()
+}
+<<< #1334 5: select and a block apply after a comment
+     val a: Vector[Array[Double]] = b.c
+     // similarUserFeatures may not contain the requested user
+   .map { x =>
+       similarUserFeatures.get(x)
+     }.flatten
+     // another comment
+     .map { foo =>
+       bar
+       }
+       .tail
+>>>
+val a: Vector[Array[Double]] = b.c
+// similarUserFeatures may not contain the requested user
+  .map { x =>
+    similarUserFeatures.get(x)
+  }.flatten
+  // another comment
+  .map { foo =>
+    bar
+  }
+  .tail
+<<< #1334 6: multiple select and a match after a comment
+val a: Vector[Array[Double]] = b.c
+       // Only handle first case, others will be fixed on the next pass.
+  .headOption
+  .a match {
+ case None =>
+ case _ =>
+}
+>>>
+val a: Vector[Array[Double]] = b.c
+// Only handle first case, others will be fixed on the next pass.
+  .headOption
+  .a match {
+  case None =>
+  case _ =>
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2332,3 +2332,110 @@ object a {
       x
     }
 }
+<<< #1334 1: continue chain indent after a comment
+class Foo {
+  val vv = v.aaa //
+  //
+.bbb
+.ccc()
+  val vv = v.aaa //
+  val vv = v.aaa
+}
+>>>
+class Foo {
+  val vv = v
+    .aaa //
+    //
+    .bbb.ccc()
+  val vv = v.aaa //
+  val vv = v.aaa
+}
+<<< #1334 2: continue chain indent after a comment, a bit longer
+class Foo {
+  val vv = v.aaa //
+  .bbb //
+  //
+  .ccc //
+  .ddd
+  .eee()
+}
+>>>
+class Foo {
+  val vv = v
+    .aaa //
+    .bbb //
+    //
+    .ccc //
+    .ddd.eee()
+}
+<<< #1334 3: continue chain indent after a comment with apply
+class Foo {
+  val vv = v.aaa //
+  .bbb() //
+  //
+  .ccc //
+  .ddd()
+}
+>>>
+class Foo {
+  val vv = v
+    .aaa //
+    .bbb() //
+    //
+    .ccc //
+    .ddd()
+}
+<<< #1334 4: continue chain indent after a comment with apply, longer
+class Foo {
+  val vv = v.aaa //
+  .bbb() //
+  .ccc() //
+  .ddd()
+}
+>>>
+class Foo {
+  val vv = v
+    .aaa //
+    .bbb() //
+    .ccc() //
+    .ddd()
+}
+<<< #1334 5: select and a block apply after a comment
+     val a: Vector[Array[Double]] = b.c
+     // similarUserFeatures may not contain the requested user
+   .map { x =>
+       similarUserFeatures.get(x)
+     }.flatten
+     // another comment
+     .map { foo =>
+       bar
+       }
+       .tail
+>>>
+val a: Vector[Array[Double]] =
+  b.c
+    // similarUserFeatures may not contain the requested user
+    .map { x =>
+      similarUserFeatures.get(x)
+    }
+    .flatten
+    // another comment
+    .map { foo =>
+      bar
+    }.tail
+<<< #1334 6: multiple select and a match after a comment
+val a: Vector[Array[Double]] = b.c
+       // Only handle first case, others will be fixed on the next pass.
+  .headOption
+  .a match {
+ case None =>
+ case _ =>
+}
+>>>
+val a: Vector[Array[Double]] =
+  b.c
+    // Only handle first case, others will be fixed on the next pass.
+    .headOption.a match {
+    case None =>
+    case _ =>
+  }


### PR DESCRIPTION
This doesn't address the newlines.source=classic case as it follows a vastly different execution path. Helps with #1334.