### PR TITLE
FormatToken: store the syntax of tokens in meta

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -86,7 +86,7 @@ private class BestFirstSearch private (
 
   def provided(formatToken: FormatToken): Split = {
     // TODO(olafur) the indentation is not correctly set.
-    val split = Split(Provided(formatToken.between.map(_.syntax).mkString), 0)
+    val split = Split(Provided(formatToken), 0)
     val result =
       if (formatToken.left.is[LeftBrace])
         split.withIndent(Num(2), matching(formatToken.left), ExpiresOn.Before)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -551,11 +551,11 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       isNewline: Boolean
   )(implicit style: ScalafmtConfig): Int = {
     if (style.verticalAlignMultilineOperators)
-      if (InfixApp.isAssignment(formatToken.left.syntax)) 2 else 0
+      if (InfixApp.isAssignment(formatToken.meta.left.text)) 2 else 0
     else if (
       !app.rhs.headOption.exists { x =>
         x.is[Term.Block] || x.is[Term.NewAnonymous]
-      } && isInfixTopLevelMatch(app.all, formatToken.left.syntax, false)
+      } && isInfixTopLevelMatch(app.all, formatToken.meta.left.text, false)
     ) 2
     else if (isInfixTopLevelMatch(app.all, app.op.value, true)) 0
     else if (!isNewline && !isSingleLineComment(formatToken.right)) 0

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -44,7 +44,7 @@ object FormatTokens {
     */
   def apply(tokens: Tokens, owner: Token => Tree): FormatTokens = {
     var left = tokens.head
-    var lowner = owner(left)
+    var lmeta = FormatToken.TokenMeta(owner(left), left.syntax)
     val result = Array.newBuilder[FormatToken]
     var ftIdx = 0
     var wsIdx = 0
@@ -53,12 +53,12 @@ object FormatTokens {
     arr.foreach {
       case Whitespace() => tokIdx += 1
       case right =>
-        val rowner = owner(right)
+        val rmeta = FormatToken.TokenMeta(owner(right), right.syntax)
         val meta =
-          FormatToken.Meta(arr.slice(wsIdx, tokIdx), ftIdx, lowner, rowner)
+          FormatToken.Meta(arr.slice(wsIdx, tokIdx), ftIdx, lmeta, rmeta)
         result += FormatToken(left, right, meta)
         left = right
-        lowner = rowner
+        lmeta = rmeta
         ftIdx += 1
         tokIdx += 1
         wsIdx = tokIdx

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -6,13 +6,10 @@ sealed abstract class Modification {
   @inline final def isNewline: Boolean = newlines != 0
 }
 
-case class Provided(code: String) extends Modification {
-  override lazy val newlines: Int = code.count(_ == '\n')
-  override lazy val length: Int = {
-    val firstLine = code.indexOf('\n')
-    if (firstLine == -1) code.length
-    else firstLine
-  }
+case class Provided(ft: FormatToken) extends Modification {
+  override val newlines: Int = ft.newlinesBetween
+  override lazy val length: Int =
+    if (newlines == 0) ft.betweenText.length else ft.betweenText.indexOf('\n')
 }
 
 case object NoSplit extends Modification {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -12,9 +12,9 @@ class TokenTraverser(tokens: Tokens) {
     var i = 0
     tokens.foreach { tok =>
       if (!formatOff) {
-        if (TokenOps.isFormatOff(tok)) formatOff = true
+        if (TokenOps.isFormatOff(tok, tok.syntax)) formatOff = true
       } else {
-        if (TokenOps.isFormatOn(tok)) formatOff = false
+        if (TokenOps.isFormatOn(tok, tok.syntax)) formatOff = false
         else excluded += TokenOps.hash(tok)
       }
       map += (tok -> i)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -689,14 +689,15 @@ object TreeOps {
     }
   }
 
-  def isTripleQuote(token: Token): Boolean = token.syntax.startsWith("\"\"\"")
+  @inline
+  def isTripleQuote(syntax: String): Boolean = syntax.startsWith("\"\"\"")
 
   def getStripMarginChar(ft: FormatToken): Option[Char] = {
     ft.left match {
       case _: Token.Interpolation.Start =>
         val ti = TreeOps.findInterpolate(ft.meta.leftOwner)
         ti.flatMap(TreeOps.getStripMarginChar)
-      case string: Token.Constant.String if isTripleQuote(string) =>
+      case _: Token.Constant.String if isTripleQuote(ft.meta.left.text) =>
         TreeOps.getStripMarginChar(ft.meta.leftOwner)
       case _ => None
     }


### PR DESCRIPTION
We access it frequently, and constructing it is not free. Should help with #1949.