### PR TITLE
PolicyOps: remove redundant SLB policy end filter

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -162,16 +162,10 @@ class FormatOps(
       .fold(identity, identity)
 
   final def nextNonComment(curr: FormatToken): FormatToken =
-    findToken(curr, next) {
-      case FormatToken(_, _: T.Comment, _) => false
-      case _ => true
-    }.fold(identity, identity)
+    findToken(curr, next)(!_.right.is[T.Comment]).fold(identity, identity)
 
   final def prevNonComment(curr: FormatToken): FormatToken =
-    findToken(curr, prev) {
-      case FormatToken(_: T.Comment, _, _) => false
-      case _ => true
-    }.fold(identity, identity)
+    findToken(curr, prev)(!_.left.is[T.Comment]).fold(identity, identity)
 
   final def rhsOptimalToken(
       start: FormatToken

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -128,37 +128,50 @@ case class Split(
   def withSingleLine(
       expire: Token,
       exclude: => Set[Range] = Set.empty,
+      endPolicy: Policy.End = Policy.End.On,
       noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false
   )(implicit line: sourcecode.Line): Split =
-    withSingleLineAndOptimal(expire, expire, exclude, noSyntaxNL, killOnFail)
+    withSingleLineAndOptimal(
+      expire,
+      expire,
+      exclude,
+      endPolicy,
+      noSyntaxNL,
+      killOnFail
+    )
 
   def withSingleLineOpt(
       expire: Option[Token],
       exclude: => Set[Range] = Set.empty,
+      endPolicy: Policy.End = Policy.End.On,
       noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false
   )(implicit line: sourcecode.Line): Split =
-    expire.fold(this)(withSingleLine(_, exclude, noSyntaxNL, killOnFail))
+    expire.fold(this)(
+      withSingleLine(_, exclude, endPolicy, noSyntaxNL, killOnFail)
+    )
 
   def withSingleLineAndOptimal(
       expire: Token,
       optimal: Token,
       exclude: => Set[Range] = Set.empty,
+      endPolicy: Policy.End = Policy.End.On,
       noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false
   )(implicit line: sourcecode.Line): Split =
     withOptimalToken(optimal, killOnFail)
-      .withSingleLineNoOptimal(expire, exclude, noSyntaxNL)
+      .withSingleLineNoOptimal(expire, exclude, endPolicy, noSyntaxNL)
 
   def withSingleLineNoOptimal(
       expire: Token,
       exclude: => Set[Range] = Set.empty,
+      endPolicy: Policy.End = Policy.End.On,
       noSyntaxNL: Boolean = false
   )(implicit line: sourcecode.Line): Split =
     withPolicy(
-      SingleLineBlock(
-        expire,
+      new SingleLineBlock(
+        endPolicy(expire),
         exclude,
         penaliseNewlinesInsideTokens = noSyntaxNL
       )


### PR DESCRIPTION
The policy itself applies the same filter already, so the additional check is unnecessary.

Now that explicit expire token is no longer needed, provide instead an instance of Policy.End.WithPos, and modify Split invocations to be able to expire differently.