### PR TITLE
Scaladoc: support gaps in code, refs with punctuation

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV  = "4.3.14"
+  val scalametaV  = "4.3.15"
   val scalatestV  = "3.1.2"
   val scalacheckV = "1.14.3"
   val coursier    = "1.0.3"

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -621,8 +621,8 @@ class FormatWriter(formatOps: FormatOps) {
                       sb.append(getIndentation(2 + margin.length)).append(x)
                     else {
                       val offset = matcher.end()
-                      val codeIndent =
-                        math.max(margin.length, offset - offset % 2)
+                      val extra = math.max(0, offset - margin.length)
+                      val codeIndent = margin.length + extra - extra % 2
                       sb.append(getIndentation(codeIndent))
                       sb.append(CharBuffer.wrap(x, offset, x.length))
                     }

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -205,9 +205,14 @@ maxColumn = 30
 
 {{{
 multi
-line
-code
+  line
+    code
 }}}
+* {{{
+* multi
+*   line
+*     code
+* }}}
 @tparam t type, @see [[d]] ({{{single-line code}}})
   */
   val a = 1
@@ -227,6 +232,11 @@ code
  * line
  * code
  * }}}
+ * {{{
+ * multi
+ *  line
+ *    code
+ * }}}
  * @tparam t
  *   type, @see [[d]]
  *   ({{{single-line code}}})
@@ -244,9 +254,14 @@ maxColumn = 30
 
 {{{
 multi
-line
-code
+  line
+    code
 }}}
+* {{{
+* multi
+*   line
+*     code
+* }}}
 @tparam t type, @see [[d]] ({{{single-line code}}})
   */
   val a = 1
@@ -265,6 +280,11 @@ code
   * line
   * code
   * }}}
+  * {{{
+  * multi
+  *  line
+  *    code
+  * }}}
   * @tparam t
   *   type, @see [[d]]
   *   ({{{single-line code}}})
@@ -282,9 +302,14 @@ maxColumn = 30
 
 {{{
 multi
-line
-code
+  line
+    code
 }}}
+*  {{{
+*  multi
+*    line
+*      code
+*  }}}
 @tparam t type, @see [[d]] ({{{single-line code}}})
   */
   val a = 1
@@ -302,6 +327,11 @@ code
  *  multi
  *  line
  *  code
+ *  }}}
+ *  {{{
+ *  multi
+ *    line
+ *      code
  *  }}}
  *  @tparam t
  *    type, @see [[d]]
@@ -766,6 +796,100 @@ object a {
    *  | r22 1  |  r22 2 |        |        |        |        |
    *  | r333 1 | r333 2 | r333 3 | r333 4 | r333 5 | r333 6 |
    *  tail
+   */
+}
+<<< #1887 7 Asterisk: list only
+docstrings.wrap = yes
+docstrings.style = Asterisk
+maxColumn = 24
+===
+object a {
+  /** 1. foo
+    * 1. bar
+   */
+}
+>>>
+Idempotency violated
+object a {
+
+  /**
+   *   1. foo
+   *      1. bar
+   */
+}
+<<< #1887 7 SpaceAsterisk: list only
+docstrings.wrap = yes
+docstrings.style = SpaceAsterisk
+maxColumn = 24
+===
+object a {
+  /** 1. foo
+   * 1. bar
+   */
+}
+>>>
+object a {
+
+  /** 1. foo
+    *   1. bar
+    */
+}
+<<< #1887 7 AsteriskSpace: list only
+docstrings.wrap = yes
+docstrings.style = AsteriskSpace
+maxColumn = 24
+===
+object a {
+  /** 1. foo
+    * 1. bar
+   */
+}
+>>>
+object a {
+
+  /** 1. foo
+   *    1. bar
+   */
+}
+<<< #1887 8 Asterisk: punctuation after link/code
+docstrings.wrap = yes
+docstrings.style = Asterisk
+===
+object a {
+  /** [[ref]]!.. {{{foo}}}??? */
+}
+>>>
+Idempotency violated
+object a {
+
+  /**
+   *  [[ref]]!.. {{{foo}}}???
+   */
+}
+<<< #1887 8 SpaceAsterisk: punctuation after link/code
+docstrings.wrap = yes
+docstrings.style = SpaceAsterisk
+===
+object a {
+  /** [[ref]]!.. {{{foo}}}??? */
+}
+>>>
+object a {
+
+  /** [[ref]]!.. {{{foo}}}???
+    */
+}
+<<< #1887 8 AsteriskSpace: punctuation after link/code
+docstrings.wrap = yes
+docstrings.style = AsteriskSpace
+===
+object a {
+  /** [[ref]]!.. {{{foo}}}??? */
+}
+>>>
+object a {
+
+  /** [[ref]]!.. {{{foo}}}???
    */
 }
 <<< keep inner asterisks, Asterisk

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -234,8 +234,8 @@ multi
  * }}}
  * {{{
  * multi
- *  line
- *    code
+ *   line
+ *     code
  * }}}
  * @tparam t
  *   type, @see [[d]]
@@ -282,8 +282,8 @@ multi
   * }}}
   * {{{
   * multi
-  *  line
-  *    code
+  *   line
+  *     code
   * }}}
   * @tparam t
   *   type, @see [[d]]

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -303,10 +303,12 @@ maxColumn = 30
 {{{
 multi
   line
+
     code
 }}}
 *  {{{
 *  multi
+
 *    line
 *      code
 *  }}}
@@ -326,10 +328,12 @@ multi
  *  {{{
  *  multi
  *  line
+ *
  *  code
  *  }}}
  *  {{{
  *  multi
+ *
  *    line
  *      code
  *  }}}
@@ -809,12 +813,11 @@ object a {
    */
 }
 >>>
-Idempotency violated
 object a {
 
   /**
    *   1. foo
-   *      1. bar
+   *   1. bar
    */
 }
 <<< #1887 7 SpaceAsterisk: list only
@@ -830,7 +833,7 @@ object a {
 >>>
 object a {
 
-  /** 1. foo
+  /**   1. foo
     *   1. bar
     */
 }
@@ -847,7 +850,8 @@ object a {
 >>>
 object a {
 
-  /** 1. foo
+  /**
+   *    1. foo
    *    1. bar
    */
 }
@@ -859,11 +863,10 @@ object a {
   /** [[ref]]!.. {{{foo}}}??? */
 }
 >>>
-Idempotency violated
 object a {
 
   /**
-   *  [[ref]]!.. {{{foo}}}???
+   * [[ref]]!.. {{{foo}}}???
    */
 }
 <<< #1887 8 SpaceAsterisk: punctuation after link/code


### PR DESCRIPTION
Upgrade to scalameta 4.3.15 to get the updated scaladoc parser.