### PR TITLE
Router: prefer not breaking before lambda params

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -302,15 +302,15 @@ class Router(formatOps: FormatOps) {
 
         val splits = Seq(
           singleLineSplit,
+          Split(nl, 1)
+            .withPolicy(newlineBeforeClosingCurly)
+            .withIndent(2, close, Before),
           Split(Space, 0)
             .onlyIf(lambdaNLOnly.contains(false) && lambdaPolicy != null)
             .notIf(style.newlines.sourceIs(Newlines.keep) && newlines != 0)
             .withOptimalTokenOpt(lambdaArrow)
             .withIndent(lambdaIndent, close, Before)
-            .withPolicy(lambdaPolicy),
-          Split(nl, 1)
-            .withPolicy(newlineBeforeClosingCurly)
-            .withIndent(2, close, Before)
+            .withPolicy(lambdaPolicy)
         )
         right match {
           case t: T.Xml.Start => withIndentOnXmlStart(t, splits)

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2538,3 +2538,41 @@ object a {
   val foo: Int = /* comment */
     baz
 }
+<<< prefer no break before lambda parameters
+newlines.alwaysBeforeMultilineDef = false
+===
+object a {
+  def a(b: Int, d: Range): Set[Int] =
+    // comment 1
+    d.map(x => Foo.bar.baz(Bar.baz(x)))
+      .bar.baz.qux(foo(b, c)).flatMap {
+        y =>
+          // comment 2
+          val a: Int = y.getOrElse(
+            foo.bar,
+            throw new Exception(
+              "missing " + foo(y)
+            )
+          ).toInt
+          // comment 3
+          Some(a).filter(d.contains)
+      }
+}
+>>>
+object a {
+  def a(b: Int, d: Range): Set[Int] =
+    // comment 1
+    d.map(x => Foo.bar.baz(Bar.baz(x)))
+      .bar.baz.qux(foo(b, c)).flatMap {
+        y =>
+          // comment 2
+          val a: Int = y.getOrElse(
+            foo.bar,
+            throw new Exception(
+              "missing " + foo(y)
+            )
+          ).toInt
+          // comment 3
+          Some(a).filter(d.contains)
+      }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2563,16 +2563,16 @@ object a {
   def a(b: Int, d: Range): Set[Int] =
     // comment 1
     d.map(x => Foo.bar.baz(Bar.baz(x)))
-      .bar.baz.qux(foo(b, c)).flatMap {
-        y =>
-          // comment 2
-          val a: Int = y.getOrElse(
-            foo.bar,
-            throw new Exception(
-              "missing " + foo(y)
-            )
-          ).toInt
-          // comment 3
-          Some(a).filter(d.contains)
+      .bar.baz.qux(foo(b, c))
+      .flatMap { y =>
+        // comment 2
+        val a: Int = y.getOrElse(
+          foo.bar,
+          throw new Exception(
+            "missing " + foo(y)
+          )
+        ).toInt
+        // comment 3
+        Some(a).filter(d.contains)
       }
 }


### PR DESCRIPTION
A split from a later line has higher preference.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/138ce00b316773b54c87f425c40550328a90761a?w=1