### PR TITLE
Documentation: retire Homebrew, point to coursier

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -215,7 +215,7 @@ Create a standalone executable in `/usr/local/bin/scalafmt` with (sudo if
 necessary):
 
 ```sh
-coursier bootstrap org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
+coursier bootstrap org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \
   -r sonatype:snapshots --main org.scalafmt.cli.Cli \
   --standalone \
   -o /usr/local/bin/scalafmt
@@ -225,7 +225,7 @@ scalafmt --version # should be @STABLE_VERSION@
 Alternatively you can create a slim 15 KiB bootstrap script with:
 
 ```sh
-coursier bootstrap org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
+coursier bootstrap org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \
   -r sonatype:snapshots --main org.scalafmt.cli.Cli \
   -o scalafmt
 ./scalafmt --version # should be @STABLE_VERSION@
@@ -292,7 +292,7 @@ vim/Emacs/Atom/Sublime/VS Code.
   necessary)
 
 ```sh
-coursier bootstrap --standalone org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
+coursier bootstrap --standalone org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \
   -r sonatype:snapshots -f --main com.martiansoftware.nailgun.NGServer \
   -o /usr/local/bin/scalafmt_ng
 scalafmt_ng & // start nailgun in background

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -211,9 +211,20 @@ To install Coursier see
 <a href="https://get-coursier.io/docs/cli-installation" target="_blank">here</a>
 </div>
 
+#### install
+
+If you're using a recent version of `coursier` which supports direct
+[installation](https://get-coursier.io/docs/cli-overview.html#install)
+of packages, the simplest approach is by running
+
+```sh
+cs install scalafmt
+scalafmt --version # should be @STABLE_VERSION@
+```
+
 #### standalone
 
-You can create a complete standalone executable with:
+Alternatively, you can create a complete standalone executable with:
 
 ```sh
 coursier bootstrap org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -307,15 +307,17 @@ once in awhile.
 
 ### Homebrew
 
-You can install scalafmt via Homebrew using a custom formula
+The recommended way to install the scalafmt command line tool is with
+[Coursier](#coursier), itself available via Homebrew.
 
 ```sh
-brew install --HEAD olafurpg/scalafmt/scalafmt
+brew install coursier/formulas/coursier
+coursier install scalafmt
 scalafmt --version // should be @STABLE_VERSION@
-
-// to upgrade between releases
-brew upgrade scalafmt
 ```
+
+If necessary, make sure to follow the Coursier instructions for updating
+`$PATH` so that the `scalafmt` binary becomes available in your terminal.
 
 ### Arch Linux
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -216,8 +216,9 @@ necessary):
 
 ```sh
 coursier bootstrap org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
-  -r sonatype:snapshots \
-  -o /usr/local/bin/scalafmt --standalone --main org.scalafmt.cli.Cli
+  -r sonatype:snapshots --main org.scalafmt.cli.Cli \
+  --standalone \
+  -o /usr/local/bin/scalafmt
 scalafmt --version # should be @STABLE_VERSION@
 ```
 
@@ -225,8 +226,8 @@ Alternatively you can create a slim 15 KiB bootstrap script with:
 
 ```sh
 coursier bootstrap org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
-  -r sonatype:snapshots \
-  -o scalafmt --main org.scalafmt.cli.Cli
+  -r sonatype:snapshots --main org.scalafmt.cli.Cli \
+  -o scalafmt
 ./scalafmt --version # should be @STABLE_VERSION@
 ```
 
@@ -292,8 +293,8 @@ vim/Emacs/Atom/Sublime/VS Code.
 
 ```sh
 coursier bootstrap --standalone org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
-  -r sonatype:snapshots \
-  -o /usr/local/bin/scalafmt_ng -f --main com.martiansoftware.nailgun.NGServer
+  -r sonatype:snapshots -f --main com.martiansoftware.nailgun.NGServer \
+  -o /usr/local/bin/scalafmt_ng
 scalafmt_ng & // start nailgun in background
 ng ng-alias scalafmt org.scalafmt.cli.Cli
 ng scalafmt --version # should be @STABLE_VERSION@

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -211,18 +211,21 @@ To install Coursier see
 <a href="https://get-coursier.io/docs/cli-installation" target="_blank">here</a>
 </div>
 
-Create a standalone executable in `/usr/local/bin/scalafmt` with (sudo if
-necessary):
+#### standalone
+
+You can create a complete standalone executable with:
 
 ```sh
 coursier bootstrap org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \
   -r sonatype:snapshots --main org.scalafmt.cli.Cli \
   --standalone \
-  -o /usr/local/bin/scalafmt
-scalafmt --version # should be @STABLE_VERSION@
+  -o scalafmt
+./scalafmt --version # should be @STABLE_VERSION@
 ```
 
-Alternatively you can create a slim 15 KiB bootstrap script with:
+#### slim
+
+Finally, you can choose to obtain a slim 15 KiB bootstrap script instead with:
 
 ```sh
 coursier bootstrap org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -207,7 +207,8 @@ The recommended way to install the scalafmt command line tool is with
 ### Coursier
 
 <div class="sidenote">
-To install Coursier see <a href="https://get-coursier.io/docs/cli-overview" target="_blank">here</a>
+To install Coursier see
+<a href="https://get-coursier.io/docs/cli-installation" target="_blank">here</a>
 </div>
 
 Create a standalone executable in `/usr/local/bin/scalafmt` with (sudo if
@@ -223,12 +224,9 @@ scalafmt --version # should be @STABLE_VERSION@
 Alternatively you can create a slim 15 KiB bootstrap script with:
 
 ```sh
-curl -Lo coursier https://git.io/coursier-cli
-chmod +x coursier
-./coursier bootstrap org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
+coursier bootstrap org.scalameta:scalafmt-cli_2.12:@STABLE_VERSION@ \
   -r sonatype:snapshots \
   -o scalafmt --main org.scalafmt.cli.Cli
-rm -f coursier
 ./scalafmt --version # should be @STABLE_VERSION@
 ```
 


### PR DESCRIPTION
Also, make the coursier examples directly usable via copy-paste, update the installation link and use scala 2.13 in examples.