### PR TITLE
FormatWriter: fix indent for complex interpolation

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -270,26 +270,6 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     )
   }
 
-  def isTripleQuote(token: Token): Boolean = token.syntax.startsWith("\"\"\"")
-
-  def getStripMarginChar(ft: FormatToken): Option[Char] = {
-    def getChar(ft: FormatToken): Option[Char] =
-      if (!ft.left.is[T.Dot] || ft.right.syntax != "stripMargin") None
-      else
-        tokens(ft, 2) match {
-          case FormatToken(_: T.LeftParen, r: T.Constant.Char, _) =>
-            Some(r.value)
-          case _ => Some('|')
-        }
-    ft.left match {
-      case start: T.Interpolation.Start =>
-        getChar(tokens(matching(start), 1))
-      case string: T.Constant.String if isTripleQuote(string) =>
-        getChar(next(ft))
-      case _ => None
-    }
-  }
-
   @inline
   final def startsStatement(tok: FormatToken): Option[Tree] =
     startsStatement(tok.right)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -254,11 +254,12 @@ class FormatWriter(formatOps: FormatOps) {
 
     class Entry(val i: Int) {
       val curr = locations(i)
-      val previous = locations(math.max(i - 1, 0))
+      def previous = locations(math.max(i - 1, 0))
 
       @inline def tok = curr.formatToken
       @inline def state = curr.state
-      @inline def lastModification = previous.state.split.modification
+      @inline def prevState = curr.state.prev
+      @inline def lastModification = prevState.split.modification
 
       def getWhitespace(alignOffset: Int): String = {
         // TODO this could get slow for really long comment blocks. If that
@@ -279,12 +280,11 @@ class FormatWriter(formatOps: FormatOps) {
 
           case nl: NewlineT
               if nl.acceptNoSplit && !tok.left.isInstanceOf[T.Comment] &&
-                state.indentation >= previous.state.column =>
+                state.indentation >= prevState.column =>
             ""
 
           case nl: NewlineT
-              if nl.acceptSpace &&
-                state.indentation >= previous.state.column =>
+              if nl.acceptSpace && state.indentation >= prevState.column =>
             " "
 
           case _: NewlineT

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -182,9 +182,9 @@ object a {
     |  update targeting_segments
     |  set status = '$status',
     |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
-        |${sizeCondition.fold("")(cond => s"  customers = $cond,")}
-        |  updated_at = now()
-        |  where id in (${audienceIds.mkString(",")})""".stripMargin
+    |${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+    |  updated_at = now()
+    |  where id in (${audienceIds.mkString(",")})""".stripMargin
 }
 <<< align, complex interpolation
 align.stripMargin = true
@@ -204,7 +204,7 @@ object a {
      |  update targeting_segments
      |  set status = '$status',
      |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
-        |${sizeCondition.fold("")(cond => s"  customers = $cond,")}
-        |  updated_at = now()
-        |  where id in (${audienceIds.mkString(",")})""".stripMargin
+     |${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+     |  updated_at = now()
+     |  where id in (${audienceIds.mkString(",")})""".stripMargin
 }

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -164,3 +164,47 @@ align.stripMargin = false
 >>>
 """|first
   |second""".stripMargin
+<<< no align, complex interpolation
+align.stripMargin = false
+===
+object a {
+     s"""
+        |  update targeting_segments
+        |  set status = '$status',
+        |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        |${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        |  updated_at = now()
+        |  where id in (${audienceIds.mkString(",")})""".stripMargin
+}
+>>>
+object a {
+  s"""
+    |  update targeting_segments
+    |  set status = '$status',
+    |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        |${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        |  updated_at = now()
+        |  where id in (${audienceIds.mkString(",")})""".stripMargin
+}
+<<< align, complex interpolation
+align.stripMargin = true
+===
+object a {
+     s"""
+        |  update targeting_segments
+        |  set status = '$status',
+        |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        |${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        |  updated_at = now()
+        |  where id in (${audienceIds.mkString(",")})""".stripMargin
+}
+>>>
+object a {
+  s"""
+     |  update targeting_segments
+     |  set status = '$status',
+     |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        |${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        |  updated_at = now()
+        |  where id in (${audienceIds.mkString(",")})""".stripMargin
+}


### PR DESCRIPTION
Rather than basing the indent on the `Interpolation.Part` (which might be preceded by an unrelated `Interpolation.Start`), find the containing `Term.Interpolate` instead.