### PR TITLE
#1627 [24]: FormatOps bugfix: ignore NL before infix for fold/unfold

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -496,7 +496,7 @@ class FormatOps(
   def beforeInfixSplit(
       owner: Term.ApplyInfix,
       formatToken: FormatToken
-  )(implicit line: sourcecode.Line, style: ScalafmtConfig): Seq[Split] = {
+  )(implicit style: ScalafmtConfig): Seq[Split] = {
     val InfixApp(app) = owner
     infixSplitImpl(app, formatToken, true)
   }
@@ -505,7 +505,7 @@ class FormatOps(
       app: InfixApp,
       formatToken: FormatToken,
       beforeLhs: Boolean
-  )(implicit line: sourcecode.Line, style: ScalafmtConfig): Seq[Split] = {
+  )(implicit style: ScalafmtConfig): Seq[Split] = {
     // NOTE. Silly workaround because we call infixSplit from assignment =, see #798
     val treeOpt =
       if (!beforeLhs && app.isRightAssoc)
@@ -546,7 +546,7 @@ class FormatOps(
   def insideInfixSplit(
       app: InfixApp,
       ft: FormatToken
-  )(implicit line: sourcecode.Line, style: ScalafmtConfig): Seq[Split] =
+  )(implicit style: ScalafmtConfig): Seq[Split] =
     app.all match {
       case t: Type.ApplyInfix
           if style.spaces.neverAroundInfixTypes.contains(t.op.value) =>

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1549,10 +1549,8 @@ val a =
       8 % 9
     }
 >>>
-val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-    8 % 9
-  }
+val a = 1 + 2 * 3 && 4 ^ 5 || 6 op
+  7 map { 8 % 9 }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
 >>>

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1747,15 +1747,15 @@ val a =
       8 % 9
     }
 >>>
-val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+val a = 1 + 2 * 3 && 4 ^ 5 || 6 op
+  7 map {
     8 % 9
   }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
 >>>
-val a =
-  1 + 2 * 3 || 4 ^ 5 && 6 op 7 map {
+val a = 1 + 2 * 3 || 4 ^ 5 && 6 op
+  7 map {
     8 % 9
   }
 <<< 8.3: infix with longer left ||, narrow


### PR DESCRIPTION
Helps with #1627.