### PR TITLE
FormatOps: method to check classic select chain

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2338,6 +2338,34 @@ foo.bar(_ + 1)
 foo.bar(_ + 1).baz(_ > 2).qux
 ```
 
+### `optIn.encloseClassicChains`
+
+Controls what happens if a chain enclosed in parentheses is followed by
+additional selects. Those additional selects will be considered part of
+the enclosed chain if and only if this flag is false.
+
+> Since 2.6.2.
+
+```scala mdoc:defaults
+optIn.encloseClassicChains
+```
+
+```scala mdoc:scalafmt
+optIn.encloseClassicChains = true
+maxColumn = 30
+---
+(foo.map(_ + 1).map(_ + 1))
+  .filter(_ > 2)
+```
+
+```scala mdoc:scalafmt
+optIn.encloseClassicChains = false
+maxColumn = 30
+---
+(foo.map(_ + 1).map(_ + 1))
+  .filter(_ > 2)
+```
+
 ## Miscellaneous
 
 ### `optIn.forceBlankLineBeforeDocstring`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2225,9 +2225,17 @@ object A {
 }
 ```
 
-## Miscellaneous
+## Classic select chains
+
+The parameters below control formatting of select chains when `newlines.source = classic`,
+and specifically which select expressions are included in a chain.
+
+Generally, a chain can either be formatted on one line up to the last select, or will
+have a break on the first select.
 
 ### `includeCurlyBraceInSelectChains`
+
+Controls if select followed by curly braces can _start_ a chain.
 
 ```scala mdoc:defaults
 includeCurlyBraceInSelectChains
@@ -2254,6 +2262,8 @@ List(1)
 
 ### `includeNoParensInSelectChains`
 
+Controls if select _not_ followed by an apply can _start_ a chain.
+
 ```scala mdoc:defaults
 includeNoParensInSelectChains
 ```
@@ -2274,6 +2284,9 @@ List(1).toIterator.buffered.map(_ + 2).filter(_ > 2)
 
 ### `optIn.breakChainOnFirstMethodDot`
 
+Keeps the break on the first select of the chain if the source contained one.
+Has no effect if there was no newline in the source.
+
 ```scala mdoc:defaults
 optIn.breakChainOnFirstMethodDot
 ```
@@ -2290,10 +2303,42 @@ foo
 ```scala mdoc:scalafmt
 optIn.breakChainOnFirstMethodDot = true
 ---
+// preserve break on first dot and break on subsequent dots
 foo
