### PR TITLE
FormatWriter: don't align `Defn` with `Block` as body

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -10,6 +10,7 @@ import org.scalafmt.util.{LiteralOps, TreeOps}
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.meta.Case
+import scala.meta.Defn
 import scala.meta.tokens.Token
 import scala.meta.tokens.{Token => T}
 import scala.meta.transversers.Traverser
@@ -501,6 +502,11 @@ class FormatWriter(formatOps: FormatOps) {
         // containers that can be traversed further if on same line
         case Some(p @ (_: Case)) =>
           if (isSameLine(p)) getAlignContainerParent(p) else p
+        // containers that can be traversed further if single-stat
+        case Some(p: Defn.Def) =>
+          if (p.body.is[Term.Block]) p else getAlignContainerParent(p)
+        case Some(p: Defn.Val) =>
+          if (p.rhs.is[Term.Block]) p else getAlignContainerParent(p)
         case Some(p) => p.parent.getOrElse(p)
         case _ => child
       }
@@ -518,6 +524,9 @@ class FormatWriter(formatOps: FormatOps) {
               else getAlignContainerParent(x)
             }
             .getOrElse(t)
+
+        case _: Defn | _: Case =>
+          getAlignContainerParent(t, Some(t))
 
         case _ => getAlignContainerParent(t)
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -506,16 +506,19 @@ class FormatWriter(formatOps: FormatOps) {
     private def getAlignContainer(
         t: Tree
     )(implicit floc: FormatLocation): Tree =
-      if (!t.is[Term.ApplyInfix]) getAlignContainerParent(t)
-      else
-        TreeOps
-          .findTreeWithParentSimple(t)(!_.is[Term.ApplyInfix])
-          .map { x =>
-            val p = x.parent.get
-            if (p.is[Term.Apply]) p.parent.getOrElse(p)
-            else getAlignContainerParent(x)
-          }
-          .getOrElse(t)
+      t match {
+        case _: Term.ApplyInfix =>
+          TreeOps
+            .findTreeWithParentSimple(t)(!_.is[Term.ApplyInfix])
+            .map { x =>
+              val p = x.parent.get
+              if (p.is[Term.Apply]) p.parent.getOrElse(p)
+              else getAlignContainerParent(x)
+            }
+            .getOrElse(t)
+
+        case _ => getAlignContainerParent(t)
+      }
 
     private def getAlignContainerComment(
         t: Tree

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -830,3 +830,59 @@ object a {
     42
   }
 }
+<<< singleline def without blanks
+align.preset = most
+===
+object a {
+  def a: Int = b % c
+  def aa: Int = bb % cc
+  def aaa: Int = bbb % ccc
+}
+>>>
+object a {
+  def a: Int   = b   % c
+  def aa: Int  = bb  % cc
+  def aaa: Int = bbb % ccc
+}
+<<< singleline def with blocks and without blanks
+align.preset = most
+===
+object a {
+  def a: Int = { b % c }
+  def aa: Int = { bb % cc }
+  def aaa: Int = { bbb % ccc }
+}
+>>>
+object a {
+  def a: Int   = { b % c }
+  def aa: Int  = { bb % cc }
+  def aaa: Int = { bbb % ccc }
+}
+<<< singleline val without blanks
+align.preset = most
+===
+object a {
+  val a: Int = b % c
+  val aa: Int = bb % cc
+  val aaa: Int = bbb % ccc
+}
+>>>
+object a {
+  val a: Int   = b   % c
+  val aa: Int  = bb  % cc
+  val aaa: Int = bbb % ccc
+}
+<<< singleline val with blocks and without blanks
+align.preset = most
+===
+object a {
+  val a: Int = { b % c }
+  val aa: Int = { bb % cc }
+  val aaa: Int = { bbb % ccc }
+}
+>>>
+object a {
+  val a: Int   = { b % c }
+  val aa: Int  = { bb % cc }
+  val aaa: Int = { bbb % ccc }
+}

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -815,15 +815,15 @@ object a {
 }
 >>>
 object a {
-  def foo: Int       = {
+  def foo: Int = {
     val x = ???
     42
   }
-  def bar: Int       = {
+  def bar: Int = {
     for { x <- "hey" } yield x
     42
   }
-  def fooBig: Int    = {
+  def fooBig: Int = {
     42
   }
   def fooBigger: Int = {
@@ -854,8 +854,8 @@ object a {
 }
 >>>
 object a {
-  def a: Int   = { b % c }
-  def aa: Int  = { bb % cc }
+  def a: Int = { b % c }
+  def aa: Int = { bb % cc }
   def aaa: Int = { bbb % ccc }
 }
 <<< singleline val without blanks
@@ -882,7 +882,7 @@ object a {
 }
 >>>
 object a {
-  val a: Int   = { b % c }
-  val aa: Int  = { bb % cc }
+  val a: Int = { b % c }
+  val aa: Int = { bb % cc }
   val aaa: Int = { bbb % ccc }
 }


### PR DESCRIPTION
Non-block, even if multiline, definitions are still allowed.

