### PR TITLE
Policy: preserve original policies and ranges for control

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -741,11 +741,11 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       .onlyIf(singleLinePolicy.isDefined && beforeLhs)
       .withIndent(nlIndentLength, singleLineExpire, ExpiresOn.After)
       .withSingleLine(singleLineExpire)
-      .andThenPolicyOpt(singleLinePolicy)
+      .andPolicyOpt(singleLinePolicy)
     val spaceSingleLine = Split(Space, 0)
       .onlyIf(newStmtMod.isEmpty)
       .withSingleLine(singleLineExpire)
-      .andThenPolicyOpt(singleLinePolicy)
+      .andPolicyOpt(singleLinePolicy)
     val singleLineSplits = Seq(
       spaceSingleLine.onlyFor(SplitTag.InfixChainNoNL),
       spaceSingleLine.onlyIf(singleLinePolicy.isDefined),
@@ -774,14 +774,14 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       }
 
       val nlSplit = Split(nlMod, 0)
-        .andThenPolicyOpt(breakAfterClose)
+        .andPolicyOpt(breakAfterClose)
         .withIndent(nlIndent)
         .withPolicy(nlPolicy)
       val singleLineSplit = Split(Space, 0)
         .notIf(noSingleLine)
         .withSingleLine(endOfNextOp.getOrElse(close))
-        .andThenPolicyOpt(breakAfterClose)
-        .andThenPolicy(getSingleLineInfixPolicy(close))
+        .andPolicyOpt(breakAfterClose)
+        .andPolicy(getSingleLineInfixPolicy(close))
       Seq(singleLineSplit, nlSplit)
     }
 
@@ -1080,7 +1080,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
           if (!s.isNL) s
           else {
             replaced = true
-            s.orElsePolicy(onBreakPolicy)
+            s.orPolicy(onBreakPolicy)
           }
         val splits = d.splits.map(decisionPf)
         if (replaced) Some(splits) else None
@@ -1202,7 +1202,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
         // a class with type AND value params. Otherwise it is a class with
         // just type params.
         findFirst(afterTypes, lastParen)(t => t.left.is[T.LeftParen])
-          .fold(base)(t => base.orElse(OneArgOneLineSplit(t)))
+          .fold(base)(t => base | OneArgOneLineSplit(t))
       } else base
     }
 
@@ -1259,7 +1259,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
 
     // Our policy is a combination of OneArgLineSplit and a custom splitter
     // for parameter groups.
-    val policy = oneLinePerArg.orElse(paramGroupSplitter)
+    val policy = oneLinePerArg | paramGroupSplitter
 
     val firstIndent =
       if (r.is[T.RightParen]) // An empty param group

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -55,6 +55,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     else baseStyle.copy(newlines = checkedNewlines)
   }
   val runner = initStyle.runner
+  import PolicyOps._
   import TokenOps._
   import TreeOps._
   implicit val dialect = initStyle.runner.dialect

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1084,7 +1084,13 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     if (onBreakPolicy.isEmpty) Policy.NoPolicy
     else {
       val f: Policy.Pf = { case OnBreakDecision(d) => d }
-      onBreakPolicy.copy(f = f, expire = tok.end)
+      new Policy.Clause(f, tok.end) {
+        override def filter(pred: Policy.Clause => Boolean): Policy = {
+          val filteredOnBreak = onBreakPolicy.filter(pred)
+          if (filteredOnBreak.isEmpty) Policy.NoPolicy
+          else delayedBreakPolicy(tok, leftCheck)(filteredOnBreak)
+        }
+      }
     }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1062,7 +1062,8 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
   }
 
   def delayedBreakPolicy(
-      leftCheck: Option[Token => Boolean]
+      tok: Token,
+      leftCheck: Option[Token => Boolean] = None
   )(onBreakPolicy: Policy)(implicit line: sourcecode.Line): Policy = {
     object OnBreakDecision {
       def unapply(d: Decision): Option[Seq[Split]] =
@@ -1080,8 +1081,11 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
         if (replaced) Some(splits) else None
       }
     }
