### PR TITLE
Router: idempotence of breakChainOnFirstMethodDot

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1311,7 +1311,7 @@ class Router(formatOps: FormatOps) {
           Split(NoSplit, 0)
             .notIf(ignoreNoSplit)
             .withPolicy(noSplitPolicy),
-          Split(NewlineT(acceptNoSplit = true), nlCost)
+          Split(NewlineT(acceptNoSplit = !ignoreNoSplit), nlCost)
             .withPolicy(newlinePolicy)
             .withIndent(2, optimalToken, After)
         )

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -833,7 +833,6 @@ optIn.configStyleArguments = true
         .renderedTo(
           "Digest realm=\"testrealm@host.com\",qop=\"auth,auth-int\",nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093,opaque=5ccc069c403ebaf9f0171e9517f40e41")
 >>>
-Idempotency violated
 `WWW-Authenticate`(
   HttpChallenge(
     "Digest",
@@ -844,9 +843,10 @@ Idempotency violated
       "opaque" -> "5ccc069c403ebaf9f0171e9517f40e41"
     )
   )
-).renderedTo(
-  "Digest realm=\"testrealm@host.com\",qop=\"auth,auth-int\",nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093,opaque=5ccc069c403ebaf9f0171e9517f40e41"
 )
+  .renderedTo(
+    "Digest realm=\"testrealm@host.com\",qop=\"auth,auth-int\",nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093,opaque=5ccc069c403ebaf9f0171e9517f40e41"
+  )
 <<< #1803
 preset = intellij
 danglingParentheses.preset = true
@@ -864,7 +864,6 @@ Await
               1.second)
           .getMessage
 >>>
-Idempotency violated
 Await
   .result(
     Unmarshal(
@@ -873,7 +872,9 @@ Await
         """this is
             |just preamble text""".stripMarginWithNewline("\r\n")
       )
-    ).to[Multipart.General].failed,
+    )
+      .to[Multipart.General]
+      .failed,
     1.second
   )
   .getMessage
@@ -921,14 +922,14 @@ object a {
   )
 }
 >>>
-Idempotency violated
 object a {
   lazy val mod = project(
     "mod",
     Seq(common, db, user, hub, security, game, analyse, evaluation, report)
-  ).settings(
-    libraryDependencies ++= provided(play.api, play.test, RM, PRM)
   )
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+    )
 }
 <<< #1804, no breakChainOnFirstMethodDot
 preset = intellij
