### PR TITLE
BestFirstSearch: make the Provided split active

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -85,7 +85,9 @@ private class BestFirstSearch private (
 
   def provided(formatToken: FormatToken): Split = {
     // TODO(olafur) the indentation is not correctly set.
-    val split = Split(Provided(formatToken), 0)
+    val split = new Split(Provided(formatToken), 0) {
+      override def activateFor(splitTag: SplitTag): Split = this
+    }
     val result =
       if (formatToken.left.is[LeftBrace])
         split.withIndent(Num(2), matching(formatToken.left), ExpiresOn.Before)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -52,7 +52,7 @@ class FormatWriter(formatOps: FormatOps) {
         // formatting flag fetches from the previous state because of
         // `formatToken.left` rendering. `FormatToken(x, // format: on)` will have
         // formatOff = false, but x still should not be formatted
-        case token if state.formatOff => sb.append(formatToken.meta.left.text)
+        case _ if state.formatOff => sb.append(formatToken.meta.left.text)
         case _: T.Comment =>
           entry.formatComment
         case _: T.Interpolation.Part | _: T.Constant.String =>

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -877,3 +877,17 @@ object a {
       case r: dag.Reduce => List(r)
     } distinct
 }
+<<< #2070
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+===
+object Dummy {
+  def dummy(list: List[Int]): List[Int] =
+    list
+      .map(_ + 1)
+      // format: off
+      .map(_ * 2)
+      // format: on
+}
+>>>
+BestFirstSearch:327 Failed to format

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -890,4 +890,11 @@ object Dummy {
       // format: on
 }
 >>>
-BestFirstSearch:327 Failed to format
+object Dummy {
+  def dummy(list: List[Int]): List[Int] =
+    list
+      .map(_ + 1)
+      // format: off
+      .map(_ * 2)
+      // format: on
+}


### PR DESCRIPTION
Otherwise, an attempt to activate a tag leads to deactivation of this split.

Fixes #2070.