### PR TITLE
ScalafmtReflectConfig: invoked .forSbt, not legacy dialect

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflectConfig.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflectConfig.scala
@@ -44,7 +44,7 @@ class ScalafmtReflectConfig private[dynamic] (
     matcher.invokeAs[java.lang.Boolean]("matches", filename.asParam)
   }
 
-  private val sbtDialect: Object = {
+  private def sbtDialect: Object = {
     try dialectsCls.invokeStatic("Sbt")
     catch {
       case ReflectionException(_: NoSuchMethodException) =>
@@ -52,9 +52,13 @@ class ScalafmtReflectConfig private[dynamic] (
     }
   }
 
-  def withSbtDialect: ScalafmtReflectConfig = {
-    // TODO: maybe hold loaded classes in some helper class not to reload them each time during copy?
-    val newTarget = target.invoke("withDialect", (dialectCls, sbtDialect))
+  lazy val withSbtDialect: ScalafmtReflectConfig = {
+    val newTarget =
+      try target.invoke("forSbt")
+      catch {
+        case ReflectionException(_: NoSuchMethodException) =>
+          target.invoke("withDialect", (dialectCls, sbtDialect))
+      }
     new ScalafmtReflectConfig(fmtReflect, newTarget, classLoader)
   }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -213,7 +213,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
   //checkVersion("0.2.8") // fails for now
 
   check("parse-error") { f =>
-    def check(): Unit = {
+    def check(version: String): Unit = {
+      f.setVersion(version)
       f.assertError(
         "object object A",
         """|parse-error.scala:1:8: error: identifier expected but object found
@@ -221,10 +222,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
           |       ^^^^^^""".stripMargin
       )
     }
-    f.setVersion(latest)
-    check()
-    f.setVersion("1.0.0")
-    check()
+    check(latest)
+    check("1.0.0")
   }
 
   check("missing-version") { f => f.assertMissingVersion() }
@@ -248,16 +247,14 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
         |]
         |""".stripMargin
     )
-    def check(): Unit = {
+    def check(version: String): Unit = {
+      f.setVersion(version)
       f.assertNotIgnored("path/FooSpec.scala")
       f.assertIgnored("path/App.scala")
       f.assertIgnored("path/UserSpec.scala")
     }
-    f.setVersion(latest)
-    check()
-    f.setVersion("1.0.0")
-    check()
-    f.ignoreExcludeFilters()
+    check(latest)
+    check("1.0.0")
   }
 
   check("ignore-exclude-filters") { f =>
@@ -271,14 +268,14 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
         |]
         |""".stripMargin
     )
-    def check(): Unit = {
+    def check(version: String): Unit = {
+      f.setVersion(version)
       f.assertNotIgnored("path/App.pm")
       f.assertNotIgnored("path/App.scala")
       f.assertNotIgnored("path/UserSpec.scala")
     }
-    f.setVersion(latest)
     f.ignoreExcludeFilters()
-    check()
+    check(latest)
   }
 
   check("config-error") { f =>
@@ -336,7 +333,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
   }
 
   check("sbt") { f =>
-    def check(): Unit = {
+    def check(version: String): Unit = {
+      f.setVersion(version)
       List("build.sbt", "build.sc").foreach { filename =>
         f.assertFormat(
           "lazy   val   x =  project",
@@ -355,10 +353,8 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
       """|project.includeFilters = [ ".*" ]
         |""".stripMargin
     )
-    f.setVersion(latest)
-    check()
-    f.setVersion("1.2.0")
-    check()
+    check(latest)
+    check("1.2.0")
   }
 
   check("no-config") { f =>

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -359,7 +359,16 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
               |                           ^""".stripMargin,
             path
           )
-        isWrappedLiteralFailure
+        def isWrappedLiteralSuccess: Unit =
+          f.assertFormat(
+            wrappedLiteral,
+            wrappedLiteral.replaceAll("  +", " ").trim + "\n",
+            path
+          )
+        if (version > "2.0")
+          isWrappedLiteralSuccess
+        else
+          isWrappedLiteralFailure
       }
     }
     f.setConfig(

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -173,6 +173,7 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
   }
 
   private val testedVersions = Seq(
+    "2.5.3",
     "2.0.0-RC4",
     "1.6.0-RC4",
     "1.5.1",
@@ -195,7 +196,7 @@ class DynamicSuite extends AnyFunSuite with DiffAssertions {
     }
   }
 
-  def latest = "2.0.0-RC1"
+  def latest = "2.5.3"
 
   def checkVersion(version: String): Unit = {
     check(s"v$version") { f =>


### PR DESCRIPTION
For processing `.sbt` files, we were explicitly using a specific legacy dialect rather than obtaining (via `.forSbt`) a modified configuration suitable for processing these files.

Fixes #2069.