### PR TITLE
FormatOps bugfix: get TParams correctly, not the Paramss

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1385,7 +1385,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
           (name, getArgs(paramss))
         else {
           // XXX: backwards-compatible hack
-          val useTParams = t.is[Defn.Def] ||
+          val useTParams = style.activeForEdition_2020_03 || t.is[Defn.Def] ||
             t.is[Type.Param] || t.is[Decl.Type] || t.is[Defn.Type]
           (name, if (useTParams) tparams else paramss.flatten)
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -839,7 +839,7 @@ class Router(formatOps: FormatOps) {
             newlinePenalty: Int
         )(implicit line: sourcecode.Line): Policy = {
           val baseSingleLinePolicy = if (isBracket) {
-            if (singleArgument)
+            if (!multipleArgs)
               penalizeAllNewlines(
                 close,
                 newlinePenalty,
@@ -848,14 +848,14 @@ class Router(formatOps: FormatOps) {
             else SingleLineBlock(close)
           } else {
             val penalty =
-              if (singleArgument) newlinePenalty
+              if (!multipleArgs) newlinePenalty
               else Constants.ShouldBeNewline
             penalizeAllNewlines(
               close,
               penalty = penalty,
               ignore = insideBraces,
-              penalizeLambdas = !singleArgument,
-              penaliseNewlinesInsideTokens = !singleArgument
+              penalizeLambdas = multipleArgs,
+              penaliseNewlinesInsideTokens = multipleArgs
             )
           }
 
@@ -975,7 +975,7 @@ class Router(formatOps: FormatOps) {
             .withIndent(if (align) StateColumn else indent, close, Before),
           Split(Newline, (3 + nestedPenalty) * bracketCoef + nlPenalty)
             .withPolicy(oneArgOneLine)
-            .onlyIf(!singleArgument && !alignTuple)
+            .onlyIf(multipleArgs && !alignTuple)
             .withIndent(indent, close, Before)
         ) ++ splitsForAssign.getOrElse(Seq.empty)
 

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -753,3 +753,22 @@ object a {
       // c1
   )
 }
+<<< #1800
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+===
+final case class StreamedEntityCreator[
+    -A <: ParserOutput, +B >: HttpEntity.Strict <: HttpEntity](
+    creator: Source[A, NotUsed] ⇒ B)
+    extends EntityCreator[A, B] {
+  def apply(parts: Source[A, NotUsed]) = creator(parts)
+}
+>>>
+Idempotency violated
+final case class StreamedEntityCreator[
+  -A <: ParserOutput, +B >: HttpEntity.Strict <: HttpEntity
+](creator: Source[A, NotUsed] ⇒ B)
+    extends EntityCreator[A, B] {
+  def apply(parts: Source[A, NotUsed]) = creator(parts)
+}

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -765,9 +765,9 @@ final case class StreamedEntityCreator[
   def apply(parts: Source[A, NotUsed]) = creator(parts)
 }
 >>>
-Idempotency violated
 final case class StreamedEntityCreator[
-  -A <: ParserOutput, +B >: HttpEntity.Strict <: HttpEntity
+  -A <: ParserOutput,
+  +B >: HttpEntity.Strict <: HttpEntity
 ](creator: Source[A, NotUsed] ⇒ B)
     extends EntityCreator[A, B] {
   def apply(parts: Source[A, NotUsed]) = creator(parts)

--- a/scalafmt-tests/src/test/resources/default/Trait.stat
+++ b/scalafmt-tests/src/test/resources/default/Trait.stat
@@ -112,6 +112,9 @@ align.preset = none
      with Serializable { }
 >>>
 trait CounterLike[
-    K, V, +M <: scala.collection.mutable.Map[K, V], +This <: Counter[K, V]]
+    K,
+    V,
+    +M <: scala.collection.mutable.Map[K, V],
+    +This <: Counter[K, V]]
     extends TensorLike[K, V, This]
     with Serializable {}


### PR DESCRIPTION
For traits/classes/method calls etc., the number of type parameters was identified incorrectly, instead using the number of constructor parameters.

The algorithm, as written, distinguishes between "not one" and "not many" (thus covering zero in both cases); so in cases where these flags were different for type parameters and apply/ctor parameters, type parameters were not formatted correctly (when the method had one type and one argument, or multiple types and multiple arguments, formatting worked as expected).

`scala-repos` diffs:

- FormatOps: get TParams correctly, not the Paramss
  - https://github.com/kitbellew/scala-repos/commit/ffe29bb89a70e94c918adf608694561aa9b2e43b
- Router: exclude no-arg apply from a split
  - https://github.com/kitbellew/scala-repos/commit/5c2644ba026f7bc2bf95371546283ec8c43cd75d

Fixes #1800.