### PR TITLE
FormatOps: fix finding `=>` in lambda without args

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1355,6 +1355,10 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
           else tokens(nextNonComment(maybeArrow), 1)
         }
       }
+      .orElse {
+        val headToken = tokens(term.tokens.head)
+        findFirst(headToken, term.tokens.last)(_.left.is[T.RightArrow])
+      }
 
   // look for arrow before body, if any, else after cond/pat
   def getCaseArrow(term: Case): FormatToken =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -185,8 +185,7 @@ class Router(formatOps: FormatOps) {
           startsStatement(right) match {
             case Some(owner: Term.Function) =>
               val arrow = getFuncArrow(lastLambda(owner))
-              val expire =
-                arrow.getOrElse(tokens(owner.params.last.tokens.last))
+              val expire = arrow.getOrElse(tokens(owner.tokens.last))
               (expire, arrow.map(_.left), 0)
             case _ =>
               selfAnnotation match {

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -453,3 +453,11 @@ class A {
       }
       .f("f")
 }
+<<< #1969
+object a {
+  And("foo") { () =>
+    // bar
+  }
+}
+>>>
+java.util.NoSuchElementException: last of empty list

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -460,4 +460,8 @@ object a {
   }
 }
 >>>
-java.util.NoSuchElementException: last of empty list
+object a {
+  And("foo") { () =>
+    // bar
+  }
+}


### PR DESCRIPTION
Fixes #1969.