### PR TITLE
RedundantParens: don't rewrite (()), aka Lit.Unit

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -24,7 +24,7 @@ class RedundantParens(implicit ctx: RewriteCtx) extends RewriteSession {
     }
 
   private[rewrite] val rewriteFunc: PartialFunction[Tree, Unit] = {
-    case t @ (_: Term.Tuple | _: Type.Tuple) => remove(t, 2)
+    case t @ (_: Term.Tuple | _: Type.Tuple | _: Lit.Unit) => remove(t, 2)
 
     case g: Enumerator.Guard => remove(g.cond)
 

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -269,5 +269,5 @@ object a {
 }
 >>>
 object a {
-  print("") shouldBe ()
+  print("") shouldBe (())
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -263,3 +263,11 @@ object a {
 object a {
   scalacOptions ~= (_ filterNot (_ startsWith "-Xlint"))
 }
+<<< Lit.Unit preserved
+object a {
+  print("") shouldBe (())
+}
+>>>
+object a {
+  print("") shouldBe ()
+}


### PR DESCRIPTION
Reported on gitter.