### PR TITLE
Router: allow space after "{" in partial functions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -884,6 +884,47 @@ else {
 }
 ```
 
+### `newlines.beforeCurlyLambdaParams`
+
+This parameter controls whether a newline is forced between the opening curly brace
+and the parameters of a lambda or partial function. Added in 2.7.0, replacing
+boolean `alwaysBeforeCurlyBraceLambdaParams`.
+
+```scala mdoc:defaults
+newlines.beforeCurlyLambdaParams
+```
+
+```scala mdoc:scalafmt
+newlines.beforeCurlyLambdaParams = never
+---
+// should keep one-line
+x.map { x => s"${x._1} -> ${x._2}" }
+x.map { case (c, i) => s"$c -> $i" }
+// should unfold, break on { since case fits on a line but lambda doesn't
+x.zipWithIndex.map { case (c, i) => s"$c -> $i" }
+// should unfold, break on => since case doesn't fit on a line
+x.zipWithIndex.map { case (c, i) => s"$c -> $i (long comment)" }
+```
+
+```scala mdoc:scalafmt
+newlines.beforeCurlyLambdaParams = always
+---
+// should unfold, break on {, though fits on a line
+x.map { x => s"${x._1} -> ${x._2}" }
+x.map { case (c, i) => s"$c -> $i" }
+```
+
+```scala mdoc:scalafmt
+newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
+---
+// should keep one-line
+x.map { x => s"${x._1} -> ${x._2}" }
+x.map { case (c, i) => s"$c -> $i" }
+// should unfold, break on { as lambda doesn't fit on a line
+x.zipWithIndex.map { case (c, i) => s"$c -> $i" }
+x.zipWithIndex.map { case (c, i) => s"$c -> $i (long comment)" }
+```
+
 ### `newlines.afterCurlyLambda`
 
 This parameter controls handling of newlines after the arrow following the

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ReaderUtil.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ReaderUtil.scala
@@ -6,27 +6,16 @@ import metaconfig._
 import metaconfig.Configured._
 
 object ReaderUtil {
-  // Poor mans coproduct reader
-  def oneOf[T: ClassTag](options: sourcecode.Text[T]*): ConfCodec[T] =
-    oneOfImpl((lowerCase _).compose(lowerCaseNoBackticks), options)
 
-  def oneOfIgnoreBackticks[T: ClassTag](
-      options: sourcecode.Text[T]*
-  ): ConfCodec[T] =
-    oneOfImpl(lowerCaseNoBackticks, options)
-
-  private def lowerCase(s: String): String = s.toLowerCase
   private def lowerCaseNoBackticks(s: String): String =
     s.toLowerCase().replace("`", "")
 
