### PR TITLE
FormatWriter bugfix: comment format on lookaround

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -940,14 +940,14 @@ object FormatWriter {
   private def getIndentation(len: Int): String =
     if (len < indentations.length) indentations(len) else " " * len
 
-  private val trailingSpace = Pattern.compile("\\h+$", Pattern.MULTILINE)
+  private val trailingSpace = Pattern.compile("\\h++$", Pattern.MULTILINE)
   private def removeTrailingWhiteSpace(str: String): String = {
     trailingSpace.matcher(str).replaceAll("")
   }
 
-  private val leadingAsteriskSpace = Pattern.compile("(?<=\n)\\h*(?=[*][^*])")
+  private val leadingAsteriskSpace = Pattern.compile("(?<=\n)\\h*+(?=[*][^*])")
   private val onelineDocstring = Pattern.compile(
-    "^/\\*\\*(?:\n\\h*\\*?)?\\h*([^*][^\n]*[^\n\\h])(?:\n\\h*\\**?)?\\h*\\*/$"
+    "^/\\*\\*(?:\n\\h*+\\*?)?\\h*+([^*][^\n]*[^\n\\h])(?:\n\\h*+\\**?)?\\h*+\\*/$"
   )
 
   @inline
@@ -956,7 +956,7 @@ object FormatWriter {
 
   @inline
   private def compileStripMarginPattern(pipe: Char) =
-    Pattern.compile(s"(?<=\n)\\h*(?=\\${pipe})")
+    Pattern.compile(s"(?<=\n)\\h*+(?=\\${pipe})")
 
   private val leadingPipeSpace = compileStripMarginPattern('|')
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -379,9 +379,7 @@ class FormatWriter(formatOps: FormatOps) {
         tupleOpt.fold(text) {
           case (pipe, indent) =>
             val spaces = getIndentation(indent)
-            getStripMarginPattern(pipe)
-              .matcher(text)
-              .replaceAll(s"\n${spaces}$$1")
+            getStripMarginPattern(pipe).matcher(text).replaceAll(spaces)
         }
       }
 
@@ -421,12 +419,12 @@ class FormatWriter(formatOps: FormatOps) {
         val spaces: String = getIndentation(
           prevState.indentation + (if (style.docstrings.isScalaDoc) 2 else 1)
         )
-        leadingAsteriskSpace.matcher(text).replaceAll(s"\n${spaces}*$$1")
+        leadingAsteriskSpace.matcher(text).replaceAll(spaces)
       }
 
       private def formatMultilineComment(text: String): String = {
         val spaces: String = getIndentation(prevState.indentation + 1)
-        leadingAsteriskSpace.matcher(text).replaceAll(s"\n${spaces}*$$1")
+        leadingAsteriskSpace.matcher(text).replaceAll(spaces)
       }
 
       private def formatSinglelineComment(text: String): String = {
@@ -947,7 +945,7 @@ object FormatWriter {
     trailingSpace.matcher(str).replaceAll("")
   }
 
-  private val leadingAsteriskSpace = Pattern.compile("\n\\h*\\*([^*])")
+  private val leadingAsteriskSpace = Pattern.compile("(?<=\n)\\h*(?=[*][^*])")
   private val onelineDocstring = Pattern.compile(
     "^/\\*\\*(?:\n\\h*\\*?)?\\h*([^*][^\n]*[^\n\\h])(?:\n\\h*\\**?)?\\h*\\*/$"
   )
@@ -958,7 +956,7 @@ object FormatWriter {
 
   @inline
   private def compileStripMarginPattern(pipe: Char) =
-    Pattern.compile(s"\n\\h*(\\${pipe})")
+    Pattern.compile(s"(?<=\n)\\h*(?=\\${pipe})")
 
   private val leadingPipeSpace = compileStripMarginPattern('|')
 

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -62,7 +62,7 @@ docstrings.style = ScalaDoc
 >>>
 /** Align by second asterisk.
   *
- *
+  *
   */
 <<< format commaent with single asterisk, JavaDoc
 docstrings.style = JavaDoc
@@ -74,5 +74,5 @@ docstrings.style = JavaDoc
 >>>
 /** Align by first asterisk.
  *
-  *
+ *
  */

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -52,3 +52,27 @@ package foo
 abstract class Dsl
 class A extends Dsl
 class B extends Dsl
+<<< format commaent with single asterisk, ScalaDoc
+docstrings.style = ScalaDoc
+===
+/** Align by second asterisk.
+ *
+ *
+ */
+>>>
+/** Align by second asterisk.
+  *
+ *
+  */
+<<< format commaent with single asterisk, JavaDoc
+docstrings.style = JavaDoc
+===
+/** Align by first asterisk.
+  *
+  *
+  */
+>>>
+/** Align by first asterisk.
+ *
+  *
+ */


### PR DESCRIPTION
Our comment-space-and-asterisk-matching regular expression was modified to avoid lookaround constructs, but that inadvertently introduced a bug.

When the comment line contains just a single asterisk, the character that follows it is the newline; that newline should be included as the last character of one regex match and then as the first character of the next match. Alas, that doesn't happen.

Therefore, restore the positive lookaround constructs to avoid this bug.

While it's not clear how properly used lookaround constructs should affect performance when compared to the same expression being captured, let's also add possessive quantifiers to improve matching performance.