### PR TITLE
Router: set cost of case label to 0

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1648,7 +1648,7 @@ class Router(formatOps: FormatOps) {
 
         Seq(
           Split(Space, 0).withSingleLine(expire, killOnFail = true),
-          Split(Space, 1)
+          Split(Space, 0)
             .withPolicy(
               decideNewlinesOnlyAfterToken(arrow),
               ignore = noDelayedBreak

--- a/scalafmt-tests/src/test/resources/default/Idempotency.stat
+++ b/scalafmt-tests/src/test/resources/default/Idempotency.stat
@@ -26,8 +26,8 @@ val bindingFuture = Http().bindAndHandleSync({
     {
       val bindingFuture = Http().bindAndHandleSync(
           { case HttpRequest(_, _, headers, _, _) ⇒
-            val upgrade = headers.collectFirst {
-              case u: UpgradeToWebSocket ⇒ u
+            val upgrade = headers.collectFirst { case u: UpgradeToWebSocket ⇒
+              u
             }.get
             upgrade.handleMessages(
                 Flow.fromSinkAndSource(Sink.ignore,

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -853,8 +853,8 @@ object a {
 >>>
 object a {
   def a = {
-    val paramFieldId: Box[String] = (stuff.collect {
-      case FormFieldId(id) => id
+    val paramFieldId: Box[String] = (stuff.collect { case FormFieldId(id) =>
+      id
     }).headOption
   }
 }

--- a/scalafmt-tests/src/test/resources/default/TermParam.stat
+++ b/scalafmt-tests/src/test/resources/default/TermParam.stat
@@ -8,6 +8,6 @@ scrut.branchSwitch(scrut.value,
 >>>
 scrut.branchSwitch(scrut.value,
                    casevals = normalcases.map { case (v, _) => v },
-                   casefs = normalcases.map {
-                     case (_, body) => genExpr(body, _: Focus)
+                   casefs = normalcases.map { case (_, body) =>
+                     genExpr(body, _: Focus)
                    })

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1693,8 +1693,8 @@ val strings = Seq(
     "Metrics:",
     s"  $metricHeader: ${bestScore.score}"
   ) ++
-  otherMetricHeaders.zip(bestScore.otherScores).map {
-    case (h, s) => s"  $h: $s"
+  otherMetricHeaders.zip(bestScore.otherScores).map { case (h, s) =>
+    s"  $h: $s"
   } ++
   outputPath.toSeq.map { p =>
     s"The best variant params can be found in $p"

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1629,8 +1629,8 @@ val strings = Seq(
   s"  $bestEPStr",
   "Metrics:",
   s"  $metricHeader: ${bestScore.score}"
-) ++ otherMetricHeaders.zip(bestScore.otherScores).map {
-  case (h, s) => s"  $h: $s"
+) ++ otherMetricHeaders.zip(bestScore.otherScores).map { case (h, s) =>
+  s"  $h: $s"
 } ++ outputPath.toSeq.map { p =>
   s"The best variant params can be found in $p"
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -757,8 +757,8 @@ function { implicit c =>
 }
 >>>
 function { implicit c =>
-  {
-    case bar => foo
+  { case bar =>
+    foo
   }
 }
 <<< #1888 nested partial function in parens
@@ -771,8 +771,8 @@ object a {
 }
 >>>
 object a {
-  function(c => {
-    case bar => foo
+  function(c => { case bar =>
+    foo
   })
 }
 <<< try with partially enclosed 1: paren kept

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -164,8 +164,8 @@ object a {
   x.zipWithIndex.map { x =>
     s"${x._1} -> ${x._2}"
   }
-  x.zipWithIndex.map {
-    case (c, i) => s"$c -> $i"
+  x.zipWithIndex.map { case (c, i) =>
+    s"$c -> $i"
   }
   x.zipWithIndex.map { case (c, i) =>
     s"$c -> $i (long comment)"


### PR DESCRIPTION
This is a follow-on to #2125.

`scala-repos` diffs: https://github.com/kitbellew/scala-repos/commit/e095bf83c3f3cf7cb19499267d1f33ad26568df5