### PR TITLE
ScalafmtConfig: validate once in the decoder only

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/ValidationOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/ValidationOps.scala
@@ -3,19 +3,25 @@ package org.scalafmt.util
 import scala.collection.mutable
 
 object ValidationOps {
-  def assertNonNegative(ns: sourcecode.Text[Int]*): Unit = {
+
+  def addIfNegative(
+      ns: sourcecode.Text[Int]*
+  )(implicit errors: mutable.Buffer[String]): Unit =
     ns.foreach { n =>
       if (n.value < 0)
-        throw new IllegalArgumentException(
-          s"${n.source} must be non-negative, was ${n.value}"
-        )
+        errors += s"${n.source} must be non-negative, was ${n.value}"
     }
-  }
 
   def addIf(
       what: sourcecode.Text[Boolean],
       why: => String = ""
   )(implicit errors: mutable.Buffer[String]): Unit =
-    if (what.value) errors += what.source + why
+    addIfDirect(what.value, what.source + why)
+
+  def addIfDirect(
+      what: Boolean,
+      why: => String = ""
+  )(implicit errors: mutable.Buffer[String]): Unit =
+    if (what) errors += why
 
 }


### PR DESCRIPTION
There are multiple places where a configuration instance is created, and some of them are not really appropriate for validation, such as `StyleMap` where custom configuration copies are created based on comments in the code, or to support `binPack.literalArgumentLists`.

Therefore, let's just validate the initial configuration in the decoder and not the custom adjustments.

Fixes #2098.