### PR TITLE
FormatWriter: use getAlignContainer to flush on comments

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -549,6 +549,8 @@ class FormatWriter(formatOps: FormatOps) {
             }
             .getOrElse(t)
 
+        case AlignContainer(t) if floc.formatToken.right.is[T.Comment] => t
+
         case _: Defn | _: Case => getAlignContainerParent(t, Some(t))
 
         case _ => getAlignContainerParent(t)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -498,6 +498,18 @@ class FormatWriter(formatOps: FormatOps) {
             Some(tree)
           case _ => None
         }
+
+      object WithBody {
+        def unapply(tree: Tree): Option[Tree] =
+          tree match {
+            case p: Defn.Def => Some(p.body)
+            case p: Defn.Val => Some(p.rhs)
+            case p: Defn.Trait => Some(p.templ)
+            case p: Defn.Class => Some(p.templ)
+            case p: Defn.Object => Some(p.templ)
+            case _ => None
+          }
+      }
     }
 
     @tailrec
@@ -517,10 +529,8 @@ class FormatWriter(formatOps: FormatOps) {
         case Some(p @ (_: Case)) =>
           if (isSameLine(p)) getAlignContainerParent(p) else p
         // containers that can be traversed further if single-stat
-        case Some(p: Defn.Def) =>
-          if (p.body.is[Term.Block]) p else getAlignContainerParent(p)
-        case Some(p: Defn.Val) =>
-          if (p.rhs.is[Term.Block]) p else getAlignContainerParent(p)
+        case Some(p @ AlignContainer.WithBody(b)) =>
+          if (b.is[Term.Block]) p else getAlignContainerParent(p)
         case Some(p) => p.parent.getOrElse(p)
         case _ => child
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -556,14 +556,6 @@ class FormatWriter(formatOps: FormatOps) {
         case _ => getAlignContainerParent(t)
       }
 
-    private def getAlignContainerComment(
-        t: Tree
-    )(implicit floc: FormatLocation): Tree =
-      t match {
-        case _: Template | _: Term.Block | _: Term.Match => t
-        case _ => getAlignContainerParent(t)
-      }
-
     def getAlignContainer(implicit location: FormatLocation): Option[Tree] = {
       val ft = location.formatToken
       val slc = isSingleLineComment(ft.right)
@@ -573,7 +565,7 @@ class FormatWriter(formatOps: FormatOps) {
         val owner = getAlignOwner(ft)
         if (!pattern.matcher(owner.getClass.getName).find()) None
         else if (!slc) Some(getAlignContainer(owner))
-        else Some(getAlignContainerComment(ft.meta.rightOwner))
+        else Some(getAlignContainer(ft.meta.rightOwner))
       }
     }
 

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -819,11 +819,11 @@ object a {
     42
   // comment
 
-  def fooBar: Int       =
+  def fooBar: Int =
     42
 
   /* comment */
-  def fooBarBaz: Int    =
+  def fooBarBaz: Int =
     42
 
   // comment

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -794,6 +794,42 @@ object a {
     42
   }
 }
+<<< multiline with blanks and comments and no blocks
+align.preset = most
+===
+object a {
+  def foo: Int =
+    42
+  // comment
+
+  def fooBar: Int =
+    42
+
+  /* comment */
+  def fooBarBaz: Int =
+    42
+
+  // comment
+  def fooBarBazQux: Int =
+    42
+}
+>>>
+object a {
+  def foo: Int =
+    42
+  // comment
+
+  def fooBar: Int       =
+    42
+
+  /* comment */
+  def fooBarBaz: Int    =
+    42
+
+  // comment
+  def fooBarBazQux: Int =
+    42
+}
 <<< multiline without blanks
 align.preset = most
 ===
@@ -831,8 +867,6 @@ object a {
   }
 }
 <<< singleline def without blanks
-align.preset = most
-===
 object a {
   def a: Int = b % c
   def aa: Int = bb % cc
@@ -845,8 +879,6 @@ object a {
   def aaa: Int = bbb % ccc
 }
 <<< singleline def with blocks and without blanks
-align.preset = most
-===
 object a {
   def a: Int = { b % c }
   def aa: Int = { bb % cc }
@@ -859,8 +891,6 @@ object a {
   def aaa: Int = { bbb % ccc }
 }
 <<< singleline val without blanks
-align.preset = most
-===
 object a {
   val a: Int = b % c
   val aa: Int = bb % cc
@@ -873,8 +903,6 @@ object a {
   val aaa: Int = bbb % ccc
 }
 <<< singleline val with blocks and without blanks
-align.preset = most
-===
 object a {
   val a: Int = { b % c }
   val aa: Int = { bb % cc }


### PR DESCRIPTION
We use this method to determine whether to flush the align block, and it didn't work correctly on a comment following a blank line.
