### PR TITLE
FormatWriter bugfix: align strip margin in `s"""|`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -372,7 +372,7 @@ class FormatWriter(formatOps: FormatOps) {
                 val indent =
                   if (!style.align.stripMargin) tiState.indentation
                   else
-                    tiState.column + (ti.args.headOption match {
+                    tiState.column + (ti.parts.headOption match {
                       case Some(Lit.String(x)) if x(0) == pipe => 1
                       case _ => 0
                     })

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -91,6 +91,22 @@ val x = s"""Formatter changed AST
            ?$diff
         """
   .stripMargin('?')
+<<< Align | margin 1 | interpolate, different char, starts string
+val x = s"""?Formatter changed AST
+      |=====================
+      |$diff
+      ?=====================
+      ?$diff
+        """
+        .stripMargin('?')
+>>>
+val x = s"""?Formatter changed AST
+      |=====================
+      |$diff
+           ?=====================
+           ?$diff
+        """
+  .stripMargin('?')
 <<< No align | margin 1 | interpolate, different char
 align.stripMargin = false
 ===

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -103,8 +103,8 @@ val x = s"""?Formatter changed AST
 val x = s"""?Formatter changed AST
       |=====================
       |$diff
-           ?=====================
-           ?$diff
+            ?=====================
+            ?$diff
         """
   .stripMargin('?')
 <<< No align | margin 1 | interpolate, different char


### PR DESCRIPTION
Fixes #1998.