### PR TITLE
Documentation: add newlines.alwaysBeforeMultilineDef

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -696,6 +696,30 @@ package core {
 }
 ```
 
+### `newlines.alwaysBeforeMultilineDef`
+
+This parameter forces a new line before the method body on multiline defs:
+
+```scala mdoc:defaults
+newlines.alwaysBeforeMultilineDef
+```
+
+```scala mdoc:scalafmt
+newlines.alwaysBeforeMultilineDef = true
+---
+def foo: String = "123".map { x =>
+  x.toUpper
+}
+```
+
+```scala mdoc:scalafmt
+newlines.alwaysBeforeMultilineDef = false
+---
+def foo: String = "123".map { x =>
+  x.toUpper
+}
+```
+
 ### `newlines.topLevelStatementsMinBreaks`
 
 > Since v2.5.0.


### PR DESCRIPTION
Documentation for `newlines.alwaysBeforeMultilineDef`.

The new section clarifies that the new line is added before the def's method body, not the def itself.