### PR TITLE
ScalafmtDynamic: throw once if can't resolve config

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
@@ -75,6 +75,7 @@ final case class ScalafmtDynamic(
         codeFormatted
       case Left(error) =>
         reportError(file, error)
+        if (error.isInstanceOf[ConfigError]) throw error
         code
     }
   }
@@ -235,7 +236,7 @@ final case class ScalafmtDynamic(
 
   override def createSession(config: Path): ScalafmtSession =
     resolveConfig(config).fold(
-      error => { reportError(config, error); null },
+      error => { reportError(config, error); throw error },
       config => new MySession(config)
     )
 

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -62,10 +62,6 @@ case class ScalafmtReflect(
 
   def parseConfig(configPath: Path): ScalafmtReflectConfig = {
     val configText = ConfigFactory.parseFile(configPath.toFile).root.render()
-    parseConfigFromString(configText)
-  }
-
-  def parseConfigFromString(configText: String): ScalafmtReflectConfig = {
     val configured: Object =
       try { // scalafmt >= 1.6.0
         scalafmtCls.invokeStatic("parseHoconConfig", configText.asParam)
@@ -85,7 +81,10 @@ case class ScalafmtReflect(
       new ScalafmtReflectConfig(this, configured.invoke("get"), classLoader)
     } catch {
       case ReflectionException(e) =>
-        throw ScalafmtConfigException(e.getMessage)
+        throw new ScalafmtDynamicError.ConfigParseError(
+          configPath,
+          e.getMessage
+        )
     }
   }
 

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -75,6 +75,11 @@ case class ScalafmtReflect(
             configText.asParam,
             fromHoconEmptyPath.asParam(optionCls)
           )
+        case ReflectionException(e) =>
+          throw new ScalafmtDynamicError.ConfigParseError(
+            configPath,
+            e.getMessage
+          )
       }
 
     try {

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/exceptions/ScalafmtConfigException.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/exceptions/ScalafmtConfigException.scala
@@ -1,3 +1,0 @@
-package org.scalafmt.dynamic.exceptions
-
-case class ScalafmtConfigException(e: String) extends Exception(e)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -279,7 +279,7 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
         |""".stripMargin
     )
     f.assertError(
-      """|error: path/.scalafmt.conf: Invalid field: max. Expected one of version, maxColumn, docstrings, optIn, binPack, continuationIndent, align, spaces, literals, lineEndings, rewriteTokens, rewrite, indentOperator, newlines, runner, indentYieldKeyword, importSelectors, unindentTopLevelOperators, includeCurlyBraceInSelectChains, includeNoParensInSelectChains, assumeStandardLibraryStripMargin, danglingParentheses, poorMansTrailingCommasInConfigStyle, trailingCommas, verticalMultilineAtDefinitionSite, verticalMultilineAtDefinitionSiteArityThreshold, verticalMultiline, onTestFailure, encoding, project
+      """|error: path/.scalafmt.conf: Invalid config: Invalid field: max. Expected one of version, maxColumn, docstrings, optIn, binPack, continuationIndent, align, spaces, literals, lineEndings, rewriteTokens, rewrite, indentOperator, newlines, runner, indentYieldKeyword, importSelectors, unindentTopLevelOperators, includeCurlyBraceInSelectChains, includeNoParensInSelectChains, assumeStandardLibraryStripMargin, danglingParentheses, poorMansTrailingCommasInConfigStyle, trailingCommas, verticalMultilineAtDefinitionSite, verticalMultilineAtDefinitionSiteArityThreshold, verticalMultiline, onTestFailure, encoding, project
         |""".stripMargin
     )
   }
@@ -319,7 +319,7 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
   check("wrong-version") { f =>
     f.setVersion("1.0")
     f.assertError(
-      """|error: path/.scalafmt.conf: org.scalafmt.dynamic.exceptions.ScalafmtException: failed to resolve Scalafmt version '1.0'
+      """|error: path/.scalafmt.conf: org.scalafmt.dynamic.exceptions.ScalafmtException: failed to download v=1.0
         |Caused by: org.scalafmt.dynamic.ScalafmtVersion$InvalidVersionException: Invalid scalafmt version 1.0
         |""".stripMargin
     )
@@ -354,7 +354,7 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
 
   check("no-config") { f =>
     Files.delete(f.config)
-    f.assertError("""|error: path/.scalafmt.conf: file does not exist
+    f.assertError("""|error: path/.scalafmt.conf: Missing config
       |""".stripMargin)
   }
 


### PR DESCRIPTION
Intellij invokes the createSession method directly and doesn't expect the null value we return there, so throw ConfigError instead.

Similarly, in the Runner, change the implementation of MyInstanceSession to verify the config first, so that the config parsing exception is not thrown for every file we are trying to format.