### PR TITLE
Router: prefer case break after `=>` over `if`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -415,7 +415,7 @@ class Router(formatOps: FormatOps) {
         val caseStat = leftOwner.asInstanceOf[Case]
         if (isCaseBodyABlock(tok, caseStat)) Seq(Split(Space, 0))
         else {
-          def newlineSplit(cost: Int) = {
+          def newlineSplit(cost: Int)(implicit line: sourcecode.Line) = {
             val noIndent = rhsIsCommentedOut(tok)
             val isDouble = tok.hasBlankLine && caseStat.body.tokens.isEmpty
             Split(NewlineT(isDouble = isDouble, noIndent = noIndent), cost)

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2421,3 +2421,22 @@ object a {
     StructField("fieldB", DataTypes.StringType)
   ))
 }
+<<< prefer break after =>, not before `if`
+maxColumn = 74
+===
+object a {
+  val a = partitions.map { p =>
+    a match {
+      case Some(dstPartition) if dstPartition.location != p.location => updateBuilder += p
+    }
+  }
+}
+>>>
+object a {
+  val a = partitions.map { p =>
+    a match {
+      case Some(dstPartition)
+          if dstPartition.location != p.location => updateBuilder += p
+    }
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2435,8 +2435,8 @@ object a {
 object a {
   val a = partitions.map { p =>
     a match {
-      case Some(dstPartition)
-          if dstPartition.location != p.location => updateBuilder += p
+      case Some(dstPartition) if dstPartition.location != p.location =>
+        updateBuilder += p
     }
   }
 }


### PR DESCRIPTION
By changing the line associated with the newline split after `=>`, we give higher priority to the State ending in this split compared to the State ending in the space split when cost and depth are the same.