### PR TITLE
FormatWriter: no arbitrary depth to match align

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -1,12 +1,12 @@
 package org.scalafmt.config
 
 import java.nio.file
+import java.util.regex
 
 import scala.collection.mutable
 import scala.io.Codec
 import scala.meta.Dialect
 import scala.util.Try
-import scala.util.matching.Regex
 import metaconfig.annotation._
 import metaconfig._
 import metaconfig.Configured._
@@ -207,8 +207,8 @@ case class ScalafmtConfig(
   private implicit def danglingParenthesesReader = danglingParentheses.decoder
   private implicit def indentOperatorReader = indentOperator.decoder
   private implicit def importSelectorsReader = importSelectors.decoder
-  lazy val alignMap: Map[String, Regex] =
-    align.tokens.map(x => x.code -> x.owner.r).toMap
+  lazy val alignMap: Map[String, regex.Pattern] =
+    align.tokens.map(x => x.code -> x.owner.r.pattern).toMap
   private implicit val confObjReader = ScalafmtConfig.confObjReader
   private def baseDecoder = generic.deriveDecoder(this).noTypos
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -60,7 +60,6 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     getMatchingParentheses(tree.tokens)
   val styleMap =
     new StyleMap(tokens, initStyle, ownersMap, matchingParentheses)
-  private val vAlignDepthCache = mutable.Map.empty[Tree, Int]
   // Maps token to number of non-whitespace bytes before the token's position.
   private final val nonWhitespaceOffset: Map[Token, Int] = {
     val resultB = Map.newBuilder[Token, Int]
@@ -1073,23 +1072,6 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   def decideNewlinesOnlyAfterToken(token: Token): Policy.Pf = {
     case d: Decision if d.formatToken.left eq token =>
       d.onlyNewlinesWithoutFallback
-  }
-
-  // Returns the depth of this node in the AST, used to prevent false positives.
-  final def vAlignDepth(tree: Tree): Int = {
-    vAlignDepthCache.getOrElseUpdate(tree, vAlignDepthUnCached(tree))
-  }
-
-  private final def vAlignDepthUnCached(tree: Tree): Int = {
-    val count: Int = tree match {
-      // infix applications don't count towards the length, context #531
-      case _: Term.ApplyInfix => 0
-      case _ => 1
-    }
-    tree.parent match {
-      case Some(parent) => count + vAlignDepth(parent)
-      case None => count
-    }
   }
 
   def getForceConfigStyle: (Set[Tree], Set[TokenHash]) = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -8,7 +8,6 @@ import org.scalafmt.util.TokenOps._
 import org.scalafmt.util.{LiteralOps, TreeOps}
 
 import scala.annotation.tailrec
-import scala.collection.IndexedSeq
 import scala.collection.mutable
 import scala.meta.tokens.Token
 import scala.meta.tokens.{Token => T}
@@ -563,10 +562,10 @@ class FormatWriter(formatOps: FormatOps) {
       var columnShift = 0
       val finalResult = Map.newBuilder[TokenHash, Int]
       var maxMatches = Integer.MIN_VALUE
-      var block = Vector.empty[Array[FormatLocation]]
+      var block = Vector.empty[IndexedSeq[FormatLocation]]
       val locationIter = new LocationsIterator(locations)
       while (locationIter.hasNext) {
-        val columnCandidates = Array.newBuilder[FormatLocation]
+        val columnCandidates = IndexedSeq.newBuilder[FormatLocation]
         def shouldContinue(floc: FormatLocation): Boolean = {
           val ok = !floc.state.split.modification.isNewline
           if (!ok || floc.formatToken.leftHasNewline) columnShift = 0
@@ -634,7 +633,7 @@ class FormatWriter(formatOps: FormatOps) {
               column += 1
             }
             if (candidates.isEmpty || doubleNewline) {
-              block = Vector.empty[Array[FormatLocation]]
+              block = Vector.empty[IndexedSeq[FormatLocation]]
             } else {
               block = Vector(candidates)
             }
@@ -647,7 +646,7 @@ class FormatWriter(formatOps: FormatOps) {
   }
 
   private def prepareAlignmentInfo(
-      block: Vector[Array[FormatLocation]],
+      block: IndexedSeq[IndexedSeq[FormatLocation]],
       separatorLengthGaps: Array[Int],
       column: Int
   ): Vector[AlignmentUnit] = {
@@ -718,7 +717,7 @@ object FormatWriter {
     buf += ""
     // use the previous indentation to add another space
     (1 until size).foreach(_ => buf += " " + buf.last)
-    buf
+    buf.toIndexedSeq
   }
 
   // see if indentation level is cached first

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -476,9 +476,9 @@ class FormatWriter(formatOps: FormatOps) {
       case c: T.Comment if isSingleLineComment(c) => "//"
       case t => t.syntax
     }
-    location.style.alignMap.get(code).exists { ownerRegexp =>
+    location.style.alignMap.get(code).exists { pattern =>
       val owner = getAlignOwner(location.formatToken)
-      ownerRegexp.findFirstIn(owner.getClass.getName).isDefined
+      pattern.matcher(owner.getClass.getName).find()
     }
   }
 

--- a/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
+++ b/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
@@ -72,12 +72,12 @@ libraryDependencies ++= Seq(
 <<< align all blocks
 libraryDependencies ++= Seq(
 "io.get-coursier" % "interface" %% "0.0.17",
-"com.geirsson1111111" %%% "metaconfig-core" % metaconfigV % Test,
+"com.geirsson1111111" %%% "metaconfig-core" % foo(a %% b) % Test,
 "org.scalacheck" %% "scalacheck" % sclacheckV % Test
 )
 >>>
 libraryDependencies ++= Seq(
   "io.get-coursier"       % "interface"      %% "0.0.17",
-  "com.geirsson1111111" %%% "metaconfig-core" % metaconfigV % Test,
-  "org.scalacheck"       %% "scalacheck"      % sclacheckV  % Test
+  "com.geirsson1111111" %%% "metaconfig-core" % foo(a %% b) % Test,
+  "org.scalacheck"       %% "scalacheck"      % sclacheckV % Test
 )

--- a/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
+++ b/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
@@ -79,5 +79,5 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "io.get-coursier"       % "interface"      %% "0.0.17",
   "com.geirsson1111111" %%% "metaconfig-core" % foo(a %% b) % Test,
-  "org.scalacheck"       %% "scalacheck"      % sclacheckV % Test
+  "org.scalacheck"       %% "scalacheck"      % sclacheckV  % Test
 )

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -605,7 +605,7 @@ object fmt {
 >>>
 object fmt {
   val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
-  val claim   = JwtClaim(content    = content)
+  val claim   = JwtClaim(content = content)
   val content = payload.toString
 }
 <<< #1896 2: short non-matching first
@@ -619,7 +619,7 @@ object fmt {
 }
 >>>
 object fmt {
-  val claim   = JwtClaim(content    = content)
+  val claim   = JwtClaim(content = content)
   val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
   val content = payload.toString
 }

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -593,3 +593,46 @@ x match {
   case 1  => a   -> b
   case 42 => abc -> 3
 }
+<<< #1896 1: long non-matching first
+align.preset = most
+align.tokens.add = [{code = "=", owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type)|Term.Assign)"}]
+===
+object fmt {
+  val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
+  val claim   = JwtClaim(content = content)
+  val content = payload.toString
+}
+>>>
+object fmt {
+  val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
+  val claim   = JwtClaim(content    = content)
+  val content = payload.toString
+}
+<<< #1896 2: short non-matching first
+align.preset = most
+align.tokens.add = [{code = "=", owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type)|Term.Assign)"}]
+===
+object fmt {
+  val claim   = JwtClaim(content = content)
+  val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
+  val content = payload.toString
+}
+>>>
+object fmt {
+  val claim   = JwtClaim(content    = content)
+  val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
+  val content = payload.toString
+}
+<<< #1896 3
+align.preset = most
+align.tokens.add = [{code = "=", owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type)|Term.Assign)"}]
+===
+JwtClaim(
+  abc = cba,
+  content = content
+)
+>>>
+JwtClaim(
+  abc     = cba,
+  content = content
+)

--- a/scalafmt-tests/src/test/resources/align/TrollAlignment.stat
+++ b/scalafmt-tests/src/test/resources/align/TrollAlignment.stat
@@ -15,5 +15,5 @@ align.tokenCategory {
 >>>
 {
   x match { case 1 => 2 }
-  for { a          <- b } yield b
+  for { a <- b } yield b
 }

--- a/scalafmt-tests/src/test/resources/align/defaultTokenOwners.stat
+++ b/scalafmt-tests/src/test/resources/align/defaultTokenOwners.stat
@@ -23,7 +23,7 @@ object fmt {
 object fmt {
   val header  = JwtHeader(algorithm = Some(JwtAlgorithm.HMD5))
   val content = payload.toString
-  val claim   = JwtClaim(content    = content)
+  val claim   = JwtClaim(content = content)
 }
 <<< fallback to any owner
 align.tokens.add = ["!"]

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -49,12 +49,12 @@ class StyleMapTest extends AnyFunSuite {
     val newFormatOps = new FormatOps(code, printlnConfig)
 
     val newHeadConfig = newFormatOps.styleMap.at(headToken)
-    assert(headConfig.alignMap("=").regex == defaultEquals)
-    assert(newHeadConfig.alignMap("=").regex == overrideEquals)
+    assert(headConfig.alignMap("=").pattern() == defaultEquals)
+    assert(newHeadConfig.alignMap("=").pattern() == overrideEquals)
 
     val newPrintlnConfig = newFormatOps.styleMap.at(printlnToken)
-    assert(printlnConfig.alignMap("=").regex == overrideEquals)
-    assert(newPrintlnConfig.alignMap("=").regex == overrideEquals)
+    assert(printlnConfig.alignMap("=").pattern() == overrideEquals)
+    assert(newPrintlnConfig.alignMap("=").pattern() == overrideEquals)
   }
 
   test("newlines.implicitParamListModifierForce") {


### PR DESCRIPTION
To avoid aligning unrelated locations, don't compare just the depth from root. Instead, look for specific block/template/etc which logically contains the given expression and any "siblings" to align against.

Also, we'd determine the count of matches between two consecutive lines, only to get the maximum across the block. However, in order to avoid considering non-matching candidates, let's truncate the candidates when they don't match.

Fixes #1921.
Fixes #1896.