### PR TITLE
Rewrite: replace delimiters with space

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-case.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-case.stat
@@ -89,3 +89,15 @@ val a = b.c(d =>
 val a = b.c(d => {e}, f =>g match {  case h =>})
 >>>
 val a = b.c(d => e, f => g match { case h => })
+<<< #2117 if without a space
+object a {
+  a match {
+    case a if{a} =>
+  }
+}
+>>>
+test does not parse
+object a {
+  a match {
+    case a ifa =>
+               ^

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-case.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces-case.stat
@@ -96,8 +96,8 @@ object a {
   }
 }
 >>>
-test does not parse
 object a {
   a match {
-    case a ifa =>
-               ^
+    case a if a =>
+  }
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -856,4 +856,4 @@ object Issue {
 2
 }op2 3
 >>>
-1 op12op2 3
+1 op1 2 op2 3

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -851,3 +851,9 @@ object Issue {
     val _ = f()
   }
 }
+<<< #2117 maintain delimiter after removing newline in infix
+1 op1{
+2
+}op2 3
+>>>
+1 op12op2 3

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -283,3 +283,15 @@ object a {
     a <- b
   } yield a
 }
+<<< #2117 if without a space
+object a {
+  a match {
+    case a if(((a))) =>
+  }
+}
+>>>
+test does not parse
+object a {
+  a match {
+    case a ifa =>
+               ^

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -290,8 +290,8 @@ object a {
   }
 }
 >>>
-test does not parse
 object a {
   a match {
-    case a ifa =>
-               ^
+    case a if a =>
+  }
+}


### PR DESCRIPTION
Parens/braces serve as delimiters (such as in "if(x"), so when we remove them, we must ensure that tokens before and after continue to be clearly separated. For that, let's just replace these delimiters with spaces, as formatter will remove any redundant space later.

Generalizes #2118.