### PR TITLE
Dependencies: upgrade scalameta to 4.3.19

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV  = "4.3.18"
+  val scalametaV  = "4.3.19"
   val scalatestV  = "3.2.0"
   val scalacheckV = "1.14.3"
   val coursier    = "1.0.3"


### PR DESCRIPTION
Includes bugfixes to 2.13/dotty parsing (try with any expression and negative numeric type literals).

Fixes #2023.