### PR TITLE
ScalafmtDynamicRunner: read and format only matching files

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -33,7 +33,7 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
             .map(OsSpecific.fixSeparatorsInPathPattern)
         )
 
-        val inputMethods = getInputMethods(options, Some(filterMatcher))
+        val inputMethods = getInputMethods(options, filterMatcher.matchesFile)
         if (inputMethods.isEmpty && options.mode.isEmpty && !options.stdIn)
           throw NoMatchingFiles
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
@@ -6,6 +6,7 @@ import java.nio.file.Paths
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.function.UnaryOperator
 
+import org.scalafmt.CompatParCollections.Converters._
 import org.scalafmt.Error.{MisformattedFile, NoMatchingFiles}
 import org.scalafmt.interfaces.Scalafmt
 import org.scalafmt.interfaces.ScalafmtSession
@@ -48,7 +49,7 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
 
     val exitCode = new AtomicReference(ExitCode.Ok)
     breakable {
-      inputMethods.foreach { inputMethod =>
+      inputMethods.par.foreach { inputMethod =>
         try {
           val code = handleFile(inputMethod, session, options)
           exitCode.getAndUpdate(new UnaryOperator[ExitCode] {

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.cli
+
 import java.nio.file.Paths
-import java.util.concurrent.atomic.{AtomicReference, AtomicInteger}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.function.UnaryOperator
 
 import org.scalafmt.Error.{MisformattedFile, NoMatchingFiles}
@@ -15,7 +16,10 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
       options: CliOptions,
       termDisplayMessage: String
   ): ExitCode = {
-    val inputMethods = getInputMethods(options, None)
+    val inputMethods = getInputMethods(
+      options,
+      (x: AbsoluteFile) => true
+    )
     if (inputMethods.isEmpty && options.mode.isEmpty && !options.stdIn)
       throw NoMatchingFiles
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -1,7 +1,7 @@
 package org.scalafmt.cli
+
 import java.io.OutputStreamWriter
 
-import org.scalafmt.config.FilterMatcher
 import org.scalafmt.util.{AbsoluteFile, FileOps}
 
 trait ScalafmtRunner {
@@ -29,7 +29,7 @@ trait ScalafmtRunner {
 
   protected def getInputMethods(
       options: CliOptions,
-      filter: Option[FilterMatcher]
+      filter: AbsoluteFile => Boolean
   ): Seq[InputMethod] = {
     if (options.stdIn) {
       Seq(InputMethod.StdinCode(options.assumeFilename, options.common.in))
@@ -45,11 +45,8 @@ trait ScalafmtRunner {
   /** Returns file paths defined via options.{customFiles,customExclude} */
   private[this] def getFilesFromCliOptions(
       options: CliOptions,
-      filter: Option[FilterMatcher]
+      canFormat: AbsoluteFile => Boolean
   ): Seq[AbsoluteFile] = {
-    def canFormat(f: AbsoluteFile): Boolean =
-      filter.forall(_.matches(f))
-
     val files = options.fileFetchMode match {
       case m @ (GitFiles | RecursiveSearch) =>
         val fetchFiles: AbsoluteFile => Seq[AbsoluteFile] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FilterMatcher.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FilterMatcher.scala
@@ -5,15 +5,13 @@ import scala.util.matching.Regex
 import org.scalafmt.util.AbsoluteFile
 
 case class FilterMatcher(include: Regex, exclude: Regex) {
-  def matches(file: AbsoluteFile): Boolean = matches(file.path)
+  def matchesFile(file: AbsoluteFile): Boolean = matches(file.path)
   def matches(input: String): Boolean =
     include.findFirstIn(input).isDefined &&
       exclude.findFirstIn(input).isEmpty
 }
 
 object FilterMatcher {
-  val matchEverything = new FilterMatcher(".*".r, mkRegexp(Nil))
-
   def mkRegexp(filters: Seq[String], strict: Boolean = false): Regex =
     filters match {
       case Nil => "$a".r // will never match anything

--- a/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtSession.java
+++ b/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtSession.java
@@ -1,0 +1,27 @@
+package org.scalafmt.interfaces;
+
+import java.nio.file.Path;
+
+/**
+ * A session based on a fixed configuration.
+ */
+public interface ScalafmtSession {
+
+    /**
+     * Format a single file with the given configuration.
+     *
+     * @param file relative or absolute path to the file being formatted. Used only for the path
+     *             name, the file does not have to exist on disk.
+     * @param code the text contents to format.
+     * @return the formatted contents if formatting was successful, otherwise the original text
+     * contents.
+     */
+    String format(Path file, String code);
+
+
+    /**
+     * Whether the path matches the 'project.{excludeFilters,includeFilters}' setting.
+     */
+    boolean matchesProjectFilters(Path file);
+
+}

--- a/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtSessionFactory.java
+++ b/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtSessionFactory.java
@@ -1,0 +1,12 @@
+package org.scalafmt.interfaces;
+
+import java.nio.file.Path;
+
+public interface ScalafmtSessionFactory extends Scalafmt {
+
+    /**
+     * Create a ScalafmtSession to format a batch of files using fixed configuration.
+     */
+    ScalafmtSession createSession(Path config);
+
+}


### PR DESCRIPTION
- `ScalafmtSession`: add an interface for batch format. If we need to format a number of files using the same exact scalafmt configuration, let's create a session.
  - This will also allow us to filter inputs based on the project files which was not available and led to dynamic runner loading and formatting all files, including those not covered by the configuration.
- `ScalafmtDynamicRunner`: pre-filter based on customFiles if specified.
- `ScalafmtDynamicRunner`: try to use `ScalafmtSession` to avoid loading unnecessary files

Fixes #1460.