### PR TITLE
FormatWriter: simplify two regular expressions; fix pipe char bug

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -368,7 +368,9 @@ class FormatWriter(formatOps: FormatOps) {
         tupleOpt.fold(text) {
           case (pipe, indent) =>
             val spaces = getIndentation(indent)
-            getStripMarginPattern(pipe).matcher(text).replaceAll(spaces)
+            getStripMarginPattern(pipe)
+              .matcher(text)
+              .replaceAll(s"\n${spaces}$$1")
         }
       }
 
@@ -820,8 +822,8 @@ object FormatWriter {
     trailingSpace.matcher(str).replaceAll("")
   }
 
-  private val leadingAsteriskSpace =
-    Pattern.compile("(?<=\\n)\\h*(?=[*][^*])")
+  private val leadingAsteriskSpace = Pattern.compile("\n\\h*\\*([^*])")
+
   private def formatComment(
       comment: T.Comment,
       indent: Int
@@ -834,7 +836,9 @@ object FormatWriter {
         val isDocstring = comment.syntax.startsWith("/**") && style.scalaDocs
         val spaces: String =
           getIndentation(if (isDocstring) (indent + 2) else (indent + 1))
-        leadingAsteriskSpace.matcher(comment.syntax).replaceAll(spaces)
+        leadingAsteriskSpace
+          .matcher(comment.syntax)
+          .replaceAll(s"\n${spaces}*$$1")
       } else {
         comment.syntax
       }
@@ -844,9 +848,11 @@ object FormatWriter {
   @inline
   private def getStripMarginPattern(pipe: Char) =
     if (pipe == '|') leadingPipeSpace else compileStripMarginPattern(pipe)
+
   @inline
   private def compileStripMarginPattern(pipe: Char) =
-    Pattern.compile(s"(?<=\\n)\\h*(?=[$pipe])")
+    Pattern.compile(s"\n\\h*(\\${pipe})")
+
   private val leadingPipeSpace = compileStripMarginPattern('|')
 
 }

--- a/scalafmt-tests/src/test/resources/default/Comment.stat
+++ b/scalafmt-tests/src/test/resources/default/Comment.stat
@@ -1,4 +1,9 @@
-80 columns                                                                     |
+80 columns                                                                     ##
+## Devos BEWARE of reformatting this file, it contains essential invisible
+## horizontal whitespace as defined by Java 8 java.util.regex.Pattern
+## "\\h": [\x20\t\xA0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000].
+## For quick reference \x20 is ASCII space, \t is tab.
+|
 <<< keep blank lines
 {
 
@@ -125,7 +130,7 @@ object a {
   /*
 
    /**
-     		* comment
+     * comment
      */
 
   def undefined = ???
@@ -140,5 +145,107 @@ object a {
    */
 
   def undefined = ???
+   */
+}
+<<< remove tabs in leading horizontal whitespace
+object A {
+  /*
+		* leading tabs (\t)
+	* second line
+  */
+}
+>>>
+object A {
+  /*
+   * leading tabs (\t)
+   * second line
+   */
+}
+<<< remove Unicode U+2000 in leading horizontal whitespace
+object B {
+  /*
+     * leading Unicode U+2000, spaces
+        * second line (spaces only)
+  */
+}
+>>>
+object B {
+  /*
+   * leading Unicode U+2000, spaces
+   * second line (spaces only)
+   */
+}
+<<< remove Unicode U+1680 in leading horizontal whitespace
+object C {
+  /*
+     * leading space, Unicode U+1680, spaces
+        * second line (spaces only)
+           * You may see U+1680 (Ogham mark) but it IS whitespace.
+  */
+}
+>>>
+object C {
+  /*
+   * leading space, Unicode U+1680, spaces
+   * second line (spaces only)
+   * You may see U+1680 (Ogham mark) but it IS whitespace.
+   */
+}
+<<< remove various Unicode characters in leading horizontal whitespace
+object D {
+  /*
+     * leading Unicode U+00A0, spaces
+    * leading Unicode U+1680, spaces
+᠎      * leading Unicode U+180E, spaces
+     * leading Unicode U+2000, spaces
+ 	* leading Unicode U+2001, tab
+ 	* leading Unicode U+2002, tab
+ 	* leading Unicode U+2003, tab
+ 	* leading Unicode U+2004, tab
+ 	* leading Unicode U+2005, tab
+ 	* leading Unicode U+2006, tab
+ 	* leading Unicode U+2007, tab
+ 	* leading Unicode U+2008, tab
+ 	* leading Unicode U+2009, tab
+ 	* leading Unicode U+200A, tab
+ 	* leading Unicode U+202F, tab
+ 	* leading Unicode U+205F, tab
+　   * leading Unicode U+3000, spaces
+*/
+}
+>>>
+object D {
+  /*
+   * leading Unicode U+00A0, spaces
+   * leading Unicode U+1680, spaces
+   * leading Unicode U+180E, spaces
+   * leading Unicode U+2000, spaces
+   * leading Unicode U+2001, tab
+   * leading Unicode U+2002, tab
+   * leading Unicode U+2003, tab
+   * leading Unicode U+2004, tab
+   * leading Unicode U+2005, tab
+   * leading Unicode U+2006, tab
+   * leading Unicode U+2007, tab
+   * leading Unicode U+2008, tab
+   * leading Unicode U+2009, tab
+   * leading Unicode U+200A, tab
+   * leading Unicode U+202F, tab
+   * leading Unicode U+205F, tab
+   * leading Unicode U+3000, spaces
+   */
+}
+<<< remove Unicode U+3000 in leading horizontal whitespace
+object Z {
+  /*
+　   * leading Unicode U+3000, spaces
+        * second line (spaces only)
+  */
+}
+>>>
+object Z {
+  /*
+   * leading Unicode U+3000, spaces
+   * second line (spaces only)
    */
 }

--- a/scalafmt-tests/src/test/resources/spaces/TrailingWhiteSpace.stat
+++ b/scalafmt-tests/src/test/resources/spaces/TrailingWhiteSpace.stat
@@ -1,0 +1,47 @@
+maxColumn = 80
+# Devos: be careful this file contains essential but invisible spaces.
+# Trailing space inside comments is tested in CommentTest.
+<<< Remove trailing spaces outside of comments.
+object A {
+  val a = 1    
+  val b = 2    
+}
+>>>
+object A {
+  val a = 1
+  val b = 2
+}
+<<< Remove trailing tab-blank-tab combinations outside of comments.
+object B {
+  val a = 1	 	
+  val b = 2	 	
+}
+>>>
+object B {
+  val a = 1
+  val b = 2
+}
+<<< Document trailing Unicode whitespace in code rejection by parser.
+object C {
+  // Trailing Unicode whitespace in comments gets removed. See CommentTest.
+  //
+  // Trailing Unicode whitespace in non-comment code gets rejected
+  // by parser.
+  // scala REPL (exercised on 2.13.1) reports:
+  // "error: illegal character '\u2000'"
+  //
+  // scalafmt 2.5.0-RC3 parser reports:
+  // scala.meta.internal.tokenizers.Reporter.syntaxError
+}
+>>>
+object C {
+  // Trailing Unicode whitespace in comments gets removed. See CommentTest.
+  //
+  // Trailing Unicode whitespace in non-comment code gets rejected
+  // by parser.
+  // scala REPL (exercised on 2.13.1) reports:
+  // "error: illegal character '\u2000'"
+  //
+  // scalafmt 2.5.0-RC3 parser reports:
+  // scala.meta.internal.tokenizers.Reporter.syntaxError
+}

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -208,3 +208,69 @@ object a {
      |  updated_at = now()
      |  where id in (${audienceIds.mkString(",")})""".stripMargin
 }
+<<< align, pipe character: RIGHT PARENTHESIS
+align.stripMargin = true
+===
+object a {
+     s"""
+        )  update targeting_segments
+        )  set status = '$status',
+        )${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        )${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        )  updated_at = now()
+        )  where id in (${audienceIds.mkString(",")})""".stripMargin(')')
+}
+>>>
+object a {
+  s"""
+     )  update targeting_segments
+     )  set status = '$status',
+     )${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+     )${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+     )  updated_at = now()
+     )  where id in (${audienceIds.mkString(",")})""".stripMargin(')')
+}
+<<< align, pipe character: DOLLAR SIGN
+align.stripMargin = true
+===
+object a {
+     s"""
+        $$  update targeting_segments
+        $$  set status = '$status',
+        $$${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        $$${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        $$  updated_at = now()
+        $$  where id in (${audienceIds.mkString(",")})""".stripMargin('$')
+}
+>>>
+object a {
+  s"""
+     $$  update targeting_segments
+     $$  set status = '$status',
+     $$${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+     $$${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+     $$  updated_at = now()
+     $$  where id in (${audienceIds.mkString(",")})""".stripMargin('$')
+}
+<<< align, pipe character: REVERSE SOLIDUS a.k.a. backslash
+align.stripMargin = true
+===
+object a {
+     s"""
+        \  update targeting_segments
+        \  set status = '$status',
+        \${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+        \${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+        \  updated_at = now()
+        \  where id in (${audienceIds.mkString(",")})""".stripMargin('\\')
+}
+>>>
+object a {
+  s"""
+     \  update targeting_segments
+     \  set status = '$status',
+     \${lastBuiltOpt.fold("")(dt => s"  last_built = '${formatDate(dt)}',")}
+     \${sizeCondition.fold("")(cond => s"  customers = $cond,")}
+     \  updated_at = now()
+     \  where id in (${audienceIds.mkString(",")})""".stripMargin('\\')
+}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
@@ -44,4 +44,80 @@ class CommentTest extends AnyFunSuite with DiffAssertions {
     val obtained = Scalafmt.format(original, javadocStyle).get
     assertNoDiff(obtained, expected)
   }
+
+  test("remove trailing tabs in comments") {
+    val trailingSpace = "\t \t"
+    val original = s"""object a {
+      |  // inline comment$trailingSpace
+      |/**$trailingSpace
+      |  * Y is cool$trailingSpace
+      |  */
+      |/*$trailingSpace
+      |  * X is cool$trailingSpace
+      |  */
+      |/*
+      |    I have blank lines.
+      |
+      |    Please preserve them.
+      |  */
+      |val y = 2
+      |}
+                   """.stripMargin
+    val expected = """object a {
+      |  // inline comment
+      |  /**
+      |   * Y is cool
+      |   */
+      |  /*
+      |   * X is cool
+      |   */
+      |  /*
+      |    I have blank lines.
+      |
+      |    Please preserve them.
+      |   */
+      |  val y = 2
+      |}
+      |""".stripMargin
+    val obtained = Scalafmt.format(original, javadocStyle).get
+    assertNoDiff(obtained, expected)
+  }
+
+  test("remove various trailing Unicode whitespace in comments") {
+    val trailingSpace = "   　" // U+00A0, U+2000, U+1680, U+3000
+    val original = s"""object a {
+      |  // inline comment$trailingSpace
+      |/**$trailingSpace
+      |  * Y is cool$trailingSpace
+      |  */
+      |/*$trailingSpace
+      |  * X is cool$trailingSpace
+      |  */
+      |/*
+      |    I have blank lines.
+      |
+      |    Please preserve them.
+      |  */
+      |val y = 2
+      |}
+                   """.stripMargin
+    val expected = """object a {
+      |  // inline comment
+      |  /**
+      |   * Y is cool
+      |   */
+      |  /*
+      |   * X is cool
+      |   */
+      |  /*
+      |    I have blank lines.
+      |
+      |    Please preserve them.
+      |   */
+      |  val y = 2
+      |}
+      |""".stripMargin
+    val obtained = Scalafmt.format(original, javadocStyle).get
+    assertNoDiff(obtained, expected)
+  }
 }


### PR DESCRIPTION
  * The primary purpose of this PR is simplify two regular expressions
    (regexen). One used by `leadingAsteriskSpace` and the other by
    `compileStripMarginPattern`.

    Discussions about readability are always subjective. I believe
    that removing the positive and negative lookaheads makes it
    more likely that the next maintainer will be able to read and
    comprehend the code.

    Discussions about runtime performance improvements without
    demonstrable data are worth than useless.  lookaheads are
    known to have a high runtime cost. It is believable, but not
    asserted by this PR for lack of evidence, that the code of this
    PR will have better performance characteristics.

 *  Unicode whitespace handling was added, along with test cases.

 * This PR supersedes the Work In Progress PR #1924. It has
   benefited greatly from discussions and multiple rounds of review there.
   My thanks and appreciation to the patient reviewers.

  * Whilst simplifying the two regex expressions, I noticed what I
    believe to be a bug in `compileStripMarginPattern`. Scala allows
    any character other than NULL to be used as a pipe character.
    Java requires that Dollar ($) and backslash (\) characters
    in the replacement string be quoted (e.g. in a string: "\\$").
    The code prior to this PR did not do this.

 * Previous regexen precluded Scala Native support. The ones of this
   PR do not. Scala Native does not yet support "\h" but it is
   believable that such support could be added.

 * The handling of `compileStripMarginPattern` is a bit tricky.
    Every/any regex expression should be sealed with the Curse of the Mummy,
    but that one is particularly deserving.

     The active pipe character is not in scope where the replaceAll() is done.
     Using a capture group allows the pipe character from where the pattern
     is compiled to be used in replaceAll(),

 * I did not test it but the `\n` approach should work on the/most Windows
   operating system. It is what has been in the scalafmt code for years.

Documentation:

  * The tab and Unicode whitespace changes deserve a quick release note as they change the
    behavior seen by end users.

    I will check the Contributing section of the web site to see if I can figure out what needs to
    be done.

Testing:

  * Built from a clean slate and manually tested ("test/test")
    using sbt 1.3.10 & Java 8 on X86_64 only. All tests pass.