### PR TITLE
WIP: internal/FormatWriter simplify two regexen; fix pipe char bug

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -736,8 +736,7 @@ object FormatWriter {
     trailingSpace.matcher(str).replaceAll("")
   }
 
-  private val leadingAsteriskSpace =
-    Pattern.compile("\n\\h*\\*([^*])", Pattern.MULTILINE)
+  private val leadingAsteriskSpace = Pattern.compile("\n\\h*\\*([^*])")
   private def formatComment(
       comment: T.Comment,
       indent: Int
@@ -762,8 +761,7 @@ object FormatWriter {
     if (pipe == '|') leadingPipeSpace else compileStripMarginPattern(pipe)
   @inline
   private def compileStripMarginPattern(pipe: Char) =
-    // capture group is used to pass pipe character to distant replaceAll.
-    Pattern.compile(s"\n\\h*(\\${pipe})", Pattern.MULTILINE)
+    Pattern.compile(s"\n\\h*(\\${pipe})")
   private val leadingPipeSpace = compileStripMarginPattern('|')
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -368,7 +368,9 @@ class FormatWriter(formatOps: FormatOps) {
         tupleOpt.fold(text) {
           case (pipe, indent) =>
             val spaces = getIndentation(indent)
-            getStripMarginPattern(pipe).matcher(text).replaceAll(spaces)
+            getStripMarginPattern(pipe)
+              .matcher(text)
+              .replaceAll(s"\n${spaces}$$1")
         }
       }
 
@@ -735,7 +737,7 @@ object FormatWriter {
   }
 
   private val leadingAsteriskSpace =
-    Pattern.compile("(?<=\\n)\\h*(?=[*][^*])")
+    Pattern.compile("\n\\h*\\*([^*])", Pattern.MULTILINE)
   private def formatComment(
       comment: T.Comment,
       indent: Int
@@ -746,7 +748,9 @@ object FormatWriter {
         val isDocstring = comment.syntax.startsWith("/**") && style.scalaDocs
         val spaces: String =
           getIndentation(if (isDocstring) (indent + 2) else (indent + 1))
-        leadingAsteriskSpace.matcher(comment.syntax).replaceAll(spaces)
+        leadingAsteriskSpace
+          .matcher(comment.syntax)
+          .replaceAll(s"\n${spaces}*$$1")
       } else {
         comment.syntax
       }
@@ -758,7 +762,8 @@ object FormatWriter {
     if (pipe == '|') leadingPipeSpace else compileStripMarginPattern(pipe)
   @inline
   private def compileStripMarginPattern(pipe: Char) =
-    Pattern.compile(s"(?<=\\n)\\h*(?=[$pipe])")
+    // capture group is used to pass pipe character to distant replaceAll.
+    Pattern.compile(s"\n\\h*(\\${pipe})", Pattern.MULTILINE)
   private val leadingPipeSpace = compileStripMarginPattern('|')
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -731,12 +731,30 @@ object FormatWriter {
     }
   }
 
-  private val trailingSpace = Pattern.compile("\\h+$", Pattern.MULTILINE)
+  /**
+    * No Unicode is necessary in the three (3) Pattern.compile() below.
+    * scalafmt parser will have already have objected.
+    * https://github.com/scala/scala/blob/2.11.x/spec/01-lexical-syntax.md
+    * gives the recognized scala whitespace characters.
+    * "Whitespace characters. \U0020 | \U0009 | \U000D | \U000A"
+    * (original text has lowercase u. U substituted here to allow scalafmt
+    *  to format this file.)
+    *
+    * Of the characters which the parser will pass, only space (\u0020)
+    * and tab (\u0009) are horizontal whitespace.
+    * Save execution time by not checking what the character could not be.
+    *
+    * */
+
+  private val trailingSpace =
+    Pattern.compile("[\\x20\\t]+$", Pattern.MULTILINE)
+
   private def removeTrailingWhiteSpace(str: String): String = {
     trailingSpace.matcher(str).replaceAll("")
   }
 
-  private val leadingAsteriskSpace = Pattern.compile("\n\\h*\\*([^*])")
+  private val leadingAsteriskSpace = Pattern.compile("\n[\\x20\\t]*\\*([^*])")
+
   private def formatComment(
       comment: T.Comment,
       indent: Int
@@ -759,9 +777,11 @@ object FormatWriter {
   @inline
   private def getStripMarginPattern(pipe: Char) =
     if (pipe == '|') leadingPipeSpace else compileStripMarginPattern(pipe)
+
   @inline
   private def compileStripMarginPattern(pipe: Char) =
-    Pattern.compile(s"\n\\h*(\\${pipe})")
+    Pattern.compile(s"\n[\\x20\\t]*(\\${pipe})")
+
   private val leadingPipeSpace = compileStripMarginPattern('|')
 
 }

--- a/scalafmt-tests/src/test/resources/default/Comment.stat
+++ b/scalafmt-tests/src/test/resources/default/Comment.stat
@@ -125,7 +125,7 @@ object a {
   /*
 
    /**
-     		* comment
+     * comment
      */
 
   def undefined = ???
@@ -140,5 +140,17 @@ object a {
    */
 
   def undefined = ???
+   */
+}
+<<< remove spaces and tabs in leading horizontal whitespace
+object A {
+  /*
+		* remove spaces & 2 tabs (\t) in leading horizontal whitespace
+  */
+}
+>>>
+object A {
+  /*
+   * remove spaces & 2 tabs (\t) in leading horizontal whitespace
    */
 }

--- a/scalafmt-tests/src/test/resources/spaces/TrailingWhiteSpace.stat
+++ b/scalafmt-tests/src/test/resources/spaces/TrailingWhiteSpace.stat
@@ -1,0 +1,25 @@
+maxColumn = 80
+# Devos: be careful this file contains essential but invisible spaces.
+<<< Remove trailing spaces from variables
+object A {
+  val a = 1    
+  val b = 2    
+}
+>>>
+object A {
+  val a = 1
+  val b = 2
+}
+<<< Remove trailing tab-blank-tab combinations from variables
+object B {
+  val a = 1	 	
+  val b = 2	 	
+}
+>>>
+object B {
+  val a = 1
+  val b = 2
+}
+
+
+

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -208,3 +208,69 @@ object a {
      |  updated_at = now()
      |  where id in (${audienceIds.mkString(",")})""".stripMargin
 }
+<<< align, pipe character: RIGHT PARENTHESIS
+align.stripMargin = true
+===
+object a {
+     s"""
+        )  update targeting_segments
+        )  set status = '$status',
+        )${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        )${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        )  updated_at = now()
+        )  where id in (${audienceIds.mkString(",")})""".stripMargin(')')
+}
+>>>
+object a {
+  s"""
+     )  update targeting_segments
+     )  set status = '$status',
+     )${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+     )${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+     )  updated_at = now()
+     )  where id in (${audienceIds.mkString(",")})""".stripMargin(')')
+}
+<<< align, pipe character: DOLLAR SIGN
+align.stripMargin = true
+===
+object a {
+     s"""
+        $$  update targeting_segments
+        $$  set status = '$status',
+        $$${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        $$${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        $$  updated_at = now()
+        $$  where id in (${audienceIds.mkString(",")})""".stripMargin('$')
+}
+>>>
+object a {
+  s"""
+     $$  update targeting_segments
+     $$  set status = '$status',
+     $$${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+     $$${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+     $$  updated_at = now()
+     $$  where id in (${audienceIds.mkString(",")})""".stripMargin('$')
+}
+<<< align, pipe character: REVERSE SOLIDUS a.k.a. backslash
+align.stripMargin = true
+===
+object a {
+     s"""
+        \  update targeting_segments
+        \  set status = '$status',
+        \${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        \${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        \  updated_at = now()
+        \  where id in (${audienceIds.mkString(",")})""".stripMargin('\\')
+}
+>>>
+object a {
+  s"""
+     \  update targeting_segments
+     \  set status = '$status',
+     \${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+     \${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+     \  updated_at = now()
+     \  where id in (${audienceIds.mkString(",")})""".stripMargin('\\')
+}


### PR DESCRIPTION
  * This PR was motivated by recent discussions related to Scalafmt
    PRs #1916, #1917, and those mentioned in those PRs.

  * The primary purpose of this PR is to provide a concrete example
    of how the regular expressions for `leadingAsteriskSpace` and
    `compileStripMarginPattern` be simplified.

    Discussions about readability are always subjective. I believe
    that removing the positive and negative lookaheads makes it
    more likely that the next maintainer will be able to read and
    comprehend the code.

    Discussions about runtime performance improvements without
    demonstrable data are worth than useless.  lookaheads are
    known to have a high runtime cost. It is believable, but not
    asserted by this PR for lack of evidence, that the code of this
    PR will have better performance characteristics.

  * Whilst simplifying the two regex expressions, I noticed what I
    believe to be a bug in `compileStripMarginPattern`. Scala allows
    any character other than NULL to be used as a pipe character.
    Java requires that Dollar ($) and backslash (\) characters
    in the replacement string be quoted (e.g. in a string: "\\$").
    The code prior to this PR did not do this.
  
  * The handling of `compileStripMarginPattern` is a bit tricky. Every/any regex expression should
     be sealed with the Curse of the Mummy, but that one is particularly deserving.

     The active pipe character is not in scope where the replaceAll() is done. 
     Using a capture group allows the pipe character from where the pattern is compiled to be
     used in replaceAll(),
     
     Agreed, a code smell, but, as a guest, I wanted/needed to minimize changes to the 
     existing code. One capture group is not all that expensive. The "[^*]" character class
     in `leadingAsteriskSpace` probably takes more memory.

  * The code of this PR passes all current scalafmt tests:
    `sbt> tests/test`
 ```
[info] ScalaTest
[info] Run completed in 1 minute, 23 seconds.
[info] Total number of tests run: 2406
[info] Suites: completed 18, aborted 0
[info] Tests: succeeded 2406, failed 0, canceled 0, ignored 8, pending 0
[info] All tests passed.
[info] Passed: Total 2406, Failed 0, Errors 0, Passed 2406, Ignored 8
[success] Total time: 90 s (01:30), completed Apr 28, 2020, 2:41:12 PM
 ```

  * Three cases were added to  `./scalafmt-tests/src/test/resources/test/StripMargin.stat` to 
     ensure that potentially troublesome stripMargin() pipe characters, such as Dollar Sign,
     Backslash, and Right Parenthesis work as intended.
 
     Test cases for Unicode characters in leadingAsteriskSpace for trailing whitespace
     remain as an exercise for the reader. The lack of such tests is a blemish on my
     engineering.

 * I did not test it but the `\n` approach should work on the/most Windows operating system.
   It is what has been in the code for years.

 * The regular expressions in this PR should work with Scala Native and make an eventual
    port easier.

Documentation:

  * None required. The changes in this PR should cause no user visible
    change. I do not know if the practice of scalafmt development is to create
    a change log entry for user invisible changes or if the git history is enough.

Testing:

  * Built from a clean slate and manually tested ("test/test")
    using sbt 1.3.10 & Java 11 on X86_64 only. All tests pass.