### PR TITLE
Docstrings: rename styles, clean up text after `*`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,18 +92,18 @@ docstrings.style
 ```
 
 ```scala mdoc:scalafmt
-docstrings.style = ScalaDoc
+docstrings.style = SpaceAsterisk
 ---
-/** Align by second asterisk.
- *
+/** Format intermediate lines with a space and an asterisk,
+ * both below the two asterisks of the first line
  */
 ```
 
 ```scala mdoc:scalafmt
-docstrings.style = JavaDoc
+docstrings.style = Asterisk
 ---
-/** Align by first asterisk.
-  *
+/** Skip first line, format intermediate lines with an asterisk
+  * below the first asterisk of the first line (aka JavaDoc)
   */
 ```
 
@@ -123,7 +123,7 @@ val a = 1
 ```
 
 ```scala mdoc:scalafmt
-docstrings.style = JavaDoc
+docstrings.style = Asterisk
 docstrings.oneline = unfold
 ---
 /** Align by first asterisk. */

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,14 @@ docstrings.style = Asterisk
   */
 ```
 
+```scala mdoc:scalafmt
+docstrings.style = AsteriskSpace
+---
+/** Format intermediate lines with an asterisk and a space,
+  * both below the two asterisks of the first line
+  */
+```
+
 #### `docstrings.oneline`
 
 ```scala mdoc:defaults

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
@@ -2,21 +2,38 @@ package org.scalafmt.config
 
 import metaconfig._
 
+/**
+  * @param oneline
+  *        - if fold, try to fold short docstrings into a single line
+  *        - if unfold, unfold a single-line docstring into multiple lines
+  * @param style
+  *        - preserve: keep existing formatting
+  *        - Asterisk: format intermediate lines with an asterisk below the
+  *          first asterisk of the first line (aka JavaDoc)
+  *        - SpaceAsterisk: format intermediate lines with a space and
+  *          an asterisk, both below the two asterisks of the first line
+  */
 case class Docstrings(
     oneline: Docstrings.Oneline = Docstrings.Oneline.keep,
-    style: Option[Docstrings.Style] = Some(Docstrings.ScalaDoc)
+    style: Option[Docstrings.Style] = Some(Docstrings.SpaceAsterisk)
 ) {
   import Docstrings._
 
-  def isScalaDoc: Boolean = style.contains(ScalaDoc)
+  def isSpaceAsterisk: Boolean = style.contains(SpaceAsterisk)
 
   implicit lazy val decoder: ConfDecoder[Docstrings] = {
     val genericDecoder = generic.deriveDecoder(this).noTypos
     new ConfDecoder[Docstrings] {
       override def read(conf: Conf): Configured[Docstrings] =
         conf match {
-          case Conf.Str("preserve") => Configured.ok(copy(style = None))
-          case _: Conf.Str => reader.read(conf).map(x => copy(style = Some(x)))
+          case Conf.Str("preserve") =>
+            Configured.ok(copy(style = None))
+          case Conf.Str("ScalaDoc") =>
+            Configured.ok(copy(style = Some(SpaceAsterisk)))
+          case Conf.Str("JavaDoc") =>
+            Configured.ok(copy(style = Some(Asterisk)))
+          case _: Conf.Str =>
+            reader.read(conf).map(x => copy(style = Some(x)))
           case _ => genericDecoder.read(conf)
         }
     }
@@ -31,11 +48,11 @@ object Docstrings {
   implicit val encoder = generic.deriveEncoder[Docstrings]
 
   sealed abstract class Style
-  case object JavaDoc extends Style
-  case object ScalaDoc extends Style
+  case object Asterisk extends Style
+  case object SpaceAsterisk extends Style
 
   implicit val reader: ConfCodec[Style] =
-    ReaderUtil.oneOf[Style](JavaDoc, ScalaDoc)
+    ReaderUtil.oneOf[Style](Asterisk, SpaceAsterisk)
 
   sealed abstract class Oneline
   object Oneline {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
@@ -19,6 +19,7 @@ case class Docstrings(
 ) {
   import Docstrings._
 
+  def isAsterisk: Boolean = style.contains(Asterisk)
   def isSpaceAsterisk: Boolean = style.contains(SpaceAsterisk)
 
   implicit lazy val decoder: ConfDecoder[Docstrings] = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
@@ -12,6 +12,8 @@ import metaconfig._
   *          first asterisk of the first line (aka JavaDoc)
   *        - SpaceAsterisk: format intermediate lines with a space and
   *          an asterisk, both below the two asterisks of the first line
+  *        - AsteriskSpace: format intermediate lines with an asterisk
+  *          and a space, both below the two asterisks of the first line
   */
 case class Docstrings(
     oneline: Docstrings.Oneline = Docstrings.Oneline.keep,
@@ -21,6 +23,7 @@ case class Docstrings(
 
   def isAsterisk: Boolean = style.contains(Asterisk)
   def isSpaceAsterisk: Boolean = style.contains(SpaceAsterisk)
+  def isAsteriskSpace: Boolean = style.contains(AsteriskSpace)
 
   implicit lazy val decoder: ConfDecoder[Docstrings] = {
     val genericDecoder = generic.deriveDecoder(this).noTypos
@@ -51,9 +54,10 @@ object Docstrings {
   sealed abstract class Style
   case object Asterisk extends Style
   case object SpaceAsterisk extends Style
+  case object AsteriskSpace extends Style
 
   implicit val reader: ConfCodec[Style] =
-    ReaderUtil.oneOf[Style](Asterisk, SpaceAsterisk)
+    ReaderUtil.oneOf[Style](Asterisk, SpaceAsterisk, AsteriskSpace)
 
   sealed abstract class Oneline
   object Oneline {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -19,10 +19,6 @@ import org.scalafmt.util.ValidationOps
   *                the plan is to use this field for the IntelliJ+sbt integrations.
   * @param maxColumn Column limit, any formatting exceeding this field is
   *                  penalized heavily.
-  * @param docstrings Several options:
-  *                   - ScalaDoc: format as Scala docs
-  *                   - JavaDocs: format as Java docs
-  *                   - preserve: keep existing formatting
   * @param assumeStandardLibraryStripMargin If true, the margin character | is treated
   *                                as the new indentation in multiline strings
   *                                ending with `.stripMargin`.
@@ -337,7 +333,7 @@ object ScalafmtConfig {
     // config style. It's fixable, but I don't want to spend time on it
     // right now.
     runner = conservativeRunner,
-    docstrings = default.docstrings.copy(style = Some(Docstrings.JavaDoc)),
+    docstrings = default.docstrings.copy(style = Some(Docstrings.Asterisk)),
     align = default.align.copy(
       arrowEnumeratorGenerator = false,
       tokens = Seq(AlignToken.caseArrow),

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -439,7 +439,7 @@ class FormatWriter(formatOps: FormatOps) {
         def appendLineBreak = sb.append('\n').append(spaces).append('*')
         sb.append("/**")
         val sbLen = sb.length()
-        var prevWasBlank = false
+        var prevWasBlank = style.docstrings.isAsterisk
         while (matcher.find()) {
           val contentBeg = matcher.start(2)
           val contentEnd = matcher.end(2)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -412,6 +412,7 @@ class FormatWriter(formatOps: FormatOps) {
                 val extraIndent = if (style.docstrings.isSpaceAsterisk) 2 else 1
                 val spaces = getIndentation(prevState.indentation + extraIndent)
                 sb.append("/**\n").append(spaces).append("* ")
+                if (style.docstrings.isAsteriskSpace) sb.append(' ')
                 sb.append(matcher.group(1))
                 sb.append('\n').append(spaces).append("*/")
                 true
@@ -431,6 +432,7 @@ class FormatWriter(formatOps: FormatOps) {
       private def formatMultilineDocstring(
           text: String
       )(implicit sb: StringBuilder): Unit = {
+        val isExtraSpace = style.docstrings.isAsteriskSpace
         val extraIndent = if (style.docstrings.isSpaceAsterisk) 2 else 1
         val spaces: String = getIndentation(prevState.indentation + extraIndent)
         // remove "/**" and "*/"
@@ -451,7 +453,8 @@ class FormatWriter(formatOps: FormatOps) {
               prevWasBlank = false
             }
             val leadSpaces = matcher.end(1) - matcher.start(1)
-            sb.append(getIndentation(math.max(1, leadSpaces)))
+            val minSpaces = if (isExtraSpace && sb.length() != sbLen) 2 else 1
+            sb.append(getIndentation(math.max(minSpaces, leadSpaces)))
             sb.append(CharBuffer.wrap(trimmed, contentBeg, contentEnd))
           }
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -408,7 +408,7 @@ class FormatWriter(formatOps: FormatOps) {
                 sb.append("/** ").append(matcher.group(1)).append(" */")
                 true
               case Docstrings.Oneline.unfold =>
-                val extraIndent = if (style.docstrings.isScalaDoc) 2 else 1
+                val extraIndent = if (style.docstrings.isSpaceAsterisk) 2 else 1
                 val spaces = getIndentation(prevState.indentation + extraIndent)
                 sb.append("/**\n").append(spaces).append("* ")
                 sb.append(matcher.group(1))
@@ -430,9 +430,8 @@ class FormatWriter(formatOps: FormatOps) {
       private def formatMultilineDocstring(
           text: String
       )(implicit sb: StringBuilder): Unit = {
-        val spaces: String = getIndentation(
-          prevState.indentation + (if (style.docstrings.isScalaDoc) 2 else 1)
-        )
+        val extraIndent = if (style.docstrings.isSpaceAsterisk) 2 else 1
+        val spaces: String = getIndentation(prevState.indentation + extraIndent)
         val trimmed = removeTrailingWhiteSpace(text)
         sb.append(leadingAsteriskSpace.matcher(trimmed).replaceAll(spaces))
       }

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -46,8 +46,9 @@ docstrings.style = Asterisk
     */
 class Main
 >>>
-/** Top line.
- *  Main entry-point.
+/**
+ * Top line.
+ * Main entry-point.
  */
 class Main
 <<< #1403 1: Asterisk 2

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -14,7 +14,7 @@ object a {
    */
   val y = 2
 }
-<<< #1403 1
+<<< #1403 1: preserve
 docstrings = preserve
 ===
 /**
@@ -26,9 +26,45 @@ class Main
    * Main entry-point.
     */
 class Main
-<<< #1403 2
+<<< #1403 1: ScalaDoc
+docstrings = ScalaDoc
+===
+/**
+   * Main entry-point.
+    */
+class Main
+>>>
+/**
+  * Main entry-point.
+  */
+class Main
+<<< #1403 1: Asterisk
+docstrings.style = Asterisk
+===
+/**
+   * Main entry-point.
+    */
+class Main
+>>>
+/**
+ * Main entry-point.
+ */
+class Main
+<<< #1403 1: SpaceAsterisk
+docstrings.style = SpaceAsterisk
+===
+/**
+  * Main entry-point.
+  */
+class Main
+>>>
+/**
+  * Main entry-point.
+  */
+class Main
+<<< #1403 2: fold Asterisk
 docstrings.oneline = fold
-docstrings.style = JavaDoc
+docstrings.style = Asterisk
 ===
 /**
   * Main entry-point.
@@ -37,9 +73,9 @@ class Main
 >>>
 /** Main entry-point. */
 class Main
-<<< #1403 3
+<<< #1403 2: fold SpaceAsterisk
 docstrings.oneline = fold
-docstrings.style = ScalaDoc
+docstrings.style = SpaceAsterisk
 ===
 /**
   * Main entry-point.
@@ -48,9 +84,9 @@ class Main
 >>>
 /** Main entry-point. */
 class Main
-<<< #1403 4
+<<< #1403 3: unfold Asterisk
 docstrings.oneline = unfold
-docstrings.style = JavaDoc
+docstrings.style = Asterisk
 ===
 /** Main entry-point. */
 class Main
@@ -59,9 +95,9 @@ class Main
  * Main entry-point.
  */
 class Main
-<<< #1403 5
+<<< #1403 3: unfold SpaceAsterisk
 docstrings.oneline = unfold
-docstrings.style = ScalaDoc
+docstrings.style = SpaceAsterisk
 ===
 /** Main entry-point. */
 class Main

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -17,49 +17,73 @@ object a {
 <<< #1403 1: preserve
 docstrings = preserve
 ===
-/**
+/** Top line.
    * Main entry-point.
     */
 class Main
 >>>
-/**
+/** Top line.
    * Main entry-point.
     */
 class Main
 <<< #1403 1: ScalaDoc
 docstrings = ScalaDoc
 ===
-/**
+/** Top line.
    * Main entry-point.
     */
 class Main
 >>>
-/**
+/** Top line.
   * Main entry-point.
   */
 class Main
-<<< #1403 1: Asterisk
+<<< #1403 1: Asterisk 1
+docstrings.style = Asterisk
+===
+/**Top line.
+   *Main entry-point.
+    */
+class Main
+>>>
+/**Top line.
+ *Main entry-point.
+ */
+class Main
+<<< #1403 1: Asterisk 2
 docstrings.style = Asterisk
 ===
 /**
-   * Main entry-point.
+   *Main entry-point.
     */
 class Main
 >>>
 /**
- * Main entry-point.
+ *Main entry-point.
  */
 class Main
-<<< #1403 1: SpaceAsterisk
+<<< #1403 1: SpaceAsterisk 1
+docstrings.style = SpaceAsterisk
+===
+/**Top line.
+   *Main entry-point.
+    */
+class Main
+>>>
+/**Top line.
+  *Main entry-point.
+  */
+class Main
+<<< #1403 1: SpaceAsterisk 2
 docstrings.style = SpaceAsterisk
 ===
 /**
-  * Main entry-point.
-  */
+   *Main entry-point.
+    */
 class Main
 >>>
 /**
-  * Main entry-point.
+  *Main entry-point.
   */
 class Main
 <<< #1403 2: fold Asterisk

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -46,8 +46,8 @@ docstrings.style = Asterisk
     */
 class Main
 >>>
-/**Top line.
- *Main entry-point.
+/** Top line.
+ *  Main entry-point.
  */
 class Main
 <<< #1403 1: Asterisk 2
@@ -59,7 +59,7 @@ docstrings.style = Asterisk
 class Main
 >>>
 /**
- *Main entry-point.
+ * Main entry-point.
  */
 class Main
 <<< #1403 1: SpaceAsterisk 1
@@ -70,8 +70,8 @@ docstrings.style = SpaceAsterisk
     */
 class Main
 >>>
-/**Top line.
-  *Main entry-point.
+/** Top line.
+  * Main entry-point.
   */
 class Main
 <<< #1403 1: SpaceAsterisk 2
@@ -83,7 +83,7 @@ docstrings.style = SpaceAsterisk
 class Main
 >>>
 /**
-  *Main entry-point.
+  * Main entry-point.
   */
 class Main
 <<< #1403 2: fold Asterisk

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -87,6 +87,46 @@ class Main
   * Main entry-point.
   */
 class Main
+<<< #1403 1: AsteriskSpace 1
+docstrings.style = AsteriskSpace
+===
+/**
+   *Indent0
+  * Indent1
+  *  Indent2
+ *   Indent3
+*    Indent4
+    */
+class Main
+>>>
+/**
+ *  Indent0
+ *  Indent1
+ *  Indent2
+ *   Indent3
+ *    Indent4
+ */
+class Main
+<<< #1403 1: AsteriskSpace 2
+docstrings.style = AsteriskSpace
+===
+/**Top line.
+   *Indent0
+  * Indent1
+  *  Indent2
+ *   Indent3
+*    Indent4
+    */
+class Main
+>>>
+/** Top line.
+ *  Indent0
+ *  Indent1
+ *  Indent2
+ *   Indent3
+ *    Indent4
+ */
+class Main
 <<< #1403 2: fold Asterisk
 docstrings.oneline = fold
 docstrings.style = Asterisk
@@ -101,6 +141,17 @@ class Main
 <<< #1403 2: fold SpaceAsterisk
 docstrings.oneline = fold
 docstrings.style = SpaceAsterisk
+===
+/**
+  * Main entry-point.
+  */
+class Main
+>>>
+/** Main entry-point. */
+class Main
+<<< #1403 2: fold AsteriskSpace
+docstrings.oneline = fold
+docstrings.style = AsteriskSpace
 ===
 /**
   * Main entry-point.
@@ -130,4 +181,15 @@ class Main
 /**
   * Main entry-point.
   */
+class Main
+<<< #1403 3: unfold AsteriskSpace
+docstrings.oneline = unfold
+docstrings.style = AsteriskSpace
+===
+/** Main entry-point. */
+class Main
+>>>
+/**
+ *  Main entry-point.
+ */
 class Main

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -71,6 +71,7 @@ docstrings.style = Asterisk
   *
   */
 >>>
-/** Align by
+/**
+ * Align by
  * first asterisk.
  */

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -63,6 +63,17 @@ docstrings.style = SpaceAsterisk
 /** Align by
   * second asterisk.
   */
+<<< format comment with single asterisk, AsteriskSpace
+docstrings.style = AsteriskSpace
+===
+/** Align space by
+  * second asterisk.
+  *
+  */
+>>>
+/** Align space by
+ *  second asterisk.
+ */
 <<< format comment with single asterisk, Asterisk
 docstrings.style = Asterisk
 ===

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -55,24 +55,24 @@ class B extends Dsl
 <<< format comment with single asterisk, SpaceAsterisk
 docstrings.style = SpaceAsterisk
 ===
-/** Align by second asterisk.
- *
+/** Align by
+ * second asterisk.
  *
  */
 >>>
-/** Align by second asterisk.
-  *
+/** Align by
+  * second asterisk.
   *
   */
 <<< format comment with single asterisk, Asterisk
 docstrings.style = Asterisk
 ===
-/** Align by first asterisk.
-  *
+/** Align by
+  * first asterisk.
   *
   */
 >>>
-/** Align by first asterisk.
- *
+/** Align by
+ * first asterisk.
  *
  */

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -52,8 +52,8 @@ package foo
 abstract class Dsl
 class A extends Dsl
 class B extends Dsl
-<<< format commaent with single asterisk, ScalaDoc
-docstrings.style = ScalaDoc
+<<< format comment with single asterisk, SpaceAsterisk
+docstrings.style = SpaceAsterisk
 ===
 /** Align by second asterisk.
  *
@@ -64,8 +64,8 @@ docstrings.style = ScalaDoc
   *
   *
   */
-<<< format commaent with single asterisk, JavaDoc
-docstrings.style = JavaDoc
+<<< format comment with single asterisk, Asterisk
+docstrings.style = Asterisk
 ===
 /** Align by first asterisk.
   *

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -62,7 +62,6 @@ docstrings.style = SpaceAsterisk
 >>>
 /** Align by
   * second asterisk.
-  *
   */
 <<< format comment with single asterisk, Asterisk
 docstrings.style = Asterisk
@@ -74,5 +73,4 @@ docstrings.style = Asterisk
 >>>
 /** Align by
  * first asterisk.
- *
  */

--- a/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
@@ -8,7 +8,7 @@ class CommentTest extends AnyFunSuite with DiffAssertions {
 
   private val javadocStyle: ScalafmtConfig =
     ScalafmtConfig.default.copy(docstrings =
-      ScalafmtConfig.default.docstrings.copy(style = Some(Docstrings.JavaDoc))
+      ScalafmtConfig.default.docstrings.copy(style = Some(Docstrings.Asterisk))
     )
 
   test("remove trailing space in comments") {


### PR DESCRIPTION
* rename to `JavaDoc` to `Asterisk`, and `ScalaDoc` to `SpaceAsterisk`; keep old names for compatibility
* add a new style, `AsteriskSpace`
* clean up text after `*`, adding leading space as needed, removing redundant blank lines
* in `Asterisk` style, to get proper alignment, start text on the second line (what the linked issue called _burning the first line_)

Fixes #891.