### PR TITLE
Router: penalize NL on breakChainOnFirstMethodDot

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1302,7 +1302,11 @@ class Router(formatOps: FormatOps) {
               case _ => 0
             }
           } else 0
-        val nlCost = 2 + nestedPenalty + chainLengthPenalty
+        // when the flag is on, penalize break, to avoid idempotence issues;
+        // otherwise, after the break is chosen, the flag prohibits nosplit
+        val nlBaseCost =
+          if (style.optIn.breakChainOnFirstMethodDot && tok.noBreak) 3 else 2
+        val nlCost = nlBaseCost + nestedPenalty + chainLengthPenalty
         Seq(
           Split(NoSplit, 0)
             .notIf(ignoreNoSplit)

--- a/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
+++ b/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
@@ -24,8 +24,9 @@ for {
 } yield cond
 >>>
 for {
-  variable <- record.field.field1
-                .map(_.toString)
+  variable <- record.field.field1.map(
+                _.toString
+              )
   cond <- if (variable) doSomething
           else doAnything
 } yield cond
@@ -36,8 +37,9 @@ for {
 } yield cond
 >>>
 for {
-  variable <- record.field.field1
-                .map(_.toString)
+  variable <- record.field.field1.map(
+                _.toString
+              )
   cond <- if (variable) doSomething
           else doAnything
 } yield cond
@@ -58,8 +60,9 @@ for {
 } yield cond
 >>>
 for {
-  variable <- record.field.field1
-                .map(_.toString)
+  variable <- record.field.field1.map(
+                _.toString
+              )
   cond = if (variable) doSomething
          else doAnything
 } yield cond

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -778,6 +778,28 @@ commonConfig(
       """))
     .withFallback(MultiNodeClusterSpec.clusterConfigWithFailureDetectorPuppet)
 )
+<<< #1799
+preset = intellij
+danglingParentheses.preset = true
+optIn.configStyleArguments = true
+===
+override final def next(): To =
+  if (hasNext) {
+    val ret = _next
+    _next = null.asInstanceOf[To] // Mark as consumed aaaaaaaaaaaaaaaaaa(nice to the GC, don't leak the last returned value)
+    _hasNext = false // Mark as consumed (we need to look for the next value)
+    ret
+  } else throw new java.util.NoSuchElementException("next")
+>>>
+Idempotency violated
+override final def next(): To =
+  if (hasNext) {
+    val ret = _next
+    _next = null
+        .asInstanceOf[To] // Mark as consumed aaaaaaaaaaaaaaaaaa(nice to the GC, don't leak the last returned value)
+    _hasNext = false // Mark as consumed (we need to look for the next value)
+    ret
+  } else throw new java.util.NoSuchElementException("next")
 <<< #1800
 preset = intellij
 danglingParentheses.preset = true

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -791,12 +791,11 @@ override final def next(): To =
     ret
   } else throw new java.util.NoSuchElementException("next")
 >>>
-Idempotency violated
 override final def next(): To =
   if (hasNext) {
     val ret = _next
-    _next = null
-        .asInstanceOf[To] // Mark as consumed aaaaaaaaaaaaaaaaaa(nice to the GC, don't leak the last returned value)
+    _next =
+      null.asInstanceOf[To] // Mark as consumed aaaaaaaaaaaaaaaaaa(nice to the GC, don't leak the last returned value)
     _hasNext = false // Mark as consumed (we need to look for the next value)
     ret
   } else throw new java.util.NoSuchElementException("next")

--- a/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
@@ -99,8 +99,11 @@ val boss = system.actorOf(Props(new Actor {
         requestMethod = HttpMethods.HEAD,
         response = HttpResponse(
           headers = List(Age(30)),
-          entity = HttpEntity
-            .Default(ContentTypes.`text/plain(UTF-8)`, 100, Source.empty)
+          entity = HttpEntity.Default(
+            ContentTypes.`text/plain(UTF-8)`,
+            100,
+            Source.empty
+          )
         )
       ) should renderTo(
         """HTTP/1.1 200 OK

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -57,8 +57,9 @@ new Compiler(
 );
 >>>
 new Compiler(
-    primitives.opti___________ons
-      .has("primitives"),
+    primitives.opti___________ons.has(
+        "primitives"
+    ),
     minify.options.has("minify"),
     preserve.options.has("preserve"),
     liveAnalysis.check(


### PR DESCRIPTION
When the flag is on, penalize break, to avoid idempotence issues; otherwise, after the break is chosen, the flag prohibits nosplit. Fixes #1799.

*No* changes in `scala-repos`.