-  .map(_ + 1) // preserve existing newlines
-  .filter(_ > 2)
+  .map(_ + 1).filter(_ > 2)
 ```
+
+### `optIn.breaksInsideChains`
+
+If false, each subsequent select within the chain will behave exactly like the first,
+that is, either the entire chain will be formatted on one line, or will contain a break
+on every select.
+
+If true, preserves existence or lack of breaks on subsequent selects. If there's at
+least one break, that will force a break on the first select since the chain can't
+be formatted on one line.
+
+```scala mdoc:defaults
+optIn.breaksInsideChains
+```
+
+```scala mdoc:scalafmt
+optIn.breaksInsideChains = true
+---
+foo.bar(_ + 1)
+  .baz(_ > 2).qux
+foo.bar(_ + 1).baz(_ > 2).qux
+```
+
+```scala mdoc:scalafmt
+optIn.breaksInsideChains = false
+---
+foo.bar(_ + 1)
+  .baz(_ > 2).qux
+foo.bar(_ + 1).baz(_ > 2).qux
+```
+
+## Miscellaneous
 
 ### `optIn.forceBlankLineBeforeDocstring`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
@@ -45,6 +45,25 @@ import metaconfig.generic.Surface
   *     foo.map(_ + 1).filter( > 2)
   *   }}}
   *
+  * @param encloseClassicChains
+  *   NB: ignored unless newlines.source=classic.
+  *   Controls what happens if a chain enclosed in parentheses is followed by
+  *   additional selects. Those additional selects will be considered part of
+  *   the enclosed chain if and only if this flag is false.
+  *   {{{
+  *     // original
+  *     (foo.map(_ + 1).map(_ + 1))
+  *       .filter(_ > 2)
+  *     // if true
+  *     (foo.map(_ + 1).map(_ + 1))
+  *       .filter(_ > 2)
+  *     // if false
+  *     (foo
+  *       .map(_ + 1)
+  *       .map(_ + 1))
+  *       .filter(_ > 2)
+  *   }}}
+  *
   * @param annotationNewlines
   *   - if newlines.source is missing or keep:
   *     - if true, will keep existing line breaks around annotations
@@ -85,6 +104,7 @@ case class OptIn(
     configStyleArguments: Boolean = true,
     breaksInsideChains: Boolean = false,
     breakChainOnFirstMethodDot: Boolean = true,
+    encloseClassicChains: Boolean = false,
     selfAnnotationNewline: Boolean = true,
     annotationNewlines: Boolean = true,
     // Candidate to become default false at some point.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -156,9 +156,7 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
         }
 
       ft.meta.leftOwner match {
-        case t: Term.Select
-            if startsOpenApply &&
-              !existsParentOfType[Import](ft.meta.leftOwner) =>
+        case t: Term.Select if startsOpenApply =>
           val chain = getSelectChain(t, Vector(t))
           if (openApply.is[T.LeftBrace] && isShortCurlyChain(chain)) None
           else Some(tok -> chain)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -37,7 +37,8 @@ case class NewlineT(
   override def toString = {
     val double = if (isDouble) "Double" else ""
     val indent = if (noIndent) "NoIndent" else ""
-    double + indent + "Newline"
+    val altStr = alt.fold("")(x => "|" + x.mod.toString)
+    double + indent + "Newline" + altStr
   }
   override val newlines: Int = if (isDouble) 2 else 1
   override val length: Int = 0

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1201,7 +1201,8 @@ class Router(formatOps: FormatOps) {
       case t @ FormatToken(left, _: T.Dot, _)
           if !style.newlines.sourceIs(Newlines.classic) &&
             rightOwner.is[Term.Select] =>
-        val (expireTree, nextSelect) = findLastApplyAndNextSelect(rightOwner)
+        val (expireTree, nextSelect) =
+          findLastApplyAndNextSelect(rightOwner, true)
         val prevSelect = findPrevSelect(rightOwner.asInstanceOf[Term.Select])
         val expire = lastToken(expireTree)
 
@@ -1249,8 +1250,7 @@ class Router(formatOps: FormatOps) {
 
         // trigger indent only on the first newline
         val indent = Indent(Num(2), expire, After)
-        val willBreak =
-          nextNonCommentSameLine(tokens(formatToken, 2)).right.is[T.Comment]
+        val willBreak = nextNonCommentSameLine(tokens(t, 2)).right.is[T.Comment]
         val splits = baseSplits.map { s =>
           if (willBreak || s.isNL) s.withIndent(indent)
           else s.andThenPolicyOpt(delayedBreakPolicy)
@@ -1273,7 +1273,10 @@ class Router(formatOps: FormatOps) {
           else optimalToken
 
         def getNewline(ft: FormatToken): NewlineT = {
-          val (_, nextSelect) = findLastApplyAndNextSelect(ft.meta.rightOwner)
+          val (_, nextSelect) = findLastApplyAndNextSelect(
+            ft.meta.rightOwner,
+            style.optIn.encloseClassicChains
+          )
           val endSelect = nextSelect.fold(optimalToken)(x => lastToken(x.qual))
           val nlAlt = ModExt(NoSplit).withIndent(-2, endSelect, After)
           NewlineT(alt = Some(nlAlt))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1190,7 +1190,7 @@ class Router(formatOps: FormatOps) {
         }(getInfixSplitsBeforeLhs(_, formatToken, Right(rhs)))
 
       case FormatToken(_, _: T.Dot, _)
-          if style.newlines.sourceIgnored &&
+          if !style.newlines.sourceIs(Newlines.keep) &&
             rightOwner.is[Term.Select] && findTreeWithParent(rightOwner) {
             case _: Type.Select | _: Importer | _: Pkg => Some(true)
             case _: Term.Select | SplitCallIntoParts(_, _) => None

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -440,21 +440,21 @@ object TreeOps {
       splitDefnIntoParts.lift(tree)
   }
 
-  def isChainApplyParent(parent: Tree, child: Tree): Boolean =
-    splitCallIntoParts.lift(parent).exists(_._1 == child)
-
   @tailrec
-  final def getSelectChain(
+  def getSelectChain(
       child: Tree,
+      lastApply: Tree,
       accum: Vector[Term.Select]
   ): Vector[Term.Select] = {
-    child.parent match {
-      case Some(parent: Term.Select) =>
-        getSelectChain(parent, accum :+ parent)
-      case Some(parent) if isChainApplyParent(parent, child) =>
-        getSelectChain(parent, accum)
-      case els => accum
-    }
+    if (child eq lastApply) accum
+    else
+      child.parent match {
+        case Some(parent: Term.Select) =>
+          getSelectChain(parent, lastApply, accum :+ parent)
+        case Some(parent @ SplitCallIntoParts(`child`, _)) =>
+          getSelectChain(parent, lastApply, accum)
+        case els => accum
+      }
   }
 
   def startsSelectChain(tree: Tree): Boolean =
@@ -748,5 +748,13 @@ object TreeOps {
 
   @inline
   def ifWithoutElse(t: Term.If) = t.elsep.is[Lit.Unit]
+
+  def cannotStartSelectChain(select: Term.Select): Boolean =
+    select.qual match {
+      case _: Term.Placeholder => true
+      case t: Term.Name => isSymbolicName(t.value)
+      case t: Term.Select => isSymbolicName(t.name.value)
+      case _ => false
+    }
 
 }

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -278,3 +278,490 @@ object a {
   keys.clear() // we need to remove the selected keys from the set, otherwise they remain selected
 >>>
 keys.clear() // we need to remove the selected keys from the set, otherwise they remain selected
+<<< #2061 1
+object a {
+@SerialVersionUID(1)
+ class VectorBuilder[@spec(Double, Int, Float, Long) E](
+     private var _index: Array[Int],
+     private var _data: Array[E],
+     private var used: Int,
+     var length: Int)(implicit
+     ring: Semiring[E],
+     zero: Zero[E])
+     extends NumericOps[VectorBuilder[E]]
+     with Serializable {
+
+     }
+}
+>>>
+object a {
+  @SerialVersionUID(1)
+  class VectorBuilder[@spec(Double, Int, Float, Long) E](
+      private var _index: Array[Int],
+      private var _data: Array[E],
+      private var used: Int,
+      var length: Int)(implicit
+      ring: Semiring[E],
+      zero: Zero[E])
+      extends NumericOps[VectorBuilder[E]]
+      with Serializable {}
+}
+<<< #2061 2
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+===
+object a {
+  object b {
+   val existingNamespace = client.admin.listNamespaceDescriptors()
+     .map(_.getName)
+    val existingNamespace = client.admin
+      .listNamespaceDescriptors()
+      .map(_.getName)
+  }
+  def insertAndGetEvents(eventClient: LEvents) = {
+    val insertedEvent: List[Option[Event]] = listOfEvents.zip(insertedEventId)
+      .map { case (e, id) => Some(e.copy(eventId = Some(id))) }
+  }
+}
+>>>
+object a {
+  object b {
+    val existingNamespace = client.admin
+      .listNamespaceDescriptors()
+      .map(_.getName)
+    val existingNamespace = client.admin
+      .listNamespaceDescriptors()
+      .map(_.getName)
+  }
+  def insertAndGetEvents(eventClient: LEvents) = {
+    val insertedEvent: List[Option[Event]] = listOfEvents
+      .zip(insertedEventId)
+      .map { case (e, id) => Some(e.copy(eventId = Some(id))) }
+  }
+}
+<<< #2061 3
+preset = default
+===
+object a {
+  val algoPredictsMap: Map[EX, RDD[(QX, Seq[P])]] = (0 until evalCount)
+    .map { ex => {
+      val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc.union(algoPredicts)
+       .groupByKey()
+       .mapValues { ps => {
+         assert (ps.size == algoCount, "Must have same length as algoCount")
+         // TODO. Check size == algoCount
+         ps.toSeq.sortBy(_._1).map(_._2)
+       }}
+    }
+  }
+}
+>>>
+object a {
+  val algoPredictsMap: Map[EX, RDD[(QX, Seq[P])]] = (0 until evalCount)
+    .map { ex =>
+      {
+        val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc
+          .union(algoPredicts)
+          .groupByKey()
+          .mapValues { ps =>
+            {
+              assert(ps.size == algoCount, "Must have same length as algoCount")
+              // TODO. Check size == algoCount
+              ps.toSeq.sortBy(_._1).map(_._2)
+            }
+          }
+      }
+    }
+}
+<<< #2061 4
+preset = default
+optIn.breakChainOnFirstMethodDot = false
+includeNoParensInSelectChains = false
+===
+object a {
+  override def extraTests(): Unit = {
+     "decode concatenated compressions" in {
+       ourDecode(
+         Seq(
+           encode("Hello, "),
+           encode("dear "),
+           encode("User!")).join) should readAs("Hello, dear User!")
+     }
+  }
+}
+>>>
+object a {
+  override def extraTests(): Unit = {
+    "decode concatenated compressions" in {
+      ourDecode(
+        Seq(encode("Hello, "), encode("dear "), encode("User!")).join
+      ) should readAs("Hello, dear User!")
+    }
+  }
+}
+<<< #2061 5
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+===
+object a {
+  def a = {
+    try {
+      pmmObject.instance
+        .asInstanceOf[PersistentModelLoader[AP, M]](runId, params, sc)
+      pmmObject.instance.asInstanceOf[PersistentModelLoader[AP, M]](
+              runId,
+              params,
+              sc)
+    }
+  }
+}
+>>>
+object a {
+  def a = {
+    try {
+      pmmObject.instance
+        .asInstanceOf[PersistentModelLoader[AP, M]](runId, params, sc)
+      pmmObject.instance
+        .asInstanceOf[PersistentModelLoader[AP, M]](runId, params, sc)
+    }
+  }
+}
+<<< #2061 6
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+===
+object a {
+  def a = {
+    try {
+    val a =
+          actorSystem.scheduler.schedule(
+            0.seconds,
+            1.days,
+            upgrade,
+            UpgradeCheck())
+    }
+  }
+}
+>>>
+object a {
+  def a = {
+    try {
+      val a =
+        actorSystem.scheduler.schedule(
+          0.seconds,
+          1.days,
+          upgrade,
+          UpgradeCheck()
+        )
+    }
+  }
+}
+<<< #2061 7
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+===
+object a {
+  def a = {
+    try {
+      val driver = extendedSystem.dynamicAccess
+        .createInstanceFor[Transport](fqn, args)
+        .recover({
+
+          case exception ⇒
+            throw new IllegalArgumentException(
+              s"Cannot instantiate transport [$fqn]. " +
+                "Make sure it extends [akka.remote.transport.Transport] and has constructor with " +
+                "[akka.actor.ExtendedActorSystem] and [com.typesafe.config.Config] parameters",
+              exception)
+
+        })
+        .get
+    }
+  }
+}
+>>>
+object a {
+  def a = {
+    try {
+      val driver = extendedSystem.dynamicAccess
+        .createInstanceFor[Transport](fqn, args)
+        .recover({
+
+          case exception ⇒
+            throw new IllegalArgumentException(
+              s"Cannot instantiate transport [$fqn]. " +
+                "Make sure it extends [akka.remote.transport.Transport] and has constructor with " +
+                "[akka.actor.ExtendedActorSystem] and [com.typesafe.config.Config] parameters",
+              exception
+            )
+
+        })
+        .get
+    }
+  }
+}
+<<< #2061 8
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+===
+object a {
+  val identifier: P[Ast.identifier] =
+    P((letter | "_") ~ (letter | digit | "_").rep).!.filter(
+      !keywordList.contains(_)).map(Ast.identifier)
+  def a = {
+    a match {
+      case (
+          com.twitter.finagle.exp.Address
+            .ServiceFactory(sf: ServiceFactory[Req, Rep], _),
+           _) =>
+       sf
+    }
+  }
+}
+>>>
+object a {
+  val identifier: P[Ast.identifier] =
+    P((letter | "_") ~ (letter | digit | "_").rep).!.filter(
+      !keywordList.contains(_)
+    ).map(Ast.identifier)
+  def a = {
+    a match {
+      case (
+            com.twitter.finagle.exp.Address
+              .ServiceFactory(sf: ServiceFactory[Req, Rep], _),
+            _
+          ) =>
+        sf
+    }
+  }
+}
+<<< #2061 9
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+===
+object a {
+  "produce one-to-several transformation as expected" in assertAllStagesStopped {
+      val p2 = Source
+        .fromPublisher(p)
+        .transform(() ⇒
+          new StatefulStage[Int, Int] {
+            var tot = 0
+
+            lazy val waitForNext = new State {
+            }
+          })
+  }
+}
+>>>
+object a {
+  "produce one-to-several transformation as expected" in assertAllStagesStopped {
+    val p2 = Source
+      .fromPublisher(p)
+      .transform(() ⇒
+        new StatefulStage[Int, Int] {
+          var tot = 0
+
+          lazy val waitForNext = new State {}
+        }
+      )
+  }
+}
+<<< #2061 10
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+===
+object a {
+  def a = {
+    try {
+      (r.param("args").map { args =>
+        <result>{args.split(",").map(_.toInt).reduceLeft(operation)}</result>
+      }) ?~ "Missing args"
+    }
+  }
+}
+>>>
+object a {
+  def a = {
+    try {
+      (r.param("args").map { args =>
+        <result>{args.split(",").map(_.toInt).reduceLeft(operation)}</result>
+      }) ?~ "Missing args"
+    }
+  }
+}
+<<< #2061 11
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+danglingParentheses.preset = false
+===
+object a {
+  def a = {
+    (BinaryFormat.clock(since).read(ByteArray.parseBytes(bytes), false, false))(
+      chess.White)
+  }
+}
+>>>
+object a {
+  def a = {
+    (BinaryFormat.clock(since).read(ByteArray.parseBytes(bytes), false, false))(
+      chess.White)
+  }
+}
+<<< #2061 12
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+danglingParentheses.preset = false
+===
+object a {
+  def a = {
+    try {
+      if (patt.getParent /*list of ids*/ .getParent
+              .isInstanceOf[ScVariable]) {
+        kinds contains VAR
+        val isNamedDynamic =
+          r.isDynamic && r.name == ResolvableReferenceExpression
+              .APPLY_DYNAMIC_NAMED
+        }
+       else kinds contains VAL
+    }
+  }
+}
+>>>
+object a {
+  def a = {
+    try {
+      if (patt.getParent /*list of ids*/ .getParent
+          .isInstanceOf[ScVariable]) {
+        kinds contains VAR
+        val isNamedDynamic =
+          r.isDynamic && r.name == ResolvableReferenceExpression.APPLY_DYNAMIC_NAMED
+      } else kinds contains VAL
+    }
+  }
+}
+<<< #2061 13
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+danglingParentheses.preset = false
+===
+object a {
+  def getReturnType: PsiType = {
+    if (DumbService
+        .getInstance(getProject)
+        .isDumb || !SyntheticClasses.get(getProject).isClassesRegistered) {
+       return null //no resolve during dumb mode or while synthetic classes is not registered
+    }
+  }
+}
+>>>
+object a {
+  def getReturnType: PsiType = {
+    if (DumbService
+        .getInstance(getProject)
+        .isDumb || !SyntheticClasses.get(getProject).isClassesRegistered) {
+      return null //no resolve during dumb mode or while synthetic classes is not registered
+    }
+  }
+}
+<<< #2061 14
+preset = default
+optIn.breakChainOnFirstMethodDot = false
+includeNoParensInSelectChains = false
+danglingParentheses.preset = false
+===
+object a {
+  class a {
+    def a = {
+      "zip" in {
+        intercept[IllegalStateException] {
+          Await.result(
+            Promise
+              .failed[String](f)
+              .future zip Promise.successful("foo").future,
+            timeout)
+        } should ===(f)
+      }
+    }
+  }
+}
+>>>
+object a {
+  class a {
+    def a = {
+      "zip" in {
+        intercept[IllegalStateException] {
+          Await.result(
+            Promise
+              .failed[String](f)
+              .future zip Promise.successful("foo").future,
+            timeout)
+        } should ===(f)
+      }
+    }
+  }
+}
+<<< #2061 15
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+danglingParentheses.preset = false
+===
+object a {
+  def a = {
+    try {
+      intercept[IllegalStateException] {
+        if (sqlSerDe == null || sqlSerDe._2 == null || !(sqlSerDe._2)(
+              dos,
+              value)) {
+          writeType(dos, "jobj")
+          writeJObj(dos, value)
+        }
+      } should ===(f)
+    }
+  }
+}
+>>>
+object a {
+  def a = {
+    try {
+      intercept[IllegalStateException] {
+        if (sqlSerDe == null || sqlSerDe._2 == null || !(sqlSerDe._2)(
+            dos,
+            value)) {
+          writeType(dos, "jobj")
+          writeJObj(dos, value)
+        }
+      } should ===(f)
+    }
+  }
+}
+<<< #2061 16
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+danglingParentheses.preset = false
+===
+object a {
+  def a = {
+    val paramFieldId: Box[String] = (stuff.collect {
+         case FormFieldId(id) => id
+    }).headOption
+  }
+}
+>>>
+object a {
+  def a = {
+    val paramFieldId: Box[String] = (stuff.collect {
+      case FormFieldId(id) => id
+    }).headOption
+  }
+}

--- a/scalafmt-tests/src/test/resources/test/includeNoParensInSelectChains.stat
+++ b/scalafmt-tests/src/test/resources/test/includeNoParensInSelectChains.stat
@@ -9,6 +9,16 @@ List(1)
   .buffered
   .map(_ + 2)
   .filter(_ > 2)
+<<< include applications without parens in select chains 2
+List(1)
+  .toIterator.buffered
+  .map(_ + 2).filter(_ > 2)
+>>>
+List(1)
+  .toIterator
+  .buffered
+  .map(_ + 2)
+  .filter(_ > 2)
 <<< don't throw exception (#1407)
 object CirceWritable {
   implicit def contentTypeOf_CirceJson(): ContentTypeOf[io.circe.Json] =


### PR DESCRIPTION
Let's extract the select chain matching logic into a method so that it can be reused within another rule.

Need to add a new parameter as classic chain logic, intentionally or not, forgot to check when chains "break out" of parenthesized expressions, so to avoid massive changes put the corrected logic under a parameter.

Helps with #2042.