### PR TITLE
Router: merge classic select chain rule with other

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -573,7 +573,7 @@ class Router(formatOps: FormatOps) {
         val forceNewlineBeforeExtends = Policy(expire) {
           case Decision(t @ FormatToken(_, _: T.KwExtends, _), s)
               if t.meta.rightOwner == leftOwner =>
-            s.filter(x => x.isNL && (x.activeTag ne SplitTag.OnelineWithChain))
+            s.filter(x => x.isNL && !x.isActiveFor(SplitTag.OnelineWithChain))
         }
         val policyEnd = defnBeforeTemplate(leftOwner).fold(r)(_.tokens.last)
         val policy = delayedBreakPolicy(policyEnd)(forceNewlineBeforeExtends)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -2,27 +2,16 @@ package org.scalafmt.internal
 
 sealed abstract class SplitTag {
 
-  def activateOnly(splits: Seq[Split]): Seq[Split]
+  final def activateOnly(splits: Seq[Split]): Seq[Split] =
+    splits.map(_.activateFor(this))
 
 }
 
 object SplitTag {
 
-  abstract class Base extends SplitTag {
-    override final def activateOnly(splits: Seq[Split]): Seq[Split] = splits
-  }
-
-  abstract class Custom extends SplitTag {
-    override final def activateOnly(splits: Seq[Split]): Seq[Split] =
-      splits.map(_.activateFor(this)).filter(_.isActive)
-  }
-
-  case object Active extends Base
-  case object Ignored extends Base
-
-  case object OneArgPerLine extends Custom
-  case object SelectChainFirstNL extends Custom
-  case object InfixChainNoNL extends Custom
-  case object OnelineWithChain extends Custom
+  case object OneArgPerLine extends SplitTag
+  case object SelectChainFirstNL extends SplitTag
+  case object InfixChainNoNL extends SplitTag
+  case object OnelineWithChain extends SplitTag
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -11,6 +11,7 @@ object SplitTag {
 
   case object OneArgPerLine extends SplitTag
   case object SelectChainFirstNL extends SplitTag
+  case object SelectChainSecondNL extends SplitTag
   case object InfixChainNoNL extends SplitTag
   case object OnelineWithChain extends SplitTag
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -90,18 +90,6 @@ object TokenOps {
     Space(!Character.isLetterOrDigit(lastCharacter) && lastCharacter != '`')
   }
 
-  def isOpenApply(
-      token: Token,
-      includeCurly: Boolean = false,
-      includeNoParens: Boolean = false
-  ): Boolean =
-    token match {
-      case LeftParen() | LeftBracket() => true
-      case LeftBrace() if includeCurly => true
-      case Dot() if includeNoParens => true
-      case _ => false
-    }
-
   @inline
   def isSingleLineComment(c: String): Boolean = c.startsWith("//")
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -426,23 +426,6 @@ object TreeOps {
       splitDefnIntoParts.lift(tree)
   }
 
-  @tailrec
-  def getSelectChain(
-      child: Tree,
-      lastApply: Tree,
-      accum: Vector[Term.Select]
-  ): Vector[Term.Select] = {
-    if (child eq lastApply) accum
-    else
-      child.parent match {
-        case Some(parent: Term.Select) =>
-          getSelectChain(parent, lastApply, accum :+ parent)
-        case Some(parent @ SplitCallIntoParts(`child`, _)) =>
-          getSelectChain(parent, lastApply, accum)
-        case els => accum
-      }
-  }
-
   /**
     * How many parents of tree are Term.Apply?
     */

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -62,7 +62,7 @@ val lastToken = owner.body.tokens.filter {
   case _: Whitespace | _: Comment => false
   case _ => true
 } // edge case, if body is empty expire on arrow.
-.lastOption.getOrElse(arrow)
+  .lastOption.getOrElse(arrow)
 <<< apply infix has indent
 val expireAAAAAAAAAAAAAAAAAAAAA = owner.tokens.
   find(t => t.isInstanceOf[`=`] && owners(t) == owner)
@@ -310,7 +310,7 @@ object a {
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
     joinBy TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))(_._1, _._1)
     //Flatten out to three values:
-  .toTypedPipe
+    .toTypedPipe
     .map { kvw => (kvw._1, kvw._2._1._2, kvw._2._2._2) }
     .write(TypedText.tsv[(Int, Int, Int)]("out2"))
 }
@@ -875,5 +875,5 @@ object a {
   val reduces = node
     .foldDown[List[dag.Reduce]](true) {
       case r: dag.Reduce => List(r)
-  } distinct
+    } distinct
 }

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -743,6 +743,67 @@ object a {
     }
   }
 }
