### PR TITLE
RedundantParens: support additional patterns

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -14,16 +14,18 @@ class RedundantParens(implicit ctx: RewriteCtx) extends RewriteSession {
 
   override def rewrite(tree: Tree): Unit =
     tree match {
-      case g: Enumerator.Guard => remove(g.cond)
-
-      case t @ Term.Apply(_, List(b: Term.Block))
-          if ctx.style.activeForEdition_2020_01 &&
-            b.tokens.headOption.exists(_.is[Token.LeftBrace]) =>
-        val lastTok = t.tokens.last
-        ctx.getMatchingOpt(lastTok).foreach(removeBetween(_, lastTok))
-
-      case _ =>
+      case t => rewriteFunc.lift(t)
     }
+
+  private val rewriteFunc: PartialFunction[Tree, Unit] = {
+    case g: Enumerator.Guard => remove(g.cond)
+
+    case t @ Term.Apply(_, List(b: Term.Block))
+        if ctx.style.activeForEdition_2020_01 &&
+          b.tokens.headOption.exists(_.is[Token.LeftBrace]) =>
+      val lastTok = t.tokens.last
+      ctx.getMatchingOpt(lastTok).foreach(removeBetween(_, lastTok))
+  }
 
   private def remove(tree: Tree): Unit =
     removeByTokens(tree.tokens)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -1,7 +1,7 @@
 package org.scalafmt.rewrite
 
+import scala.annotation.tailrec
 import scala.meta._
-import scala.meta.tokens.Token.{LeftParen, RightParen}
 
 object RedundantParens extends Rewrite {
   override def create(implicit ctx: RewriteCtx): RewriteSession =
@@ -12,43 +12,64 @@ class RedundantParens(implicit ctx: RewriteCtx) extends RewriteSession {
 
   import ctx.dialect
 
-  def isWrappedInParens(tokens: Tokens): Boolean =
-    tokens.nonEmpty && tokens.head.is[LeftParen] && tokens.last.is[RightParen]
-
   override def rewrite(tree: Tree): Unit =
     tree match {
-      case g: Enumerator.Guard =>
-        val tokens: Tokens = g.cond.tokens
-        if (isWrappedInParens(tokens)) {
-          val openParensCount = tokens.segmentLength(_.is[LeftParen], 0)
-          val closeParensCount =
-            tokens.reverse.segmentLength(_.is[RightParen], 0)
-          val parensToRemoveCount = Math.min(openParensCount, closeParensCount)
-          val leftSegment: Tokens = tokens.slice(0, parensToRemoveCount)
-          val rightSegment: Tokens =
-            tokens.slice(tokens.length - parensToRemoveCount, tokens.length)
-          leftSegment.zip(rightSegment.reverse).foreach {
-            case (left, right) if ctx.isMatching(left, right) =>
-              ctx.addPatchSet(TokenPatch.Remove(left), TokenPatch.Remove(right))
-            case _ =>
-          }
-        }
+      case g: Enumerator.Guard => remove(g.cond)
 
       case t @ Term.Apply(_, List(b: Term.Block))
           if ctx.style.activeForEdition_2020_01 &&
             b.tokens.headOption.exists(_.is[Token.LeftBrace]) =>
-        t.tokens.lastOption.filter(_.is[RightParen]).foreach { rparen =>
-          ctx.getMatchingOpt(rparen).foreach { lparen =>
-            implicit val builder = Seq.newBuilder[TokenPatch]
-            builder += TokenPatch.Remove(lparen)
-            builder += TokenPatch.Remove(rparen)
-            ctx.removeLFToAvoidEmptyLine(lparen)
-            ctx.removeLFToAvoidEmptyLine(rparen)
-            ctx.addPatchSet(builder.result(): _*)
-          }
-        }
+        val lastTok = t.tokens.last
+        ctx.getMatchingOpt(lastTok).foreach(removeBetween(_, lastTok))
 
       case _ =>
     }
+
+  private def remove(tree: Tree): Unit =
+    removeByTokens(tree.tokens)
+
+  private def removeByTokens(toks: Tokens): Unit =
+    toks.headOption.foreach { head =>
+      val beg = ctx.getIndex(head)
+      removeParensByIndex(beg until (beg + toks.length))
+    }
+
+  private def removeBetween(b: Token, e: Token): Unit =
+    removeParensByIndex(ctx.getIndex(b) to ctx.getIndex(e))
+
+  private def removeParensByIndex(range: Range): Unit = {
+    val beg = range.head
+    val end = range.last
+    val mid = (beg + end) / 2
+    val toks = ctx.tokens
+    @tailrec
+    def getOutOfRange(off: Int): Int = {
+      val idx = beg + off
+      if (idx >= mid) off
+      else
+        toks(idx) match {
+          case lp: Token.LeftParen =>
+            ctx.getMatchingOpt(lp) match {
+              case Some(rp) if toks(end - off) eq rp => getOutOfRange(off + 1)
+              case _ => off
+            }
+          case _ => off
+        }
+    }
+    val offEnd = getOutOfRange(0) - 1
+    if (offEnd >= 0) {
+      val offBeg = 0
+      if (offBeg <= offEnd) {
+        implicit val builder = Seq.newBuilder[TokenPatch]
+        (offBeg to offEnd).foreach { x =>
+          builder += TokenPatch.Remove(toks(beg + x))
+          builder += TokenPatch.Remove(toks(end - x))
+        }
+        ctx.removeLFToAvoidEmptyLine(toks(beg + offBeg), toks(beg + offEnd))
+        ctx.removeLFToAvoidEmptyLine(toks(end - offEnd), toks(end - offBeg))
+        ctx.addPatchSet(builder.result(): _*)
+      }
+    }
+  }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -33,6 +33,8 @@ case class RewriteCtx(
   @inline def isMatching(a: Token, b: Token) =
     getMatchingOpt(a).contains(b)
 
+  @inline def getIndex(token: Token) = tokenTraverser.getIndex(token)
+
   def applyPatches: String =
     tokens.toIterator
       .map(x => patchBuilder.get(x.start -> x.end).fold(x.syntax)(_.newTok))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -66,17 +66,22 @@ case class RewriteCtx(
     nonWs.map((_, lf))
   }
 
-  def getPatchToAvoidEmptyLine(token: Token): Option[TokenPatch] =
-    if (!onlyWhitespaceBefore(token)) None
-    else
+  // end is inclusive
+  def removeLFToAvoidEmptyLine(
+      beg: Token,
+      end: Token
+  )(implicit builder: Rewrite.PatchBuilder): Unit =
+    if (onlyWhitespaceBefore(beg))
       tokenTraverser
-        .findAfter(token)(RewriteCtx.isLFSkipWhitespace)
+        .findAfter(end)(RewriteCtx.isLFSkipWhitespace)
         .map(TokenPatch.Remove)
+        .foreach(builder += _)
 
+  @inline
   def removeLFToAvoidEmptyLine(
       token: Token
   )(implicit builder: Rewrite.PatchBuilder): Unit =
-    getPatchToAvoidEmptyLine(token).foreach(builder += _)
+    removeLFToAvoidEmptyLine(token, token)
 
 }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -26,6 +26,8 @@ class TokenTraverser(tokens: Tokens) {
   final def isExcluded(token: Token): Boolean =
     excludedTokens.contains(TokenOps.hash(token))
 
+  @inline def getIndex(token: Token): Int = tok2idx(token)
+
   def nextToken(token: Token): Token = {
     tok2idx.get(token) match {
       case Some(i) if tokens.length > i + 1 =>

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -201,7 +201,7 @@ align.openParenCallSite = false
 rewrite.rules = [RedundantBraces, RedundantParens]
 ===
 def test(dataFrame: DataFrame) = {
-    val zeroAccumulator = Array.fill(1)((0.0, 0))
+    val zeroAccumulator = Array.fill(1)(((0.0, 0)))
 
     dataFrame.rdd.aggregate(zeroAccumulator)({(acc, row) => acc.zip(row.toSeq).map{ case (x, y) => {
       if(true) (1, 2)

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -133,3 +133,29 @@ object a {
 object a {
   a { b; c }
 }
+<<< #1895 1
+object a {
+  val x = ((1))
+}
+>>>
+object a {
+  val x = ((1))
+}
+<<< #1895 2
+object a {
+  val z = ((insertData *> readDatabase(id)))
+}
+>>>
+object a {
+  val z = ((insertData *> readDatabase(id)))
+}
+<<< #1895 3
+rewrite.rules = [AvoidInfix, RedundantParens]
+===
+object a {
+  val z = (((insertData) op readDatabase(id)))
+}
+>>>
+object a {
+  val z = ((insertData).op(readDatabase(id)))
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -63,7 +63,7 @@ object a {
   def c(b: List[Int]): List[Int] =
     for {
       a <- b
-      if (a) || (a)
+      if a || a
     } yield a
 }
 <<< nested compound statement
@@ -79,7 +79,7 @@ object a {
   def c(b: List[Int]): List[Int] =
     for {
       a <- b
-      if ((a)) || ((a))
+      if a || a
     } yield a
 }
 <<< basic match
@@ -88,7 +88,7 @@ object a {
 }
 >>>
 object a {
-  b match { case _ if (a) => b }
+  b match { case _ if a => b }
 }
 <<< compound match
 object a {
@@ -96,7 +96,7 @@ object a {
 }
 >>>
 object a {
-  b match { case _ if (a) || (a) => b }
+  b match { case _ if a || a => b }
 }
 <<< nested compound match
 object a {
@@ -104,7 +104,7 @@ object a {
 }
 >>>
 object a {
-  b match { case _ if ((a) || (a)) => b }
+  b match { case _ if a || a => b }
 }
 <<< single-arg apply of a block 1
 object a {
@@ -139,7 +139,7 @@ object a {
 }
 >>>
 object a {
-  val x = ((1))
+  val x = 1
 }
 <<< #1895 2
 object a {
@@ -147,7 +147,7 @@ object a {
 }
 >>>
 object a {
-  val z = ((insertData *> readDatabase(id)))
+  val z = insertData *> readDatabase(id)
 }
 <<< #1895 3
 rewrite.rules = [AvoidInfix, RedundantParens]
@@ -157,5 +157,5 @@ object a {
 }
 >>>
 object a {
-  val z = ((insertData).op(readDatabase(id)))
+  val z = insertData.op(readDatabase(id))
 }


### PR DESCRIPTION
Literals, names, case clause conditions, val/def body (in this latter case, use the partial function to ensure the body wouldn't be amended twice). Also, remove inner parens.

Fixes #1895.