### PR TITLE
RedundantParens: may not be redundant around infix

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -242,3 +242,16 @@ object a {
       .on((x.id === key).and(y.id === key))
   ).toList
 }
+<<< ONLY don't rewrite infix as rhs
+object a {
+  private val foo = ((bar == baz
+     || bar == baz)
+      || bar == baz)
+}
+>>>
+Idempotency violated
+object a {
+  private val foo = bar == baz
+  || bar == baz
+    || bar == baz
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -242,16 +242,15 @@ object a {
       .on((x.id === key).and(y.id === key))
   ).toList
 }
-<<< ONLY don't rewrite infix as rhs
+<<< don't rewrite infix as rhs
 object a {
   private val foo = ((bar == baz
      || bar == baz)
       || bar == baz)
 }
 >>>
-Idempotency violated
 object a {
-  private val foo = bar == baz
-  || bar == baz
-    || bar == baz
+  private val foo = ((bar == baz
+    || bar == baz)
+    || bar == baz)
 }


### PR DESCRIPTION
If there's a newline before the infix operator, parens are required.