-  private def oneOfImpl[T: ClassTag](
-      sanitize: String => String,
-      options: Seq[sourcecode.Text[T]]
-  ): ConfCodec[T] = {
-    val m = options.map(x => sanitize(x.source) -> x.value).toMap
+  // Poor mans coproduct reader
+  def oneOf[T: ClassTag](options: sourcecode.Text[T]*): ConfCodec[T] = {
+    val m = options.map(x => lowerCaseNoBackticks(x.source) -> x.value).toMap
     val decoder = ConfDecoder.instance[T] {
       case Conf.Str(x) =>
-        m.get(sanitize(x)) match {
+        m.get(lowerCaseNoBackticks(x)) match {
           case Some(y) =>
             Ok(y)
           case None =>
@@ -44,4 +33,5 @@ object ReaderUtil {
     }
     ConfCodec.EncoderDecoderToCodec(encoder, decoder)
   }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -232,8 +232,8 @@ case class ScalafmtConfig(
 
   // Edition 2019-11
   val activeForEdition_2019_11: Boolean = activeFor(Edition(2019, 11))
-  val newlinesBeforeSingleArgParenLambdaParams: Boolean =
-    newlines.alwaysBeforeCurlyBraceLambdaParams || !activeForEdition_2019_11
+  val newlinesBeforeSingleArgParenLambdaParams =
+    newlines.alwaysBeforeCurlyLambdaParams || !activeForEdition_2019_11
   val newlinesBetweenCurlyAndCatchFinally: Boolean =
     newlines.alwaysBeforeElseAfterCurlyIf && activeForEdition_2019_11
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
@@ -9,7 +9,7 @@ case class SortSettings(
 object SortSettings {
 
   implicit val SortSettingsModKeyReader: ConfCodec[ModKey] =
-    ReaderUtil.oneOfIgnoreBackticks[ModKey](
+    ReaderUtil.oneOf[ModKey](
       `implicit`,
       `final`,
       `sealed`,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -195,8 +195,7 @@ class Router(formatOps: FormatOps) {
             case Some(owner: Term.Function) =>
               val arrow = getFuncArrow(lastLambda(owner))
               val expire = arrow.getOrElse(tokens(owner.tokens.last))
-              val nlOnly =
-                style.newlines.alwaysBeforeCurlyBraceLambdaParams
+              val nlOnly = style.newlines.alwaysBeforeCurlyLambdaParams
               (expire, arrow.map(_.left), 0, nlOnly)
             case _ =>
               selfAnnotation match {

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -8,9 +8,8 @@ List(Split(Space, 0).withPolicy(SingleLineBlock(close)),
 >>>
 List(Split(Space, 0).withPolicy(SingleLineBlock(close)),
      Split(nl, 1)
-       .withPolicy({
-         case Decision(t @ FormatToken(_, `close`, _), s) =>
-           Decision(t, List(Split(Newline, 0)))
+       .withPolicy({ case Decision(t @ FormatToken(_, `close`, _), s) =>
+         Decision(t, List(Split(Newline, 0)))
        })
        .withIndent(2, close, Right))
 <<< Massive 2
@@ -31,9 +30,8 @@ List(Split(Space,
            ignoreIf = blockSize > style.maxColumn),
      Split(nl,
            1,
-           policy = {
-             case Decision(t @ FormatToken(_, `close`, _), s) =>
-               Decision(t, List(Split(Newline, 0)))
+           policy = { case Decision(t @ FormatToken(_, `close`, _), s) =>
+             Decision(t, List(Split(Newline, 0)))
            }))
 <<< Massive (good API) 3
 Split(Space, 0).withPolicy {
@@ -138,9 +136,8 @@ Seq(
     // Either everything fits in one line or break on =>
     Split(Space, 0).withPolicy(SingleLineBlock(lastToken)),
     Split(Space, 1)
-      .withPolicy(Policy({
-                           case Decision(t @ FormatToken(`arrow`, _, _), s) =>
-                             Decision(t, s.filter(_.modification.isNewline))
+      .withPolicy(Policy({ case Decision(t @ FormatToken(`arrow`, _, _), s) =>
+                           Decision(t, s.filter(_.modification.isNewline))
                          },
                          expire = lastToken.end))
       .withIndent(2, lastToken, Left) // case body indented by 2.

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -239,17 +239,15 @@ if (other == null) {
 >>>
 {
   {
-    phrase(a ^^ {
-      case p1 =>
-        Rowset(
-            p1.toSeq map {
-              fromXML[eveapi.xml.char.ContactList.Row](_,
-                                                       scalaxb.ElemName(node))
-            },
-            ListMap(
-                List(
-                    (node \ "@name").headOption.map(x => DataRecord())
-                ).flatten: _*))
+    phrase(a ^^ { case p1 =>
+      Rowset(
+          p1.toSeq map {
+            fromXML[eveapi.xml.char.ContactList.Row](_, scalaxb.ElemName(node))
+          },
+          ListMap(
+              List(
+                  (node \ "@name").headOption.map(x => DataRecord())
+              ).flatten: _*))
     })
   }
 }
@@ -274,8 +272,8 @@ object ExternForwarder {
       case DefDef()
           if isExternModule(from.symbol)
             && params.length == args.length
-            && params.zip(args).forall {
-              case _ => false
+            && params.zip(args).forall { case _ =>
+              false
             } =>
         Some(sel.symbol)
       case _ =>

--- a/scalafmt-tests/src/test/resources/default/Case.stat
+++ b/scalafmt-tests/src/test/resources/default/Case.stat
@@ -89,8 +89,8 @@ x match {
 {
   def testZipPartitions4(rdd: RDD[Int]): Unit = {
     rdd
-      .zipPartitions(rdd, rdd, rdd) {
-        case (it1, it2, it3, it4) => return; it1
+      .zipPartitions(rdd, rdd, rdd) { case (it1, it2, it3, it4) =>
+        return; it1
       }
       .count()
   }

--- a/scalafmt-tests/src/test/resources/default/Idempotency.stat
+++ b/scalafmt-tests/src/test/resources/default/Idempotency.stat
@@ -25,15 +25,14 @@ val bindingFuture = Http().bindAndHandleSync({
   {
     {
       val bindingFuture = Http().bindAndHandleSync(
-          {
-            case HttpRequest(_, _, headers, _, _) ⇒
-              val upgrade = headers.collectFirst {
-                case u: UpgradeToWebSocket ⇒ u
-              }.get
-              upgrade.handleMessages(
-                  Flow.fromSinkAndSource(Sink.ignore,
-                                         Source.fromPublisher(source)),
-                  None)
+          { case HttpRequest(_, _, headers, _, _) ⇒
+            val upgrade = headers.collectFirst {
+              case u: UpgradeToWebSocket ⇒ u
+            }.get
+            upgrade.handleMessages(
+                Flow.fromSinkAndSource(Sink.ignore,
+                                       Source.fromPublisher(source)),
+                None)
           },
           interface = "localhost",
           port = 0)

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -217,10 +217,9 @@ def test(dataFrame: DataFrame) = {
   dataFrame.rdd
     .aggregate(zeroAccumulator)(
       (acc, row) =>
-        acc.zip(row.toSeq).map {
-          case (x, y) =>
-            if (true) (1, 2)
-            else (x._1 + 2, x._2 + 1)
+        acc.zip(row.toSeq).map { case (x, y) =>
+          if (true) (1, 2)
+          else (x._1 + 2, x._2 + 1)
         },
       (acc1, acc2) => acc1.zip(acc2).map { case (x, y) => (x._1 + y._1, x._2 + y._2) }
     )

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -522,15 +522,13 @@ object a {
     try {
       val driver = extendedSystem.dynamicAccess
         .createInstanceFor[Transport](fqn, args)
-        .recover({
-
-          case exception ⇒
-            throw new IllegalArgumentException(
-              s"Cannot instantiate transport [$fqn]. " +
-                "Make sure it extends [akka.remote.transport.Transport] and has constructor with " +
-                "[akka.actor.ExtendedActorSystem] and [com.typesafe.config.Config] parameters",
-              exception
-            )
+        .recover({ case exception ⇒
+          throw new IllegalArgumentException(
+            s"Cannot instantiate transport [$fqn]. " +
+              "Make sure it extends [akka.remote.transport.Transport] and has constructor with " +
+              "[akka.actor.ExtendedActorSystem] and [com.typesafe.config.Config] parameters",
+            exception
+          )
 
         })
         .get
@@ -873,8 +871,8 @@ object a {
 >>>
 object a {
   val reduces = node
-    .foldDown[List[dag.Reduce]](true) {
-      case r: dag.Reduce => List(r)
+    .foldDown[List[dag.Reduce]](true) { case r: dag.Reduce =>
+      List(r)
     } distinct
 }
 <<< #2070

--- a/scalafmt-tests/src/test/resources/default/Unindent.stat
+++ b/scalafmt-tests/src/test/resources/default/Unindent.stat
@@ -332,13 +332,12 @@ assertEquals(1,
 }
 >>>
 {
-  val sourceToBuffer: Map[ScaldingSource, Buffer[Tuple]] = (lasts.map {
-    case (b, it) =>
+  val sourceToBuffer: Map[ScaldingSource, Buffer[Tuple]] =
+    (lasts.map { case (b, it) =>
       lastMappable(b) -> toBuffer(it)
-  } ++ streams.map {
-    case (b, it) =>
+    } ++ streams.map { case (b, it) =>
       streamMappable(b) -> toBuffer(it)
-  }).toMap
+    }).toMap
 }
 <<< nullDF
 {

--- a/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
+++ b/scalafmt-tests/src/test/resources/newdefault/SearchState.stat
@@ -59,9 +59,8 @@ val boss = system.actorOf(Props(new Actor {
     case e: IllegalStateException if e.getMessage == "expected" ⇒
       SupervisorStrategy.Resume
   }
-  def receive = {
-    case p: TypedProps[_] ⇒
-      context.sender() ! TypedActor(context).typedActorOf(p)
+  def receive = { case p: TypedProps[_] ⇒
+    context.sender() ! TypedActor(context).typedActorOf(p)
   }
 }))
 <<< test setup idempotency

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -569,15 +569,14 @@ object a {
           managedClasspath in Provided,
           fullClasspath in Runtime,
           fullClasspath in Compile,
-          fullClasspath in Test) map {
-          case ((conf, expected), p, r, c, t) =>
-            val cp =
-              if (conf == Compile.name) c
-              else if (conf == Runtime.name) r
-              else if (conf == Provided.name) p
-              else if (conf == Test.name) t
-              else sys.error("Invalid config: " + conf)
-            checkServletAPI(cp.files, expected, conf)
+          fullClasspath in Test) map { case ((conf, expected), p, r, c, t) =>
+          val cp =
+            if (conf == Compile.name) c
+            else if (conf == Runtime.name) r
+            else if (conf == Provided.name) p
+            else if (conf == Test.name) t
+            else sys.error("Invalid config: " + conf)
+          checkServletAPI(cp.files, expected, conf)
         }
       }
     )

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -587,15 +587,14 @@ object a {
           fullClasspath in Runtime,
           fullClasspath in Compile,
           fullClasspath in Test
-        ) map {
-          case ((conf, expected), p, r, c, t) =>
-            val cp =
-              if (conf == Compile.name) c
-              else if (conf == Runtime.name) r
-              else if (conf == Provided.name) p
-              else if (conf == Test.name) t
-              else sys.error("Invalid config: " + conf)
-            checkServletAPI(cp.files, expected, conf)
+        ) map { case ((conf, expected), p, r, c, t) =>
+          val cp =
+            if (conf == Compile.name) c
+            else if (conf == Runtime.name) r
+            else if (conf == Provided.name) p
+            else if (conf == Test.name) t
+            else sys.error("Invalid config: " + conf)
+          checkServletAPI(cp.files, expected, conf)
         }
       }
     )
@@ -720,12 +719,11 @@ object A {
       _.y(
         abcd,
         { case ((abcdefghij, aswbasdfaw), asfda) => aswdf },
-        {
-          case (abcdefghij, sadfasdass) =>
-            (
-              asdfa.sadvfs(abcdefghij).get,
-              asdfasdfasfdasda.asdfas(asdfasdaas).get
-            )
+        { case (abcdefghij, sadfasdass) =>
+          (
+            asdfa.sadvfs(abcdefghij).get,
+            asdfasdfasfdasda.asdfas(asdfasdaas).get
+          )
         },
         foo
       )
@@ -751,12 +749,11 @@ object A {
         abcd,
         { { case ((abcdefghij, aswbasdfaw), asfda) => aswdf } },
         {
-          {
-            case (abcdefghij, sadfasdass) =>
-              (
-                asdfa.sadvfs(abcdefghij).get,
-                asdfasdfasfdasda.asdfas(asdfasdaas).get
-              )
+          { case (abcdefghij, sadfasdass) =>
+            (
+              asdfa.sadvfs(abcdefghij).get,
+              asdfasdfasfdasda.asdfas(asdfasdaas).get
+            )
           }
         },
         foo

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -508,8 +508,7 @@ val nested =
 >>>
 val nested =
   promiseIntercept(new Actor {
-    def receive = {
-      case _ ⇒
+    def receive = { case _ ⇒
     }
   })(result)
 <<< 2.21 val with apply type

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -560,8 +560,7 @@ val nested =
 val nested =
   promiseIntercept(
     new Actor {
-      def receive = {
-        case _ ⇒
+      def receive = { case _ ⇒
       }
     }
   )(result)
@@ -1825,9 +1824,8 @@ val strings = Seq(
   ) ++
   otherMetricHeaders
     .zip(bestScore.otherScores)
-    .map {
-      case (h, s) =>
-        s"  $h: $s"
+    .map { case (h, s) =>
+      s"  $h: $s"
     } ++
   outputPath
     .toSeq
@@ -2505,9 +2503,8 @@ object a {
           x.tree
             .children
             .tail
-            .map {
-              case E(F(g)) =>
-                g.asInstanceOf[String]
+            .map { case E(F(g)) =>
+              g.asInstanceOf[String]
             }
         }
         .headOption

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -528,9 +528,8 @@ object a {
   def findAccountByAPIKey(apiKey: APIKey) =
     byKeyCache.get(apiKey) match {
       case None =>
-        delegate.findAccountByAPIKey(apiKey) map {
-          case (x, y) =>
-            x map y tap (add(apiKey, _)) unsafePerformIO
+        delegate.findAccountByAPIKey(apiKey) map { case (x, y) =>
+          x map y tap (add(apiKey, _)) unsafePerformIO
         }
     }
 }

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -167,9 +167,8 @@ object a {
   x.zipWithIndex.map {
     case (c, i) => s"$c -> $i"
   }
-  x.zipWithIndex.map {
-    case (c, i) =>
-      s"$c -> $i (long comment)"
+  x.zipWithIndex.map { case (c, i) =>
+    s"$c -> $i (long comment)"
   }
   x.zipWithIndex.map {
     case (c, i) if c != i =>
@@ -192,7 +191,9 @@ object a {
   x.map {
     x => s"${x._1} -> ${x._2}"
   }
-  x.map { case (c, i) => s"$c -> $i" }
+  x.map {
+    case (c, i) => s"$c -> $i"
+  }
   x.zipWithIndex.map {
     x => s"${x._1} -> ${x._2}"
   }
@@ -208,8 +209,8 @@ object a {
       s"$c -> $i"
   }
 }
-<<< #2099 beforeCurlyLambdaParams = multilineCaseOnly
-newlines.beforeCurlyLambdaParams = multilineCaseOnly
+<<< #2099 beforeCurlyLambdaParams = multilineWithCaseOnly
+newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
 ===
 object a {
   x.map { x => s"${x._1} -> ${x._2}" }

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -146,3 +146,95 @@ call(1) { x => // nothing
 >>>
 call(1) { x => // nothing
 }
+<<< #2099 beforeCurlyLambdaParams = false
+newlines.beforeCurlyLambdaParams = false
+===
+object a {
+  x.map { x => s"${x._1} -> ${x._2}" }
+  x.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { x => s"${x._1} -> ${x._2}" }
+  x.zipWithIndex.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { case (c, i) => s"$c -> $i (long comment)" }
+  x.zipWithIndex.map { case (c, i) if c != i => s"$c -> $i" }
+}
+>>>
+object a {
+  x.map { x => s"${x._1} -> ${x._2}" }
+  x.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { x =>
+    s"${x._1} -> ${x._2}"
+  }
+  x.zipWithIndex.map {
+    case (c, i) => s"$c -> $i"
+  }
+  x.zipWithIndex.map {
+    case (c, i) =>
+      s"$c -> $i (long comment)"
+  }
+  x.zipWithIndex.map {
+    case (c, i) if c != i =>
+      s"$c -> $i"
+  }
+}
+<<< #2099 beforeCurlyLambdaParams = true
+newlines.beforeCurlyLambdaParams = true
+===
+object a {
+  x.map { x => s"${x._1} -> ${x._2}" }
+  x.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { x => s"${x._1} -> ${x._2}" }
+  x.zipWithIndex.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { case (c, i) => s"$c -> $i (long comment)" }
+  x.zipWithIndex.map { case (c, i) if c != i => s"$c -> $i" }
+}
+>>>
+object a {
+  x.map {
+    x => s"${x._1} -> ${x._2}"
+  }
+  x.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map {
+    x => s"${x._1} -> ${x._2}"
+  }
+  x.zipWithIndex.map {
+    case (c, i) => s"$c -> $i"
+  }
+  x.zipWithIndex.map {
+    case (c, i) =>
+      s"$c -> $i (long comment)"
+  }
+  x.zipWithIndex.map {
+    case (c, i) if c != i =>
+      s"$c -> $i"
+  }
+}
+<<< #2099 beforeCurlyLambdaParams = multilineCaseOnly
+newlines.beforeCurlyLambdaParams = multilineCaseOnly
+===
+object a {
+  x.map { x => s"${x._1} -> ${x._2}" }
+  x.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { x => s"${x._1} -> ${x._2}" }
+  x.zipWithIndex.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { case (c, i) => s"$c -> $i (long comment)" }
+  x.zipWithIndex.map { case (c, i) if c != i => s"$c -> $i" }
+}
+>>>
+object a {
+  x.map { x => s"${x._1} -> ${x._2}" }
+  x.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { x =>
+    s"${x._1} -> ${x._2}"
+  }
+  x.zipWithIndex.map {
+    case (c, i) => s"$c -> $i"
+  }
+  x.zipWithIndex.map {
+    case (c, i) =>
+      s"$c -> $i (long comment)"
+  }
+  x.zipWithIndex.map {
+    case (c, i) if c != i =>
+      s"$c -> $i"
+  }
+}

--- a/scalafmt-tests/src/test/resources/unit/TermApply.stat
+++ b/scalafmt-tests/src/test/resources/unit/TermApply.stat
@@ -65,13 +65,12 @@ function(a, b, c, {
     case Foo("a", 1) => Foo("b", 2)
   })
 >>>
-function(
-    a,
-    b,
-    c,
-    {
-      case Foo("a", 1) => Foo("b", 2)
-    })
+function(a,
+         b,
+         c,
+         { case Foo("a", 1) =>
+           Foo("b", 2)
+         })
 <<< MUST NOT use automatic formatting 1 alexandru/scala-best-practices
 val dp = new DispatchPlan(Set(filteredAssets), start =
   startDate, end = endDate, product, scheduleMap, availabilityMap,


### PR DESCRIPTION
Support only a single case clause without conditions.

Fixes #150. Fixes #2099.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/baa0d4f436f1bcb7e6b44f834dafb26fcc9b3bb0?w=1