### PR TITLE
Newlines: rename afterCurlyLambda{,Params}

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -925,19 +925,22 @@ x.zipWithIndex.map { case (c, i) => s"$c -> $i" }
 x.zipWithIndex.map { case (c, i) => s"$c -> $i (long comment)" }
 ```
 
-### `newlines.afterCurlyLambda`
+### `newlines.afterCurlyLambdaParams`
 
 This parameter controls handling of newlines after the arrow following the
 parameters of a curly brace lambda or partial function, and whether a space
 can be used for one-line formatting of the entire function body (if allowed
 but the body doesn't fit, a break is always forced).
 
+This parameter was renamed in 2.7.0 from `afterCurlyLambda`, for clarity and
+consistency with `beforeCurlyLambdaParams` defined above.
+
 ```scala mdoc:defaults
-newlines.afterCurlyLambda
+newlines.afterCurlyLambdaParams
 ```
 
 ```scala mdoc:scalafmt
-newlines.afterCurlyLambda = squash
+newlines.afterCurlyLambdaParams = squash
 ---
 // remove all blank lines if any
 // one-line formatting is allowed
@@ -952,7 +955,7 @@ something.map { x => f(x) }
 ```
 
 ```scala mdoc:scalafmt
-newlines.afterCurlyLambda = never
+newlines.afterCurlyLambdaParams = never
 ---
 // remove all blank lines if any
 // one-line formatting depends on newlines.source:
@@ -968,7 +971,7 @@ something.map { x => f(x) }
 ```
 
 ```scala mdoc:scalafmt
-newlines.afterCurlyLambda = preserve
+newlines.afterCurlyLambdaParams = preserve
 ---
 // if blank lines are present, keep only one
 // one-line formatting depends on newlines.source:
@@ -984,7 +987,7 @@ something.map { x => f(x) }
 ```
 
 ```scala mdoc:scalafmt
-newlines.afterCurlyLambda = always
+newlines.afterCurlyLambdaParams = always
 ---
 // ensure a single blank line
 // one-line formatting is not allowed
@@ -1246,12 +1249,12 @@ List(1, 2, 3).map { x => x + 1 }
 ```
 
 Entire power of `RedundantBraces` can be accessed with
-`newlines.afterCurlyLambda=squash`. It will try to squash lambda body in one
+`newlines.afterCurlyLambdaParams=squash`. It will try to squash lambda body in one
 line and then replace braces with parens:
 
 ```scala mdoc:scalafmt
 rewrite.rules = [RedundantBraces]
-newlines.afterCurlyLambda=squash
+newlines.afterCurlyLambdaParams=squash
 ---
 List(1, 2, 3).map { x =>
   x + 1
@@ -1339,7 +1342,7 @@ s"user id is ${id}"
 ```
 
 `rewrite.redundantBraces.parensForOneLineApply` is `true` by default for `edition` >= 2020-01.
-See also [newlines.afterCurlyLambda = squash](#newlinesaftercurlylambda).
+See also [newlines.afterCurlyLambdaParams = squash](#newlinesaftercurlylambdaparams).
 
 ```scala mdoc:scalafmt
 rewrite.rules = [RedundantBraces]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -45,7 +45,7 @@ import metaconfig.generic.Surface
   *       consume(n)
   *   }
   *   }}}
-  * @param afterCurlyLambda
+  * @param afterCurlyLambdaParams
   *   If `never` (default), it will remove any extra lines below curly lambdas
   *   {{{
   *   something.map { x =>
@@ -167,7 +167,9 @@ case class Newlines(
       "2.5.0"
     )
     private val alwaysBeforeTopLevelStatements: Boolean = false,
-    afterCurlyLambda: AfterCurlyLambdaParams = AfterCurlyLambdaParams.never,
+    @annotation.ExtraName("afterCurlyLambda")
+    afterCurlyLambdaParams: AfterCurlyLambdaParams =
+      AfterCurlyLambdaParams.never,
     implicitParamListModifierForce: Seq[BeforeAfter] = Seq.empty,
     implicitParamListModifierPrefer: Option[BeforeAfter] = None,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -342,7 +342,9 @@ object ScalafmtConfig {
     locally {
       implicit val errors = new mutable.ArrayBuffer[String]
       if (newlines.sourceIgnored) {
-        addIf(newlines.afterCurlyLambda == AfterCurlyLambdaParams.preserve)
+        addIf(
+          newlines.afterCurlyLambdaParams == AfterCurlyLambdaParams.preserve
+        )
         addIf(optIn.configStyleArguments && align.openParenCallSite)
         addIf(optIn.configStyleArguments && align.openParenDefnSite)
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1198,7 +1198,7 @@ class FormatOps(
   def getSpaceAndNewlineAfterCurlyLambda(
       newlines: Int
   )(implicit style: ScalafmtConfig): (Boolean, NewlineT) =
-    style.newlines.afterCurlyLambda match {
+    style.newlines.afterCurlyLambdaParams match {
       case Newlines.AfterCurlyLambdaParams.squash => (true, Newline)
       case Newlines.AfterCurlyLambdaParams.never =>
         val space = style.newlines.source match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -369,7 +369,7 @@ class Router(formatOps: FormatOps) {
             leftOwner.is[Template] || leftOwner.parent.exists(_.is[Template])
 
           def noSquash =
-            style.newlines.afterCurlyLambda ne
+            style.newlines.afterCurlyLambdaParams ne
               Newlines.AfterCurlyLambdaParams.squash
 
           isCurlyLambda && (style.newlines.source match {


### PR DESCRIPTION
For consistency with the beforeCurlyLambdaParams parameter.