### PR TITLE
State: indicate if all alternatives were newlines

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -167,7 +167,7 @@ private class BestFirstSearch private (
           val tokenHash = hash(splitToken.left)
           if (
             emptyQueueSpots.contains(tokenHash) ||
-            dequeueOnNewStatements &&
+            dequeueOnNewStatements && curr.allAltAreNL &&
             dequeueSpots.contains(tokenHash) &&
             (depth > 0 || !isInsideNoOptZone(splitToken))
           )
@@ -191,10 +191,11 @@ private class BestFirstSearch private (
           )
         } else {
           val actualSplit = getActiveSplits(curr, maxCost)
+          val allAltAreNL = actualSplit.forall(_.isNL)
 
           var optimalNotFound = true
           actualSplit.foreach { split =>
-            val nextState = curr.next(split)
+            val nextState = curr.next(split, allAltAreNL)
             val updateBest = !keepSlowStates && depth == 0 &&
               split.isNL && !best.contains(curr.depth)
             if (updateBest) {
@@ -290,7 +291,7 @@ private class BestFirstSearch private (
         else {
           runner.event(Enqueue(split))
           implicit val style = styleMap.at(tokens(state.depth))
-          val nextState = state.next(split)
+          val nextState = state.next(split, false)
           traverseSameLine(nextState, depth)
         }
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -24,6 +24,7 @@ final case class State(
     indentation: Int,
     pushes: Seq[ActualIndent],
     column: Int,
+    allAltAreNL: Boolean,
     delayedPenalty: Int, // apply if positive, ignore otherwise
     formatOff: Boolean
 ) {
@@ -37,7 +38,8 @@ final case class State(
     * Calculates next State given split at tok.
     */
   def next(
-      initialNextSplit: Split
+      initialNextSplit: Split,
+      nextAllAltAreNL: Boolean
   )(implicit style: ScalafmtConfig, fops: FormatOps): State = {
     val tok = fops.tokens(depth)
     val right = tok.right
@@ -117,6 +119,7 @@ final case class State(
       nextIndent,
       nextIndents,
       nextStateColumn,
+      nextAllAltAreNL,
       nextDelayedPenalty,
       nextFormatOff
     )
@@ -270,6 +273,7 @@ object State {
     0,
     Seq.empty,
     0,
+    false,
     0,
     formatOff = false
   )

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1768,8 +1768,7 @@ val a = b match {
 }
 >>>
 val a = b match {
-  case i: EngineInstance =>
-    JObject(
+  case i: EngineInstance => JObject(
       JField("id", JString(i.id)) :: JField("status", JString(i.status)) ::
         JField("startTime", JString(i.startTime.toString)) ::
         JField("endTime", JString(i.endTime.toString)) ::


### PR DESCRIPTION
In BestFirstSearch, let's only start a new generation on a newline split if all its alternatives were also newlines.

Makes formatting of [partial] function parameters more consistent. Helps with #150. Helps with #2099.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/cbfbeb8d7efbfb8bbc8a64fcad600d44b87ff5c1?w=1