@@ -975,7 +976,8 @@ object a {
   lazy val mod = project(
     "mod",
     Seq(common, db, user, hub, security, game, analyse, evaluation, report)
-  ).settings(
+  )
+    .settings(
       libraryDependencies ++= provided(play.api, play.test, RM, PRM)
     )
     .settings(

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -819,3 +819,195 @@ pushInput(
       "This alien landing came quite unexpected. Communication has been garbled."
   )
 )
+<<< #1802
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+===
+`WWW-Authenticate`(
+          HttpChallenge("Digest",
+                        "testrealm@host.com",
+                        Map("qop" -> "auth,auth-int",
+                            "nonce" -> "dcd98b7102dd2f0e8b11d0f600bfb0c093",
+                            "opaque" -> "5ccc069c403ebaf9f0171e9517f40e41")))
+        .renderedTo(
+          "Digest realm=\"testrealm@host.com\",qop=\"auth,auth-int\",nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093,opaque=5ccc069c403ebaf9f0171e9517f40e41")
+>>>
+Idempotency violated
+`WWW-Authenticate`(
+  HttpChallenge(
+    "Digest",
+    "testrealm@host.com",
+    Map(
+      "qop" -> "auth,auth-int",
+      "nonce" -> "dcd98b7102dd2f0e8b11d0f600bfb0c093",
+      "opaque" -> "5ccc069c403ebaf9f0171e9517f40e41"
+    )
+  )
+).renderedTo(
+  "Digest realm=\"testrealm@host.com\",qop=\"auth,auth-int\",nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093,opaque=5ccc069c403ebaf9f0171e9517f40e41"
+)
+<<< #1803
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+optIn.breakChainOnFirstMethodDot = true
+===
+Await
+          .result(
+              Unmarshal(HttpEntity(
+                      `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+                      """this is
+            |just preamble text""".stripMarginWithNewline("\r\n")))
+                .to[Multipart.General]
+                .failed,
+              1.second)
+          .getMessage
+>>>
+Idempotency violated
+Await
+  .result(
+    Unmarshal(
+      HttpEntity(
+        `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+        """this is
+            |just preamble text""".stripMarginWithNewline("\r\n")
+      )
+    ).to[Multipart.General].failed,
+    1.second
+  )
+  .getMessage
+<<< #1803, no breakChainOnFirstMethodDot
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+optIn.breakChainOnFirstMethodDot = false
+===
+Await
+          .result(
+              Unmarshal(HttpEntity(
+                      `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+                      """this is
+            |just preamble text""".stripMarginWithNewline("\r\n")))
+                .to[Multipart.General]
+                .failed,
+              1.second)
+          .getMessage
+>>>
+Await
+  .result(
+    Unmarshal(
+      HttpEntity(
+        `multipart/mixed` withBoundary "XYZABC" withCharset `UTF-8`,
+        """this is
+            |just preamble text""".stripMarginWithNewline("\r\n")
+      )
+    ).to[Multipart.General].failed,
+    1.second
+  )
+  .getMessage
+<<< #1804
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+optIn.breakChainOnFirstMethodDot = true
+===
+object a {
+  lazy val mod = project(
+      "mod",
+      Seq(common, db, user, hub, security, game, analyse, evaluation, report))
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+  )
+}
+>>>
+Idempotency violated
+object a {
+  lazy val mod = project(
+    "mod",
+    Seq(common, db, user, hub, security, game, analyse, evaluation, report)
+  ).settings(
+    libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+  )
+}
+<<< #1804, no breakChainOnFirstMethodDot
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+optIn.breakChainOnFirstMethodDot = false
+===
+object a {
+  lazy val mod = project(
+      "mod",
+      Seq(common, db, user, hub, security, game, analyse, evaluation, report))
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+  )
+}
+>>>
+object a {
+  lazy val mod = project(
+    "mod",
+    Seq(common, db, user, hub, security, game, analyse, evaluation, report)
+  ).settings(
+    libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+  )
+}
+<<< #1804 bis
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+optIn.breakChainOnFirstMethodDot = true
+===
+object a {
+  lazy val mod = project(
+      "mod",
+      Seq(common, db, user, hub, security, game, analyse, evaluation, report))
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+  )
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+  )
+}
+>>>
+object a {
+  lazy val mod = project(
+    "mod",
+    Seq(common, db, user, hub, security, game, analyse, evaluation, report)
+  ).settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+    )
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+    )
+}
+<<< #1804 bis, no breakChainOnFirstMethodDot
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+optIn.breakChainOnFirstMethodDot = false
+===
+object a {
+  lazy val mod = project(
+      "mod",
+      Seq(common, db, user, hub, security, game, analyse, evaluation, report))
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+  )
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+  )
+}
+>>>
+object a {
+  lazy val mod = project(
+    "mod",
+    Seq(common, db, user, hub, security, game, analyse, evaluation, report)
+  ).settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+    )
+    .settings(
+      libraryDependencies ++= provided(play.api, play.test, RM, PRM)
+    )
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -238,7 +238,8 @@ object a {
   join(a, b)((x, y) =>
     where(
       (x.foo < maxRetry).and(y.retryCount === x.bar).and(task.status === Failed)
-    ).select(task)
+    )
+      .select(task)
       .on((x.id === key).and(y.id === key))
   ).toList
 }

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -10,6 +10,8 @@ function(
     b
 )
 <<< penalty #248
+optIn.breakChainOnFirstMethodDot = false
+===
      def iterator(): Iterator[A] =
       toIterator(it
             .asInstanceOf[IteratorMethodAccess]


### PR DESCRIPTION
If this flag is set, we must preserve a break if it's there. Therefore, we can't "tuck" a Newline into a NoSplit as it both violates the flag and leads to non-idempotent formatting.

Fixes #1802. Fixes #1803. Fixes #1804.