### PR TITLE
RedundantBraces: don't rewrite anon infix funcs

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -8,7 +8,7 @@ object AvoidInfix extends Rewrite {
   override def create(implicit ctx: RewriteCtx): RewriteSession =
     new AvoidInfix
 
-  private def hasPlaceholder(tree: Tree): Boolean = {
+  def hasPlaceholder(tree: Tree): Boolean = {
     val queue = new mutable.Queue[Tree]
     queue += tree
     @tailrec

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -278,11 +278,11 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
 
         case p: Term.ApplyInfix =>
           stat match {
-            case _: Term.ApplyInfix =>
+            case t: Term.ApplyInfix if !AvoidInfix.hasPlaceholder(t) =>
               val useRight = isSingleElement(p.args, b)
               SyntacticGroupOps.groupNeedsParenthesis(
                 TreeSyntacticGroup(p),
-                TreeSyntacticGroup(stat),
+                TreeSyntacticGroup(t),
                 if (useRight) Side.Right else Side.Left
               )
             case _: Name | _: Lit => false

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -826,3 +826,11 @@ object a {
   try x.y
   catch handler
 }
+<<< #1953
+object a {
+  scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") }
+}
+>>>
+object a {
+  scalacOptions ~= _ filterNot (_ startsWith "-Xlint")
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -832,5 +832,5 @@ object a {
 }
 >>>
 object a {
-  scalacOptions ~= _ filterNot (_ startsWith "-Xlint")
+  scalacOptions ~= { _ filterNot (_ startsWith "-Xlint") }
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -254,3 +254,11 @@ object a {
     || bar == baz)
     || bar == baz)
 }
+<<< #1953
+object a {
+  scalacOptions ~= (_ filterNot (_ startsWith "-Xlint"))
+}
+>>>
+object a {
+  scalacOptions ~= (_ filterNot (_ startsWith "-Xlint"))
+}


### PR DESCRIPTION
Fixes #1953.
Helps with #1952.