### PR TITLE
RedundantBraces: fix try with partially enclosed expressions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -23,7 +23,7 @@ class RedundantParens(implicit ctx: RewriteCtx) extends RewriteSession {
       case t => rewriteFunc.applyOrElse(t, (x: Tree) => remove(x, 1))
     }
 
-  private val rewriteFunc: PartialFunction[Tree, Unit] = {
+  private[rewrite] val rewriteFunc: PartialFunction[Tree, Unit] = {
     case t @ (_: Term.Tuple | _: Type.Tuple) => remove(t, 2)
 
     case g: Enumerator.Guard => remove(g.cond)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -701,4 +701,22 @@ object TreeOps {
     }
   }
 
+  @tailrec
+  def findFirstTreeBetween(tree: Tree, beg: Token, end: Token): Option[Tree] = {
+    def isWithinRange(x: Tokens): Boolean = {
+      x.nonEmpty && x.head.start >= beg.start && x.last.end <= end.end
+    }
+    def matches(tree: Tree): Boolean = {
+      val x = tree.tokens
+      isWithinRange(x) ||
+      x.nonEmpty && x.head.start <= beg.start && x.last.end >= end.end
+    }
+    if (isWithinRange(tree.tokens)) Some(tree)
+    else
+      tree.children.find(matches) match {
+        case Some(c) => findFirstTreeBetween(c, beg, end)
+        case _ => None
+      }
+  }
+
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -776,3 +776,49 @@ object a {
     case bar => foo
   })
 }
+<<< try with partially enclosed 1: paren kept
+object a {
+  try { (x).y } catch { case a => }
+  try { (x).y } catch handler
+}
+>>>
+test does not parse
+object a {
+  try  (x).y  catch { case a => }
+          ^
+<<< try with partially enclosed 2: paren removed
+rewrite.rules = [RedundantBraces, RedundantParens]
+===
+object a {
+  try { (x).y } catch { case a => }
+  try { (x).y } catch handler
+}
+>>>
+object a {
+  try x.y
+  catch { case a => }
+  try x.y
+  catch handler
+}
+<<< try with partially enclosed 3: brace kept
+object a {
+  try { {x + y}.z } catch { case a => }
+  try { {x + y}.y } catch handler
+}
+>>>
+test does not parse
+object a {
+  try  {x + y}.z  catch { case a => }
+              ^
+<<< try with partially enclosed 4: brace removed
+object a {
+  try { {x}.z } catch { case a => }
+  try { {x}.y } catch handler
+}
+>>>
+object a {
+  try x.z
+  catch { case a => }
+  try x.y
+  catch handler
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -782,10 +782,12 @@ object a {
   try { (x).y } catch handler
 }
 >>>
-test does not parse
 object a {
-  try  (x).y  catch { case a => }
-          ^
+  try { (x).y }
+  catch { case a => }
+  try { (x).y }
+  catch handler
+}
 <<< try with partially enclosed 2: paren removed
 rewrite.rules = [RedundantBraces, RedundantParens]
 ===
@@ -806,10 +808,12 @@ object a {
   try { {x + y}.y } catch handler
 }
 >>>
-test does not parse
 object a {
-  try  {x + y}.z  catch { case a => }
-              ^
+  try { { x + y }.z }
+  catch { case a => }
+  try { { x + y }.y }
+  catch handler
+}
 <<< try with partially enclosed 4: brace removed
 object a {
   try { {x}.z } catch { case a => }


### PR DESCRIPTION
Until scala 2.13, removing braces around partially enclosed (paren or brace) `try` body isn't supported. See https://github.com/scalameta/scalameta/issues/2031.