### PR TITLE
Usage of default align token owners

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
@@ -25,7 +25,9 @@ object AlignToken {
   implicit val DefaultAlignTokenDecoder: ConfDecoder[AlignToken] =
     ConfDecoder.instance[AlignToken] {
       case Conf.Str("caseArrow") => Ok(caseArrow)
-      case Conf.Str(regex) => Ok(AlignToken(regex, ".*"))
+      case Conf.Str(regex) =>
+        val owner = default.find(_.code == regex).fold(".*")(_.owner)
+        Ok(AlignToken(regex, owner))
       case els => fallbackAlign.reader.read(els)
     }
 

--- a/scalafmt-tests/src/test/resources/align/defaultTokenOwners.stat
+++ b/scalafmt-tests/src/test/resources/align/defaultTokenOwners.stat
@@ -1,0 +1,39 @@
+align.tokens.add = ["="]
+<<< don't align independent columns (see #1896)
+object fmt {
+  val header = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
+  val content = payload.toString
+  val claim = JwtClaim(content = content)
+}
+>>>
+object fmt {
+  val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
+  val content = payload.toString
+  val claim   = JwtClaim(content = content)
+}
+<<< respect specified owner
+align.tokens.add = [{code = "=", owner = "(Term.Assign|Defn.Val)"}]
+===
+object fmt {
+  val header = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
+  val content = payload.toString
+  val claim = JwtClaim(content = content)
+}
+>>>
+object fmt {
+  val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
+  val content = payload.toString
+  val claim   = JwtClaim(content    = content)
+}
+<<< fallback to any owner
+align.tokens.add = ["!"]
+===
+object fmt {
+  aaa ! 2
+  bb ! 3
+}
+>>>
+object fmt {
+  aaa ! 2
+  bb  ! 3
+}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -33,7 +33,7 @@ class StyleMapTest extends AnyFunSuite {
   test("align.tokens.add") {
     val code =
       """object a {
-        |  // scalafmt: { align.tokens.add = ["="] }
+        |  // scalafmt: { align.tokens.add = [{ code="=", owner=".*" }] }
         |  println(1)
         |}
       """.stripMargin.parse[Source].get


### PR DESCRIPTION
Fixes #1896

Motivation described in the issue. Now users don't need to copy-paste
token owners from sources to get optimal alignment for dedicated tokens.

It will slightly change the value of user configs so need to be described in release notes.