-    if (onBreakPolicy.isEmpty) onBreakPolicy
-    else onBreakPolicy.copy(f = { case OnBreakDecision(d) => d })
+    if (onBreakPolicy.isEmpty) Policy.NoPolicy
+    else {
+      val f: Policy.Pf = { case OnBreakDecision(d) => d }
+      onBreakPolicy.copy(f = f, expire = tok.end)
+    }
   }
 
   def decideNewlinesOnlyBeforeClose(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -426,26 +426,6 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
       s.map(_.withIndent(indent, close, ExpiresOn.After))
   }
 
-  def penalizeAllNewlines(
-      expire: Token,
-      penalty: Int,
-      penalizeLambdas: Boolean = true,
-      ignore: FormatToken => Boolean = _ => false,
-      penaliseNewlinesInsideTokens: Boolean = false
-  )(implicit line: sourcecode.Line): Policy =
-    Policy(expire) {
-      case Decision(tok, s)
-          if tok.right.end < expire.end &&
-            (penalizeLambdas || !tok.left.is[T.RightArrow]) && !ignore(tok) =>
-        s.map {
-          case split
-              if split.isNL ||
-                (penaliseNewlinesInsideTokens && tok.leftHasNewline) =>
-            split.withPenalty(penalty)
-          case x => x
-        }
-    }
-
   def penalizeNewlineByNesting(from: Token, to: Token)(implicit
       line: sourcecode.Line
   ): Policy = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -26,13 +26,13 @@ case class Policy(
         expire = math.max(minExpire, expire)
       )
 
-  def orElse(other: Policy): Policy =
+  def |(other: Policy): Policy =
     orElse(other.f, other.expire)
 
-  def orElse(other: Option[Policy]): Policy =
-    other.fold(this)(orElse)
+  def |(other: Option[Policy]): Policy =
+    other.fold(this)(|)
 
