### PR TITLE
ScalafmtRunner: fix handling of trait "extends"

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -69,7 +69,7 @@ object Scalafmt {
           code
         }
         val toParse = Rewrite(Input.VirtualFile(filename, unixCode), style)
-        val tree = runner.dialect(toParse).parse(runner.parser).get
+        val tree = runner.parse(toParse).get
         val formatOps = new FormatOps(tree, style)
         runner.event(CreateFormatOps(formatOps))
         val formatWriter = new FormatWriter(formatOps)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
@@ -35,6 +35,17 @@ case class ScalafmtRunner(
       )
     )
 
+  private lazy val correctedDialect: Dialect = {
+    // without allowTraitParameters, our code handling "extends" wouldn't work
+    // owner of "extends" would be Name.Anonymous, expects Trait or Template
+    dialect
+      .copy(allowTraitParameters = true)
+      // this must be explicit, .copy() loses it
+      .withAllowNumericLiteralUnderscoreSeparators(
+        dialect.allowNumericLiteralUnderscoreSeparators
+      )
+  }
+
   def event(evt: => FormatEvent): Unit =
     if (null != eventCallback) eventCallback(evt)
 
@@ -42,7 +53,7 @@ case class ScalafmtRunner(
     if (null != eventCallback) evts.foreach(eventCallback)
 
   def parse(input: meta.inputs.Input): Parsed[_ <: Tree] =
-    dialect(input).parse(parser)
+    correctedDialect(input).parse(parser)
 
 }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
@@ -5,6 +5,7 @@ import scala.meta.Dialect
 import scala.meta.Tree
 import scala.meta.dialects.Scala213
 import scala.meta.parsers.Parse
+import scala.meta.parsers.Parsed
 
 /**
   * A FormatRunner configures how formatting should behave.
@@ -39,6 +40,9 @@ case class ScalafmtRunner(
 
   def events(evts: => Iterator[FormatEvent]): Unit =
     if (null != eventCallback) evts.foreach(eventCallback)
+
+  def parse(input: meta.inputs.Input): Parsed[_ <: Tree] =
+    dialect(input).parse(parser)
 
 }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -150,7 +150,7 @@ object Rewrite {
     if (rewrites.isEmpty) {
       input
     } else {
-      style.runner.dialect(input).parse(style.runner.parser) match {
+      style.runner.parse(input) match {
         case Parsed.Success(ast) =>
           val ctx = RewriteCtx(style, ast)
           val rewriteSessions = rewrites.map(_.create(ctx)).toList

--- a/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
+++ b/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
@@ -25,8 +25,9 @@ trait SampleTrait extends A with B with C with D with E{
   def foo: Boolean = true
 }
 >>>
-trait SampleTrait extends A with B
-with C with D with E {
+trait SampleTrait
+    extends A with B with C with D
+    with E {
   self: LongNameMixin
     with B with C with D
     with EEEEEEEEE =>

--- a/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
+++ b/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
@@ -16,3 +16,20 @@ trait SampleTrait
 
   def foo: Boolean = true
 }
+<<< #370 scala211
+runner.dialect = scala211
+===
+trait SampleTrait extends A with B with C with D with E{
+  self: LongNameMixin with B with C with D with EEEEEEEEE =>
+
+  def foo: Boolean = true
+}
+>>>
+trait SampleTrait extends A with B
+with C with D with E {
+  self: LongNameMixin
+    with B with C with D
+    with EEEEEEEEE =>
+
+  def foo: Boolean = true
+}


### PR DESCRIPTION
As it stands, using any dialect with `allowTraitParameters = false` leads to a problem (including Scala211, Scala212 and even Scala213), and only default and Dotty dialects work correctly.

Our code, in multiple places, expects the `extends` keyword to be owned by the `trait` tree whereas for older dialects `scalameta` assigns it to `Name.Anonymous` (which is owned by `Init` and only then the trait).

For formatting purposes, we can leave it to the user's `scalac` to determine whether this specific feature (`allowTraitParameters`) should be supported; enabling for formatting purposes only doesn't change how the code is parsed when this feature _is not used_.