### PR TITLE
Fix a problem where parens are removed after a yield

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -99,6 +99,15 @@ class RedundantParens(implicit ctx: RewriteCtx) extends RewriteSession {
         }
         ctx.removeLFToAvoidEmptyLine(toks(beg + offBeg), toks(beg + offEnd))
         ctx.removeLFToAvoidEmptyLine(toks(end - offEnd), toks(end - offBeg))
+
+        if (beg > 0) {
+          toks(beg - 1) match {
+            case t: Token.KwYield =>
+              builder += TokenPatch.AddRight(t, " ", keepTok = true)
+            case _ => ()
+          }
+        }
+
         ctx.addPatchSet(builder.result(): _*)
       }
     }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -271,3 +271,15 @@ object a {
 object a {
   print("") shouldBe (())
 }
+<<< yield without a space
+object a {
+  val x = for {
+    a <- b
+  } yield(a)
+}
+>>>
+object a {
+  val x = for {
+    a <- b
+  } yield a
+}


### PR DESCRIPTION
it's a problem when there is no space between the yield and the
parens because it leaves the code in a broken state (won't compile)

Fixes #2117