### PR TITLE
RedundantBraces bugfix: skip deep if without else

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-if.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-if.stat
@@ -229,3 +229,23 @@ object a {
       a; b
   }
 }
+<<< #1956
+object a {
+  if (a) {
+    if (b)
+      println("b!")
+    else if (c)
+      println("c!")
+  } else if (d)
+    println("d!")
+}
+>>>
+object a {
+  if (a)
+    if (b)
+      println("b!")
+    else if (c)
+      println("c!")
+    else if (d)
+      println("d!")
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-if.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-if.stat
@@ -241,11 +241,11 @@ object a {
 }
 >>>
 object a {
-  if (a)
+  if (a) {
     if (b)
       println("b!")
     else if (c)
       println("c!")
-    else if (d)
-      println("d!")
+  } else if (d)
+    println("d!")
 }


### PR DESCRIPTION
Previously, we'd check only the first if for existence of an else, to see if braces around it can be removed. Now let's traverse the nested ifs to make sure all of them have an else, otherwise don't rewrite.

Fixes #1956.