### PR TITLE
PolicyOps: shorten extra flags (noSyntaxNL, okSLC)

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -173,7 +173,7 @@ case class Split(
       new SingleLineBlock(
         endPolicy(expire),
         exclude,
-        penaliseNewlinesInsideTokens = noSyntaxNL
+        noSyntaxNL = noSyntaxNL
       )
     )
 


### PR DESCRIPTION
Replace disallowSingleLineComments and penaliseNewlinesInsideTokens.