### PR TITLE
Router: merge config-style rule into others

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -941,9 +941,21 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     result.result()
   }
 
+  def mustUseConfigStyle(
+      ft: FormatToken,
+      allowForce: => Boolean = true
+  )(implicit style: ScalafmtConfig): Boolean =
+    style.optIn.configStyleArguments && couldUseConfigStyle(ft, allowForce)
+
+  def couldUseConfigStyle(
+      ft: FormatToken,
+      allowForce: => Boolean = true
+  )(implicit style: ScalafmtConfig): Boolean =
+    opensConfigStyle(ft) || allowForce && forceConfigStyle(ft.meta.leftOwner)
+
   def opensConfigStyle(
       ft: => FormatToken,
-      whenSourceIgnored: Boolean
+      whenSourceIgnored: Boolean = false
   )(implicit style: ScalafmtConfig): Boolean =
     if (style.newlines.sourceIgnored) whenSourceIgnored
     else opensConfigStyleClassic(ft)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -706,7 +706,7 @@ class Router(formatOps: FormatOps) {
             case _ => false
           }
 
-        val nestedPenalty = nestedApplies(leftOwner) + lhsPenalty
+        val nestedPenalty = 1 + nestedApplies(leftOwner) + lhsPenalty
         val excludeRanges =
           if (isBracket) insideBlockRanges[T.LeftBracket](tok, close)
           else if (
@@ -818,13 +818,11 @@ class Router(formatOps: FormatOps) {
               val newlineAfterAssignDecision =
                 if (newlinePolicy.isEmpty) Policy.emptyPf
                 else decideNewlinesOnlyAfterToken(breakToken)
-              val noSplitCost = 1 + nestedPenalty
-              val newlineCost = Constants.ExceedColumnPenalty + noSplitCost
               Seq(
-                Split(Newline, newlineCost)
+                Split(Newline, nestedPenalty + Constants.ExceedColumnPenalty)
                   .withPolicy(newlinePolicy)
                   .withIndent(indent, close, Before),
-                Split(NoSplit, noSplitCost)
+                Split(NoSplit, nestedPenalty)
                   .withSingleLine(breakToken)
                   .andThenPolicy(
                     newlinePolicy.andThen(newlineAfterAssignDecision)
@@ -854,7 +852,7 @@ class Router(formatOps: FormatOps) {
             .onlyIf(noSplitMod != null)
             .withOptimalToken(expirationToken)
             .withIndent(noSplitIndent, close, Before),
-          Split(newlineMod, (1 + nestedPenalty) * bracketCoef + nlPenalty)
+          Split(newlineMod, nestedPenalty * bracketCoef + nlPenalty)
             .withPolicy(newlinePolicy.andThen(singleLine(4)))
             .onlyIf(!multipleArgs && !alignTuple && splitsForAssign.isEmpty)
             .withOptimalToken(expirationToken)
@@ -867,7 +865,7 @@ class Router(formatOps: FormatOps) {
                 style.newlines.notBeforeImplicitParamListModifier)
             )
             .withIndent(if (align) StateColumn else indent, close, Before),
-          Split(Newline, (3 + nestedPenalty) * bracketCoef + nlPenalty)
+          Split(Newline, (2 + nestedPenalty) * bracketCoef + nlPenalty)
             .withPolicy(oneArgOneLine)
             .onlyIf(multipleArgs && !alignTuple)
             .withIndent(indent, close, Before)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -144,6 +144,9 @@ case class Split(
     else if (policy.isEmpty) copy(policy = newPolicy)
     else copy(policy = policy.andThen(newPolicy))
 
+  def andThenPolicy(newPolicy: => Policy, ignore: Boolean): Split =
+    if (ignore) this else andThenPolicy(newPolicy)
+
   def andThenPolicyOpt(newPolicy: => Option[Policy]): Split =
     if (isIgnored) this
     else newPolicy.fold(this)(andThenPolicy)

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -635,9 +635,12 @@ SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages = None)/*comment 123 c
 }
 >>>
 {
-  val config =
-    WSClientConfig(SSLConfig(loose = SSLLooseConfig(allowLegacyHelloMessages =
-      None) /*comment 123 comment 234*/ )) //comment 345 comment 456
+  val config = WSClientConfig(
+      SSLConfig(loose =
+        SSLLooseConfig(allowLegacyHelloMessages =
+          None) /*comment 123 comment 234*/
+      )
+  ) //comment 345 comment 456
 }
 <<< #1604 3: apply with assign and attached comments
 {
@@ -767,13 +770,16 @@ optIn.configStyleArguments = true
         .withFallback(
             MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet))
 >>>
-Idempotency violated
 commonConfig(
   debugConfig(on = false)
-    .withFallback(ConfigFactory.parseString("""
+    .withFallback(
+      ConfigFactory.parseString(
+        """
       akka.cluster.periodic-tasks-initial-delay = 300 s # turn off all periodic tasks
       akka.cluster.publish-stats-interval = 0 s # always, when it happens
-      """))
+      """
+      )
+    )
     .withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet)
 )
 <<< #1800
@@ -805,11 +811,11 @@ pushInput(closeFrame(
                 mask = true,
                 msg = "This alien landing came quite unexpected. Communication has been garbled."))
 >>>
-Idempotency violated
 pushInput(
   closeFrame(
     Protocol.CloseCodes.UnexpectedCondition,
     mask = true,
-    msg = "This alien landing came quite unexpected. Communication has been garbled."
+    msg =
+      "This alien landing came quite unexpected. Communication has been garbled."
   )
 )

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -753,6 +753,29 @@ object a {
       // c1
   )
 }
+<<< #1798
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+===
+  commonConfig(
+      debugConfig(on = false)
+        .withFallback(ConfigFactory.parseString("""
+      akka.cluster.periodic-tasks-initial-delay = 300 s # turn off all periodic tasks
+      akka.cluster.publish-stats-interval = 0 s # always, when it happens
+      """))
+        .withFallback(
+            MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet))
+>>>
+Idempotency violated
+commonConfig(
+  debugConfig(on = false)
+    .withFallback(ConfigFactory.parseString("""
+      akka.cluster.periodic-tasks-initial-delay = 300 s # turn off all periodic tasks
+      akka.cluster.publish-stats-interval = 0 s # always, when it happens
+      """))
+    .withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet)
+)
 <<< #1800
 preset = intellij
 danglingParentheses.preset = true
@@ -772,3 +795,21 @@ final case class StreamedEntityCreator[
     extends EntityCreator[A, B] {
   def apply(parts: Source[A, NotUsed]) = creator(parts)
 }
+<<< #1801
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+===
+pushInput(closeFrame(
+                Protocol.CloseCodes.UnexpectedCondition,
+                mask = true,
+                msg = "This alien landing came quite unexpected. Communication has been garbled."))
+>>>
+Idempotency violated
+pushInput(
+  closeFrame(
+    Protocol.CloseCodes.UnexpectedCondition,
+    mask = true,
+    msg = "This alien landing came quite unexpected. Communication has been garbled."
+  )
+)


### PR DESCRIPTION
Having a separate, slightly different rule was leading to a number of idempotence issues.

The idea is that if the primary rule produces a config-style formatting, it must follow the same policy as one that had been set by the earlier config-style rule.

Fixes #1798.
Fixes #1801.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/4e21556434e9512246bb44382b0beb651fa1d80f