### PR TITLE
When using in pipeline don't print info to stderr

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -54,7 +54,7 @@ object CliOptions {
         out =
           guardPrintStream(parsed.quiet && !parsed.stdIn)(parsed.common.out),
         info = guardPrintStream(
-          parsed.quiet || parsed.writeMode == WriteMode.List
+          parsed.stdIn || parsed.quiet || parsed.writeMode == WriteMode.List
         )(auxOut),
         debug = guardPrintStream(parsed.quiet)(
           if (parsed.debug) auxOut else init.common.debug

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -54,7 +54,7 @@ object CliOptions {
         out =
           guardPrintStream(parsed.quiet && !parsed.stdIn)(parsed.common.out),
         info = guardPrintStream(
-          parsed.stdIn || parsed.quiet || parsed.writeMode == WriteMode.List
+          parsed.stdIn || parsed.writeMode == WriteMode.Stdout || parsed.quiet || parsed.writeMode == WriteMode.List
         )(auxOut),
         debug = guardPrintStream(parsed.quiet)(
           if (parsed.debug) auxOut else init.common.debug

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -113,11 +113,12 @@ class CliOptionsTest extends AnyFunSuite {
     assert(opt.scalafmtConfig.isNotOk)
   }
 
-  test(
-    "don't write info when part of a pipeline receiving from stdin writing to stdout"
-  ) {
-    val args = Array("--stdin")
-    val options = Cli.getConfig(args, baseCliOptions).get
-    assert(options.common.info == NoopOutputStream.printStream)
+  test("don't write info when writing to stdout") {
+    val stdinArgs = Array("--stdin")
+    val stdoutArgs = Array("--stdout")
+    for(args <- Seq(stdinArgs, stdoutArgs)) {
+      val options = Cli.getConfig(args, baseCliOptions).get
+      assert(options.common.info == NoopOutputStream.printStream)
+    }
   }
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -113,7 +113,9 @@ class CliOptionsTest extends AnyFunSuite {
     assert(opt.scalafmtConfig.isNotOk)
   }
 
-  test("don't write info when part of a pipeline receiving from stdin writing to stdout") {
+  test(
+    "don't write info when part of a pipeline receiving from stdin writing to stdout"
+  ) {
     val args = Array("--stdin")
     val options = Cli.getConfig(args, baseCliOptions).get
     assert(options.common.info == NoopOutputStream.printStream)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -112,4 +112,10 @@ class CliOptionsTest extends AnyFunSuite {
     )
     assert(opt.scalafmtConfig.isNotOk)
   }
+
+  test("don't write info when part of a pipeline receiving from stdin writing to stdout") {
+    val args = Array("--stdin")
+    val options = Cli.getConfig(args, baseCliOptions).get
+    assert(options.common.info == NoopOutputStream.printStream)
+  }
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -116,7 +116,7 @@ class CliOptionsTest extends AnyFunSuite {
   test("don't write info when writing to stdout") {
     val stdinArgs = Array("--stdin")
     val stdoutArgs = Array("--stdout")
-    for(args <- Seq(stdinArgs, stdoutArgs)) {
+    for (args <- Seq(stdinArgs, stdoutArgs)) {
       val options = Cli.getConfig(args, baseCliOptions).get
       assert(options.common.info == NoopOutputStream.printStream)
     }


### PR DESCRIPTION
When receiving data via stdIn and printing to stdout don't print info messages to stderr. Stderr output might be used to detect failure, info messages (like "Reformatting..."). The alternative is to use --quiet which also removes valid error messages.

The use-case here is the integration into emacs format-all plugin, which is currently using `--quiet` to silence errors. Ideally it should report the errors on failure, but not show info output on every format.