### PR TITLE
Policy: introduce more specific expire strategies

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -410,9 +410,8 @@ class FormatOps(
   def penalizeNewlineByNesting(from: Token, to: Token)(implicit
       line: sourcecode.Line
   ): Policy = {
-    val range = Range(from.start, to.end).inclusive
-    Policy(to) {
-      case Decision(t, s) if range.contains(t.right.start) =>
+    Policy(to, Policy.End.Before) {
+      case Decision(t, s) if t.right.start >= from.start =>
         val nonBoolPenalty =
           if (isBoolOperator(t.left)) 0
           else 5

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -166,6 +166,11 @@ object Policy {
         ft.left.end <= endPos
       override def toString: String = ">"
     }
+    case object Before extends End {
+      def notExpiredBy(ft: FormatToken, endPos: Int): Boolean =
+        ft.right.end < endPos
+      override def toString: String = "<"
+    }
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -56,7 +56,7 @@ object Policy {
 
   def apply(
       expire: Token,
-      endPolicy: End = End.After,
+      endPolicy: End,
       noDequeue: Boolean = false
   )(f: Pf)(implicit line: sourcecode.Line): Policy =
     new ClauseImpl(f, expire.end, endPolicy, noDequeue)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -73,7 +73,7 @@ object Policy {
     }
 
     override def unexpired(ft: FormatToken): Policy =
-      if (ft.left.end < endPos) this else NoPolicy
+      if (ft.left.end <= endPos) this else NoPolicy
 
     override def filter(pred: Clause => Boolean): Policy =
       if (pred(this)) this else NoPolicy

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -171,6 +171,11 @@ object Policy {
         ft.right.end < endPos
       override def toString: String = "<"
     }
+    case object On extends End {
+      def notExpiredBy(ft: FormatToken, endPos: Int): Boolean =
+        ft.right.end <= endPos
+      override def toString: String = "@"
+    }
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -8,9 +8,9 @@ class PolicySummary(val policies: Vector[Policy]) {
 
   @inline def noDequeue = policies.exists(_.exists(_.noDequeue))
 
-  def combine(other: Policy, position: Int): PolicySummary = {
+  def combine(other: Policy, ft: FormatToken): PolicySummary = {
     // TODO(olafur) filter policies by expiration date
-    val activePolicies = policies.flatMap(_.unexpiredOpt(position))
+    val activePolicies = policies.flatMap(_.unexpiredOpt(ft))
     val newPolicies =
       if (other == NoPolicy) activePolicies
       else other +: activePolicies

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -6,7 +6,7 @@ import org.scalafmt.util.LoggerOps
 class PolicySummary(val policies: Vector[Policy]) {
   import LoggerOps._
 
-  @inline def noDequeue = policies.exists(_.exists(_.noDequeue))
+  @inline def noDequeue = policies.exists(_.noDequeue)
 
   def combine(other: Policy, ft: FormatToken): PolicySummary = {
     // TODO(olafur) filter policies by expiration date

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -1,6 +1,5 @@
 package org.scalafmt.internal
 
-import org.scalafmt.internal.Policy.NoPolicy
 import org.scalafmt.util.LoggerOps
 
 class PolicySummary(val policies: Vector[Policy]) {
@@ -11,9 +10,10 @@ class PolicySummary(val policies: Vector[Policy]) {
   def combine(other: Policy, ft: FormatToken): PolicySummary = {
     // TODO(olafur) filter policies by expiration date
     val activePolicies = policies.flatMap(_.unexpiredOpt(ft))
+    val activeOther = other.unexpired(ft)
     val newPolicies =
-      if (other == NoPolicy) activePolicies
-      else other +: activePolicies
+      if (activeOther.isEmpty) activePolicies
+      else activeOther +: activePolicies
     new PolicySummary(newPolicies)
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -588,7 +588,7 @@ class Router(formatOps: FormatOps) {
             s.filter(x => x.isNL && !x.isActiveFor(SplitTag.OnelineWithChain))
         }
         val policyEnd = defnBeforeTemplate(leftOwner).fold(r)(_.tokens.last)
-        val policy = delayedBreakPolicy(policyEnd)(forceNewlineBeforeExtends)
+        val policy = delayedBreakPolicy()(forceNewlineBeforeExtends)
         Seq(Split(Space, 0).withPolicy(policy))
       // DefDef
       case tok @ FormatToken(T.KwDef(), name @ T.Ident(_), _) =>
@@ -630,7 +630,7 @@ class Router(formatOps: FormatOps) {
           if (lambdaIsABlock) None
           else
             newlinePolicy.map(
-              delayedBreakPolicy(close, lambdaLeft.map(x => _.end < x.end))
+              delayedBreakPolicy(lambdaLeft.map(x => _.end < x.end))
             )
         }
 
@@ -1229,7 +1229,7 @@ class Router(formatOps: FormatOps) {
                   val minCost = math.max(0, filtered.map(_.cost).min - 1)
                   filtered.map { x =>
                     val p =
-                      x.policy.filter(!_.isInstanceOf[PenalizeAllNewlines])
+                      x.policy.filter(!_.isInstanceOf[penalizeAllNewlines])
                     x.copy(cost = x.cost - minCost, policy = p)
                   }
                 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -74,7 +74,7 @@ final case class State(
 
     val overflow = columnOnCurrentLine - style.maxColumn
     val nextPolicy: PolicySummary =
-      policy.combine(nextSplit.policy, tok.left.end)
+      policy.combine(nextSplit.policy, tok)
 
     val (penalty, nextDelayedPenalty) =
       if (

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -74,7 +74,7 @@ final case class State(
 
     val overflow = columnOnCurrentLine - style.maxColumn
     val nextPolicy: PolicySummary =
-      policy.combine(nextSplit.policy, tok)
+      policy.combine(nextSplit.policy, fops.next(tok))
 
     val (penalty, nextDelayedPenalty) =
       if (

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -23,8 +23,8 @@ object LoggerOps {
     styles.map(x => x.source -> x.value).toMap
 
   def log(s: State): String = {
-    val policies = s.policy.policies.map(_.toString).mkString(",")
-    s"d=${s.depth} w=${s.cost} i=${s.indentation} col=${s.column}; p=$policies; s=${log(s.split)}"
+    val policies = s.policy.policies.map(_.toString).mkString("P[", ",", "]")
+    s"d=${s.depth} w=${s.cost} i=${s.indentation} col=${s.column}; $policies; s=${log(s.split)}"
   }
   def log(split: Split): String = s"$split"
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -46,7 +46,7 @@ object PolicyOps {
     import TokenOps.isSingleLineComment
     override val endPos = expire.end
     override val noDequeue: Boolean = true
-    override val endPolicy: Policy.End = Policy.End.After
+    override val endPolicy: Policy.End = Policy.End.On
     override def toString: String =
       "SLB:" + super.toString + {
         if (exclude.isEmpty) ""

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -8,7 +8,7 @@ import org.scalafmt.internal.Policy
 
 object PolicyOps {
 
-  case class penalizeAllNewlines(
+  case class PenalizeAllNewlines(
       expire: T,
       penalty: Int,
       penalizeLambdas: Boolean = true,
@@ -18,11 +18,10 @@ object PolicyOps {
       extends Policy.Clause {
     override val endPos = expire.end
     override val noDequeue: Boolean = false
-    override val endPolicy: Policy.End = Policy.End.After
+    override val endPolicy: Policy.End = Policy.End.Before
     override val f: Policy.Pf = {
       case Decision(tok, s)
-          if tok.right.end < endPos &&
-            (penalizeLambdas || !tok.left.is[T.RightArrow]) && !ignore(tok) =>
+          if (penalizeLambdas || !tok.left.is[T.RightArrow]) && !ignore(tok) =>
         s.map {
           case split
               if split.isNL ||

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -18,6 +18,7 @@ object PolicyOps {
       extends Policy.Clause {
     override val endPos = expire.end
     override val noDequeue: Boolean = false
+    override val endPolicy: Policy.End = Policy.End.After
     override val f: Policy.Pf = {
       case Decision(tok, s)
           if tok.right.end < endPos &&
@@ -46,6 +47,7 @@ object PolicyOps {
     import TokenOps.isSingleLineComment
     override val endPos = expire.end
     override val noDequeue: Boolean = true
+    override val endPolicy: Policy.End = Policy.End.After
     override def toString: String =
       "SLB:" + super.toString + {
         if (exclude.isEmpty) ""

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1931,19 +1931,16 @@ private lazy val subNode
   ((opt(
     '*'
   ) ~ '[' ~> attrName <~ '+' ~ ']' ^^ {
-    name =>
-      AttrAppendSubNode(name)
+    name => AttrAppendSubNode(name)
   }) |
     (opt(
       '*'
     ) ~ '[' ~> attrName <~ '!' ~ ']' ^^ {
-      name =>
-        AttrRemoveSubNode(name)
+      name => AttrRemoveSubNode(name)
     }) | (opt(
     '*'
   ) ~ '[' ~> attrName <~ ']' ^^ {
-    name =>
-      AttrSubNode(name)
+    name => AttrSubNode(name)
   }) |
 
     ('!' ~ '!' ^^ (a =>

--- a/scalafmt-tests/src/test/scala/org/scalafmt/Debug.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/Debug.scala
@@ -83,7 +83,7 @@ class Debug(val verbose: Boolean) {
           val clean = LoggerOps.cleanup(tok).slice(0, 15).formatted("%-15s")
           stack.prepend(
             s"${tok.end.formatted(posWidth)}: $clean" +
-              s" ${state.split} ${prev.indentation} ${prev.column} [${prev.cost}]"
+              s" ${state.split} ${prev.indentation} ${prev.column} [${state.cost}]"
           )
           iter(prev)
         }


### PR DESCRIPTION
Currently, policy expiration is applied narrowly (i.e., unlike indents which can expire _before_ or _after_ the expiration token, all policies expire the same way) and incorrectly (they expire not after the specified token, but after the one which follows).

So, add three expiration strategies (before, on, and after) and remove the current after-the-next buggy expiration.

There is **exactly one** diff in `scala-repos` (and it looks *correct*, judging by formatting of similar code before and after the modified block) and one diff in the unit tests (also, looks right), so the change also appears to fix some rare bugs.

From `scala-repos`:
```
   private val _right = new function.Function2[Any, Any, Any]
     with ((Any, Any) ⇒ Any) { def apply(l: Any, r: Any) = r }
-  private val _both =
-    new function.Function2[Any, Any, Any] with ((Any, Any) ⇒ Any) {
-      def apply(l: Any, r: Any) = new akka.japi.Pair(l, r)
-    }
+  private val _both = new function.Function2[Any, Any, Any]
+    with ((Any, Any) ⇒ Any) {
+    def apply(l: Any, r: Any) = new akka.japi.Pair(l, r)
+  }
   private val _none = new function.Function2[Any, Any, NotUsed]
     with ((Any, Any) ⇒ NotUsed) { def apply(l: Any, r: Any) = NotUsed }
```
