### PR TITLE
Router: force indent before comment, not break

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1211,9 +1211,10 @@ class Router(formatOps: FormatOps) {
 
         // trigger indent only on the first newline
         val indent = Indent(Num(2), expire, After)
-        val mustIndent = nextNonCommentSameLine(tokens(formatToken, 2)).hasBreak
+        val willBreak =
+          nextNonCommentSameLine(tokens(formatToken, 2)).right.is[T.Comment]
         val splits = baseSplits.map { s =>
-          if (mustIndent || s.modification.isNewline) s.withIndent(indent)
+          if (willBreak || s.modification.isNewline) s.withIndent(indent)
           else s.andThenPolicyOpt(delayedBreakPolicy)
         }
 

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2356,3 +2356,29 @@ val a: Vector[Array[Double]] = b.c
   case None =>
   case _ =>
 }
+<<< #1888 check presence of comment, lack of break
+maxColumn = 80
+===
+object a {
+  def b(c: D): E = {
+    val a = b.c
+      .foo(_.tree.tpe =:= typeOf[D])
+      .flatMap { x =>
+        x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
+      }
+      .headOption
+    F(c.name.toString.trim, alias, sym.typeSignature)
+  }
+}
+>>>
+object a {
+  def b(c: D): E = {
+    val a = b.c
+      .foo(_.tree.tpe =:= typeOf[D])
+      .flatMap { x =>
+        x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
+      }
+      .headOption
+    F(c.name.toString.trim, alias, sym.typeSignature)
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2226,3 +2226,27 @@ val a: Vector[Array[Double]] = b.c
   case None =>
   case _ =>
 }
+<<< #1888 check presence of comment, lack of break
+maxColumn = 80
+===
+object a {
+  def b(c: D): E = {
+    val a = b.c
+      .foo(_.tree.tpe =:= typeOf[D])
+      .flatMap { x =>
+        x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
+      }
+      .headOption
+    F(c.name.toString.trim, alias, sym.typeSignature)
+  }
+}
+>>>
+Idempotency violated
+object a {
+  def b(c: D): E = {
+    val a = b.c.foo(_.tree.tpe =:= typeOf[D]).flatMap { x =>
+        x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
+      }.headOption
+    F(c.name.toString.trim, alias, sym.typeSignature)
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2241,12 +2241,11 @@ object a {
   }
 }
 >>>
-Idempotency violated
 object a {
   def b(c: D): E = {
     val a = b.c.foo(_.tree.tpe =:= typeOf[D]).flatMap { x =>
-        x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
-      }.headOption
+      x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
+    }.headOption
     F(c.name.toString.trim, alias, sym.typeSignature)
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2322,3 +2322,29 @@ val a: Vector[Array[Double]] = b.c
   case None =>
   case _ =>
 }
+<<< #1888 check presence of comment, lack of break
+maxColumn = 80
+===
+object a {
+  def b(c: D): E = {
+    val a = b.c
+      .foo(_.tree.tpe =:= typeOf[D])
+      .flatMap { x =>
+        x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
+      }
+      .headOption
+    F(c.name.toString.trim, alias, sym.typeSignature)
+  }
+}
+>>>
+object a {
+  def b(c: D): E = {
+    val a = b.c
+      .foo(_.tree.tpe =:= typeOf[D])
+      .flatMap { x =>
+        x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
+      }
+      .headOption
+    F(c.name.toString.trim, alias, sym.typeSignature)
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2439,3 +2439,36 @@ val a: Vector[Array[Double]] =
     case None =>
     case _ =>
   }
+<<< #1888 check presence of comment, lack of break
+maxColumn = 80
+===
+object a {
+  def b(c: D): E = {
+    val a = b.c
+      .foo(_.tree.tpe =:= typeOf[D])
+      .flatMap { x =>
+        x.tree.children.tail.map { case E(F(g)) => g.asInstanceOf[String] }
+      }
+      .headOption
+    F(c.name.toString.trim, alias, sym.typeSignature)
+  }
+}
+>>>
+object a {
+  def b(c: D): E = {
+    val a =
+      b.c
+        .foo(_.tree.tpe =:= typeOf[D])
+        .flatMap { x =>
+          x.tree
+            .children
+            .tail
+            .map {
+              case E(F(g)) =>
+                g.asInstanceOf[String]
+            }
+        }
+        .headOption
+    F(c.name.toString.trim, alias, sym.typeSignature)
+  }
+}


### PR DESCRIPTION
Fixes bug introduced in #1888.