### PR TITLE
Newlines: add flexibility to implicitParamListModifier

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -772,7 +772,7 @@ something.map { x => f(x) }
 > Since v2.5.0.
 
 ```scala mdoc:defaults
-newlines.implicitParamListModifier
+newlines.implicitParamListModifierForce
 ```
 
 #### Before
@@ -782,7 +782,7 @@ newlines.implicitParamListModifier
 
 ```scala mdoc:scalafmt
 maxColumn = 60
-newlines.implicitParamListModifier = [before]
+newlines.implicitParamListModifierForce = [before]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -795,7 +795,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 
 ```scala mdoc:scalafmt
 maxColumn = 60
-newlines.implicitParamListModifier = [after]
+newlines.implicitParamListModifierForce = [after]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -804,7 +804,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 
 ```scala mdoc:scalafmt
 maxColumn = 60
-newlines.implicitParamListModifier = [before,after]
+newlines.implicitParamListModifierForce = [before,after]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -813,7 +813,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 
 ```scala mdoc:scalafmt
 maxColumn = 60
-newlines.implicitParamListModifier = []
+newlines.implicitParamListModifierForce = []
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -823,7 +823,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```scala mdoc:scalafmt
 maxColumn = 60
 optIn.configStyleArguments = true
-newlines.implicitParamListModifier = [after]
+newlines.implicitParamListModifierForce = [after]
 ---
 def format(code: String, age: Int)(
    implicit ev: Parser, c: Context
@@ -1317,7 +1317,7 @@ other(a, b)(c, d)
 ```scala mdoc:scalafmt
 maxColumn = 60
 verticalMultiline.atDefnSite = true
-newlines.implicitParamListModifier = [before]
+newlines.implicitParamListModifierForce = [before]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -1327,7 +1327,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```scala mdoc:scalafmt
 maxColumn = 60
 verticalMultiline.atDefnSite = true
-newlines.implicitParamListModifier = [after]
+newlines.implicitParamListModifierForce = [after]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
@@ -1337,7 +1337,7 @@ def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```scala mdoc:scalafmt
 maxColumn = 60
 verticalMultiline.atDefnSite = true
-newlines.implicitParamListModifier = [before,after]
+newlines.implicitParamListModifierForce = [before,after]
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -771,11 +771,33 @@ something.map { x => f(x) }
 
 > Since v2.5.0.
 
-```scala mdoc:defaults
-newlines.implicitParamListModifierForce
+#### Prefer After (default)
+
+> Prefers newline after `implicit`. Newline will be added
+> unless the entire implicit parameter list fits on a line,
+> or config style is false. Newline can also be added _before_
+> if the keyword itself would overflow the line.
+
+```scala mdoc:scalafmt
+maxColumn = 60
+newlines.implicitParamListModifierPrefer = after
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
 
-#### Before
+#### Prefer Before
+
+> Prefers newline before `implicit`. Newline will not be added
+> if the entire implicit parameter list fits on a line.
+
+```scala mdoc:scalafmt
+maxColumn = 60
+newlines.implicitParamListModifierPrefer = before
+---
+def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
+```
+
+#### Force Before
 
 > If set, forces newline before `implicit`. Otherwise, newline can still be
 > added if the keyword would overflow the line.
@@ -787,7 +809,7 @@ newlines.implicitParamListModifierForce = [before]
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
 
-#### After
+#### Force After
 
 > If set, forces newline after `implicit`. Otherwise, newline can still be added
 > unless `before` is true, or the entire implicit parameter list fits on a line,
@@ -800,20 +822,11 @@ newlines.implicitParamListModifierForce = [after]
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
 
