### PR TITLE
Router: always keep "= js.native" unbroken

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -33,7 +33,6 @@ import scala.meta.{
   Tree,
   Type
 }
-import scala.meta.prettyprinters.Structure
 import scala.meta.tokens.Token
 import scala.meta.tokens.{Token => T}
 
@@ -250,14 +249,11 @@ class FormatOps(
     *
     * Context: https://github.com/scalameta/scalafmt/issues/108
     */
-  def isJsNative(jsToken: Token): Boolean = {
-    initStyle.newlines.neverBeforeJsNative && jsToken.syntax == "js" &&
-    owners(jsToken).parent.exists(
-      _.show[
-        Structure
-      ].trim == """Term.Select(Term.Name("js"), Term.Name("native"))"""
-    )
-  }
+  def isJsNative(body: Tree): Boolean =
+    initStyle.newlines.neverBeforeJsNative && (body match {
+      case Term.Select(Term.Name("js"), Term.Name("native")) => true
+      case _ => false
+    })
 
   @inline
   final def startsStatement(tok: FormatToken): Option[Tree] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2020,12 +2020,9 @@ class Router(formatOps: FormatOps) {
       Seq(Split(Space, 0))
     else if (isSingleLineComment(ft.right))
       Seq(Split(Newline, 0).withIndent(2, expire, After))
-    else if (isJsNative(ft.right)) {
-      val spacePolicy =
-        if (!style.newlines.alwaysBeforeMultilineDef) Policy.NoPolicy
-        else SingleLineBlock(expire, exclude = exclude)
-      Seq(Split(Space, 0, policy = spacePolicy))
-    } else {
+    else if (isJsNative(body))
+      Seq(Split(Space, 0).withSingleLine(expire))
+    else {
       val spacePolicy = style.newlines.source match {
         case Newlines.classic =>
           if (ft.hasBreak) null
@@ -2108,7 +2105,7 @@ class Router(formatOps: FormatOps) {
             )
           }
       )
-    val okNewline = !isJsNative(ft.right)
+    val okNewline = !isJsNative(body)
     val spaceSplit = (style.newlines.source match {
       case Newlines.classic
           if okNewline && ft.hasBreak && ft.meta.leftOwner.is[Defn] =>


### PR DESCRIPTION
Current code is a bit ambiguous about newlines.neverBeforeJsNative and
newlines.alwaysBeforeMultilineDef when it comes to formatting methods
with "js.native" as body.