### PR TITLE
FormatWriter bugfix: comment with empty first line

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -550,7 +550,9 @@ class FormatWriter(formatOps: FormatOps) {
           if (canRewrite && text.lastIndexOf("/*") == 0) {
             val sectionIter = new SectIter {
               private val lineIter = {
-                val contents = text.substring(2, text.length - 2).trim
+                val header = mlcHeader.matcher(text)
+                val beg = if (header.lookingAt()) header.end() else 2
+                val contents = text.substring(beg, text.length - 2)
                 splitAsIterator(mlcLineDelim)(contents).buffered
               }
               private def paraEnds: Boolean = lineIter.head.isEmpty
@@ -1141,6 +1143,7 @@ object FormatWriter {
   // "slc" stands for single-line comment
   private val slcDelim = Pattern.compile("\\h++")
   // "mlc" stands for multi-line comment
+  private val mlcHeader = Pattern.compile("^/\\*\\h*+(?:\n\\h*+[*]*+\\h*+)?")
   private val mlcLineDelim = Pattern.compile("\\h*+\n\\h*+[*]*+\\h*+")
   private val mlcParagraphEnd = Pattern.compile("[.:!?=]$")
   private val mlcParagraphBeg = Pattern.compile("^(?:[-*@=]|\\d++[.:])")

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -378,7 +378,7 @@ object a {
 }
 >>>
 object a {
-  /* * foo bar */
+  /* foo bar */
 }
 <<< wrap with empty first line 2
 comments.wrap = trailing
@@ -389,5 +389,5 @@ object a {
 }
 >>>
 object a {
-  /* * foo bar */
+  /* foo bar */
 }

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -368,3 +368,26 @@ object a {
      * does not because this feature is
      * not implemented yet */
 }
+<<< wrap with empty first line 1
+comments.wrap = trailing
+===
+object a {
+  /*
+   * foo bar
+   */
+}
+>>>
+object a {
+  /* * foo bar */
+}
+<<< wrap with empty first line 2
+comments.wrap = trailing
+===
+object a {
+  /*
+   * foo bar   */
+}
+>>>
+object a {
+  /* * foo bar */
+}


### PR DESCRIPTION
It wouldn't process the first delimiter correctly and end up adding an extra asterisk.