-  def andThen(other: Policy): Policy =
+  def &(other: Policy): Policy =
     if (isEmpty) other else andThen(other.f, other.expire)
 
   /** Similar to PartialFunction.andThen, except applies second pf even if the

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -6,11 +6,11 @@ import org.scalafmt.util.LoggerOps
 class PolicySummary(val policies: Vector[Policy]) {
   import LoggerOps._
 
-  @inline def noDequeue = policies.exists(_.noDequeue)
+  @inline def noDequeue = policies.exists(_.exists(_.noDequeue))
 
   def combine(other: Policy, position: Int): PolicySummary = {
     // TODO(olafur) filter policies by expiration date
-    val activePolicies = policies.filter(_.expire > position)
+    val activePolicies = policies.flatMap(_.unexpiredOpt(position))
     val newPolicies =
       if (other == NoPolicy) activePolicies
       else other +: activePolicies

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -135,7 +135,7 @@ class Router(formatOps: FormatOps) {
 
         val newlinePolicy = style.importSelectors match {
           case ImportSelectors.noBinPack =>
-            newlineBeforeClosingCurly & OneArgOneLineSplit(formatToken)
+            newlineBeforeClosingCurly & splitOneArgOneLine(close, leftOwner)
           case ImportSelectors.binPack =>
             newlineBeforeClosingCurly
           case ImportSelectors.singleLine =>
@@ -804,8 +804,7 @@ class Router(formatOps: FormatOps) {
 
         val preferNoSplit = singleArgument &&
           style.newlines.sourceIs(Newlines.keep) && tok.noBreak
-        val oneArgOneLine =
-          newlinePolicy & OneArgOneLineSplit(formatToken)
+        val oneArgOneLine = newlinePolicy & splitOneArgOneLine(close, leftOwner)
         val extraOneArgPerLineIndent =
           if (multipleArgs && style.poorMansTrailingCommasInConfigStyle)
             Indent(Num(2), right, After)
@@ -974,7 +973,7 @@ class Router(formatOps: FormatOps) {
         val nlPolicy =
           if (onlyConfigStyle) {
             if (styleMap.forcedBinPack(leftOwner)) newlineBeforeClose
-            else OneArgOneLineSplit(formatToken) | newlineBeforeClose
+            else splitOneArgOneLine(close, leftOwner) | newlineBeforeClose
           } else if (
             style.newlines.sourceIgnored &&
             style.danglingParentheses.callSite

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -61,6 +61,7 @@ class Router(formatOps: FormatOps) {
 
   import Constants._
   import LoggerOps._
+  import PolicyOps._
   import TokenOps._
   import TreeOps._
   import formatOps._

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -575,8 +575,7 @@ class Router(formatOps: FormatOps) {
             s.filter(x => x.isNL && (x.activeTag ne SplitTag.OnelineWithChain))
         }
         val policyEnd = defnBeforeTemplate(leftOwner).fold(r)(_.tokens.last)
-        val policy = delayedBreakPolicy(None)(forceNewlineBeforeExtends)
-          .copy(expire = policyEnd.end)
+        val policy = delayedBreakPolicy(policyEnd)(forceNewlineBeforeExtends)
         Seq(Split(Space, 0).withPolicy(policy))
       // DefDef
       case tok @ FormatToken(T.KwDef(), name @ T.Ident(_), _) =>
@@ -618,7 +617,7 @@ class Router(formatOps: FormatOps) {
           if (lambdaIsABlock) None
           else
             newlinePolicy.map(
-              delayedBreakPolicy(lambdaLeft.map(open => _.end < open.end))
+              delayedBreakPolicy(close, lambdaLeft.map(x => _.end < x.end))
             )
         }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -3,6 +3,7 @@ package org.scalafmt.internal
 import scala.meta.tokens.Token
 
 import org.scalafmt.internal.Policy.NoPolicy
+import org.scalafmt.util.PolicyOps
 import org.scalafmt.util.TokenOps
 
 case class OptimalToken(token: Token, killOnFail: Boolean = false) {
@@ -42,6 +43,7 @@ case class Split(
     policy: Policy = NoPolicy,
     optimalAt: Option[OptimalToken] = None
 )(implicit val line: sourcecode.Line) {
+  import PolicyOps._
   import TokenOps._
 
   def adapt(formatToken: FormatToken): Split =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -1,0 +1,38 @@
+package org.scalafmt.util
+
+import scala.meta.tokens.{Token => T}
+
+import org.scalafmt.internal.Decision
+import org.scalafmt.internal.FormatToken
+import org.scalafmt.internal.Policy
+
+object PolicyOps {
+
+  class PenalizeAllNewlines private[PolicyOps] (f: Policy.Pf, endPos: Int)(
+      implicit line: sourcecode.Line
+  ) extends Policy.Clause(f, endPos)
+
+  def penalizeAllNewlines(
+      expire: T,
+      penalty: Int,
+      penalizeLambdas: Boolean = true,
+      ignore: FormatToken => Boolean = _ => false,
+      penaliseNewlinesInsideTokens: Boolean = false
+  )(implicit line: sourcecode.Line): PenalizeAllNewlines = {
+    val endPos = expire.end
+    val f: Policy.Pf = {
+      case Decision(tok, s)
+          if tok.right.end < endPos &&
+            (penalizeLambdas || !tok.left.is[T.RightArrow]) && !ignore(tok) =>
+        s.map {
+          case split
+              if split.isNL ||
+                (penaliseNewlinesInsideTokens && tok.leftHasNewline) =>
+            split.withPenalty(penalty)
+          case x => x
+        }
+    }
+    new PenalizeAllNewlines(f, endPos)
+  }
+
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -8,11 +8,9 @@ import scala.meta.tokens.Tokens
 
 import org.scalafmt.config.Newlines
 import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.internal.Decision
 import org.scalafmt.internal.FormatToken
 import org.scalafmt.internal.Modification
 import org.scalafmt.internal.NewlineT
-import org.scalafmt.internal.Policy
 import org.scalafmt.internal.Space
 
 /**
@@ -103,28 +101,6 @@ object TokenOps {
       case Dot() if includeNoParens => true
       case _ => false
     }
-
-  /**
-    * Forces allssplits up to including expire to be on a single line.
-    */
-  def SingleLineBlock(
-      expire: Token,
-      exclude: Set[Range] = Set.empty,
-      disallowSingleLineComments: Boolean = true,
-      penaliseNewlinesInsideTokens: Boolean = false
-  )(implicit line: sourcecode.Line): Policy = {
-    Policy(expire.end, true) {
-      case d @ Decision(tok, _)
-          if !tok.right.is[EOF] && tok.right.end <= expire.end &&
-            exclude.forall(!_.contains(tok.left.start)) &&
-            (disallowSingleLineComments || !isSingleLineComment(tok.left)) =>
-        if (penaliseNewlinesInsideTokens && tok.leftHasNewline) {
-          Seq.empty
-        } else {
-          d.noNewlines
-        }
-    }
-  }
 
   @inline
   def isSingleLineComment(c: String): Boolean = c.startsWith("//")

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -113,21 +113,17 @@ object TokenOps {
       disallowSingleLineComments: Boolean = true,
       penaliseNewlinesInsideTokens: Boolean = false
   )(implicit line: sourcecode.Line): Policy = {
-    Policy(
-      {
-        case d @ Decision(tok, _)
-            if !tok.right.is[EOF] && tok.right.end <= expire.end &&
-              exclude.forall(!_.contains(tok.left.start)) &&
-              (disallowSingleLineComments || !isSingleLineComment(tok.left)) =>
-          if (penaliseNewlinesInsideTokens && tok.leftHasNewline) {
-            Seq.empty
-          } else {
-            d.noNewlines
-          }
-      },
-      expire.end,
-      noDequeue = true
-    )
+    Policy(expire.end, true) {
+      case d @ Decision(tok, _)
+          if !tok.right.is[EOF] && tok.right.end <= expire.end &&
+            exclude.forall(!_.contains(tok.left.start)) &&
+            (disallowSingleLineComments || !isSingleLineComment(tok.left)) =>
+        if (penaliseNewlinesInsideTokens && tok.leftHasNewline) {
+          Seq.empty
+        } else {
+          d.noNewlines
+        }
+    }
   }
 
   @inline

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -53,7 +53,7 @@ object a {
 object a {
   final class Dummy[F[+_, +_]: BIOMonad: BIOPrimitives: Clock2](
     log: LogBIO[F]
-  ) extends DIResource.LiftF(F
-          .mkRef(Map.empty[Key, Item])
-          .map(new Dummy.Impl(_)))
+  ) extends DIResource.LiftF(
+        F.mkRef(Map.empty[Key, Item]).map(new Dummy.Impl(_))
+      )
 }

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -39,3 +39,21 @@ object Test {
   }
 
 }
+<<< #2044
+verticalMultiline.excludeDanglingParens = []
+===
+object a {
+  final class Dummy[F[+_, +_]: BIOMonad: BIOPrimitives: Clock2](
+    log: LogBIO[F]
+  ) extends DIResource.LiftF(
+    F.mkRef(Map.empty[Key, Item]).map(new Dummy.Impl(_))
+  )
+}
+>>>
+object a {
+  final class Dummy[F[+_, +_]: BIOMonad: BIOPrimitives: Clock2](
+    log: LogBIO[F]
+  ) extends DIResource.LiftF(F
+          .mkRef(Map.empty[Key, Item])
+          .map(new Dummy.Impl(_)))
+}


### PR DESCRIPTION
Rather than combining policy partial functions and unnecessarily extending token ranges for combined policies, keep each policy clause unchanged and introduce policy containers. This will allow removing inner policies when they reach the end of their range, or based on some other criteria (such as type of policy).

Fixes #2044. Helps with #2042.