+<<< #2061 14.1
+preset = default
+optIn.breakChainOnFirstMethodDot = false
+includeNoParensInSelectChains = true
+optIn.breaksInsideChains = true
+danglingParentheses.preset = false
+===
+object a {
+  class a {
+    def a = {
+      "zip" in {
+        intercept[IllegalStateException] {
+          Await.result(Promise.failed[String](f).future zip Promise.successful("foo").future, timeout)
+        } should ===(f)
+      }
+    }
+  }
+}
+>>>
+object a {
+  class a {
+    def a = {
+      "zip" in {
+        intercept[IllegalStateException] {
+          Await.result(
+            Promise
+              .failed[String](f).future zip Promise.successful("foo").future,
+            timeout)
+        } should ===(f)
+      }
+    }
+  }
+}
+<<< #2061 14.2
+preset = default
+optIn.breakChainOnFirstMethodDot = false
+includeNoParensInSelectChains = true
+optIn.breaksInsideChains = false
+danglingParentheses.preset = false
+===
+object a {
+  class a {
+   if (!cell
+       .routerConfig
+       .isInstanceOf[Pool] && !cell.routerConfig.isInstanceOf[Group])
+     throw ActorInitializationException(
+       "Cluster router actor can only be used with Pool or Group, not with " +
+         cell.routerConfig.getClass)
+  }
+}
+>>>
+object a {
+  class a {
+    if (!cell
+        .routerConfig
+        .isInstanceOf[Pool] && !cell.routerConfig.isInstanceOf[Group])
+      throw ActorInitializationException(
+        "Cluster router actor can only be used with Pool or Group, not with " +
+          cell.routerConfig.getClass)
+  }
+}
 <<< #2061 15
 preset = default
 optIn.breakChainOnFirstMethodDot = true
@@ -798,4 +859,21 @@ object a {
       case FormFieldId(id) => id
     }).headOption
   }
+}
+<<< curly select chain followed by infix
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+===
+object a {
+  val reduces = node
+    .foldDown[List[dag.Reduce]](true) {
+       case r: dag.Reduce => List(r)
+    } distinct
+}
+>>>
+object a {
+  val reduces = node
+    .foldDown[List[dag.Reduce]](true) {
+      case r: dag.Reduce => List(r)
+  } distinct
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2305,8 +2305,8 @@ class Foo {
 >>>
 class Foo {
   val vv = v.aaa //
-  //
-  .bbb
+    //
+    .bbb
     .ccc()
   val vv = v.aaa //
   val vv = v.aaa
@@ -2323,10 +2323,10 @@ class Foo {
 >>>
 class Foo {
   val vv = v.aaa //
-  .bbb //
-  //
-  .ccc //
-  .ddd
+    .bbb //
+    //
+    .ccc //
+    .ddd
     .eee()
 }
 <<< #1334 3: continue chain indent after a comment with apply
@@ -2372,7 +2372,7 @@ class Foo {
        .tail
 >>>
 val a: Vector[Array[Double]] = b.c
-// similarUserFeatures may not contain the requested user
+  // similarUserFeatures may not contain the requested user
   .map { x =>
     similarUserFeatures.get(x)
   }
@@ -2392,8 +2392,8 @@ val a: Vector[Array[Double]] = b.c
 }
 >>>
 val a: Vector[Array[Double]] = b.c
-// Only handle first case, others will be fixed on the next pass.
-.headOption.a match {
+  // Only handle first case, others will be fixed on the next pass.
+  .headOption.a match {
   case None =>
   case _ =>
 }

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1288,7 +1288,7 @@ object a {
 >>>
 object a {
   input.read
-  /** foo */
+    /** foo */
     .foo { bar }
     /** baz */
     .baz(qux)


### PR DESCRIPTION
This will apply the same clean indentation logic as for `newlines.source != classic`.

Requires adding support for multiple activation tags within a split; one was used to apply indent to the first break only, and the new one will be used to reduce cost of a split down the chain after the first break and remove the newline penalization policy consistent with the previous rule; this filtering capability was introduced in #2060.

Fixes #1334. Supersedes #1557.