### PR TITLE
Router: delay break if detached comment follows `{`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -183,7 +183,8 @@ class Router(formatOps: FormatOps) {
             formatToken.hasBreak || style.newlines.sourceIgnored
           )
         val nl: Modification =
-          if (isSelfAnnotationNL)
+          if (right.is[T.Comment] && tok.noBreak) Space
+          else if (isSelfAnnotationNL)
             getModCheckIndent(formatToken, math.max(newlines, 1))
           else
             NewlineT(tok.hasBlankLine || blankLineBeforeDocstring(tok))

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -55,8 +55,7 @@ for ((l, r) ← /* c1 */ { /* c2 */ Seq(
 ) checkOne(looker, l, r)
 >>>
 for (
-    (l, r) ← /* c1 */ {
-        /* c2 */
+    (l, r) ← /* c1 */ { /* c2 */
         Seq(
             SelectString("a/b/c") -> None,
             SelectString("akka://all-systems/Nobody") -> None,

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -382,8 +382,7 @@ testAsync("Resource.make is equivalent to a partially applied bracket") { implic
 >>>
 testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
   check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String] /* c1 */ ) /* c2 */ =>
-    {
-      /*c3*/
+    { /*c3*/
       acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f)
     }
   }

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
@@ -126,8 +126,7 @@ seq should have length 5
   perform(_ + 1)
 }
 >>>
-(1 to total).foreach {
-  /* c1 */
+(1 to total).foreach { /* c1 */
   _ =>
     perform(_ + 1)
 }


### PR DESCRIPTION
`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/5bb32713acf7f80b5710a6432a9671a7d1cd8307
(formatting is applied to the original code, not to the previous state of the branch; it doesn't remove newlines but instead fails to add them, as it had before).