### PR TITLE
State: fix column positions for multiline strings

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -160,7 +160,7 @@ private class BestFirstSearch private (
             tokens(deepestYet.depth)
           )
 
-        val style = styleMap.at(splitToken)
+        implicit val style = styleMap.at(splitToken)
 
         if (curr.split != null && curr.split.modification.isNewline) {
           val tokenHash = hash(splitToken.left)
@@ -193,7 +193,7 @@ private class BestFirstSearch private (
 
           var optimalNotFound = true
           actualSplit.foreach { split =>
-            val nextState = curr.next(style, split, splitToken)
+            val nextState = curr.next(split, splitToken)
             val updateBest = !keepSlowStates && depth == 0 &&
               split.modification.isNewline && !best.contains(curr.depth)
             if (updateBest) {
@@ -289,8 +289,8 @@ private class BestFirstSearch private (
         else {
           runner.event(Enqueue(split))
           val ft = tokens(state.depth)
-          val style = styleMap.at(ft)
-          val nextState = state.next(style, split, ft)
+          implicit val style = styleMap.at(ft)
+          val nextState = state.next(split, ft)
           traverseSameLine(nextState, depth)
         }
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -419,7 +419,7 @@ class Router(formatOps: FormatOps) {
                 Right(Split.ignored)
               case t if t.tokens.isEmpty || caseStat.cond.isDefined =>
                 Right(Split(Space, 0).withSingleLineOpt(t.tokens.lastOption))
-              case t: Term.If if t.elsep.tokens.isEmpty =>
+              case t: Term.If if ifWithoutElse(t) =>
                 // must not use optimal token here, will lead to column overflow
                 Right(
                   Split(Space, 0).withSingleLineNoOptimal(t.cond.tokens.last)
@@ -1974,7 +1974,7 @@ class Router(formatOps: FormatOps) {
             case _: Term.Try | _: Term.TryWithHandler =>
               SingleLineBlock(expire)
             case t: Term.If =>
-              if (t.elsep.tokens.isEmpty)
+              if (ifWithoutElse(t))
                 SingleLineBlock(t.cond.tokens.last)
               else
                 SingleLineBlock(expire)
@@ -2064,7 +2064,7 @@ class Router(formatOps: FormatOps) {
         body match {
           case t: Term.If =>
             Either.cond(
-              t.elsep.tokens.nonEmpty,
+              !ifWithoutElse(t),
               SingleLineBlock(expire),
               baseSpaceSplit.withSingleLine(t.cond.tokens.last)
             )
@@ -2153,7 +2153,7 @@ class Router(formatOps: FormatOps) {
         case Newlines.fold | Newlines.classic =>
           postCommentFT.meta.rightOwner match {
             case _: Term.Try | _: Term.TryWithHandler => Split.ignored
-            case t: Term.If if t.elsep.tokens.nonEmpty => Split.ignored
+            case t: Term.If if !ifWithoutElse(t) => Split.ignored
             case t: Term.If =>
               Split(Space, 1).withSingleLine(t.cond.tokens.last)
             case _ =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1219,7 +1219,7 @@ class Router(formatOps: FormatOps) {
                 }
               }
               Seq(
-                Split(NoSplit, 0).withSingleLine(expire),
+                Split(NoSplit, 0).withSingleLine(expire, noSyntaxNL = true),
                 Split(NewlineT(acceptNoSplit = true), 1)
                   .withPolicyOpt(forcedBreakPolicy)
               )
@@ -1278,7 +1278,8 @@ class Router(formatOps: FormatOps) {
         // the newline is too cheap even it doesn't actually prevent other newlines.
         val penalizeNewlinesInApply = penalizeAllNewlines(expire, 2)
         val noSplitPolicy =
-          SingleLineBlock(expire, exclude).andThen(penalizeNewlinesInApply)
+          SingleLineBlock(expire, exclude, penaliseNewlinesInsideTokens = true)
+            .andThen(penalizeNewlinesInApply)
         val newlinePolicy = breakOnEveryDot.andThen(penalizeNewlinesInApply)
         val ignoreNoSplit =
           style.optIn.breakChainOnFirstMethodDot && tok.hasBreak

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1348,7 +1348,7 @@ class Router(formatOps: FormatOps) {
           .orElse(template.map(_.tokens.last))
           .getOrElse(rightOwner.tokens.last)
         binPackParentConstructorSplits(
-          template.toSet,
+          template.toLeft(Seq.empty),
           lastToken,
           style.continuationIndent.extendSite
         )
@@ -1366,7 +1366,7 @@ class Router(formatOps: FormatOps) {
               } =>
             splitWithChain(
               isFirstWith(template),
-              Set(template),
+              Left(template),
               templateCurly(template).getOrElse(template.tokens.last)
             )
 
@@ -1400,7 +1400,7 @@ class Router(formatOps: FormatOps) {
           case t @ WithChain(top) =>
             splitWithChain(
               !t.lhs.is[Type.With],
-              withChain(top).toSet,
+              Right(withChain(top)),
               top.tokens.last
             )
 
@@ -1898,7 +1898,7 @@ class Router(formatOps: FormatOps) {
 
   private def splitWithChain(
       isFirstWith: Boolean,
-      chain: => Set[Tree],
+      chain: => Either[Template, Seq[Type.With]],
       lastToken: => Token
   )(implicit line: sourcecode.Line, style: ScalafmtConfig): Seq[Split] =
     if (isFirstWith) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1470,10 +1470,11 @@ class Router(formatOps: FormatOps) {
         }
         val noSpace = isSingleLineComment(right) || shouldBreak(formatToken)
         def exclude = insideBlockRanges[T.LeftBrace](formatToken, expire)
+        val noSyntaxNL = leftOwner.is[Term.ForYield] && right.is[T.KwYield]
         Seq(
           Split(Space, 0)
             .notIf(noSpace)
-            .withSingleLineNoOptimal(expire, exclude = exclude),
+            .withSingleLineNoOptimal(expire, exclude, noSyntaxNL = noSyntaxNL),
           Split(Newline, 1).withIndent(2, expire, After)
         )
       case FormatToken(T.RightBrace(), T.KwElse(), _) =>
@@ -1491,10 +1492,11 @@ class Router(formatOps: FormatOps) {
         val expire = rhsOptimalToken(tokens(rightOwner.tokens.last))
         val noSpace = shouldBreak(formatToken)
         def exclude = insideBlockRanges[T.LeftBrace](formatToken, expire)
+        val noSyntaxNL = formatToken.right.is[T.KwYield]
         Seq(
           Split(Space, 0)
             .notIf(noSpace)
-            .withSingleLineNoOptimal(expire, exclude),
+            .withSingleLineNoOptimal(expire, exclude, noSyntaxNL = noSyntaxNL),
           Split(Newline, 1)
         )
       // Last else branch

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -103,31 +103,41 @@ case class Split(
   def withSingleLine(
       expire: Token,
       exclude: => Set[Range] = Set.empty,
+      noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false
   )(implicit line: sourcecode.Line): Split =
-    withSingleLineAndOptimal(expire, expire, exclude, killOnFail)
+    withSingleLineAndOptimal(expire, expire, exclude, noSyntaxNL, killOnFail)
 
   def withSingleLineOpt(
       expire: Option[Token],
       exclude: => Set[Range] = Set.empty,
+      noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false
   )(implicit line: sourcecode.Line): Split =
-    expire.fold(this)(withSingleLine(_, exclude, killOnFail))
+    expire.fold(this)(withSingleLine(_, exclude, noSyntaxNL, killOnFail))
 
   def withSingleLineAndOptimal(
       expire: Token,
       optimal: Token,
       exclude: => Set[Range] = Set.empty,
+      noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false
   )(implicit line: sourcecode.Line): Split =
     withOptimalToken(optimal, killOnFail)
-      .withSingleLineNoOptimal(expire, exclude)
+      .withSingleLineNoOptimal(expire, exclude, noSyntaxNL)
 
   def withSingleLineNoOptimal(
       expire: Token,
-      exclude: => Set[Range] = Set.empty
+      exclude: => Set[Range] = Set.empty,
+      noSyntaxNL: Boolean = false
   )(implicit line: sourcecode.Line): Split =
-    withPolicy(SingleLineBlock(expire, exclude))
+    withPolicy(
+      SingleLineBlock(
+        expire,
+        exclude,
+        penaliseNewlinesInsideTokens = noSyntaxNL
+      )
+    )
 
   def withPolicyOpt(
       newPolicy: => Option[Policy]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -30,10 +30,9 @@ final case class State(
     * Calculates next State given split at tok.
     */
   def next(
-      style: ScalafmtConfig,
       split: Split,
       tok: FormatToken
-  ): State = {
+  )(implicit style: ScalafmtConfig): State = {
     val right = tok.right
     val tokRightSyntax = tok.meta.right.text
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -271,7 +271,6 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
           //   which would be equivalent to
           // if (a) { if (b) c else d }
           def insideIfThen = parentIf.thenp eq b
-          def ifWithoutElse(t: Term.If) = t.elsep.is[Lit.Unit]
           @tailrec
           def existsIfWithoutElse(t: Term.If): Boolean =
             t.elsep match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -190,29 +190,6 @@ object TokenOps {
       case _ => None
     }
 
-  def tokenLength(token: Token): Int =
-    token match {
-      case lit: Constant.String =>
-        // Even if the literal is not strip margined, we use the longest line
-        // excluding margins. The will only affect is multiline string literals
-        // with a short first line but long lines inside, example:
-        //
-        // val x = """short
-        //  Long aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        // """
-        //
-        // In this case, we would put a newline before """short and indent by
-        // two.
-        lit.syntax.linesIterator
-          .map(_.replaceFirst(" *|", "").length)
-          .max
-      case _ =>
-        val tokenSyntax = token.syntax
-        val firstNewline = tokenSyntax.indexOf('\n')
-        if (firstNewline == -1) tokenSyntax.length
-        else firstNewline
-    }
-
   val formatOffCode = Set(
     "// @formatter:off", // IntelliJ
     "// format: off" // scalariform

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -721,4 +721,7 @@ object TreeOps {
       }
   }
 
+  @inline
+  def ifWithoutElse(t: Term.If) = t.elsep.is[Lit.Unit]
+
 }

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -772,14 +772,10 @@ optIn.configStyleArguments = true
 >>>
 commonConfig(
   debugConfig(on = false)
-    .withFallback(
-      ConfigFactory.parseString(
-        """
+    .withFallback(ConfigFactory.parseString("""
       akka.cluster.periodic-tasks-initial-delay = 300 s # turn off all periodic tasks
       akka.cluster.publish-stats-interval = 0 s # always, when it happens
-      """
-      )
-    )
+      """))
     .withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet)
 )
 <<< #1800

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -90,8 +90,10 @@ object a {
 }
 >>>
 object a {
-  foo.B("""
-        |foo""").bar
+  foo
+    .B("""
+        |foo""")
+    .bar
 }
 <<< #1640 single select with multiline arg
 object a {

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -79,8 +79,10 @@ object Foo {
 class A(a: Int, b: String) extends B("""
 foo""") with C
 >>>
-class A(a: Int, b: String) extends B("""
-foo""") with C
+class A(a: Int, b: String)
+    extends B("""
+foo""")
+    with C
 <<< #1640 select chain with multiline arg
 object a {
   foo.B("""

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -14,8 +14,7 @@ val x = """Short line
   |Long line aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
               """
 >>>
-val x =
-  """Short line
+val x = """Short line
   |Long line aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
               """
 <<< column limit 2

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -18,6 +18,16 @@ val x =
   """Short line
   |Long line aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
               """
+<<< column limit 2
+val x =
+  """Short line
+  |Long line aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
+>>>
+val x =
+  """Short line
+  |Long line aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+              """
 <<< Single line #285
 object Foo{
   assert( keywordTokens.length % 2 == 0,
@@ -64,4 +74,45 @@ object Foo {
         catch { case e: akka.parboiled2.Parser#TracingBubbleException ⇒ $bubbleUp }"""
       else renderInner(wrapped)
   }
+}
+<<< #1640 class with multiline parent ctor
+class A(a: Int, b: String) extends B("""
+foo""") with C
+>>>
+class A(a: Int, b: String) extends B("""
+foo""") with C
+<<< #1640 select chain with multiline arg
+object a {
+  foo.B("""
+        |foo""").bar
+}
+>>>
+object a {
+  foo.B("""
+        |foo""").bar
+}
+<<< #1640 single select with multiline arg
+object a {
+  foo.B("""
+        |foo""")
+}
+>>>
+object a {
+  foo.B("""
+        |foo""")
+}
+<<< #1640 yield with multiline arg
+object a {
+  for (n ← 1 to 30) yield """
+    test-dispatcher-%s {
+      type = "akka.actor.dispatch.DispatcherModelSpec$MessageDispatcherInterceptorConfigurator"
+    }""".format(n).mkString
+}
+>>>
+object a {
+  for (n ← 1 to 30)
+    yield """
+    test-dispatcher-%s {
+      type = "akka.actor.dispatch.DispatcherModelSpec$MessageDispatcherInterceptorConfigurator"
+    }""".format(n).mkString
 }

--- a/scalafmt-tests/src/test/resources/unit/Annotations.stat
+++ b/scalafmt-tests/src/test/resources/unit/Annotations.stat
@@ -68,9 +68,10 @@ object a {
 trait Show[T, P, R]
 }
 >>>
-Idempotency violated
 object a {
-  @implicitNotFound("""Could not find an implicit Show for type ${T}, predicate ${P} and result ${R}.
-                      | You may want to define it as an implicit function that is polymorphic function over R.""".stripMargin)
+  @implicitNotFound(
+    """Could not find an implicit Show for type ${T}, predicate ${P} and result ${R}.
+      | You may want to define it as an implicit function that is polymorphic function over R.""".stripMargin
+  )
   trait Show[T, P, R]
 }

--- a/scalafmt-tests/src/test/resources/unit/Annotations.stat
+++ b/scalafmt-tests/src/test/resources/unit/Annotations.stat
@@ -56,3 +56,21 @@ private trait Iterator {
 +trait Invariant[F[_]] { self =>
 >>>
 x
+<<< #1640
+maxColumn = 120
+preset = intellij
+danglingParentheses.preset = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+@implicitNotFound("""Could not find an implicit Show for type ${T}, predicate ${P} and result ${R}.
+                    | You may want to define it as an implicit function that is polymorphic function over R.""".stripMargin)
+trait Show[T, P, R]
+}
+>>>
+Idempotency violated
+object a {
+  @implicitNotFound("""Could not find an implicit Show for type ${T}, predicate ${P} and result ${R}.
+                      | You may want to define it as an implicit function that is polymorphic function over R.""".stripMargin)
+  trait Show[T, P, R]
+}


### PR DESCRIPTION
Currently, multiline strings are handled inconsistently; computation of state columns also assumes that every line is aligned on the opening quotes, whether or not there is a margin symbol (`|`) and whether various margin-handling flags are set.

Instead, try to estimate the length of each line post-formatting and use that in computing the columns.

Fixes #1640.

`scala-repos` diffs:
- Router: no multiline tokens in extends/with chains
  - https://github.com/kitbellew/scala-repos/commit/82307937bca8f88d24b03caa863e2ccdb8c1709e
- Router: no multiline tokens in select chains
  - https://github.com/kitbellew/scala-repos/commit/bbf3b988cd3d4a09f7def2b6468db4d0c1bf6ad8
- Router: no multiline tokens in yield
  - https://github.com/kitbellew/scala-repos/commit/6324b327d3ea49ca4116a280a8fcfce8fb669d8a
- State: fix column positions for multiline strings
  - https://github.com/kitbellew/scala-repos/commit/050689f318b26ef6a0e4fe958ceae88cd916a3df