### PR TITLE
FormatWriter: optionally support multiline align

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -488,6 +488,45 @@ align.stripMargin
 This functionality is enabled in all presets except `align.preset=none` where it was
 disabled since the parameter's introduction in v2.5.0.
 
+### `align.multiline`
+
+If this flag is set, when alignment is applied, multiline statements will
+not be excluded from search of tokens to align.
+
+> Since v2.5.0.
+
+```scala mdoc:defaults
+align.multiline
+```
+
+```scala mdoc:scalafmt
+align.preset = more
+align.multiline = true
+---
+for {
+  a <- aaa
+  bbb <- bb
+  cccccc <- c {
+    3
+  }
+  dd <- ddddd
+} yield ()
+```
+
+```scala mdoc:scalafmt
+align.preset = more
+align.multiline = false
+---
+for {
+  a <- aaa
+  bbb <- bb
+  cccccc <- c {
+    3
+  }
+  dd <- ddddd
+} yield ()
+```
+
 ## Newlines
 
 The `newlines.*` options are used to configure when and where `scalafmt` should

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -61,6 +61,7 @@ import metaconfig.generic.Surface
   *   of the first line, as usual.
   */
 case class Align(
+    multiline: Boolean = false,
     stripMargin: Boolean = true,
     openParenCallSite: Boolean = false,
     openParenDefnSite: Boolean = false,
@@ -107,6 +108,7 @@ object Align {
   // only for the truest vertical aligners, this setting is open for changes,
   // please open PR addding more stuff to it if you like.
   val most: Align = more.copy(
+    multiline = true,
     arrowEnumeratorGenerator = true,
     tokenCategory = Map(
       "Equals" -> "Assign",

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -650,11 +650,9 @@ class FormatWriter(formatOps: FormatOps) {
       val widest = alignmentUnits.maxBy(_.width)
       alignmentUnits.foreach { info =>
         import info._
-        val tokenLengthGap =
-          if (!initStyle.activeForEdition_2020_03) 0
-          else widest.separatorLength - separatorLength
-        previousSeparatorLengthGaps(lineIndex) = tokenLengthGap
-        builder += tokenHash -> (widest.width - width + tokenLengthGap)
+        previousSeparatorLengthGaps(lineIndex) =
+          widest.separatorLength - separatorLength
+        builder += tokenHash -> (widest.width - width)
       }
       column += 1
     }
@@ -673,14 +671,14 @@ class FormatWriter(formatOps: FormatOps) {
       val line = block(i)
       if (column < line.length) {
         val location = line(column)
-        val previousWidth =
-          if (column == 0) 0 else line(column - 1).shift
+        val previousWidth = if (column == 0) 0 else line(column - 1).shift
         val key = location.shift - previousWidth + separatorLengthGaps(i)
         val separatorLength =
           if (location.formatToken.right.is[Token.Comment]) 0
+          else if (!initStyle.activeForEdition_2020_03) 0
           else location.formatToken.right.syntax.length
         units += AlignmentUnit(
-          key,
+          key + separatorLength,
           hash(location.formatToken.left),
           separatorLength,
           i

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -719,34 +719,4 @@ object TreeOps {
       }
   }
 
-  @tailrec
-  private def getAlignContainerParent(t: Tree): Option[Tree] =
-    t.parent match {
-      case x @ Some(
-            _: Template | _: Term.Block | _: Term.Match | _: Term.Function |
-            _: Term.PartialFunction
-          ) =>
-        x
-      case Some(p: Term.Select) => getAlignContainerParent(p)
-      case Some(p: Term.Apply) if t.is[Term.Apply] || t.is[Term.Select] =>
-        getAlignContainerParent(p)
-      case x @ Some(p) => p.parent.orElse(x)
-      case _ => Some(t)
-    }
-
-  final def getAlignContainer(t: Tree): Option[Tree] =
-    if (!t.is[Term.ApplyInfix]) getAlignContainerParent(t)
-    else
-      findTreeWithParentSimple(t)(!_.is[Term.ApplyInfix]).flatMap { x =>
-        val p = x.parent.get
-        if (p.is[Term.Apply]) p.parent.orElse(x.parent)
-        else getAlignContainerParent(x)
-      }
-
-  final def getAlignContainerComment(t: Tree): Option[Tree] =
-    t match {
-      case _: Template | _: Term.Block | _: Term.Match => Some(t)
-      case _ => getAlignContainerParent(t)
-    }
-
 }

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -684,7 +684,7 @@ object a {
       "somestring" / "other_string" / foo.identifyingid
     case tastyBar: TastyBarIdentifier =>
       "something" / "other_other" ? ("arg1" -> tastyBar.ider) & ("limit" -> 111)
-    case unknown =>
+    case unknown                      =>
       throw new IllegalArgumentException(
         s"Not sure at all what kinda class this is: ${unknown.getClass}"
       )

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -464,7 +464,19 @@ Seq (
   Seq(a % b % c, a %% bb %%% ccc, aaa % bb % c)
 )
 >>>
-java.lang.IndexOutOfBoundsException: -1 is out of bounds (min 0, max 63)
+Seq(
+  Seq(
+    Seq(a   % b  % c, a    %% bb %%% ccc, aaa % bb % c),
+    Seq(aaa % bb % c, aaa %%% bb  %% c, a     % bb % ccc),
+    Seq(
+      aaa     % bb    % c,
+      aaaaa %%% bbbb %% ccc,
+      a       % bb    % ccc
+    ),
+    a % b % c %%%% a %% bb %%% ccc %%%% aaa % bb % c
+  ),
+  Seq(a % b % c, a %% bb %%% ccc, aaa % bb % c)
+)
 <<< align comments in method chain
 foo
   .x() // comment1

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -665,6 +665,8 @@ JwtClaim(
   content = content
 )
 <<< #1504
+align.multiline = true
+===
 object a {
   val stringFoo = thing.identifier match {
     case foo : SuperFooBarIdentifier =>
@@ -678,7 +680,7 @@ object a {
 >>>
 object a {
   val stringFoo = thing.identifier match {
-    case foo: SuperFooBarIdentifier =>
+    case foo: SuperFooBarIdentifier   =>
       "somestring" / "other_string" / foo.identifyingid
     case tastyBar: TastyBarIdentifier =>
       "something" / "other_other" ? ("arg1" -> tastyBar.ider) & ("limit" -> 111)
@@ -689,6 +691,8 @@ object a {
   }
 }
 <<< #1811 1
+align.multiline = true
+===
 object a {
   for {
     a   <- Option(1)
@@ -702,15 +706,16 @@ object a {
 >>>
 object a {
   for {
-    a   <- Option(1)
-    bbb <- Option(2)
+    a      <- Option(1)
+    bbb    <- Option(2)
     cccccc <- Option {
       3
     }
-    dd <- Option(4)
+    dd     <- Option(4)
   } yield ()
 }
 <<< #1811 2
+align.multiline = true
 align.arrowEnumeratorGenerator = true
 ===
 object a {
@@ -726,22 +731,24 @@ object a {
 >>>
 object a {
   for {
-    a   <- Option(1)
-    bbb <- Option(2)
+    a      <- Option(1)
+    bbb    <- Option(2)
     cccccc <- Option {
                 3
               }
-    dd <- Option(4)
+    dd     <- Option(4)
   } yield ()
 }
 <<< #1841
+align.multiline = true
+===
 object a {
   private[this] val pbClass       = Class.forName("java.lang.ProcessBuilder")
   private[this] val redirectClass = pbClass.getClasses find (_.getSimpleName == "Redirect")
 }
 >>>
 object a {
-  private[this] val pbClass = Class.forName("java.lang.ProcessBuilder")
+  private[this] val pbClass       = Class.forName("java.lang.ProcessBuilder")
   private[this] val redirectClass =
     pbClass.getClasses find (_.getSimpleName == "Redirect")
 }

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -449,6 +449,22 @@ Seq(
   "org.scalatest"       % "scalatest_2.11"              % "3.0.0" % Test,
   "org.scalamock"      %% "scalamock-scalatest-support" % "3.2.2" % Test
 )
+<<< #531 2
+Seq (
+  Seq(
+    Seq(a % b % c, a %% bb %%% ccc, aaa % bb % c),
+    Seq(aaa % bb % c, aaa %%% bb %% c, a % bb % ccc),
+    Seq(
+      aaa % bb % c,
+      aaaaa %%% bbbb %% ccc,
+      a % bb % ccc
+    ),
+    a % b % c %%%% a %% bb %%% ccc %%%% aaa % bb % c
+  ),
+  Seq(a % b % c, a %% bb %%% ccc, aaa % bb % c)
+)
+>>>
+java.lang.IndexOutOfBoundsException: -1 is out of bounds (min 0, max 63)
 <<< align comments in method chain
 foo
   .x() // comment1
@@ -636,3 +652,84 @@ JwtClaim(
   abc     = cba,
   content = content
 )
+<<< #1504
+object a {
+  val stringFoo = thing.identifier match {
+    case foo : SuperFooBarIdentifier =>
+     "somestring" / "other_string" / foo.identifyingid
+    case tastyBar: TastyBarIdentifier =>
+     "something" / "other_other" ? ("arg1" -> tastyBar.ider) & ("limit" -> 111)
+    case unknown =>
+     throw new IllegalArgumentException(s"Not sure at all what kinda class this is: ${unknown.getClass}")
+  }
+}
+>>>
+object a {
+  val stringFoo = thing.identifier match {
+    case foo: SuperFooBarIdentifier =>
+      "somestring" / "other_string" / foo.identifyingid
+    case tastyBar: TastyBarIdentifier =>
+      "something" / "other_other" ? ("arg1" -> tastyBar.ider) & ("limit" -> 111)
+    case unknown =>
+      throw new IllegalArgumentException(
+        s"Not sure at all what kinda class this is: ${unknown.getClass}"
+      )
+  }
+}
+<<< #1811 1
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd <- Option(4)
+  } yield ()
+}
+>>>
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd <- Option(4)
+  } yield ()
+}
+<<< #1811 2
+align.arrowEnumeratorGenerator = true
+===
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd <- Option(4)
+  } yield ()
+}
+>>>
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <- Option {
+                3
+              }
+    dd <- Option(4)
+  } yield ()
+}
+<<< #1841
+object a {
+  private[this] val pbClass       = Class.forName("java.lang.ProcessBuilder")
+  private[this] val redirectClass = pbClass.getClasses find (_.getSimpleName == "Redirect")
+}
+>>>
+object a {
+  private[this] val pbClass = Class.forName("java.lang.ProcessBuilder")
+  private[this] val redirectClass =
+    pbClass.getClasses find (_.getSimpleName == "Redirect")
+}


### PR DESCRIPTION
To support this, also fix a couple of issues:

* include align gap in width:
  * because we sort on the width, we might end up with (width+gap) for the currently widest alignment spot to be less than for another, with a smaller width.
* stop align container search
  * there's a different class of containers (currently, "case"), which would only serve as a container for tokens which are formatted below it, and for tokens on the same line, we would continue the search, so that those tokens would align together with the case arrow.

Fixes #1504.
Fixes #1811.
Fixes #1841.