### PR TITLE
ScalafmtRunner: respect filters with custom files

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -105,6 +105,11 @@ object CliArgParser {
         .text(
           "file or directory, when missing all *.scala files are formatted."
         )
+      opt[Unit]("respect-project-filters")
+        .action((_, c) => c.copy(respectProjectFilters = true))
+        .text(
+          "use project filters even when specific files to format are provided"
+        )
       opt[String]('c', "config")
         .action(readConfigFromFile)
         .text("a file path to .scalafmt.conf.")

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -112,6 +112,7 @@ case class CliOptions(
     range: Set[Range] = Set.empty[Range],
     customFiles: Seq[AbsoluteFile] = Nil,
     customExcludes: Seq[String] = Nil,
+    respectProjectFilters: Boolean = false,
     git: Option[Boolean] = None,
     nonInteractive: Boolean = false,
     mode: Option[FileFetchMode] = None,

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
@@ -79,10 +79,13 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
 
   private final class MyInstanceSession(opts: CliOptions, instance: Scalafmt)
       extends ScalafmtSession {
-    private val customFiles = opts.customFiles.map(_.jfile.toPath)
+    private val customFiles =
+      if (opts.respectProjectFilters) Seq.empty
+      else opts.customFiles.filter(_.jfile.isFile).map(_.jfile.toPath)
     override def format(file: Path, code: String): String = {
       // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
       // formatted regardless of what it is or where it is.
+      // NB: Unless respectProjectFilters is also specified.
       val formatter =
         if (customFiles.contains(file)) instance
         else instance.withRespectProjectFilters(true)

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -57,6 +57,8 @@ trait ScalafmtRunner {
           case d if d.jfile.isDirectory => fetchFiles(d).filter(canFormat)
           // DESNOTE(2017-05-19, pjrt): A plain, fully passed file will (try to) be
           // formatted regardless of what it is or where it is.
+          // NB: Unless respectProjectFilters is also specified.
+          case f if options.respectProjectFilters && !canFormat(f) => Seq.empty
           case f => Seq(f)
         }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -494,7 +494,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
     }
 
     test(
-      s"includeFilters are respected? for full paths but NOT test for passed directories: $label"
+      s"includeFilters are respected for full paths but NOT test for passed directories: $label"
     ) {
       val root =
         string2dir(
@@ -515,6 +515,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val full2 = inner3 / "file2.scalahala"
 
       val opts = Seq(
+        "--respect-project-filters",
         s"""--config-str {version="$version"}"""
       ) ++ Seq(inner1, inner2, full1, full2)
       runWith(root, opts.mkString(" "))
@@ -522,7 +523,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
       assertNoDiff(inner1 / "file1.scala", formatted)
       assertNoDiff(inner2 / "file2.scalahala", unformatted)
       assertNoDiff(full1, formatted)
-      assertNoDiff(full2, formatted)
+      assertNoDiff(full2, unformatted)
     }
 
     test(s"--config accepts absolute paths: $label") {

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -467,25 +467,62 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val root =
         string2dir(
           s"""
-            |/inner/file1.scala
+            |/inner1/file1.scala
             |$unformatted
             |/inner2/file2.scalahala
             |$unformatted
-            |/inner2/file3.scalahala
+            |/inner3/file1.scala
+            |$unformatted
+            |/inner3/file2.scalahala
             |$unformatted""".stripMargin
         )
-      val inner1 = root / "inner"
+      val inner1 = root / "inner1"
       val inner2 = root / "inner2"
-      val full = inner2 / "file3.scalahala"
+      val inner3 = root / "inner3"
+      val full1 = inner3 / "file1.scala"
+      val full2 = inner3 / "file2.scalahala"
 
-      runWith(
-        root,
-        s"""--config-str {version="$version"} $inner1 $inner2 $full"""
-      )
+      val opts = Seq(
+        s"""--config-str {version="$version"}"""
+      ) ++ Seq(inner1, inner2, full1, full2)
+      runWith(root, opts.mkString(" "))
 
       assertNoDiff(inner1 / "file1.scala", formatted)
       assertNoDiff(inner2 / "file2.scalahala", unformatted)
-      assertNoDiff(full, formatted)
+      assertNoDiff(full1, formatted)
+      assertNoDiff(full2, formatted)
+    }
+
+    test(
+      s"includeFilters are respected? for full paths but NOT test for passed directories: $label"
+    ) {
+      val root =
+        string2dir(
+          s"""
+            |/inner1/file1.scala
+            |$unformatted
+            |/inner2/file2.scalahala
+            |$unformatted
+            |/inner3/file1.scala
+            |$unformatted
+            |/inner3/file2.scalahala
+            |$unformatted""".stripMargin
+        )
+      val inner1 = root / "inner1"
+      val inner2 = root / "inner2"
+      val inner3 = root / "inner3"
+      val full1 = inner3 / "file1.scala"
+      val full2 = inner3 / "file2.scalahala"
+
+      val opts = Seq(
+        s"""--config-str {version="$version"}"""
+      ) ++ Seq(inner1, inner2, full1, full2)
+      runWith(root, opts.mkString(" "))
+
+      assertNoDiff(inner1 / "file1.scala", formatted)
+      assertNoDiff(inner2 / "file2.scalahala", unformatted)
+      assertNoDiff(full1, formatted)
+      assertNoDiff(full2, formatted)
     }
 
     test(s"--config accepts absolute paths: $label") {


### PR DESCRIPTION
Previously, if specific files were provided on the command line, they would be formatted regardless of any project filters.

Here we add an option to continue applying project filters in that case.

Fixes #1964.