### PR TITLE
FormatWriter bugfix: add margin in the middle only

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -735,7 +735,7 @@ object FormatWriter {
   }
 
   private val leadingAsteriskSpace =
-    Pattern.compile("^\\h*(?=[*][^*])", Pattern.MULTILINE)
+    Pattern.compile("(?<=\\n)\\h*(?=[*][^*])")
   private def formatComment(
       comment: T.Comment,
       indent: Int
@@ -758,7 +758,7 @@ object FormatWriter {
     if (pipe == '|') leadingPipeSpace else compileStripMarginPattern(pipe)
   @inline
   private def compileStripMarginPattern(pipe: Char) =
-    Pattern.compile(s"^\\h*(?=[$pipe])", Pattern.MULTILINE)
+    Pattern.compile(s"(?<=\\n)\\h*(?=[$pipe])")
   private val leadingPipeSpace = compileStripMarginPattern('|')
 
 }

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -178,7 +178,7 @@ object a {
 }
 >>>
 object a {
-  s"""    |
+  s"""|
     |  update targeting_segments
     |  set status = '$status',
     |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -168,7 +168,7 @@ align.stripMargin = false
 align.stripMargin = false
 ===
 object a {
-     s"""
+     s"""|
         |  update targeting_segments
         |  set status = '$status',
         |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
@@ -178,7 +178,7 @@ object a {
 }
 >>>
 object a {
-  s"""
+  s"""    |
     |  update targeting_segments
     |  set status = '$status',
     |${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}


### PR DESCRIPTION
In #1911, by switching to `^` anchors, we introduced a bug.