### PR TITLE
Documentation: expand docstrings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,12 +29,14 @@ maxColumn
 
 ### `docstrings`
 
+#### `docstrings.style`
+
 ```scala mdoc:defaults
-docstrings
+docstrings.style
 ```
 
 ```scala mdoc:scalafmt
-docstrings = ScalaDoc
+docstrings.style = ScalaDoc
 ---
 /** Align by second asterisk.
  *
@@ -42,11 +44,34 @@ docstrings = ScalaDoc
 ```
 
 ```scala mdoc:scalafmt
-docstrings = JavaDoc
+docstrings.style = JavaDoc
 ---
 /** Align by first asterisk.
   *
   */
+```
+
+#### `docstrings.oneline`
+
+```scala mdoc:defaults
+docstrings.oneline
+```
+
+```scala mdoc:scalafmt
+docstrings.oneline = fold
+---
+/**
+  * Align by second asterisk.
+  */
+val a = 1
+```
+
+```scala mdoc:scalafmt
+docstrings.style = JavaDoc
+docstrings.oneline = unfold
+---
+/** Align by first asterisk. */
+val a = 1
 ```
 
 ### `assumeStandardLibraryStripMargin`

--- a/scalafmt-docs/src/main/scala/docs/ScalafmtModifier.scala
+++ b/scalafmt-docs/src/main/scala/docs/ScalafmtModifier.scala
@@ -15,6 +15,8 @@ class ScalafmtModifier extends StringModifier {
 
   import ScalafmtModifier._
 
+  private final val separator = "---\n"
+
   override val name: String = "scalafmt"
   override def process(
       info: String,
@@ -25,14 +27,14 @@ class ScalafmtModifier extends StringModifier {
       if (code.text.contains("package")) ScalafmtRunner.default
       else ScalafmtRunner.sbt
     val base = ScalafmtConfig.default.copy(runner = runner, maxColumn = 40)
-    val i = code.text.indexOf("---")
+    val i = code.text.indexOf(separator)
     val pos = Position.Range(code, 0, 0)
     if (i == -1) {
       reporter.error(pos, "Missing ---")
       "fail"
     } else {
       val config = Input.Slice(code, 0, i)
-      val program = Input.Slice(code, i + 3, code.chars.length)
+      val program = Input.Slice(code, i + separator.length, code.chars.length)
       Config.fromHoconString(config.text, None, base) match {
         case Configured.Ok(c) =>
           val parsedConfig = c.copy(runner = runner)


### PR DESCRIPTION
Also, fix bug in mdoc ScalafmtModifier which didn't remove the newline
preceding the code example prior to passing to the formatter. Without
it, `docstrings.oneline` formatting examples didn't work.