### PR TITLE
FormatOps: allow excluding end in exclude ranges

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -251,11 +251,14 @@ class FormatOps(
   def parensRange(token: Token): Option[Range] =
     matchingOpt(token).map(matchingParensRange(token, _))
 
-  def matchingParensRange(token: Token, other: Token): Range =
-    if (token.start < other.end)
-      Range(token.start, other.end)
-    else
-      Range(other.start, token.end)
+  def matchingParensRange(a: Token, b: Token): Range = {
+    def eval(lt: Token, rt: Token): Range =
+      Range(lt.start, rt.end)
+    if (a.start < b.end) eval(a, b) else eval(b, a)
+  }
+
+  def matchingParensRangeTupled: ((Token, Token)) => Range =
+    (matchingParensRange _).tupled
 
   def getExcludeIf(
       end: Token,
@@ -276,7 +279,7 @@ class FormatOps(
       end: Token,
       matches: FormatToken => Boolean
   ): Set[Range] =
-    insideBlock(start, end, matches).map((matchingParensRange _).tupled).toSet
+    insideBlock(start, end, matches).map(matchingParensRangeTupled).toSet
 
   def insideBlock[A](start: FormatToken, end: Token)(implicit
       classifier: Classifier[Token, A]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -248,17 +248,17 @@ class FormatOps(
   final def startsStatement(token: Token): Option[Tree] =
     statementStarts.get(hash(token))
 
-  def parensRange(token: Token): Option[Range] =
-    matchingOpt(token).map(matchingParensRange(token, _))
+  def parensRange(token: Token, exclusive: Boolean = true): Option[Range] =
+    matchingOpt(token).map(matchingParensRange(exclusive)(token, _))
 
-  def matchingParensRange(a: Token, b: Token): Range = {
+  def matchingParensRange(exclusive: Boolean)(a: Token, b: Token): Range = {
     def eval(lt: Token, rt: Token): Range =
-      Range(lt.start, rt.end)
+      Range(lt.start, if (exclusive) rt.start else rt.end)
     if (a.start < b.end) eval(a, b) else eval(b, a)
   }
 
-  def matchingParensRangeTupled: ((Token, Token)) => Range =
-    (matchingParensRange _).tupled
+  def matchingParensRangeTupled(exclusive: Boolean): ((Token, Token)) => Range =
+    (matchingParensRange(exclusive) _).tupled
 
   def getExcludeIf(
       end: Token,
@@ -279,7 +279,7 @@ class FormatOps(
       end: Token,
       matches: FormatToken => Boolean
   ): Set[Range] =
-    insideBlock(start, end, matches).map(matchingParensRangeTupled).toSet
+    insideBlock(start, end, matches).map(matchingParensRangeTupled(false)).toSet
 
   def insideBlock[A](start: FormatToken, end: Token)(implicit
       classifier: Classifier[Token, A]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -964,7 +964,7 @@ class Router(formatOps: FormatOps) {
               else
                 insideBlock[T.LeftBrace](formatToken, close)
             val excludeRanges: Set[Range] =
-              exclude.map((matchingParensRange _).tupled).toSet
+              exclude.map(matchingParensRangeTupled).toSet
             def ignoreBlocks(x: FormatToken): Boolean = {
               excludeRanges.exists(_.contains(x.left.end))
             }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -964,7 +964,7 @@ class Router(formatOps: FormatOps) {
               else
                 insideBlock[T.LeftBrace](formatToken, close)
             val excludeRanges: Set[Range] =
-              exclude.map(matchingParensRangeTupled).toSet
+              exclude.map(matchingParensRangeTupled(false)).toSet
             def ignoreBlocks(x: FormatToken): Boolean = {
               excludeRanges.exists(_.contains(x.left.end))
             }


### PR DESCRIPTION
For SingleLineBlock, the left token is checked in the provided exclude range sets; in some cases, say when the end token refers to the closing brace, we might want to make sure the closing brace is not followed by a newline. For that, the end token needs to be excluded from the range.