### PR TITLE
Don't fail test workflow on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: olafurpg/setup-scala@v7
         with:
           java-version: ${{ matrix.java }}
-      - run: git fetch --tags
+      - run: git fetch --tags -f
       - run:
           # for GitOps tests	
           git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"


### PR DESCRIPTION
Tests need all tags to be fetched but latest tag already pushed to master on release. For this reason git fetch fails on workflows started with git push --tags

Other jobs works correct already.