-#### Both before and after
+#### Force both before and after
 
 ```scala mdoc:scalafmt
 maxColumn = 60
 newlines.implicitParamListModifierForce = [before,after]
----
-def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
-```
-
-#### Neither before nor after
-
-```scala mdoc:scalafmt
-maxColumn = 60
-newlines.implicitParamListModifierForce = []
 ---
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -152,6 +152,7 @@ case class Newlines(
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
     implicitParamListModifierForce: Seq[Newlines.BeforeAfter] = Seq.empty,
+    implicitParamListModifierPrefer: Option[Newlines.BeforeAfter] = None,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
     afterInfix: Option[AfterInfix] = None,
@@ -160,6 +161,14 @@ case class Newlines(
     afterInfixMaxCountPerFile: Int = 500,
     avoidAfterYield: Boolean = true
 ) {
+  if (implicitParamListModifierForce.nonEmpty &&
+    implicitParamListModifierPrefer.nonEmpty) {
+    throw new ScalafmtConfigException(
+      "can't specify both " +
+        "implicitParamListModifierForce and implicitParamListModifierPrefer"
+    )
+  }
+
   val reader: ConfDecoder[Newlines] = generic.deriveDecoder(this).noTypos
   if (source != Newlines.classic) Newlines.warnSourceIsExperimental
 
@@ -197,6 +206,17 @@ case class Newlines(
     implicitParamListModifierForce.contains(Newlines.before)
   lazy val forceAfterImplicitParamListModifier: Boolean =
     implicitParamListModifierForce.contains(Newlines.after)
+
+  private def preferBeforeImplicitParamListModifier: Boolean =
+    implicitParamListModifierPrefer.contains(Newlines.before)
+  lazy val notPreferAfterImplicitParamListModifier: Boolean =
+    implicitParamListModifierForce.nonEmpty ||
+      preferBeforeImplicitParamListModifier
+  lazy val notBeforeImplicitParamListModifier: Boolean =
+    if (implicitParamListModifierForce.isEmpty)
+      !preferBeforeImplicitParamListModifier
+    else
+      !forceBeforeImplicitParamListModifier
 
   lazy val forceBlankBeforeMultilineTopLevelStmt: Boolean =
     topLevelStatements.contains(Newlines.before) ||

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -151,7 +151,7 @@ case class Newlines(
     )
     alwaysBeforeTopLevelStatements: Boolean = false,
     afterCurlyLambda: NewlineCurlyLambda = NewlineCurlyLambda.never,
-    implicitParamListModifier: Seq[Newlines.BeforeAfter] = Seq.empty,
+    implicitParamListModifierForce: Seq[Newlines.BeforeAfter] = Seq.empty,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     alwaysBeforeMultilineDef: Boolean = true,
     afterInfix: Option[AfterInfix] = None,
@@ -193,10 +193,10 @@ case class Newlines(
     else copy(afterInfix = Some(needAfterInfix))
   }
 
-  lazy val beforeImplicitParamListModifier: Boolean =
-    implicitParamListModifier.contains(Newlines.before)
-  lazy val afterImplicitParamListModifier: Boolean =
-    implicitParamListModifier.contains(Newlines.after)
+  lazy val forceBeforeImplicitParamListModifier: Boolean =
+    implicitParamListModifierForce.contains(Newlines.before)
+  lazy val forceAfterImplicitParamListModifier: Boolean =
+    implicitParamListModifierForce.contains(Newlines.after)
 
   lazy val forceBlankBeforeMultilineTopLevelStmt: Boolean =
     topLevelStatements.contains(Newlines.before) ||

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/VerticalMultiline.scala
@@ -10,13 +10,13 @@ case class VerticalMultiline(
     arityThreshold: Int = 100,
     @annotation.DeprecatedName(
       "newlineBeforeImplicitKW",
-      "Use newlines.implicitParamListModifier=[before] instead",
+      "Use newlines.implicitParamListModifierForce=[before] instead",
       "2.5.0"
     )
     newlineBeforeImplicitKW: Boolean = false,
     @annotation.DeprecatedName(
       "newlineAfterImplicitKW",
-      "Use newlines.implicitParamListModifier=[after] instead",
+      "Use newlines.implicitParamListModifierForce=[after] instead",
       "2.5.0"
     )
     newlineAfterImplicitKW: Boolean = false,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -936,8 +936,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       ft: FormatToken
   )(implicit style: ScalafmtConfig): Boolean = {
     def opensImplicit =
-      (style.newlines.afterImplicitParamListModifier || next(ft).hasBreak) &&
-        opensConfigStyleImplicitParamList(ft)
+      (style.newlines.forceAfterImplicitParamListModifier ||
+        next(ft).hasBreak) && opensConfigStyleImplicitParamList(ft)
     (ft.hasBreak || opensImplicit) && {
       val close = matching(ft.left)
       tokens(close, -1).hasBreak
@@ -949,7 +949,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   )(implicit style: ScalafmtConfig): Boolean =
     style.activeForEdition_2020_03 &&
       formatToken.right.is[T.KwImplicit] &&
-      !style.newlines.beforeImplicitParamListModifier &&
+      !style.newlines.forceBeforeImplicitParamListModifier &&
       opensImplicitParamList(formatToken).isDefined
 
   def styleAt(tree: Tree): ScalafmtConfig = {
@@ -1206,7 +1206,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
 
         val shouldAddNewline = {
           if (right.is[T.KwImplicit])
-            style.newlines.beforeImplicitParamListModifier ||
+            style.newlines.forceBeforeImplicitParamListModifier ||
             style.verticalMultiline.newlineBeforeImplicitKW
           else
             style.verticalMultiline.newlineAfterOpenParen && isDefinition
@@ -1217,7 +1217,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
             .withIndent(indentParam, close2, ExpiresOn.Before)
         )
       case Decision(t @ FormatToken(T.KwImplicit(), _, _), _)
-          if style.newlines.afterImplicitParamListModifier ||
+          if style.newlines.forceAfterImplicitParamListModifier ||
             style.verticalMultiline.newlineAfterImplicitKW =>
         Seq(Split(Newline, 0))
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -949,7 +949,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   )(implicit style: ScalafmtConfig): Boolean =
     style.activeForEdition_2020_03 &&
       formatToken.right.is[T.KwImplicit] &&
-      !style.newlines.forceBeforeImplicitParamListModifier &&
+      style.newlines.notBeforeImplicitParamListModifier &&
       opensImplicitParamList(formatToken).isDefined
 
   def styleAt(tree: Tree): ScalafmtConfig = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -949,8 +949,11 @@ class Router(formatOps: FormatOps) {
             .withIndent(indent, close, Before),
           Split(noSplitMod, (implicitPenalty + lhsPenalty) * bracketCoef)
             .withPolicy(oneArgOneLine.andThen(implicitPolicy))
-            .onlyIf(handleImplicit || (notTooManyArgs && align))
             .onlyIf(noSplitMod != null)
+            .onlyIf(
+              (notTooManyArgs && align) || (handleImplicit &&
+                style.newlines.notBeforeImplicitParamListModifier)
+            )
             .withIndent(if (align) StateColumn else indent, close, Before),
           Split(Newline, (3 + nestedPenalty) * bracketCoef)
             .withPolicy(oneArgOneLine)
@@ -1605,7 +1608,10 @@ class Router(formatOps: FormatOps) {
         } { params =>
           val spaceSplit = Split(Space, 0)
             .notIf(style.newlines.forceAfterImplicitParamListModifier)
-            .withPolicy(SingleLineBlock(params.last.tokens.last))
+            .withPolicy(
+              SingleLineBlock(params.last.tokens.last),
+              style.newlines.notPreferAfterImplicitParamListModifier
+            )
           Seq(
             spaceSplit,
             Split(Newline, if (spaceSplit.isActive) 1 else 0)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -884,7 +884,8 @@ class Router(formatOps: FormatOps) {
           opensImplicitParamList(formatToken, args)
 
         val noSplitMod =
-          if (handleImplicit && style.newlines.beforeImplicitParamListModifier)
+          if (handleImplicit &&
+            style.newlines.forceBeforeImplicitParamListModifier)
             null
           else getNoSplit(formatToken, !isBracket)
         val noSplitIndent = if (right.is[T.Comment]) indent else Num(0)
@@ -892,7 +893,8 @@ class Router(formatOps: FormatOps) {
         val align = {
           if (defnSite) style.align.openParenDefnSite
           else style.align.openParenCallSite
-        } && (!handleImplicit || style.newlines.afterImplicitParamListModifier)
+        } && (!handleImplicit ||
+          style.newlines.forceAfterImplicitParamListModifier)
         val alignTuple = align && isTuple(leftOwner)
 
         val keepConfigStyleSplit = !sourceIgnored &&
@@ -1602,7 +1604,7 @@ class Router(formatOps: FormatOps) {
           Seq(Split(Space, 0))
         } { params =>
           val spaceSplit = Split(Space, 0)
-            .notIf(style.newlines.afterImplicitParamListModifier)
+            .notIf(style.newlines.forceAfterImplicitParamListModifier)
             .withPolicy(SingleLineBlock(params.last.tokens.last))
           Seq(
             spaceSplit,

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -1,5 +1,5 @@
 maxColumn = 80
-newlines.implicitParamListModifier = [after]
+newlines.implicitParamListModifierForce = [after]
 verticalMultiline.atDefnSite = true
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 0
@@ -80,7 +80,7 @@ implicit def pairEncoder[A, B](
 ): CsvEncoder[(A, B)]
 <<< should work without explicit parameter groups (non-vm, before=T)
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifier = [before,after]
+newlines.implicitParamListModifierForce = [before,after]
 ===
 implicit def pairEncoder[A, B](
     implicit aEncoder: CsvEncoder[A],

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -1,5 +1,5 @@
 maxColumn = 80
-newlines.implicitParamListModifier = [before,after]
+newlines.implicitParamListModifierForce = [before,after]
 verticalMultiline.atDefnSite = true
 continuationIndent.defnSite = 2
 continuationIndent.extendSite = 0
@@ -97,7 +97,7 @@ implicit def pairEncoder[A, B](
 ): CsvEncoder[(A, B)]
 <<< force only before
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifier = [before]
+newlines.implicitParamListModifierForce = [before]
 ===
 object a {
   def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
@@ -116,7 +116,7 @@ object a {
 }
 <<< prefer after
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifier = [after]
+newlines.implicitParamListModifierForce = [after]
 optIn.configStyleArguments = false
 ===
 object a {
@@ -149,7 +149,7 @@ object a {
 }
 <<< prefer before
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifier = [before]
+newlines.implicitParamListModifierForce = [before]
 optIn.configStyleArguments = false
 ===
 object a {
@@ -185,7 +185,7 @@ object a {
 }
 <<< prefer after, config style
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifier = [after]
+newlines.implicitParamListModifierForce = [after]
 optIn.configStyleArguments = true
 ===
 object a {
@@ -218,7 +218,7 @@ object a {
 }
 <<< prefer before, config style
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifier = [before]
+newlines.implicitParamListModifierForce = [before]
 optIn.configStyleArguments = true
 ===
 object a {

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -109,14 +109,14 @@ object a {
     implicit aEncoder: CsvEncoder[A]
   ): CsvEncoder[(A, B)]
   def foo[A, B](
-    implicit
-    aEncoder: CsvEncoder[A],
+    implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
   ): CsvEncoder[(A, B)]
 }
 <<< prefer after
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifierForce = [after]
+newlines.implicitParamListModifierForce = []
+newlines.implicitParamListModifierPrefer = after
 optIn.configStyleArguments = false
 ===
 object a {
@@ -131,9 +131,7 @@ object a {
 }
 >>>
 object a {
-  def foo[A, B](implicit
-    aEncoder: CsvEncoder[A]
-  ): CsvEncoder[(A, B)]
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
   def foo[A, B](implicit
     aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
@@ -149,7 +147,8 @@ object a {
 }
 <<< prefer before
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifierForce = [before]
+newlines.implicitParamListModifierForce = []
+newlines.implicitParamListModifierPrefer = before
 optIn.configStyleArguments = false
 ===
 object a {
@@ -164,28 +163,24 @@ object a {
 }
 >>>
 object a {
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
   def foo[A, B](
-    implicit aEncoder: CsvEncoder[A]
-  ): CsvEncoder[(A, B)]
-  def foo[A, B](
-    implicit
-    aEncoder: CsvEncoder[A],
+    implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
   ): CsvEncoder[(A, B)]
   def foo[A, B](
-    implicit
-    aEncoder: CsvEncoder[A],
+    implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
   ): CsvEncoder[(A, B)]
   def foo[A, B](
-    implicit
-    aEncoder: CsvEncoder[A],
+    implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
   ): CsvEncoder[(A, B)]
 }
 <<< prefer after, config style
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifierForce = [after]
+newlines.implicitParamListModifierForce = []
+newlines.implicitParamListModifierPrefer = after
 optIn.configStyleArguments = true
 ===
 object a {
@@ -200,9 +195,7 @@ object a {
 }
 >>>
 object a {
-  def foo[A, B](implicit
-    aEncoder: CsvEncoder[A]
-  ): CsvEncoder[(A, B)]
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
   def foo[A, B](implicit
     aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
@@ -218,7 +211,8 @@ object a {
 }
 <<< prefer before, config style
 verticalMultiline.atDefnSite = false
-newlines.implicitParamListModifierForce = [before]
+newlines.implicitParamListModifierForce = []
+newlines.implicitParamListModifierPrefer = before
 optIn.configStyleArguments = true
 ===
 object a {
@@ -233,22 +227,17 @@ object a {
 }
 >>>
 object a {
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
   def foo[A, B](
-    implicit aEncoder: CsvEncoder[A]
-  ): CsvEncoder[(A, B)]
-  def foo[A, B](
-    implicit
-    aEncoder: CsvEncoder[A],
+    implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
   ): CsvEncoder[(A, B)]
   def foo[A, B](
-    implicit
-    aEncoder: CsvEncoder[A],
+    implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
   ): CsvEncoder[(A, B)]
   def foo[A, B](
-    implicit
-    aEncoder: CsvEncoder[A],
+    implicit aEncoder: CsvEncoder[A],
     bEncoder: CsvEncoder[B]
   ): CsvEncoder[(A, B)]
 }

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -95,3 +95,160 @@ implicit def pairEncoder[A, B](
   aEncoder: CsvEncoder[A],
   bEncoder: CsvEncoder[B]
 ): CsvEncoder[(A, B)]
+<<< force only before
+verticalMultiline.atDefnSite = false
+newlines.implicitParamListModifier = [before]
+===
+object a {
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]): CsvEncoder[(A, B)]
+}
+>>>
+object a {
+  def foo[A, B](
+    implicit aEncoder: CsvEncoder[A]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}
+<<< prefer after
+verticalMultiline.atDefnSite = false
+newlines.implicitParamListModifier = [after]
+optIn.configStyleArguments = false
+===
+object a {
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}
+>>>
+object a {
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}
+<<< prefer before
+verticalMultiline.atDefnSite = false
+newlines.implicitParamListModifier = [before]
+optIn.configStyleArguments = false
+===
+object a {
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}
+>>>
+object a {
+  def foo[A, B](
+    implicit aEncoder: CsvEncoder[A]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}
+<<< prefer after, config style
+verticalMultiline.atDefnSite = false
+newlines.implicitParamListModifier = [after]
+optIn.configStyleArguments = true
+===
+object a {
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}
+>>>
+object a {
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}
+<<< prefer before, config style
+verticalMultiline.atDefnSite = false
+newlines.implicitParamListModifier = [before]
+optIn.configStyleArguments = true
+===
+object a {
+  def foo[A, B](implicit aEncoder: CsvEncoder[A]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]): CsvEncoder[(A, B)]
+  def foo[A, B](implicit
+    aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit aEncoder: CsvEncoder[A], bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}
+>>>
+object a {
+  def foo[A, B](
+    implicit aEncoder: CsvEncoder[A]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+  def foo[A, B](
+    implicit
+    aEncoder: CsvEncoder[A],
+    bEncoder: CsvEncoder[B]
+  ): CsvEncoder[(A, B)]
+}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -57,36 +57,36 @@ class StyleMapTest extends AnyFunSuite {
     assert(newPrintlnConfig.alignMap("=").regex == overrideEquals)
   }
 
-  test("newlines.implicitParamListModifier") {
+  test("newlines.implicitParamListModifierForce") {
     val code =
       """object a {
-        |  // scalafmt: { newlines.implicitParamListModifier = [after] }
+        |  // scalafmt: { newlines.implicitParamListModifierForce = [after] }
         |  println(1)
         |}
       """.stripMargin.parse[Source].get
     val formatOps = new FormatOps(
       code,
       ScalafmtConfig(newlines =
-        Newlines(implicitParamListModifier = List(Newlines.before))
+        Newlines(implicitParamListModifierForce = List(Newlines.before))
       )
     )
-    val headToken = formatOps.tokens.head
-    val printlnToken = formatOps.tokens.find(_.left.syntax == "println").get
+    val token1 = formatOps.tokens.head
+    val token2 = formatOps.tokens.find(_.left.syntax == "println").get
 
     val defaultValue = List(Newlines.before)
     val overrideValue = List(Newlines.after)
 
-    val headConfig = formatOps.styleMap.at(headToken)
-    val printlnConfig = formatOps.styleMap.at(printlnToken)
-    val newFormatOps = new FormatOps(code, printlnConfig)
+    val style1 = formatOps.styleMap.at(token1)
+    val style2 = formatOps.styleMap.at(token2)
+    val formatOps2 = new FormatOps(code, style2)
 
-    val newHeadConfig = newFormatOps.styleMap.at(headToken)
-    assert(headConfig.newlines.implicitParamListModifier == defaultValue)
-    assert(newHeadConfig.newlines.implicitParamListModifier == overrideValue)
+    val newStyle1 = formatOps2.styleMap.at(token1)
+    assert(style1.newlines.implicitParamListModifierForce == defaultValue)
+    assert(newStyle1.newlines.implicitParamListModifierForce == overrideValue)
 
-    val newPrintlnConfig = newFormatOps.styleMap.at(printlnToken)
-    assert(printlnConfig.newlines.implicitParamListModifier == overrideValue)
-    assert(newPrintlnConfig.newlines.implicitParamListModifier == overrideValue)
+    val newStyle2 = formatOps2.styleMap.at(token2)
+    assert(style2.newlines.implicitParamListModifierForce == overrideValue)
+    assert(newStyle2.newlines.implicitParamListModifierForce == overrideValue)
   }
 
 }


### PR DESCRIPTION
Rename the current parameter appending _Force_, and add the _Prefer_ parameter as an alternative, to indicate where the break is preferred (rather than required).

`implicitParamListModifierPrefer = after` is equivalent to current `implicitParamListModifier = []`, while `implicitParamListModifierPrefer = before` restores the functionality available in 2.4.2, which was lost while combining with the vertical multiline more aggressive approach.