### PR TITLE
Router: allow folded `extends` if ctor is folded

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1261,7 +1261,8 @@ rewrite.redundantBraces.stringInterpolation = true
 s"user id is ${id}"
 ```
 
-`rewrite.redundantBraces.parensForOneLineApply` is `true` by default for `edition` >= 2020-01. See also [newlines.afterCurlyLambda = squash](http://localhost:3000/scalafmt/docs/configuration.html#newlinesaftercurlylambda)
+`rewrite.redundantBraces.parensForOneLineApply` is `true` by default for `edition` >= 2020-01.
+See also [newlines.afterCurlyLambda = squash](#newlinesaftercurlylambda).
 
 ```scala mdoc:scalafmt
 rewrite.rules = [RedundantBraces]
@@ -1994,9 +1995,13 @@ parent constructor gets its own line.
 binPack.parentConstructors
 ```
 
+> Keep in mind that explicitly specifying the default value might change
+> behaviour; other parameters, such as [`newlines.source`](#newlinessource),
+> could interpret implied default differently but yield to an explicit value.
+
 ```scala mdoc:scalafmt
-binPack.parentConstructors = true
-maxColumn = 25
+binPack.parentConstructors = Always
+maxColumn = 30
 ---
 object A {
   trait Foo
@@ -2006,11 +2011,44 @@ object A {
 ```
 
 ```scala mdoc:scalafmt
-binPack.parentConstructors = false
-maxColumn = 25
+binPack.parentConstructors = Never
+maxColumn = 30
 ---
 object A {
   trait Foo extends Bar with Baz
+}
+```
+
+```scala mdoc:scalafmt
+binPack.parentConstructors = Oneline
+maxColumn = 30
+---
+object A {
+  class Foo(a: Int)
+  extends Bar
+  with Baz
+
+  class Foo(
+    a: Int
+  )
+  extends Bar
+  with Baz
+}
+```
+
+```scala mdoc:scalafmt
+binPack.parentConstructors = OnelineIfPrimaryOneline
+maxColumn = 30
+---
+object A {
+  class Foo(a: Int, b: Int)
+  extends Bar
+  with Baz
+
+  class Foo(
+    a: Int,
+    b: Int
+  ) extends Bar with Baz
 }
 ```
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
@@ -23,9 +23,9 @@ import metaconfig._
   *                            or "Byte".
   * @param literalsExclude     Regexes for literal to exclude from [[literalArgumentLists]].
   * @param parentConstructors  Parent constructors are C and D in
-  *                            "class A extends B with C and D". If true,
+  *                            "class A extends B with C and D". If "Always",
   *                            scalafmt will fit as many parent constructors
-  *                            on a single line. If false, each parent
+  *                            on a single line. If "Never", each parent
   *                            constructor gets its own line.
   *
   */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -324,7 +324,7 @@ object ScalafmtConfig {
     binPack = BinPack(
       unsafeDefnSite = true,
       unsafeCallSite = true,
-      parentConstructors = true
+      parentConstructors = BinPack.ParentCtors.Always
     ),
     continuationIndent = ContinuationIndent(4, 4),
     importSelectors = ImportSelectors.binPack,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -5,6 +5,7 @@ import java.{util => ju}
 import org.scalafmt.CompatCollections.JavaConverters._
 import org.scalafmt.Error.UnexpectedTree
 import org.scalafmt.config.{
+  BinPack,
   Comments,
   NewlineCurlyLambda,
   Newlines,
@@ -1018,7 +1019,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       ownerSet: Set[Tree],
       lastToken: Token
   )(implicit style: ScalafmtConfig): Policy =
-    if (style.binPack.parentConstructors) NoPolicy
+    if (style.binPack.parentConstructors eq BinPack.ParentCtors.Always) NoPolicy
     else
       Policy(lastToken) {
         case d @ Decision(t @ FormatToken(_, _: T.KwWith, _), _)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -23,5 +23,6 @@ object SplitTag {
   case object OneArgPerLine extends Custom
   case object SelectChainFirstNL extends Custom
   case object InfixChainNoNL extends Custom
+  case object OnelineWithChain extends Custom
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -179,6 +179,15 @@ object TokenOps {
       case _ => None
     }
 
+  def defnBeforeTemplate(tree: Tree): Option[Tree] =
+    tree match {
+      case t: Defn.Object => Some(t.name)
+      case t: Defn.Class => Some(t.ctor)
+      case t: Defn.Trait => Some(t.ctor)
+      case t: Pkg.Object => Some(t.name)
+      case _ => None
+    }
+
   def tokenLength(token: Token): Int =
     token match {
       case lit: Constant.String =>

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2470,8 +2470,7 @@ object a {
 >>>
 object a {
   object Foo
-    extends Bar
-    with Baz
+    extends Bar with Baz
 }
 <<< #1973 2
 maxColumn = 25
@@ -2507,6 +2506,5 @@ object a {
 >>>
 object a {
   trait Foo
-    extends Bar
-    with Baz
+    extends Bar with Baz
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2,6 +2,7 @@ align.preset = none
 maxColumn = 40
 # newlines.source = classic
 runner.optimizer.forceConfigStyleOnOffset = 50
+binPack.parentConstructors = OnelineIfPrimaryOneline
 <<< 1.1: block, if-else, line too long
 if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}
 >>>

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2,6 +2,7 @@ align.preset = none
 maxColumn = 40
 newlines.source = keep
 runner.optimizer.forceConfigStyleOnOffset = 50
+binPack.parentConstructors = OnelineIfPrimaryOneline
 <<< 1.1: block, if-else, line too long
 if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}
 >>>

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2434,8 +2434,7 @@ object a {
 >>>
 object a {
   object Foo
-    extends Bar
-    with Baz
+    extends Bar with Baz
 }
 <<< #1973 2
 maxColumn = 25
@@ -2471,6 +2470,5 @@ object a {
 >>>
 object a {
   trait Foo
-    extends Bar
-    with Baz
+    extends Bar with Baz
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2566,8 +2566,7 @@ object a {
 >>>
 object a {
   object Foo
-    extends Bar
-    with Baz
+    extends Bar with Baz
 }
 <<< #1973 2
 maxColumn = 25
@@ -2603,6 +2602,5 @@ object a {
 >>>
 object a {
   trait Foo
-    extends Bar
-    with Baz
+    extends Bar with Baz
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2,6 +2,7 @@ align.preset = none
 maxColumn = 40
 newlines.source = unfold
 runner.optimizer.forceConfigStyleOnOffset = 50
+binPack.parentConstructors = OnelineIfPrimaryOneline
 <<< 1.1: block, if-else, line too long
 if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}
 >>>

--- a/scalafmt-tests/src/test/resources/optIn/Annotation.stat
+++ b/scalafmt-tests/src/test/resources/optIn/Annotation.stat
@@ -54,7 +54,8 @@ object WrapperToHaveStatTestCaseParserWorking {
 <<< non-single ident
 @bar(1) @kas("stringaaaaaaaaaaaaaawwwwwwwwwwwaaa") class Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
 >>>
-@bar(1) @kas("stringaaaaaaaaaaaaaawwwwwwwwwwwaaa") class Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
+@bar(1) @kas(
+  "stringaaaaaaaaaaaaaawwwwwwwwwwwaaa") class Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()
 <<< non-single ident 2
 @bar(1) @kas("stringaaaaaaaaaaaaaawwwwwwwwwwwaaa")
 class Bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb()


### PR DESCRIPTION
As a follow-up to #1979, allow specifying the entire `extends`/`with` chain on one line using new values of an existing `binPack.parentConstructors` parameter.

The two new options allow specifying the chain on one line if fits, either always or only when the primary constructor also fits on one line. For example:

```
class Foo(a: Int, b: Int)
  extends Bar with Baz
```
vs
```
class Foo(
    a: Int,
    b: Int
) extends Bar
    with Baz
```