### PR TITLE
BinPack: allow single-line formatting of literals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1551,6 +1551,14 @@ binPack.literalArgumentLists = false
 val secret: List[Bit] = List(0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1)
 ```
 
+```scala mdoc:scalafmt
+binPack.literalArgumentLists = true
+binPack.literalsSingleLine = true
+---
+val secret: List[Bit] = List(0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1,
+  0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1)
+```
+
 ### `includeCurlyBraceInSelectChains`
 
 ```scala mdoc:defaults

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
@@ -34,6 +34,7 @@ case class BinPack(
     unsafeDefnSite: Boolean = false,
     parentConstructors: Boolean = false,
     literalArgumentLists: Boolean = true,
+    literalsSingleLine: Boolean = false,
     literalsMinArgCount: Int = 5,
     literalsInclude: Seq[String] = Seq(".*"),
     literalsExclude: Seq[String] = Seq("String", "Term.Name")

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1345,13 +1345,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       token: Token,
       argss: Seq[Seq[A]]
   ): Option[Seq[A]] =
-    matchingOpt(token).flatMap { other =>
-      // find the arg group starting with given format token
-      val beg = math.min(token.start, other.start)
-      argss
-        .find(_.headOption.exists(_.tokens.head.start >= beg))
-        .filter(_.head.tokens.head.start <= math.max(token.end, other.end))
-    }
+    TokenOps.findArgsFor(token, argss, matchingParentheses)
 
   // look for arrow before body, if any, else after params
   def getFuncArrow(term: Term.Function): Option[FormatToken] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -251,4 +251,17 @@ object TokenOps {
   def classifyOnRight[A](cls: Classifier[Token, A])(ft: FormatToken): Boolean =
     cls(ft.right)
 
+  def findArgsFor[A <: Tree](
+      token: Token,
+      argss: Seq[Seq[A]],
+      matching: Map[TokenHash, Token]
+  ): Option[Seq[A]] =
+    matching.get(hash(token)).flatMap { other =>
+      // find the arg group starting with given format token
+      val beg = math.min(token.start, other.start)
+      argss
+        .find(_.headOption.exists(_.tokens.head.start >= beg))
+        .filter(_.head.tokens.head.start <= math.max(token.end, other.end))
+    }
+
 }

--- a/scalafmt-tests/src/test/resources/binPack/TermNameList.stat
+++ b/scalafmt-tests/src/test/resources/binPack/TermNameList.stat
@@ -94,34 +94,8 @@ val secret: List[Bit] = List(
   (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa))
 >>>
 val secret: List[Bit] = List(
-  (
-    select,
-    aaaaa,
-    bbbbbbb,
-    bbbbbbb,
-    bbbbbbb,
-    aaaaa,
-    aaaaa,
-    bbbbbbb,
-    aaaaa,
-    aaaaa,
-    aaaaa,
-    bbbbbbb,
-    aaaaa
-  ),
-  (
-    select,
-    aaaaa,
-    bbbbbbb,
-    bbbbbbb,
-    bbbbbbb,
-    aaaaa,
-    aaaaa,
-    bbbbbbb,
-    aaaaa,
-    aaaaa,
-    aaaaa,
-    bbbbbbb,
-    aaaaa
-  )
+  (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa,
+    aaaaa, aaaaa, bbbbbbb, aaaaa),
+  (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa,
+    aaaaa, aaaaa, bbbbbbb, aaaaa)
 )

--- a/scalafmt-tests/src/test/resources/binPack/TermNameList.stat
+++ b/scalafmt-tests/src/test/resources/binPack/TermNameList.stat
@@ -83,3 +83,45 @@ val a = foo(bar {
     qux // comment
   )
 })
+<<< literalsSingleLine=true
+val secret: List[Bit] = List(select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa)
+>>>
+val secret: List[Bit] = List(select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa,
+  aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa)
+<<< literalsSingleLine=true, accept no split
+val secret: List[Bit] = List(
+  (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa),
+  (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa))
+>>>
+val secret: List[Bit] = List(
+  (
+    select,
+    aaaaa,
+    bbbbbbb,
+    bbbbbbb,
+    bbbbbbb,
+    aaaaa,
+    aaaaa,
+    bbbbbbb,
+    aaaaa,
+    aaaaa,
+    aaaaa,
+    bbbbbbb,
+    aaaaa
+  ),
+  (
+    select,
+    aaaaa,
+    bbbbbbb,
+    bbbbbbb,
+    bbbbbbb,
+    aaaaa,
+    aaaaa,
+    bbbbbbb,
+    aaaaa,
+    aaaaa,
+    aaaaa,
+    bbbbbbb,
+    aaaaa
+  )
+)

--- a/scalafmt-tests/src/test/resources/binPack/TermNameList.stat
+++ b/scalafmt-tests/src/test/resources/binPack/TermNameList.stat
@@ -84,18 +84,20 @@ val a = foo(bar {
   )
 })
 <<< literalsSingleLine=true
+binPack.literalsSingleLine = true
+===
 val secret: List[Bit] = List(select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa)
 >>>
-val secret: List[Bit] = List(select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa,
-  aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa)
+val secret: List[Bit] = List(
+  select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa)
 <<< literalsSingleLine=true, accept no split
+binPack.literalsSingleLine = true
+===
 val secret: List[Bit] = List(
   (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa),
   (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa))
 >>>
 val secret: List[Bit] = List(
-  (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa,
-    aaaaa, aaaaa, bbbbbbb, aaaaa),
-  (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa,
-    aaaaa, aaaaa, bbbbbbb, aaaaa)
+  (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa),
+  (select, aaaaa, bbbbbbb, bbbbbbb, bbbbbbb, aaaaa, aaaaa, bbbbbbb, aaaaa, aaaaa, aaaaa, bbbbbbb, aaaaa)
 )


### PR DESCRIPTION
Now that we have fileOverride which can be applied to tests, one thing that is frequently needed in tests is setting up a number of instances or parameterized tests with multiple parameters, leading to extremely vertical formatting for what is essentially not code but configuration.

For that case, allow a special form of binpacking which simply formats all literal arguments on one line, even if it overflows maxColumn.