### PR TITLE
FormatOps: for source=fold, compact extends/with

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1947,7 +1947,7 @@ literals.float=Lower
 10e-1f
 ```
 
-## Miscellaneous
+## Binpacking
 
 ### `binPack.literalArgumentLists`
 
@@ -1983,6 +1983,38 @@ See also:
   added in v2.5.0
 - all other `binPack.literalXXX` parameters (see list at the bottom) are
   self-explanatory.
+
+### `binPack.parentConstructors`
+
+Parent constructors are `C` and `D` in `class A extends B with C and D`. If true,
+`scalafmt` will fit as many parent constructors on a single line. If false, each
+parent constructor gets its own line.
+
+```scala mdoc:defaults
+binPack.parentConstructors
+```
+
+```scala mdoc:scalafmt
+binPack.parentConstructors = true
+maxColumn = 25
+---
+object A {
+  trait Foo
+  extends Bar
+  with Baz
+}
+```
+
+```scala mdoc:scalafmt
+binPack.parentConstructors = false
+maxColumn = 25
+---
+object A {
+  trait Foo extends Bar with Baz
+}
+```
+
+## Miscellaneous
 
 ### `includeCurlyBraceInSelectChains`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1882,7 +1882,7 @@ class Router(formatOps: FormatOps) {
       isFirstWith: Boolean,
       chain: => Set[Tree],
       lastToken: => Token
-  ): Seq[Split] =
+  )(implicit style: ScalafmtConfig): Seq[Split] =
     if (isFirstWith) {
       binPackParentConstructorSplits(chain, lastToken, IndentForWithChains)
     } else {

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2457,3 +2457,55 @@ object a {
       baz: Seq[String] = Seq.empty)(
       f: HttpResponse => U): U = qux
 }
+<<< #1973 1
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  object Foo
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  object Foo
+    extends Bar
+    with Baz
+}
+<<< #1973 2
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  case class Foo(
+    a: Boolean,
+    b: String,
+    c: String,
+  )
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  case class Foo(
+      a: Boolean,
+      b: String,
+      c: String
+  ) extends Bar
+    with Baz
+}
+<<< #1973 3
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  trait Foo
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  trait Foo
+    extends Bar
+    with Baz
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2345,3 +2345,55 @@ object a {
   def b =
     foo.bar.baz.qux("blah blah blah")
 }
+<<< #1973 1
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  object Foo
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  object Foo
+    extends Bar
+    with Baz
+}
+<<< #1973 2
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  case class Foo(
+    a: Boolean,
+    b: String,
+    c: String,
+  )
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  case class Foo(
+      a: Boolean,
+      b: String,
+      c: String
+  ) extends Bar
+    with Baz
+}
+<<< #1973 3
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  trait Foo
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  trait Foo
+    extends Bar
+    with Baz
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2357,8 +2357,7 @@ object a {
 >>>
 object a {
   object Foo
-    extends Bar
-    with Baz
+    extends Bar with Baz
 }
 <<< #1973 2
 maxColumn = 25
@@ -2379,8 +2378,7 @@ object a {
       a: Boolean,
       b: String,
       c: String
-  ) extends Bar
-    with Baz
+  ) extends Bar with Baz
 }
 <<< #1973 3
 maxColumn = 25
@@ -2394,6 +2392,5 @@ object a {
 >>>
 object a {
   trait Foo
-    extends Bar
-    with Baz
+    extends Bar with Baz
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2421,3 +2421,55 @@ object a {
       baz: Seq[String] = Seq.empty)(
       f: HttpResponse => U): U = qux
 }
+<<< #1973 1
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  object Foo
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  object Foo
+    extends Bar
+    with Baz
+}
+<<< #1973 2
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  case class Foo(
+    a: Boolean,
+    b: String,
+    c: String,
+  )
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  case class Foo(
+      a: Boolean,
+      b: String,
+      c: String
+  ) extends Bar
+    with Baz
+}
+<<< #1973 3
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  trait Foo
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  trait Foo
+    extends Bar
+    with Baz
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2553,3 +2553,55 @@ object a {
       baz: Seq[String] = Seq.empty
   )(f: HttpResponse => U): U = qux
 }
+<<< #1973 1
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  object Foo
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  object Foo
+    extends Bar
+    with Baz
+}
+<<< #1973 2
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  case class Foo(
+    a: Boolean,
+    b: String,
+    c: String,
+  )
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  case class Foo(
+      a: Boolean,
+      b: String,
+      c: String
+  ) extends Bar
+    with Baz
+}
+<<< #1973 3
+maxColumn = 25
+continuationIndent.extendSite = 2
+===
+object a {
+  trait Foo
+  extends Bar
+  with Baz
+}
+>>>
+object a {
+  trait Foo
+    extends Bar
+    with Baz
+}


### PR DESCRIPTION
Also, describe `binPack.parentConstructors`. Fixes #1973.