### PR TITLE
Router: indent comment before first select

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -278,6 +278,10 @@ case class ScalafmtConfig(
 
   // Edition 2020-03
   val activeForEdition_2020_03: Boolean = activeFor(Edition(2020, 3))
+
+  lazy val encloseSelectChains =
+    optIn.encloseClassicChains || !newlines.sourceIs(Newlines.classic)
+
 }
 
 object ScalafmtConfig {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1406,15 +1406,19 @@ class FormatOps(val tree: Tree, baseStyle: ScalafmtConfig) {
     getClosingIfEnclosedInMatching(tree).isDefined
 
   @tailrec
-  final def findPrevSelect(tree: Tree): Option[Term.Select] =
+  final def findPrevSelect(tree: Tree, enclosed: Boolean): Option[Term.Select] =
     tree match {
       case t: Term.Select => Some(t)
       case t @ SplitCallIntoParts(fun, _) if t ne fun =>
-        if (isEnclosedInMatching(t)) None else findPrevSelect(fun)
+        if (enclosed && isEnclosedInMatching(t)) None
+        else findPrevSelect(fun, enclosed)
       case _ => None
     }
-  def findPrevSelect(tree: Term.Select): Option[Term.Select] =
-    findPrevSelect(tree.qual)
+  def findPrevSelect(
+      tree: Term.Select,
+      enclosed: Boolean = true
+  ): Option[Term.Select] =
+    findPrevSelect(tree.qual, enclosed)
 
   @tailrec
   private def findLastApplyAndNextSelectEnclosed(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1666,7 +1666,14 @@ class Router(formatOps: FormatOps) {
         val forceBlankLine = formatToken.hasBreak &&
           blankLineBeforeDocstring(formatToken)
         val mod = if (forceBlankLine) Newline2x else getMod(formatToken)
-        Seq(Split(mod, 0))
+        val indent = formatToken.meta.rightOwner match {
+          case ts: Term.Select
+              if !left.is[T.Comment] &&
+                findPrevSelect(ts, style.encloseSelectChains).isEmpty =>
+            Indent(2, nextNonComment(next(formatToken)).left, ExpiresOn.After)
+          case _ => Indent.Empty
+        }
+        Seq(Split(mod, 0).withIndent(indent))
       // Commented out code should stay to the left
       case FormatToken(c: T.Comment, _, _) if isSingleLineComment(c) =>
         Seq(Split(Newline, 0))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -54,9 +54,9 @@ object TokenOps {
       ft.meta.right.text.startsWith("/**") &&
       TreeOps
         .findTreeOrParent(ft.meta.leftOwner) {
+          case t if t.pos.end <= ft.right.start => None
           case _: Pkg | _: Source | _: Template | _: Term.Block => Some(false)
-          case t if t.pos.end > ft.right.start => Some(true)
-          case _ => None
+          case _ => Some(true)
         }
         .isEmpty
 

--- a/scalafmt-tests/src/test/resources/align/BeforeCommentWithinMethodChain.stat
+++ b/scalafmt-tests/src/test/resources/align/BeforeCommentWithinMethodChain.stat
@@ -1,8 +1,8 @@
 maxColumn = 40
 <<< keep indentation for comments within method chain in statement
 foo()
-// bar
-// baz
+ // bar
+ // baz
 .bar()
 >>>
 foo()
@@ -11,8 +11,8 @@ foo()
   .bar()
 <<< keep indentation for comments within method chain in assignment
 val res = foo()
-// bar
-// baz
+ // bar
+ // baz
 .bar()
 >>>
 val res = foo()
@@ -21,11 +21,11 @@ val res = foo()
   .bar()
 <<< don't add extra indentation for comments in middle of chain
 "x"
-// bar
-// baz
+ // bar
+ // baz
 .bar()
-// bar2
-// baz2
+ // bar2
+ // baz2
 .bar2()
 >>>
 "x"

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -309,7 +309,7 @@ object a {
 object a {
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
     joinBy TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))(_._1, _._1)
-  //Flatten out to three values:
+    //Flatten out to three values:
   .toTypedPipe
     .map { kvw => (kvw._1, kvw._2._1._2, kvw._2._2._2) }
     .write(TypedText.tsv[(Int, Int, Int)]("out2"))

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -278,6 +278,42 @@ object a {
   keys.clear() // we need to remove the selected keys from the set, otherwise they remain selected
 >>>
 keys.clear() // we need to remove the selected keys from the set, otherwise they remain selected
+<<< #2042 1
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+===
+object a {
+  val res = Seq(1, 2, 3)
+    // Keep odd numbers
+    .filter(_ % 2 == 1)
+}
+>>>
+object a {
+  val res = Seq(1, 2, 3)
+    // Keep odd numbers
+    .filter(_ % 2 == 1)
+}
+<<< #2042 2
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+===
+object a {
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
+     joinBy TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))(_._1, _._1)
+   //Flatten out to three values:
+  .toTypedPipe
+     .map { kvw => (kvw._1, kvw._2._1._2, kvw._2._2._2) }
+     .write(TypedText.tsv[(Int, Int, Int)]("out2"))
+}
+>>>
+object a {
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
+    joinBy TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))(_._1, _._1)
+  //Flatten out to three values:
+  .toTypedPipe
+    .map { kvw => (kvw._1, kvw._2._1._2, kvw._2._2._2) }
+    .write(TypedText.tsv[(Int, Int, Int)]("out2"))
+}
 <<< #2061 1
 object a {
 @SerialVersionUID(1)

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1290,7 +1290,6 @@ object a {
   input.read
   /** foo */
     .foo { bar }
-
     /** baz */
     .baz(qux)
 }

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1290,6 +1290,7 @@ object a {
   input.read
   /** foo */
     .foo { bar }
+
     /** baz */
     .baz(qux)
 }

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1275,3 +1275,21 @@ object Day extends Enumeration {
   /** Monday */
   MON = Value
 }
+<<< docstring after block
+preset = default
+===
+object a {
+  input.read
+     /** foo */
+     .foo { bar }
+     /** baz */
+     .baz(qux)
+}
+>>>
+object a {
+  input.read
+  /** foo */
+    .foo { bar }
+    /** baz */
+    .baz(qux)
+}


### PR DESCRIPTION
Move this code from FormatWriter. Fixes #2042.