### PR TITLE
#1627 [22]: Router: preserve split after `=>` in source=keep

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1584,7 +1584,7 @@ class Router(formatOps: FormatOps) {
                       !isAttachedSingleLineComment(t) =>
                   d.onlyNewlinesWithoutFallback
               },
-              ignore = style.newlines.sourceIs(Newlines.fold)
+              ignore = style.newlines.sourceIn(Newlines.fold, Newlines.keep)
             )
             .withIndent(2, expire, After) // case body indented by 2.
             .withIndent(2, arrow, After) // cond body indented by 4.

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1330,8 +1330,7 @@ a match {
 a match {
   case b =>
     bb
-  case c =>
-    cc
+  case c => cc
     ccc
   case d =>
     dd
@@ -1347,8 +1346,7 @@ a match {
 }
 >>>
 a match {
-  case b: C =>
-    d.e match {
+  case b: C => d.e match {
       case f => "g"
     }
 }


### PR DESCRIPTION
Do not force a break there, as that is inconsistent with keep.
Fixes #1518.
Helps with #1627.