### PR TITLE
TokenOps: look for "format: off" in any comment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -90,8 +90,9 @@ final case class State(
       }
     }
 
-    val nextFormatOff = TokenOps.isFormatOff(right, tokRightSyntax) ||
-      formatOff && !TokenOps.isFormatOn(right, tokRightSyntax)
+    val nextFormatOff =
+      if (formatOff) !TokenOps.isFormatOn(right)
+      else TokenOps.isFormatOff(right)
 
     State(
       cost + splitWithPenalty.cost,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -190,16 +190,27 @@ object TokenOps {
       case _ => None
     }
 
-  val formatOffCode = Set(
-    "// @formatter:off", // IntelliJ
-    "// format: off" // scalariform
+  val formatOnCode = Set(
+    "@formatter:on", // IntelliJ
+    "format: on" // scalariform
   )
 
-  def isFormatOn(token: Token, syntax: => String): Boolean =
-    token.is[Comment] && formatOnCode.contains(syntax.toLowerCase)
+  val formatOffCode = Set(
+    "@formatter:off", // IntelliJ
+    "format: off" // scalariform
+  )
 
-  def isFormatOff(token: Token, syntax: => String): Boolean =
-    token.is[Comment] && formatOffCode.contains(syntax.toLowerCase)
+  @inline
+  def isFormatOn(token: Token): Boolean = isFormatIn(token, formatOnCode)
+
+  @inline
+  def isFormatOff(token: Token): Boolean = isFormatIn(token, formatOffCode)
+
+  private def isFormatIn(token: Token, set: Set[String]): Boolean =
+    token match {
+      case t: Comment => set.contains(t.value.trim.toLowerCase)
+      case _ => false
+    }
 
   def endsWithSymbolIdent(tok: Token): Boolean =
     tok match {
@@ -219,11 +230,6 @@ object TokenOps {
     // an `_`, operators cannot. This check should suffice.
     !head.isLetter && head != '_'
   }
-
-  val formatOnCode = Set(
-    "// @formatter:on", // IntelliJ
-    "// format: on" // scalariform
-  )
 
   def shouldBreak(ft: FormatToken)(implicit style: ScalafmtConfig): Boolean =
     style.newlines.source match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -12,9 +12,9 @@ class TokenTraverser(tokens: Tokens) {
     var i = 0
     tokens.foreach { tok =>
       if (!formatOff) {
-        if (TokenOps.isFormatOff(tok, tok.syntax)) formatOff = true
+        if (TokenOps.isFormatOff(tok)) formatOff = true
       } else {
-        if (TokenOps.isFormatOn(tok, tok.syntax)) formatOff = false
+        if (TokenOps.isFormatOn(tok)) formatOff = false
         else excluded += TokenOps.hash(tok)
       }
       map += (tok -> i)


### PR DESCRIPTION
Some people expect to be able to use `/* format: off */` and others fail
to see why `//format: off` doesn't work. Use any comment and trim space.