### PR TITLE
Router: allow relative formatting of spliced XML

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2008,6 +2008,48 @@ literals.float=Lower
 10e-1f
 ```
 
+## XML
+
+Controls formatting of Scala embedded within XML.
+
+### `xmlLiterals.assumeFormatted`
+
+> Since v2.6.0.
+
+If set, formats embedded Scala relative to containing XML, making the assumption
+that XML itself is properly formatted. Otherwise, formatting is relative to the
+outer Scala code which contains the XML literals.
+
+```scala mdoc:defaults
+xmlLiterals.assumeFormatted
+```
+
+```scala mdoc:scalafmt
+maxColumn = 40
+xmlLiterals.assumeFormatted = true
+---
+object Example2 {
+  def apply() = {
+      <foo>
+        <bar>{ (1 + 2 + 3).toString("some long format") }</bar>
+      </foo>
+  }
+}
+```
+
+```scala mdoc:scalafmt
+maxColumn = 40
+xmlLiterals.assumeFormatted = false
+---
+object Example2 {
+  def apply() = {
+      <foo>
+        <bar>{ (1 + 2 + 3).toString("some long format") }</bar>
+      </foo>
+  }
+}
+```
+
 ## Binpacking
 
 ### `binPack.literalArgumentLists`

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -157,6 +157,7 @@ case class ScalafmtConfig(
     encoding: Codec = "UTF-8",
     project: ProjectFiles = ProjectFiles(),
     fileOverride: Conf.Obj = Conf.Obj.empty,
+    xmlLiterals: XmlLiterals = XmlLiterals(),
     edition: Edition = Edition.Latest
 ) {
   val allErrors = new mutable.ArrayBuffer[String]
@@ -199,6 +200,7 @@ case class ScalafmtConfig(
   private implicit def rewriteReader = rewrite.reader
   private implicit def spacesReader = spaces.reader
   private implicit def literalsReader = literals.reader
+  private implicit def xmlLiteralsDecoder = xmlLiterals.decoder
   private implicit def continuationIndentReader = continuationIndent.reader
   private implicit def binpackReader = binPack.decoder
   private implicit def newlinesReader = newlines.reader

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/XmlLiterals.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/XmlLiterals.scala
@@ -1,0 +1,15 @@
+package org.scalafmt.config
+
+import metaconfig._
+
+case class XmlLiterals(
+    assumeFormatted: Boolean = false
+) {
+  implicit val decoder: ConfDecoder[XmlLiterals] =
+    generic.deriveDecoder(this).noTypos
+}
+
+object XmlLiterals {
+  implicit val surface: generic.Surface[XmlLiterals] = generic.deriveSurface
+  implicit lazy val encoder: ConfEncoder[XmlLiterals] = generic.deriveEncoder
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
@@ -15,7 +15,7 @@ case class ModExt(
 
   def withIndent(length: => Length, expire: => Token, when: ExpiresOn): ModExt =
     length match {
-      case Length.Num(0) => this
+      case Length.Num(0, _) => this
       case x => withIndentImpl(Indent(x, expire, when))
     }
 
@@ -39,7 +39,7 @@ case class ModExt(
     indents.foldLeft(this)(_ withIndent _)
 
   private def withIndentImpl(indent: Indent): ModExt =
-    copy(indents = indent +: indents)
+    copy(indents = indents :+ indent)
 
   def switch(switchObject: AnyRef): ModExt = {
     val newIndents = indents.map(_.switch(switchObject))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -94,6 +94,7 @@ class Router(formatOps: FormatOps) {
               .withIndent(StateColumn, end, After)
               .withIndent(-1, end, After)
         )
+      // Interpolation
       case FormatToken(
             _: T.Interpolation.Id | _: T.Interpolation.Part |
             _: T.Interpolation.Start | _: T.Interpolation.SpliceStart,
@@ -1771,13 +1772,9 @@ class Router(formatOps: FormatOps) {
           )
         }
       // Interpolation
-      case FormatToken(_, T.Interpolation.Id(_) | T.Xml.Start(), _) =>
+      case FormatToken(_, _: T.Interpolation.Id, _) =>
         Seq(
           Split(Space, 0)
-        )
-      case FormatToken(T.Interpolation.Id(_) | T.Xml.Start(), _, _) =>
-        Seq(
-          Split(NoSplit, 0)
         )
       // Throw exception
       case FormatToken(T.KwThrow(), _, _) =>
@@ -1801,7 +1798,16 @@ class Router(formatOps: FormatOps) {
         Seq(
           Split(NoSplit, 0)
         )
+
       // Xml
+      case FormatToken(_, _: T.Xml.Start, _) =>
+        Seq(
+          Split(Space, 0)
+        )
+      case FormatToken(open: T.Xml.Start, _, _) =>
+        Seq(
+          Split(NoSplit, 0)
+        )
       case FormatToken(T.Xml.Part(_), _, _) =>
         Seq(
           Split(NoSplit, 0)
@@ -1810,6 +1816,7 @@ class Router(formatOps: FormatOps) {
         Seq(
           Split(NoSplit, 0)
         )
+
       // Fallback
       case FormatToken(_, T.Dot(), _) =>
         Seq(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -254,4 +254,14 @@ object TokenOps {
         .filter(_.head.tokens.head.start <= math.max(token.end, other.end))
     }
 
+  def getXmlLastLineIndent(tok: Xml.Part): Option[Int] = {
+    val part = tok.value
+    val afterLastNL = part.lastIndexOf('\n') + 1
+    if (afterLastNL <= 0) None
+    else {
+      val nonWs = part.indexWhere(!_.isWhitespace, afterLastNL)
+      Some((if (nonWs < 0) part.length else nonWs) - afterLastNL)
+    }
+  }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -168,10 +168,10 @@ object TreeOps {
     var stack = List.empty[Token]
     tokens.foreach {
       case open @ (LeftBrace() | LeftBracket() | LeftParen() |
-          Interpolation.Start()) =>
+          Interpolation.Start() | Xml.Start() | Xml.SpliceStart()) =>
         stack = open :: stack
       case close @ (RightBrace() | RightBracket() | RightParen() |
-          Interpolation.End()) =>
+          Interpolation.End() | Xml.End() | Xml.SpliceEnd()) =>
         val open = stack.head
         assertValidParens(open, close)
         ret += hash(open) -> close
@@ -186,6 +186,8 @@ object TreeOps {
   def assertValidParens(open: Token, close: Token): Unit = {
     (open, close) match {
       case (Interpolation.Start(), Interpolation.End()) =>
+      case (Xml.Start(), Xml.End()) =>
+      case (Xml.SpliceStart(), Xml.SpliceEnd()) =>
       case (LeftBrace(), RightBrace()) =>
       case (LeftBracket(), RightBracket()) =>
       case (LeftParen(), RightParen()) =>

--- a/scalafmt-tests/src/test/resources/unit/Xml.stat
+++ b/scalafmt-tests/src/test/resources/unit/Xml.stat
@@ -44,10 +44,10 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+      <foo>
         <bar>{
-      1 + 2 + 3
-    }</bar>
+          1 + 2 + 3
+        }</bar>
       </foo>
   }
 }
@@ -65,9 +65,9 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>     <bar>{
-      1 + 2 + 3
-    }</bar>
+           <foo>     <bar>{
+             1 + 2 + 3
+           }</bar>
            </foo>
   }
 }
@@ -88,11 +88,11 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+      <foo>
         <bar>
           {
-      1 + 2 + 3
-    }
+            1 + 2 + 3
+          }
         </bar>
       </foo>
   }
@@ -113,11 +113,11 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+        <foo>
            <bar>
           {
-      1 + 2 + 3
-    }
+            1 + 2 + 3
+          }
         </bar>       </foo>
   }
 }
@@ -138,11 +138,11 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+      <foo>
         <bar>
         {
-      1 + 2 + 3
-    }
+          1 + 2 + 3
+        }
         </bar>
       </foo>
   }
@@ -164,11 +164,11 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+         <foo>
     <bar>
         {
-      1 + 2 + 3
-    }
+          1 + 2 + 3
+        }
         </bar>
          </foo>
   }
@@ -188,10 +188,10 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+      <foo>
         <bar baz={
-      1 + 2 + 3
-    }></bar>
+          1 + 2 + 3
+        }></bar>
       </foo>
   }
 }
@@ -210,10 +210,10 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+             <foo>
            <bar baz={
-      1 + 2 + 3
-    }></bar>
+             1 + 2 + 3
+           }></bar>
              </foo>
   }
 }
@@ -230,11 +230,11 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+      <foo>
         <bar>{
-      (1 + 2 + 3)
-        .toString("some long format")
-    }</bar>
+          (1 + 2 + 3).toString(
+              "some long format")
+        }</bar>
       </foo>
   }
 }
@@ -251,11 +251,11 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+         <foo>
           <bar>{
-      (1 + 2 + 3)
-        .toString("some long format")
-    }</bar>
+            (1 + 2 + 3).toString(
+                "some long format")
+          }</bar>
          </foo>
   }
 }
@@ -272,11 +272,11 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+      <foo>
         <bar baz={
-      (1 + 2 + 3)
-        .toString("some long format")
-    }></bar>
+          (1 + 2 + 3).toString(
+              "some long format")
+        }></bar>
       </foo>
   }
 }
@@ -293,11 +293,11 @@ object Example2 {
 >>>
 object Example2 {
   def apply() = {
-    <foo>
+   <foo>
       <bar baz={
-      (1 + 2 + 3)
-        .toString("some long format")
-    }></bar>
+        (1 + 2 + 3)
+          .toString("some long format")
+      }></bar>
    </foo>
   }
 }

--- a/scalafmt-tests/src/test/resources/unit/Xml.stat
+++ b/scalafmt-tests/src/test/resources/unit/Xml.stat
@@ -29,3 +29,275 @@
 x match { case <lift>{ _* }</lift> => }
 >>>
 x match { case <lift>{_*}</lift> => }
+<<< #1882 1
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+        <bar>{
+      1 + 2 + 3
+      }</bar>
+      </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+        <bar>{
+      1 + 2 + 3
+    }</bar>
+      </foo>
+  }
+}
+<<< #1882 1 unformatted
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>     <bar>{
+      1 + 2 + 3
+      }</bar>
+           </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>     <bar>{
+      1 + 2 + 3
+    }</bar>
+           </foo>
+  }
+}
+<<< #1882 2
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+        <bar>
+          {
+        1 + 2 + 3
+        }
+        </bar>
+      </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+        <bar>
+          {
+      1 + 2 + 3
+    }
+        </bar>
+      </foo>
+  }
+}
+<<< #1882 2 unformatted
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+           <bar>
+          {
+        1 + 2 + 3
+        }
+        </bar>       </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+           <bar>
+          {
+      1 + 2 + 3
+    }
+        </bar>       </foo>
+  }
+}
+<<< #1882 3
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+        <bar>
+        {
+      1 + 2 + 3
+      }
+        </bar>
+      </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+        <bar>
+        {
+      1 + 2 + 3
+    }
+        </bar>
+      </foo>
+  }
+}
+<<< #1882 3 unformatted
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+    <bar>
+        {
+      1 + 2 + 3
+      }
+        </bar>
+         </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+    <bar>
+        {
+      1 + 2 + 3
+    }
+        </bar>
+         </foo>
+  }
+}
+<<< #1882 4
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+        <bar baz={
+      1 + 2 + 3
+      }></bar>
+      </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+        <bar baz={
+      1 + 2 + 3
+    }></bar>
+      </foo>
+  }
+}
+<<< #1882 4 unformatted
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+           <bar baz={
+      1 + 2 + 3
+      }></bar>
+             </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+           <bar baz={
+      1 + 2 + 3
+    }></bar>
+             </foo>
+  }
+}
+<<< #1882 5
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+        <bar>{ (1 + 2 + 3).toString("some long format") }</bar>
+      </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+        <bar>{
+      (1 + 2 + 3)
+        .toString("some long format")
+    }</bar>
+      </foo>
+  }
+}
+<<< #1882 5 unformatted
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+          <bar>{ (1 + 2 + 3).toString("some long format") }</bar>
+         </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+          <bar>{
+      (1 + 2 + 3)
+        .toString("some long format")
+    }</bar>
+         </foo>
+  }
+}
+<<< #1882 6
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+      <foo>
+        <bar baz={ (1 + 2 + 3).toString("some long format") }></bar>
+      </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+        <bar baz={
+      (1 + 2 + 3)
+        .toString("some long format")
+    }></bar>
+      </foo>
+  }
+}
+<<< #1882 6 unformatted
+xmlLiterals.assumeFormatted = true
+===
+object Example2 {
+  def apply() = {
+        <foo>
+      <bar baz={ (1 + 2 + 3).toString("some long format") }></bar>
+   </foo>
+  }
+}
+>>>
+object Example2 {
+  def apply() = {
+    <foo>
+      <bar baz={
+      (1 + 2 + 3)
+        .toString("some long format")
+    }></bar>
+   </foo>
+  }
+}


### PR DESCRIPTION
It involves finding the indentation used within the xml literal and then applying it to the scala code within. We will use the ability to ignore previous indents as this indentation is not relative but absolute.

Fixes #1882.