### PR TITLE
FormatWriter: fix off-by-one bug in comment wrap

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -474,9 +474,9 @@ class FormatWriter(formatOps: FormatOps) {
         protected final val maxLength = style.maxColumn - indent - 2
 
         protected final def getFirstLineLength =
-          if (curr.hasBreakBefore) 0
+          if (breakBefore) 0
           else
-            prevState.prev.column - indent +
+            prevState.prev.column - prevState.prev.indentation +
               prevState.split.modification.length
 
         protected final def canRewrite =
@@ -491,21 +491,27 @@ class FormatWriter(formatOps: FormatOps) {
         protected final def iterWords(
             iter: WordIter,
             appendLineBreak: () => Unit,
-            lineLength: Int = 0
+            lineLength: Int = 0,
+            extraMargin: String = " "
         ): Unit =
           if (iter.hasNext) {
             val word = iter.next()
             val length = word.length
-            val maybeNextLineLength = lineLength + length
+            val maybeNextLineLength = lineLength + length + 1
             val nextLineLength =
-              if (lineLength == 0 || maybeNextLineLength <= maxLength)
+              if (
+                lineLength < extraMargin.length ||
+                maybeNextLineLength <= maxLength
+              ) {
+                sb.append(' ')
                 maybeNextLineLength
-              else {
+              } else {
                 appendLineBreak()
-                length
+                sb.append(extraMargin)
+                length + extraMargin.length
               }
-            sb.append(' ').append(word)
-            iterWords(iter, appendLineBreak, nextLineLength + 1)
+            sb.append(word)
+            iterWords(iter, appendLineBreak, nextLineLength, extraMargin)
           }
       }
 

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -315,10 +315,11 @@ object a {
 }
 >>>
 object a {
-  def a = {} /* And block-style comments
-   * should also be indented aligned
-   * sensibly, because they're just as
-   * good as single-line comments */
+  def a = {} /* And block-style
+   * comments should also be indented
+   * aligned sensibly, because they're
+   * just as good as single-line
+   * comments */
 }
 <<< #1234 5: trailing
 comments.wrap = trailing
@@ -330,9 +331,9 @@ object a {
 object a {
   def a =
     b(c) /* A really long comment that
-     * scalafmt should break up but does
-     * not because this feature is not
-     * implemented yet */
+     * scalafmt should break up but
+     * does not because this feature is
+     * not implemented yet */
 }
 <<< #1234 6: trailing
 comments.wrap = trailing
@@ -344,9 +345,9 @@ object a {
 object a {
   val a =
     b(c) /* A really long comment that
-     * scalafmt should break up but does
-     * not because this feature is not
-     * implemented yet */
+     * scalafmt should break up but
+     * does not because this feature is
+     * not implemented yet */
 }
 <<< #1234 7: trailing, use slc
 comments.wrap = trailing
@@ -363,7 +364,7 @@ object a {
 object a {
   val a =
     b(c) /* A really long comment that
-     * scalafmt should break up but does
-     * not because this feature is not
-     * implemented yet */
+     * scalafmt should break up but
+     * does not because this feature is
+     * not implemented yet */
 }


### PR DESCRIPTION
Also, allow formatting text with additional space indentation after the
asterisk.