### PR TITLE
Router: standard rule for body of def/if-else/case

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -833,28 +833,139 @@ package core {
 }
 ```
 
-### `newlines.alwaysBeforeMultilineDef`
+### `newlines.beforeMultiline`
 
-This parameter forces a new line before the method body on multiline defs:
+> Since 2.7.0
 
-```scala mdoc:defaults
-newlines.alwaysBeforeMultilineDef
-```
+This parameter controls whether to force a new line before a multi-line body of
+`case/if/val` and how to format it if the space is allowed. (For multi-line bodies
+of method definitions, please see [`newlines.beforeMultilineDef`](#newlinesbeforemultilinedef)
+below.)
+
+It accepts the same values as [`newlines.source`](#newlinessource)
+(and defaults to that parameter's setting).
 
 ```scala mdoc:scalafmt
-newlines.alwaysBeforeMultilineDef = true
+newlines.beforeMultiline = unfold
 ---
-def foo: String = "123".map { x =>
-  x.toUpper
+a match {
+  // had space after "=>"
+  case a => if (step != 0)
+      d.name should be("dir" + step)
+  // had newline after "=>"
+  case a =>
+    if (step != 0)
+      d.name should be("dir" + step)
 }
 ```
 
 ```scala mdoc:scalafmt
-newlines.alwaysBeforeMultilineDef = false
+newlines.beforeMultiline = fold
 ---
+a match {
+  // had space after "=>"
+  case a => if (step != 0)
+      d.name should be("dir" + step)
+  // had newline after "=>"
+  case a =>
+    if (step != 0)
+      d.name should be("dir" + step)
+}
+```
+
+```scala mdoc:scalafmt
+newlines.beforeMultiline = keep
+---
+a match {
+  // had space after "=>"
+  case a => if (step != 0)
+      d.name should be("dir" + step)
+  // had newline after "=>"
+  case a =>
+    if (step != 0)
+      d.name should be("dir" + step)
+}
+```
+
+```scala mdoc:scalafmt
+# newlines.beforeMultiline = classic
+---
+a match {
+  // had space after "=>"
+  case a => if (step != 0)
+      d.name should be("dir" + step)
+  // had newline after "=>"
+  case a =>
+    if (step != 0)
+      d.name should be("dir" + step)
+}
+```
+
+### `newlines.beforeMultilineDef`
+
+> Since 2.7.0
+
+This parameter applies to multi-line definitions only. It accepts the same values
+as [`newlines.beforeMultiline`](#newlinesbeforemultiline) (and defaults to that
+parameter's setting).
+
+It replaced deprecated boolean `newlines.alwaysBeforeMultilineDef` (with `false`
+mapped to `fold` and `true` to `unfold`).
+
+```scala mdoc:scalafmt
+newlines.beforeMultilineDef = unfold
+---
+// had space after "="
 def foo: String = "123".map { x =>
   x.toUpper
 }
+// had newline after "="
+def foo: String =
+  "123".map { x =>
+    x.toUpper
+  }
+```
+
+```scala mdoc:scalafmt
+newlines.beforeMultilineDef = fold
+---
+// had space after "="
+def foo: String = "123".map { x =>
+  x.toUpper
+}
+// had newline after "="
+def foo: String =
+  "123".map { x =>
+    x.toUpper
+  }
+```
+
+```scala mdoc:scalafmt
+newlines.beforeMultilineDef = keep
+---
+// had space after "="
+def foo: String = "123".map { x =>
+  x.toUpper
+}
+// had newline after "="
+def foo: String =
+  "123".map { x =>
+    x.toUpper
+  }
+```
+
+```scala mdoc:scalafmt
+# newlines.beforeMultilineDef = classic
+---
+// had space after "="
+def foo: String = "123".map { x =>
+  x.toUpper
+}
+// had newline after "="
+def foo: String =
+  "123".map { x =>
+    x.toUpper
+  }
 ```
 
 ### `newlines.alwaysBeforeElseAfterCurlyIf`

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
@@ -1,11 +1,8 @@
 package org.scalafmt.config
 
-import metaconfig._
 import java.io.File
-import metaconfig.Conf
-import metaconfig.ConfError
-import metaconfig.Configured
-import metaconfig.Configured.Ok
+
+import metaconfig._
 import org.scalafmt.config.PlatformConfig._
 
 // NOTE: these methods are intended for internal usage and are subject to
@@ -53,12 +50,12 @@ object Config {
   ): Configured[ScalafmtConfig] =
     conf.andThen { baseConf =>
       val next = path match {
-        case None => Ok(baseConf)
+        case None => Configured.Ok(baseConf)
         case Some(p) =>
           baseConf match {
             case Conf.Obj(values) =>
               values
-                .collectFirst { case (`p`, value) => Ok(value) }
+                .collectFirst { case (`p`, value) => Configured.Ok(value) }
                 .getOrElse(
                   ConfError.message(s"Config $baseConf has no field $p").notOk
                 )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -81,17 +81,17 @@ import metaconfig.generic.Surface
   *     // ...
   *   }
   *   else //...
-  * @param alwaysBeforeMultilineDef
-  *   If true, add a newline before the body of a multiline def without
+  * @param beforeMultilineDef
+  *   If unfold (or true), add a newline before the body of a multiline def without
   *   curly braces. See #1126 for discussion.
   *   For example,
   *   {{{
-  *     // newlines.alwaysBeforeMultilineDef = false
+  *     // newlines.beforeMultilineDef = fold
   *     def foo(bar: Bar): Foo = bar
   *       .flatMap(f)
   *       .map(g)
   *
-  *     // newlines.alwaysBeforeMultilineDef = true
+  *     // newlines.beforeMultilineDef = unfold
   *     def foo(bar: Bar): Foo =
   *       bar
   *         .flatMap(f)
@@ -173,7 +173,14 @@ case class Newlines(
     implicitParamListModifierForce: Seq[BeforeAfter] = Seq.empty,
     implicitParamListModifierPrefer: Option[BeforeAfter] = None,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
-    alwaysBeforeMultilineDef: Boolean = false,
+    @annotation.DeprecatedName(
+      "alwaysBeforeMultilineDef",
+      "Use newlines.beforeMultilineDef instead",
+      "2.7.0"
+    )
+    private val alwaysBeforeMultilineDef: Boolean = false,
+    private[config] val beforeMultiline: Option[SourceHints] = None,
+    private[config] val beforeMultilineDef: Option[SourceHints] = None,
     afterInfix: Option[AfterInfix] = None,
     afterInfixBreakOnNested: Boolean = false,
     afterInfixMaxCountPerExprForSome: Int = 10,
@@ -246,6 +253,11 @@ case class Newlines(
 
   lazy val alwaysBeforeCurlyLambdaParams = alwaysBeforeCurlyBraceLambdaParams ||
     (beforeCurlyLambdaParams eq BeforeCurlyLambdaParams.always)
+
+  lazy val getBeforeMultiline = beforeMultiline.getOrElse(source)
+  lazy val getBeforeMultilineDef = beforeMultilineDef.getOrElse {
+    if (alwaysBeforeMultilineDef) Newlines.unfold else getBeforeMultiline
+  }
 
 }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -173,7 +173,7 @@ case class Newlines(
     implicitParamListModifierForce: Seq[BeforeAfter] = Seq.empty,
     implicitParamListModifierPrefer: Option[BeforeAfter] = None,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
-    alwaysBeforeMultilineDef: Boolean = true,
+    alwaysBeforeMultilineDef: Boolean = false,
     afterInfix: Option[AfterInfix] = None,
     afterInfixBreakOnNested: Boolean = false,
     afterInfixMaxCountPerExprForSome: Int = 10,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -347,6 +347,18 @@ object ScalafmtConfig {
         )
         addIf(optIn.configStyleArguments && align.openParenCallSite)
         addIf(optIn.configStyleArguments && align.openParenDefnSite)
+        newlines.beforeMultiline.foreach { x =>
+          addIfDirect(
+            x.eq(Newlines.classic) || x.eq(Newlines.keep),
+            s"newlines.beforeMultiline=$x"
+          )
+        }
+        newlines.beforeMultilineDef.foreach { x =>
+          addIfDirect(
+            x.eq(Newlines.classic) || x.eq(Newlines.keep),
+            s"newlines.beforeMultilineDef=$x"
+          )
+        }
       }
       if (newlines.source == Newlines.unfold) {
         addIf(align.arrowEnumeratorGenerator)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1989,17 +1989,16 @@ class Router(formatOps: FormatOps) {
     else if (isJsNative(body))
       Seq(Split(Space, 0).withSingleLine(expire))
     else {
-      val spacePolicy = style.newlines.source match {
+      val beforeMultiline = style.newlines.getBeforeMultilineDef
+      val spacePolicy = beforeMultiline match {
+        case Newlines.classic | Newlines.keep if ft.hasBreak =>
+          null
+
         case Newlines.classic | Newlines.keep =>
-          if (ft.hasBreak) null
-          else if (style.newlines.alwaysBeforeMultilineDef)
-            SingleLineBlock(expire)
-          else Policy.NoPolicy
+          Policy.NoPolicy
 
         case Newlines.unfold => SingleLineBlock(expire)
 
-        case Newlines.fold if style.newlines.alwaysBeforeMultilineDef =>
-          SingleLineBlock(expire)
         case Newlines.fold =>
           body match {
             case _: Term.Try | _: Term.TryWithHandler =>
@@ -2018,7 +2017,7 @@ class Router(formatOps: FormatOps) {
           .withIndent(2, expire, After)
           .withPolicy(
             PenalizeAllNewlines(expire, 1),
-            !style.newlines.sourceIgnored
+            beforeMultiline.in(Newlines.keep, Newlines.classic)
           )
       )
     }

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -182,8 +182,6 @@ object a {
   final val OVERLOADED    = 1L << 33 // symbol
 }
 <<< tricky regex #138
-newlines.alwaysBeforeMultilineDef = false
-===
 def f[A](x: A)(f: A => Int) = f(x) match {
   case 1 => true
   case 222 => false
@@ -199,11 +197,10 @@ def f[A](x: A)(f: A => Int) = f(x) match {
   case 222 => false
 }
 >>>
-def f[A](x: A)(f: A => Int) =
-  f(x) match {
-    case 1   => true
-    case 222 => false
-  }
+def f[A](x: A)(f: A => Int) = f(x) match {
+  case 1   => true
+  case 222 => false
+}
 <<< conflicting number of columns
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % "test",
@@ -309,8 +306,6 @@ for {
   aaa = List(1)
 } yield 1
 <<< don't jump scope #152
-newlines.alwaysBeforeMultilineDef = false
-===
 object Cleaver {
    def apply[R, A, B](): Cleaver[R, A, B] = new Cleaver[R, A, B] {
     def split(x: R): A -> B               = (l(x), r(x))
@@ -333,11 +328,10 @@ object Cleaver {
  }
 >>>
 object Cleaver {
-  def apply[R, A, B](): Cleaver[R, A, B] =
-    new Cleaver[R, A, B] {
-      def split(x: R): A -> B = (l(x), r(x))
-      def join(x: A -> B): R  = f(x._1, x._2)
-    }
+  def apply[R, A, B](): Cleaver[R, A, B] = new Cleaver[R, A, B] {
+    def split(x: R): A -> B = (l(x), r(x))
+    def join(x: A -> B): R  = f(x._1, x._2)
+  }
 }
 <<< only align single-line statements
 {

--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -112,15 +112,14 @@ def processOptions(): Unit = {
 
 )
 >>>
-private def scalaJSStageSettings =
-  Seq(
-      usesScalaJSLinkerTag in key := {
-        Tags
-      },
-      // Prevent this linker from being used concurrently
-      concurrentRestrictions in Global +=
-        Tags.limit((usesScalaJSLinkerTag in key).value, 1)
-  )
+private def scalaJSStageSettings = Seq(
+    usesScalaJSLinkerTag in key := {
+      Tags
+    },
+    // Prevent this linker from being used concurrently
+    concurrentRestrictions in Global +=
+      Tags.limit((usesScalaJSLinkerTag in key).value, 1)
+)
 <<< testFilter
   val testFilter: String => Boolean = {
     options.testFilter match {
@@ -230,11 +229,10 @@ callStatement = js.If(
         } else {
           val reflBoxClassPatched = {
 
-            def isIntOrLongKind(kind: TypeKind) =
-              kind match {
-                case _: INT | LONG => true
-                case _ => false
-              }
+            def isIntOrLongKind(kind: TypeKind) = kind match {
+              case _: INT | LONG => true
+              case _ => false
+            }
             if (
                 rtClass == BoxedDoubleClass &&
                 toTypeKind(implMethodSym.tpe.resultType) == DoubleKind &&

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -513,14 +513,13 @@ def startSharding(system: ActorSystem, mediator: ActorRef, shardCount: Int): Uni
 >>>
 def startSharding(system: ActorSystem,
                   mediator: ActorRef,
-                  shardCount: Int): Unit =
-  ClusterSharding(system).start(
-      className[Flow],
-      props(mediator),
-      ClusterShardingSettings(system),
-      { case (name: String, payload) => (name, payload) },
-      { case (name: String, _) => (name.hashCode % shardCount).toString }
-  )
+                  shardCount: Int): Unit = ClusterSharding(system).start(
+    className[Flow],
+    props(mediator),
+    ClusterShardingSettings(system),
+    { case (name: String, payload) => (name, payload) },
+    { case (name: String, _) => (name.hashCode % shardCount).toString }
+)
 <<< spray shit
 newlines.avoidForSimpleOverflow = [punct]
 ===

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -267,18 +267,17 @@ if (other == null) {
     }
 >>>
 object ExternForwarder {
-  def unapply(tree: Tree): Option[Symbol] =
-    tree match {
-      case DefDef()
-          if isExternModule(from.symbol)
-            && params.length == args.length
-            && params.zip(args).forall { case _ =>
-              false
-            } =>
-        Some(sel.symbol)
-      case _ =>
-        None
-    }
+  def unapply(tree: Tree): Option[Symbol] = tree match {
+    case DefDef()
+        if isExternModule(from.symbol)
+          && params.length == args.length
+          && params.zip(args).forall { case _ =>
+            false
+          } =>
+      Some(sel.symbol)
+    case _ =>
+      None
+  }
 }
 <<< #408
 1 match {

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -13,9 +13,8 @@ object a {
   /**
     * Returns True is this state will always return better formatting than other.
     */
-  def alwaysBetter(other: State): Boolean =
-    this.cost <= other.cost &&
-      this.indentation <= other.indentation
+  def alwaysBetter(other: State): Boolean = this.cost <= other.cost &&
+    this.indentation <= other.indentation
 }
 <<< context bound
 def addDefn[T <: Keyword: ClassTag](mods: Seq[Mod], tree: Tree): Unit
@@ -151,12 +150,11 @@ def viewMethod: Gen[ViewClass.Op] = oneOf(
   chooseRange ^^ lop(r => s"slice $r"  -> (_ slice r))
 )
 >>>
-def viewMethod: Gen[ViewClass.Op] =
-  oneOf(
-      lowHalf ^^ lop(n => s"drop $n" -> (_ drop n)),
-      highHalf ^^ lop(n => s"take $n" -> (_ take n)),
-      chooseRange ^^ lop(r => s"slice $r" -> (_ slice r))
-  )
+def viewMethod: Gen[ViewClass.Op] = oneOf(
+    lowHalf ^^ lop(n => s"drop $n" -> (_ drop n)),
+    highHalf ^^ lop(n => s"take $n" -> (_ take n)),
+    chooseRange ^^ lop(r => s"slice $r" -> (_ slice r))
+)
 <<< typelevel/cats
   implicit def validatedInstances[E](implicit E: Semigroup[E]): Traverse[Validated[E, ?]] with ApplicativeError[Validated[E, ?], E] = 2
 >>>
@@ -287,22 +285,20 @@ def zip[C](x: A =>? C): A =>? (B, C) = 2
 def foo = bar.flatMap(x => f(x))
   .flatMap(y => g(y)).map(z => veryLongFunctionNameFor80Characters(z))
 >>>
-def foo =
-  bar
-    .flatMap(x => f(x))
-    .flatMap(y => g(y))
-    .map(z => veryLongFunctionNameFor80Characters(z))
+def foo = bar
+  .flatMap(x => f(x))
+  .flatMap(y => g(y))
+  .map(z => veryLongFunctionNameFor80Characters(z))
 <<< #1126
 def foo = Future({
   val bar = fetchBar()
   bar.map(_ + 10)
 })
 >>>
-def foo =
-  Future({
-    val bar = fetchBar()
-    bar.map(_ + 10)
-  })
+def foo = Future({
+  val bar = fetchBar()
+  bar.map(_ + 10)
+})
 <<< #915 No space on both sides of operator method definition by default
 trait Test[A] {
   def <=>[B](that: Test[B]): Int

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -115,13 +115,12 @@ def foo(x: Int) = x match {
     (y: Int) => -y
   }
 >>>
-def foo(x: Int) =
-  x match {
-    case 1 =>
-      (y: Int) => y
-    case _ =>
-      (y: Int) => -y
-  }
+def foo(x: Int) = x match {
+  case 1 =>
+    (y: Int) => y
+  case _ =>
+    (y: Int) => -y
+}
 <<< SKIP y u break line? Answer: Because optimizer.recurseOnBlocks
 {
   def foo =

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -461,7 +461,7 @@ object a {
     }
   }
 }
-<<< #2061 6
+<<< #2061 6.1 with break
 preset = default
 optIn.breakChainOnFirstMethodDot = true
 includeNoParensInSelectChains = false
@@ -489,6 +489,35 @@ object a {
           upgrade,
           UpgradeCheck()
         )
+    }
+  }
+}
+<<< #2061 6.1 without break
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+===
+object a {
+  def a = {
+    try {
+    val a = actorSystem.scheduler.schedule(
+      0.seconds,
+      1.days,
+      upgrade,
+      UpgradeCheck())
+    }
+  }
+}
+>>>
+object a {
+  def a = {
+    try {
+      val a = actorSystem.scheduler.schedule(
+        0.seconds,
+        1.days,
+        upgrade,
+        UpgradeCheck()
+      )
     }
   }
 }
@@ -856,6 +885,44 @@ object a {
     val paramFieldId: Box[String] = (stuff.collect { case FormFieldId(id) =>
       id
     }).headOption
+  }
+}
+<<< #2061 16.1 no break before case, break after arrow
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+danglingParentheses.preset = false
+===
+object a {
+  def a = {
+    val paramFieldId: Box[String] = (stuff.collect { case FormFieldId(id) =>
+     id }).headOption
+  }
+}
+>>>
+object a {
+  def a = {
+    val paramFieldId: Box[String] = (stuff.collect { case FormFieldId(id) =>
+      id
+    }).headOption
+  }
+}
+<<< #2061 16.1 no break before case, no break after arrow
+preset = default
+optIn.breakChainOnFirstMethodDot = true
+includeNoParensInSelectChains = false
+danglingParentheses.preset = false
+===
+object a {
+  def a = {
+    val paramFieldId: Box[String] = (stuff.collect { case FormFieldId(id) => id }).headOption
+  }
+}
+>>>
+object a {
+  def a = {
+    val paramFieldId: Box[String] =
+      (stuff.collect { case FormFieldId(id) => id }).headOption
   }
 }
 <<< curly select chain followed by infix

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.stat
@@ -49,11 +49,10 @@ package a {
         3
       }
 
-      def e =
-        a match {
-          case 1 => true
-          case 2 => false
-        }
+      def e = a match {
+        case 1 => true
+        case 2 => false
+      }
     }
   }
 }
@@ -320,15 +319,14 @@ object hello {
 >>>
 object hello {
 
-  def x =
-    for {
-      _ <- {
-        val testObject = Constructor(
-          fieldOne = valueOne,
-          fieldTwo = None
-        )
-      }
-    } yield ()
+  def x = for {
+    _ <- {
+      val testObject = Constructor(
+        fieldOne = valueOne,
+        fieldTwo = None
+      )
+    }
+  } yield ()
 }
 <<< consider multiline private defs as top level statements
 object Test {

--- a/scalafmt-tests/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/src/test/resources/newlines/source.source
@@ -81,43 +81,39 @@ private[parser] trait CacheControlHeader {
   this: Parser with CommonRules with CommonActions with StringBuilding ⇒
 
   // http://tools.ietf.org/html/rfc7234#section-5.2
-  def `cache-control` =
-    rule {
-      oneOrMore(`cache-directive`).separatedBy(listSep) ~ EOI ~>
-        (`Cache-Control`(_))
-    }
+  def `cache-control` = rule {
+    oneOrMore(`cache-directive`).separatedBy(listSep) ~ EOI ~>
+      (`Cache-Control`(_))
+  }
 
-  def `cache-directive` =
-    rule(
-      "no-store" ~ push(`no-store`) | "no-transform" ~ push(`no-transform`) |
-        "max-age=" ~ `delta-seconds` ~>
-        (`max-age`(_)) |
-        "max-stale" ~ optional(ws('=') ~ `delta-seconds`) ~>
-        (`max-stale`(_)) |
-        "min-fresh=" ~ `delta-seconds` ~>
-        (`min-fresh`(_)) | "only-if-cached" ~ push(`only-if-cached`) |
-        "public" ~ push(`public`) |
-        "private" ~
-        (ws('=') ~ `field-names` ~> (`private`(_: _*)) |
-          push(`private`(Nil: _*))) |
-        "no-cache" ~
-        (ws('=') ~ `field-names` ~> (`no-cache`(_: _*)) | push(`no-cache`)) |
-        "must-revalidate" ~ push(`must-revalidate`) |
-        "proxy-revalidate" ~ push(`proxy-revalidate`) |
-        "s-maxage=" ~ `delta-seconds` ~>
-        (`s-maxage`(_)) |
-        token ~ optional(ws('=') ~ word) ~>
-        (CacheDirective.custom(_, _)))
+  def `cache-directive` = rule(
+    "no-store" ~ push(`no-store`) | "no-transform" ~ push(`no-transform`) |
+      "max-age=" ~ `delta-seconds` ~>
+      (`max-age`(_)) |
+      "max-stale" ~ optional(ws('=') ~ `delta-seconds`) ~>
+      (`max-stale`(_)) |
+      "min-fresh=" ~ `delta-seconds` ~>
+      (`min-fresh`(_)) | "only-if-cached" ~ push(`only-if-cached`) |
+      "public" ~ push(`public`) |
+      "private" ~
+      (ws('=') ~ `field-names` ~> (`private`(_: _*)) |
+        push(`private`(Nil: _*))) |
+      "no-cache" ~
+      (ws('=') ~ `field-names` ~> (`no-cache`(_: _*)) | push(`no-cache`)) |
+      "must-revalidate" ~ push(`must-revalidate`) |
+      "proxy-revalidate" ~ push(`proxy-revalidate`) |
+      "s-maxage=" ~ `delta-seconds` ~>
+      (`s-maxage`(_)) |
+      token ~ optional(ws('=') ~ word) ~>
+      (CacheDirective.custom(_, _)))
 
   def `field-names` = rule { `quoted-tokens` | token ~> (Seq(_)) }
 
   def `quoted-tokens` =
     rule { '"' ~ zeroOrMore(`quoted-tokens-elem`).separatedBy(listSep) ~ '"' }
 
-  def `quoted-tokens-elem` =
-    rule {
-      clearSB() ~
-        zeroOrMore(!'"' ~ !',' ~ qdtext ~ appendSB() | `quoted-pair`) ~
-        push(sb.toString)
-    }
+  def `quoted-tokens-elem` = rule {
+    clearSB() ~ zeroOrMore(!'"' ~ !',' ~ qdtext ~ appendSB() | `quoted-pair`) ~
+      push(sb.toString)
+  }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1500,8 +1500,8 @@ object a {
 }
 >>>
 object a {
-  def a =
-    for (a <- b; if cc < dd) yield a
+  def a = for (a <- b; if cc < dd)
+    yield a
 }
 <<< 7.2: enumerator shoft, guard long
 maxColumn = 30
@@ -2548,7 +2548,6 @@ object a {
 <<< def followed by comment, break, wrap
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int =
@@ -2565,7 +2564,6 @@ object a {
 <<< def followed by comment, break, no wrap
 maxColumn = 100
 comments.wrap = no
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int =
@@ -2583,7 +2581,6 @@ object a {
 <<< def followed by comment, no break
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int = /* comment */
@@ -2597,7 +2594,6 @@ object a {
 <<< val followed by comment, break, wrap
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int =
@@ -2614,7 +2610,6 @@ object a {
 <<< val followed by comment, break, no wrap
 maxColumn = 100
 comments.wrap = no
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int =
@@ -2632,7 +2627,6 @@ object a {
 <<< val followed by comment, no break
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int = /* comment */
@@ -2717,9 +2711,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0) // c1
-      d.name should be("dir" + step)
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) // c1
+    d.name should be("dir" + step)
 }
 <<< #2113 def 3
 maxColumn = 70
@@ -2730,10 +2723,9 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0)
-      /* c1 */
-      d.name should be("dir" + step)
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
+    /* c1 */
+    d.name should be("dir" + step)
 }
 <<< #2113 def 4
 object a {
@@ -2756,8 +2748,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0) /* c1 */ { /* c2 */
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
+    /* c1 */ { /* c2 */
       d.name should be("dir" + step)
     }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2723,8 +2723,9 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
-    /* c1 */
+  def validate(d: DirectoryProxy, step: Int): Unit = if (
+    step != 0
+  ) /* c1 */
     d.name should be("dir" + step)
 }
 <<< #2113 def 4
@@ -2748,8 +2749,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
-    /* c1 */ { /* c2 */
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */
+    { /* c2 */
       d.name should be("dir" + step)
     }
 }
@@ -2863,8 +2864,7 @@ object a {
 object a {
   a match {
     case a =>
-      if (step != 0)
-        /* c1 */
+      if (step != 0) /* c1 */
         d.name should be("dir" + step)
     case a =>
       if (step != 0 /* c1 */ )
@@ -2906,19 +2906,14 @@ object a {
 >>>
 object a {
   a match {
-    case a =>
-      if (step != 0)
-        /* c1 */
+    case a => if (step != 0) /* c1 */
         d.name should be("dir" + step)
-    case a =>
-      if (step != 0 /* c1 */ )
+    case a => if (step != 0 /* c1 */ )
         d.name should be("dir" + step)
-    case a =>
-      if (step != 0) { /* c1 */
+    case a => if (step != 0) { /* c1 */
         d.name should be("dir" + step)
       }
-    case a =>
-      if (step != 0) /* c1 */ {
+    case a => if (step != 0) /* c1 */ {
         d.name should be("dir" + step)
       }
     case a =>
@@ -2951,8 +2946,7 @@ object a {
 object a {
   a match {
     case a =>
-      if (step != 0)
-        /* c1 */
+      if (step != 0) /* c1 */
         d.name should be("dir" + step)
     case a =>
       if (step != 0 /* c1 */ )
@@ -2994,19 +2988,14 @@ object a {
 >>>
 object a {
   a match {
-    case a =>
-      if (step != 0)
-        /* c1 */
+    case a => if (step != 0) /* c1 */
         d.name should be("dir" + step)
-    case a =>
-      if (step != 0 /* c1 */ )
+    case a => if (step != 0 /* c1 */ )
         d.name should be("dir" + step)
-    case a =>
-      if (step != 0) { /* c1 */
+    case a => if (step != 0) { /* c1 */
         d.name should be("dir" + step)
       }
-    case a =>
-      if (step != 0) /* c1 */ {
+    case a => if (step != 0) /* c1 */ {
         d.name should be("dir" + step)
       }
     case a =>

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2883,6 +2883,138 @@ object a {
       }
   }
 }
+<<< #2113 case 7, beforeMultiline = fold
+newlines.beforeMultiline = fold
+===
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
+  }
+}
+<<< #2113 case 7, beforeMultiline = unfold
+newlines.beforeMultiline = unfold
+===
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
+  }
+}
+<<< #2113 case 7, beforeMultiline = keep
+newlines.beforeMultiline = keep
+===
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
+  }
+}
 <<< #2113 original
 maxColumn = 80
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1464,7 +1464,7 @@ object a {
       }
     }
 }
-<<< 7.1: enumerator and guard short, for long
+<<< 7.1.1: enumerator and guard short, for long
 object a {
   def c(b: List[Int]): List[Int] =
     for {
@@ -1479,6 +1479,29 @@ object a {
       a <- b
       if (b ++ b).length >= 2
     } yield a
+}
+<<< 7.1.2: enumerators and guard short, for long, parens
+object a {
+  for (i <- 0 until n;
+        j <- 0 until n if i + j == v)
+   yield (i, j)
+}
+>>>
+object a {
+  for (
+    i <- 0 until n;
+    j <- 0 until n if i + j == v
+  )
+    yield (i, j)
+}
+<<< 7.1.2: enumerator and guard short, for long, parens
+object a {
+  def a = for (a <- b; if cc < dd) yield a
+}
+>>>
+object a {
+  def a =
+    for (a <- b; if cc < dd) yield a
 }
 <<< 7.2: enumerator shoft, guard long
 maxColumn = 30
@@ -2619,4 +2642,277 @@ object a {
 object a {
   val foo: Int = /* comment */
     baz
+}
+<<< #2113 if-apply 1
+object a {
+  if (a)
+    Seq(
+      a,
+      b
+    )
+  else
+    Seq(
+      a,
+      b
+    )
+}
+>>>
+object a {
+  if (a)
+    Seq(
+      a,
+      b
+    )
+  else
+    Seq(
+      a,
+      b
+    )
+}
+<<< #2113 if-apply 2
+maxColumn = 30
+===
+object a {
+  if (a)
+    Seq(aaaaaaaaaa, bbbbbbbbbb)
+  else
+    Seq(aaaaaaaaaa, bbbbbbbbbb)
+}
+>>>
+object a {
+  if (a)
+    Seq(
+      aaaaaaaaaa,
+      bbbbbbbbbb
+    )
+  else
+    Seq(
+      aaaaaaaaaa,
+      bbbbbbbbbb
+    )
+}
+<<< #2113 def 1
+maxColumn = 72
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) { // c1
+      d.name should be("dir" + step)
+      validate(d.parent, step - 1)
+    }
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) { // c1
+      d.name should be("dir" + step)
+      validate(d.parent, step - 1)
+    }
+}
+<<< #2113 def 2
+maxColumn = 100
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) // c1
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) // c1
+      d.name should be("dir" + step)
+}
+<<< #2113 def 3
+maxColumn = 70
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0)
+      /* c1 */
+      d.name should be("dir" + step)
+}
+<<< #2113 def 4
+object a {
+  def validate(d: Directory): Unit = if (step != 0)
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: Directory): Unit =
+    if (step != 0)
+      d.name should be("dir" + step)
+}
+<<< #2113 def 5
+maxColumn = 80
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */ { /* c2 */
+    d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+}
+<<< #2113 case 1
+object a {
+  a match {
+    case a => d.name.should.be_dir("step1", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name.should
+        .be_dir("step1", "step2")
+  }
+}
+<<< #2113 case 2
+object a {
+  a match {
+    case a => d.name.should.be_dir("step1", "plus", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name.should.be_dir(
+        "step1",
+        "plus",
+        "step2"
+      )
+  }
+}
+<<< #2113 case 3
+object a {
+  a match {
+    case a => d.name.should.be("dir").plus("step1", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name.should
+        .be("dir")
+        .plus("step1", "step2")
+  }
+}
+<<< #2113 case 4
+object a {
+  a match {
+    case a => d.name should be("dir")
+  }
+}
+>>>
+object a {
+  a match {
+    case a => d.name should be("dir")
+  }
+}
+<<< #2113 case 5
+object a {
+  a match {
+    case a => d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name should be("dir" + step)
+  }
+}
+<<< #2113 case 6
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
+  }
+}
+<<< #2113 case 7
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
+  }
+}
+<<< #2113 original
+maxColumn = 80
+===
+object a {
+  if (!someBooleanValue) Command.invalid
+  else if (someIntValue != 1) Command.invalid
+  else someCollection.get(args.head) match {
+      case it @ Some(_) =>
+        someService.setSomeValue(it)
+        Command.success
+      case None => Command.invalid
+    }
+}
+>>>
+object a {
+  if (!someBooleanValue) Command.invalid
+  else if (someIntValue != 1) Command.invalid
+  else
+    someCollection.get(args.head) match {
+      case it @ Some(_) =>
+        someService.setSomeValue(it)
+        Command.success
+      case None => Command.invalid
+    }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1362,10 +1362,9 @@ object a {
 }
 >>>
 object a {
-  def c(b: List[Int]): List[Int] =
-    for {
-      a <- b if (b ++ b).length >= 2
-    } yield a
+  def c(b: List[Int]): List[Int] = for {
+    a <- b if (b ++ b).length >= 2
+  } yield a
 }
 <<< 7.1.2: enumerators and guard short, for long, parens
 object a {
@@ -1402,11 +1401,10 @@ object a {
 object a {
   def c(
       b: List[Int]
-  ): List[Int] =
-    for {
-      a <- b if (b ++ b)
-        .length >= 2
-    } yield a
+  ): List[Int] = for {
+    a <- b if (b ++ b)
+      .length >= 2
+  } yield a
 }
 <<< 7.3: enumerator and guard short, for short
 for (a <- b.sortBy(c)
@@ -1943,12 +1941,11 @@ object a {
 }
 >>>
 object a {
-  def `media-range-def` =
-    rule {
-      "*/*" ~ push("*") ~ push("*") |
-        `type` ~ '/' ~
-        ('*' ~ !tchar ~ push("*") | subtype) | '*' ~ push("*") ~ push("*")
-    }
+  def `media-range-def` = rule {
+    "*/*" ~ push("*") ~ push("*") |
+      `type` ~ '/' ~
+      ('*' ~ !tchar ~ push("*") | subtype) | '*' ~ push("*") ~ push("*")
+  }
 }
 <<< 8.18
 maxColumn = 80
@@ -1977,11 +1974,10 @@ def `day-name` =
        "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
         "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6))
 >>>
-def `day-name` =
-  rule(
-    "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
-      "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6)
-  )
+def `day-name` = rule(
+  "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+    "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6)
+)
 <<< 8.20
 maxColumn = 80
 ===
@@ -2091,11 +2087,10 @@ def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
       if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
   }
 >>>
-def receiveClusterEvent(evt: ClusterDomainEvent): Unit =
-  evt match {
-    case MemberUp(m) =>
-      if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
-  }
+def receiveClusterEvent(evt: ClusterDomainEvent): Unit = evt match {
+  case MemberUp(m) =>
+    if (matchingRole(m)) changeMembers(membersByAge - m + m) // replace
+}
 <<< 8.27
 maxColumn = 80
 ===
@@ -2343,8 +2338,6 @@ object a {
   )(f: HttpResponse => U): U = qux
 }
 <<< val formatting
-newlines.alwaysBeforeMultilineDef = false
-===
 object a {
   val b = throw new Exception("blah blah")
   val b = foo_bar_baz_qux("blah blah blah")
@@ -2360,8 +2353,6 @@ object a {
     foo.bar.baz.qux("blah blah blah")
 }
 <<< def formatting
-newlines.alwaysBeforeMultilineDef = false
-===
 object a {
   def b = throw new Exception("blah blah")
   def b = foo_bar_baz_qux("blah blah blah")
@@ -2465,7 +2456,6 @@ object a {
 <<< def followed by comment, break, wrap
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int =
@@ -2482,7 +2472,6 @@ object a {
 <<< def followed by comment, break, no wrap
 maxColumn = 100
 comments.wrap = no
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int =
@@ -2500,7 +2489,6 @@ object a {
 <<< def followed by comment, no break
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int = /* comment */
@@ -2514,7 +2502,6 @@ object a {
 <<< val followed by comment, break, wrap
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int =
@@ -2531,7 +2518,6 @@ object a {
 <<< val followed by comment, break, no wrap
 maxColumn = 100
 comments.wrap = no
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int =
@@ -2549,7 +2535,6 @@ object a {
 <<< val followed by comment, no break
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int = /* comment */
@@ -2561,8 +2546,6 @@ object a {
     baz
 }
 <<< prefer no break before lambda parameters
-newlines.alwaysBeforeMultilineDef = false
-===
 object a {
   def a(b: Int, d: Range): Set[Int] =
     // comment 1
@@ -2663,9 +2646,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0) // c1
-      d.name should be("dir" + step)
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) // c1
+    d.name should be("dir" + step)
 }
 <<< #2113 def 3
 maxColumn = 70
@@ -2676,10 +2658,9 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0)
-      /* c1 */
-      d.name should be("dir" + step)
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
+    /* c1 */
+    d.name should be("dir" + step)
 }
 <<< #2113 def 4
 object a {
@@ -2702,8 +2683,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0) /* c1 */ { /* c2 */
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
+    /* c1 */ { /* c2 */
       d.name should be("dir" + step)
     }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -467,10 +467,10 @@ val nested =
     .deployer
     .lookup(service.split("/").drop(1))
 >>>
-val deployment =
-  system.asInstanceOf[ActorSystemImpl]
-    .provider.deployer
-    .lookup(service.split("/").drop(1))
+val deployment = system
+  .asInstanceOf[ActorSystemImpl]
+  .provider.deployer
+  .lookup(service.split("/").drop(1))
 <<< 2.22
 maxColumn = 80
 ===
@@ -867,10 +867,11 @@ maxColumn = 80
         case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
       })
 >>>
-def activationFutureFor(
-    endpoint: ActorRef
-)(implicit timeout: Timeout, executor: ExecutionContext): Future[ActorRef] =
-  (supervisor.ask(AwaitActivation(endpoint))(timeout)).map[ActorRef]({
+def activationFutureFor(endpoint: ActorRef)(implicit
+    timeout: Timeout,
+    executor: ExecutionContext
+): Future[ActorRef] = (supervisor.ask(AwaitActivation(endpoint))(timeout))
+  .map[ActorRef]({
     case EndpointActivated(`endpoint`) ⇒ endpoint
     case EndpointFailedToActivate(`endpoint`, cause) ⇒ throw cause
   })
@@ -1340,8 +1341,8 @@ object a {
 }
 >>>
 object a {
-  val unionAlgoPredicts: RDD[(QX, Seq[P])] =
-    sc.union(algoPredicts).groupByKey().mapValues { ps =>
+  val unionAlgoPredicts: RDD[(QX, Seq[P])] = sc.union(algoPredicts)
+    .groupByKey().mapValues { ps =>
       {
         assert(
           ps.size == algoCount,
@@ -1385,8 +1386,8 @@ object a {
 }
 >>>
 object a {
-  def a =
-    for (a <- b; if cc < dd) yield a
+  def a = for (a <- b; if cc < dd)
+    yield a
 }
 <<< 7.2: enumerator short, guard long
 maxColumn = 28
@@ -2349,8 +2350,8 @@ object a {
     throw new Exception("blah blah")
   val b =
     foo_bar_baz_qux("blah blah blah")
-  val b =
-    foo.bar.baz.qux("blah blah blah")
+  val b = foo.bar.baz
+    .qux("blah blah blah")
 }
 <<< def formatting
 object a {
@@ -2364,8 +2365,8 @@ object a {
     throw new Exception("blah blah")
   def b =
     foo_bar_baz_qux("blah blah blah")
-  def b =
-    foo.bar.baz.qux("blah blah blah")
+  def b = foo.bar.baz
+    .qux("blah blah blah")
 }
 <<< #1973 1
 maxColumn = 25
@@ -2609,16 +2610,14 @@ object a {
 }
 >>>
 object a {
-  if (a)
-    Seq(
-      aaaaaaaaaa,
-      bbbbbbbbbb
-    )
-  else
-    Seq(
-      aaaaaaaaaa,
-      bbbbbbbbbb
-    )
+  if (a) Seq(
+    aaaaaaaaaa,
+    bbbbbbbbbb
+  )
+  else Seq(
+    aaaaaaaaaa,
+    bbbbbbbbbb
+  )
 }
 <<< #2113 def 1
 maxColumn = 72
@@ -2658,9 +2657,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
-    /* c1 */
-    d.name should be("dir" + step)
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) /* c1 */ d.name should be("dir" + step)
 }
 <<< #2113 def 4
 object a {
@@ -2683,8 +2681,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
-    /* c1 */ { /* c2 */
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) /* c1 */ { /* c2 */
       d.name should be("dir" + step)
     }
 }
@@ -2697,8 +2695,7 @@ object a {
 >>>
 object a {
   a match {
-    case a =>
-      d.name.should
+    case a => d.name.should
         .be_dir("step1", "step2")
   }
 }
@@ -2767,10 +2764,10 @@ object a {
 >>>
 object a {
   a match {
-    case a => if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 case 7
@@ -2794,8 +2791,7 @@ object a {
 >>>
 object a {
   a match {
-    case a => if (step != 0)
-        /* c1 */
+    case a => if (step != 0) /* c1 */
         d.name should be("dir" + step)
     case a => if (step != 0 /* c1 */ )
         d.name should be("dir" + step)
@@ -2805,10 +2801,10 @@ object a {
     case a => if (step != 0) /* c1 */ {
         d.name should be("dir" + step)
       }
-    case a => if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 case 7, beforeMultiline = unfold
@@ -2834,21 +2830,24 @@ object a {
 >>>
 object a {
   a match {
-    case a => if (step != 0)
-        /* c1 */
+    case a =>
+      if (step != 0) /* c1 */
         d.name should be("dir" + step)
-    case a => if (step != 0 /* c1 */ )
+    case a =>
+      if (step != 0 /* c1 */ )
         d.name should be("dir" + step)
-    case a => if (step != 0) { /* c1 */
+    case a =>
+      if (step != 0) { /* c1 */
         d.name should be("dir" + step)
       }
-    case a => if (step != 0) /* c1 */ {
+    case a =>
+      if (step != 0) /* c1 */ {
         d.name should be("dir" + step)
       }
-    case a => if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 case, multiple stats
@@ -2864,11 +2863,9 @@ object a {
 object a {
   a match {
     case a =>
-      if (step != 0)
-        /* c1 */
+      if (step != 0) /* c1 */
         d.name should be("dir" + step)
-      if (step != 0)
-        /* c1 */
+      if (step != 0) /* c1 */
         d.name should be("dir" + step)
   }
 }
@@ -2889,11 +2886,10 @@ object a {
 object a {
   if (!someBooleanValue) Command.invalid
   else if (someIntValue != 1) Command.invalid
-  else
-    someCollection.get(args.head) match {
-      case it @ Some(_) =>
-        someService.setSomeValue(it)
-        Command.success
-      case None => Command.invalid
-    }
+  else someCollection.get(args.head) match {
+    case it @ Some(_) =>
+      someService.setSomeValue(it)
+      Command.success
+    case None => Command.invalid
+  }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2811,6 +2811,46 @@ object a {
         }
   }
 }
+<<< #2113 case 7, beforeMultiline = unfold
+newlines.beforeMultiline = unfold
+===
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a => if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
 <<< #2113 case, multiple stats
 object a {
   a match {

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1352,7 +1352,7 @@ object a {
       }
     }
 }
-<<< 7.1: enumerator and guard short, for long
+<<< 7.1.1: enumerator and guard short, for long
 object a {
   def c(b: List[Int]): List[Int] =
     for {
@@ -1367,7 +1367,29 @@ object a {
       a <- b if (b ++ b).length >= 2
     } yield a
 }
-<<< 7.2: enumerator shoft, guard long
+<<< 7.1.2: enumerators and guard short, for long, parens
+object a {
+  for (i <- 0 until n;
+        j <- 0 until n if i + j == v)
+   yield (i, j)
+}
+>>>
+object a {
+  for (
+    i <- 0 until n;
+    j <- 0 until n if i + j == v
+  ) yield (i, j)
+}
+<<< 7.1.2: enumerator and guard short, for long, parens
+object a {
+  def a = for (a <- b; if cc < dd) yield a
+}
+>>>
+object a {
+  def a =
+    for (a <- b; if cc < dd) yield a
+}
+<<< 7.2: enumerator short, guard long
 maxColumn = 28
 ===
 object a {
@@ -2575,4 +2597,282 @@ object a {
         // comment 3
         Some(a).filter(d.contains)
       }
+}
+<<< #2113 if-apply 1
+object a {
+  if (a)
+    Seq(
+      a,
+      b
+    )
+  else
+    Seq(
+      a,
+      b
+    )
+}
+>>>
+object a {
+  if (a) Seq(a, b) else Seq(a, b)
+}
+<<< #2113 if-apply 2
+maxColumn = 30
+===
+object a {
+  if (a)
+    Seq(aaaaaaaaaa, bbbbbbbbbb)
+  else
+    Seq(aaaaaaaaaa, bbbbbbbbbb)
+}
+>>>
+object a {
+  if (a)
+    Seq(
+      aaaaaaaaaa,
+      bbbbbbbbbb
+    )
+  else
+    Seq(
+      aaaaaaaaaa,
+      bbbbbbbbbb
+    )
+}
+<<< #2113 def 1
+maxColumn = 72
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) { // c1
+      d.name should be("dir" + step)
+      validate(d.parent, step - 1)
+    }
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) { // c1
+      d.name should be("dir" + step)
+      validate(d.parent, step - 1)
+    }
+}
+<<< #2113 def 2
+maxColumn = 100
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) // c1
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) // c1
+      d.name should be("dir" + step)
+}
+<<< #2113 def 3
+maxColumn = 70
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0)
+      /* c1 */
+      d.name should be("dir" + step)
+}
+<<< #2113 def 4
+object a {
+  def validate(d: Directory): Unit = if (step != 0)
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: Directory): Unit =
+    if (step != 0)
+      d.name should be("dir" + step)
+}
+<<< #2113 def 5
+maxColumn = 80
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */ { /* c2 */
+    d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+}
+<<< #2113 case 1
+object a {
+  a match {
+    case a => d.name.should.be_dir("step1", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name.should
+        .be_dir("step1", "step2")
+  }
+}
+<<< #2113 case 2
+object a {
+  a match {
+    case a => d.name.should.be_dir("step1", "plus", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a => d.name.should.be_dir(
+        "step1",
+        "plus",
+        "step2"
+      )
+  }
+}
+<<< #2113 case 3
+object a {
+  a match {
+    case a => d.name.should.be("dir").plus("step1", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a => d.name.should.be("dir")
+        .plus("step1", "step2")
+  }
+}
+<<< #2113 case 4
+object a {
+  a match {
+    case a => d.name should be("dir")
+  }
+}
+>>>
+object a {
+  a match {
+    case a => d.name should be("dir")
+  }
+}
+<<< #2113 case 5
+object a {
+  a match {
+    case a => d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name should be("dir" + step)
+  }
+}
+<<< #2113 case 6
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a => if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
+<<< #2113 case 7
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a => if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
+<<< #2113 case, multiple stats
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+      if (step != 0) /* c1 */
+            d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+      if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+  }
+}
+<<< #2113 original
+maxColumn = 80
+===
+object a {
+  if (!someBooleanValue) Command.invalid
+  else if (someIntValue != 1) Command.invalid
+  else someCollection.get(args.head) match {
+      case it @ Some(_) =>
+        someService.setSomeValue(it)
+        Command.success
+      case None => Command.invalid
+    }
+}
+>>>
+object a {
+  if (!someBooleanValue) Command.invalid
+  else if (someIntValue != 1) Command.invalid
+  else
+    someCollection.get(args.head) match {
+      case it @ Some(_) =>
+        someService.setSomeValue(it)
+        Command.success
+      case None => Command.invalid
+    }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1454,7 +1454,7 @@ object a {
       }
     }
 }
-<<< 7.1: enumerator and guard short, for long
+<<< 7.1.1: enumerator and guard short, for long
 object a {
   def c(b: List[Int]): List[Int] =
     for {
@@ -1469,6 +1469,29 @@ object a {
       a <- b
       if (b ++ b).length >= 2
     } yield a
+}
+<<< 7.1.2: enumerators and guard short, for long, parens
+object a {
+  for (i <- 0 until n;
+        j <- 0 until n if i + j == v)
+   yield (i, j)
+}
+>>>
+object a {
+  for (
+    i <- 0 until n;
+    j <- 0 until n if i + j == v
+  )
+    yield (i, j)
+}
+<<< 7.1.2: enumerator and guard short, for long, parens
+object a {
+  def a = for (a <- b; if cc < dd) yield a
+}
+>>>
+object a {
+  def a =
+    for (a <- b; if cc < dd) yield a
 }
 <<< 7.2: enumerator shoft, guard long
 maxColumn = 30
@@ -2631,4 +2654,267 @@ object a {
 object a {
   val foo: Int = /* comment */
     baz
+}
+<<< #2113 if-apply 1
+object a {
+  if (a) Seq(a,
+    b
+  )
+  else Seq(
+    a,
+    b
+  )
+}
+>>>
+object a {
+  if (a) Seq(a, b)
+  else
+    Seq(
+      a,
+      b
+    )
+}
+<<< #2113 if-apply 2
+maxColumn = 30
+===
+object a {
+  if (a) Seq(
+    aaaaaaaaaa, bbbbbbbbbb)
+  else Seq(
+    aaaaaaaaaa, bbbbbbbbbb)
+}
+>>>
+object a {
+  if (a)
+    Seq(
+      aaaaaaaaaa,
+      bbbbbbbbbb
+    )
+  else
+    Seq(
+      aaaaaaaaaa,
+      bbbbbbbbbb
+    )
+}
+<<< #2113 def 1
+maxColumn = 72
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) { // c1
+      d.name should be("dir" + step)
+      validate(d.parent, step - 1)
+    }
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) { // c1
+      d.name should be("dir" + step)
+      validate(d.parent, step - 1)
+    }
+}
+<<< #2113 def 2
+maxColumn = 100
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) // c1
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) // c1
+      d.name should be("dir" + step)
+}
+<<< #2113 def 3
+maxColumn = 70
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0)
+      /* c1 */
+      d.name should be("dir" + step)
+}
+<<< #2113 def 4
+object a {
+  def validate(d: Directory): Unit = if (step != 0)
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: Directory): Unit =
+    if (step != 0)
+      d.name should be("dir" + step)
+}
+<<< #2113 def 5
+maxColumn = 80
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */ { /* c2 */
+    d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+}
+<<< #2113 case 1
+object a {
+  a match {
+    case a => d.name.should.be_dir("step1", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a => d.name.should.be_dir(
+        "step1",
+        "step2"
+      )
+  }
+}
+<<< #2113 case 2
+object a {
+  a match {
+    case a => d.name.should.be_dir("step1", "plus", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a => d.name.should.be_dir(
+        "step1",
+        "plus",
+        "step2"
+      )
+  }
+}
+<<< #2113 case 3
+object a {
+  a match {
+    case a => d.name.should.be("dir").plus("step1", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name.should.be("dir").plus(
+        "step1",
+        "step2"
+      )
+  }
+}
+<<< #2113 case 4
+object a {
+  a match {
+    case a => d.name should be("dir")
+  }
+}
+>>>
+object a {
+  a match {
+    case a => d.name should be("dir")
+  }
+}
+<<< #2113 case 5
+object a {
+  a match {
+    case a => d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name should be("dir" + step)
+  }
+}
+<<< #2113 case 6
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a => if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
+<<< #2113 case 7
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a => if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
+<<< #2113 original
+maxColumn = 80
+===
+object a {
+  if (!someBooleanValue) Command.invalid
+  else if (someIntValue != 1) Command.invalid
+  else someCollection.get(args.head) match {
+      case it @ Some(_) =>
+        someService.setSomeValue(it)
+        Command.success
+      case None => Command.invalid
+    }
+}
+>>>
+object a {
+  if (!someBooleanValue) Command.invalid
+  else if (someIntValue != 1) Command.invalid
+  else
+    someCollection.get(args.head) match {
+      case it @ Some(_) =>
+        someService.setSomeValue(it)
+        Command.success
+      case None => Command.invalid
+    }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1490,8 +1490,8 @@ object a {
 }
 >>>
 object a {
-  def a =
-    for (a <- b; if cc < dd) yield a
+  def a = for (a <- b; if cc < dd)
+    yield a
 }
 <<< 7.2: enumerator shoft, guard long
 maxColumn = 30
@@ -2560,7 +2560,6 @@ object a {
 <<< def followed by comment, break, wrap
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int =
@@ -2577,7 +2576,6 @@ object a {
 <<< def followed by comment, break, no wrap
 maxColumn = 100
 comments.wrap = no
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int =
@@ -2595,7 +2593,6 @@ object a {
 <<< def followed by comment, no break
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int = /* comment */
@@ -2609,7 +2606,6 @@ object a {
 <<< val followed by comment, break, wrap
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int =
@@ -2626,7 +2622,6 @@ object a {
 <<< val followed by comment, break, no wrap
 maxColumn = 100
 comments.wrap = no
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int =
@@ -2644,7 +2639,6 @@ object a {
 <<< val followed by comment, no break
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int = /* comment */
@@ -2722,9 +2716,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0) // c1
-      d.name should be("dir" + step)
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) // c1
+    d.name should be("dir" + step)
 }
 <<< #2113 def 3
 maxColumn = 70
@@ -2735,10 +2728,9 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0)
-      /* c1 */
-      d.name should be("dir" + step)
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
+    /* c1 */
+    d.name should be("dir" + step)
 }
 <<< #2113 def 4
 object a {
@@ -2761,8 +2753,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0) /* c1 */ { /* c2 */
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
+    /* c1 */ { /* c2 */
       d.name should be("dir" + step)
     }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2885,6 +2885,86 @@ object a {
         }
   }
 }
+<<< #2113 case 7, beforeMultiline = fold
+newlines.beforeMultiline = fold
+===
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a => if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
+<<< #2113 case 7, beforeMultiline = unfold
+newlines.beforeMultiline = unfold
+===
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a => if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
 <<< #2113 original
 maxColumn = 80
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -231,10 +231,12 @@ object a {
 >>>
 object a {
   val ok1 = if (a > 10) Some(a) else None
-  val ok2 = if (a > 10) { Some(a) }
-  else { None }
-  val ok3 = if (aaaa > 10000) { Some(aaaa) }
-  else { None }
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else { None }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+    else { None }
 }
 <<< 2.7 #1747: one line without else
 maxColumn = 60
@@ -277,16 +279,18 @@ object a {
       Some(a)
     else
       None
-  val ok2 = if (a > 10) {
-    Some(a)
-  } else {
-    None
-  }
-  val ok3 = if (aaaa > 10000) {
-    Some(aaaa)
-  } else {
-    None
-  }
+  val ok2 =
+    if (a > 10) {
+      Some(a)
+    } else {
+      None
+    }
+  val ok3 =
+    if (aaaa > 10000) {
+      Some(aaaa)
+    } else {
+      None
+    }
 }
 <<< 2.9 #1747: split on else
 maxColumn = 60
@@ -307,14 +311,16 @@ object a {
     if (a > 10) Some(a)
     else
       None
-  val ok2 = if (a > 10) { Some(a) }
-  else {
-    None
-  }
-  val ok3 = if (aaaa > 10000) { Some(aaaa) }
-  else {
-    None
-  }
+  val ok2 =
+    if (a > 10) { Some(a) }
+    else {
+      None
+    }
+  val ok3 =
+    if (aaaa > 10000) { Some(aaaa) }
+    else {
+      None
+    }
 }
 <<< 2.10 #1747: split on then without else
 maxColumn = 60
@@ -329,9 +335,8 @@ object a {
 }
 >>>
 object a {
-  val ok1 =
-    if (a > 10)
-      Some(a)
+  val ok1 = if (a > 10)
+    Some(a)
   val ok2 = if (a > 10) {
     Some(a)
   }
@@ -419,9 +424,8 @@ maxColumn = 80
 val attributes = for (i ← 1 to count)
  yield i
 >>>
-val attributes =
-  for (i ← 1 to count)
-    yield i
+val attributes = for (i ← 1 to count)
+  yield i
 <<< 2.15 val with literal apply
 object a {
    val a =
@@ -1360,7 +1364,8 @@ a match {
 a match {
   case b =>
     bb
-  case c => cc
+  case c =>
+    cc
     ccc
   case d =>
     dd
@@ -2662,11 +2667,10 @@ object a {
 >>>
 object a {
   if (a) Seq(a, b)
-  else
-    Seq(
-      a,
-      b
-    )
+  else Seq(
+    a,
+    b
+  )
 }
 <<< #2113 if-apply 2
 maxColumn = 30
@@ -2679,16 +2683,14 @@ object a {
 }
 >>>
 object a {
-  if (a)
-    Seq(
-      aaaaaaaaaa,
-      bbbbbbbbbb
-    )
-  else
-    Seq(
-      aaaaaaaaaa,
-      bbbbbbbbbb
-    )
+  if (a) Seq(
+    aaaaaaaaaa,
+    bbbbbbbbbb
+  )
+  else Seq(
+    aaaaaaaaaa,
+    bbbbbbbbbb
+  )
 }
 <<< #2113 def 1
 maxColumn = 72
@@ -2728,9 +2730,9 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
-    /* c1 */
-    d.name should be("dir" + step)
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) /* c1 */
+      d.name should be("dir" + step)
 }
 <<< #2113 def 4
 object a {
@@ -2753,8 +2755,8 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0)
-    /* c1 */ { /* c2 */
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) /* c1 */ { /* c2 */
       d.name should be("dir" + step)
     }
 }
@@ -2841,10 +2843,10 @@ object a {
 >>>
 object a {
   a match {
-    case a => if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 case 7
@@ -2868,8 +2870,7 @@ object a {
 >>>
 object a {
   a match {
-    case a => if (step != 0)
-        /* c1 */
+    case a => if (step != 0) /* c1 */
         d.name should be("dir" + step)
     case a => if (step != 0 /* c1 */ )
         d.name should be("dir" + step)
@@ -2879,10 +2880,10 @@ object a {
     case a => if (step != 0) /* c1 */ {
         d.name should be("dir" + step)
       }
-    case a => if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 case 7, beforeMultiline = fold
@@ -2908,8 +2909,7 @@ object a {
 >>>
 object a {
   a match {
-    case a => if (step != 0)
-        /* c1 */
+    case a => if (step != 0) /* c1 */
         d.name should be("dir" + step)
     case a => if (step != 0 /* c1 */ )
         d.name should be("dir" + step)
@@ -2919,10 +2919,10 @@ object a {
     case a => if (step != 0) /* c1 */ {
         d.name should be("dir" + step)
       }
-    case a => if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 case 7, beforeMultiline = unfold
@@ -2948,21 +2948,24 @@ object a {
 >>>
 object a {
   a match {
-    case a => if (step != 0)
-        /* c1 */
+    case a =>
+      if (step != 0) /* c1 */
         d.name should be("dir" + step)
-    case a => if (step != 0 /* c1 */ )
+    case a =>
+      if (step != 0 /* c1 */ )
         d.name should be("dir" + step)
-    case a => if (step != 0) { /* c1 */
+    case a =>
+      if (step != 0) { /* c1 */
         d.name should be("dir" + step)
       }
-    case a => if (step != 0) /* c1 */ {
+    case a =>
+      if (step != 0) /* c1 */ {
         d.name should be("dir" + step)
       }
-    case a => if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+    case a =>
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 original
@@ -2982,11 +2985,10 @@ object a {
 object a {
   if (!someBooleanValue) Command.invalid
   else if (someIntValue != 1) Command.invalid
-  else
-    someCollection.get(args.head) match {
-      case it @ Some(_) =>
-        someService.setSomeValue(it)
-        Command.success
-      case None => Command.invalid
-    }
+  else someCollection.get(args.head) match {
+    case it @ Some(_) =>
+      someService.setSomeValue(it)
+      Command.success
+    case None => Command.invalid
+  }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -921,10 +921,11 @@ object a {
 }
 >>>
 object a {
-  val a = (intercept[
-    java.lang.IllegalStateException] {
-    in.readObject
-  })
+  val a =
+    (intercept[
+      java.lang.IllegalStateException] {
+      in.readObject
+    })
 }
 <<< 3.23 enclosed, assignment, infix on left, narrow
 maxColumn = 40
@@ -2261,13 +2262,14 @@ val ret = (if (dailyStats.isEmpty)
                      yestNav) / nav - 1
                  })
 >>>
-val ret = (if (dailyStats.isEmpty)
-             0
-           else {
-             val yestStats = dailyStats.last
-             val yestNav = yestStats.nav
-             (nav - yestNav) / nav - 1
-           })
+val ret =
+  (if (dailyStats.isEmpty)
+     0
+   else {
+     val yestStats = dailyStats.last
+     val yestNav = yestStats.nav
+     (nav - yestNav) / nav - 1
+   })
 <<< 8.24
 maxColumn = 80
 ===
@@ -2821,8 +2823,7 @@ object a {
 >>>
 object a {
   def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0)
-      /* c1 */
+    if (step != 0) /* c1 */
       d.name should be("dir" + step)
 }
 <<< #2113 def 4
@@ -2847,10 +2848,9 @@ object a {
 >>>
 object a {
   def validate(d: DirectoryProxy, step: Int): Unit =
-    if (step != 0)
-      /* c1 */ { /* c2 */
-        d.name should be("dir" + step)
-      }
+    if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
 }
 <<< #2113 case 1
 object a {
@@ -2940,10 +2940,9 @@ object a {
 object a {
   a match {
     case a =>
-      if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 case 7
@@ -2968,8 +2967,7 @@ object a {
 object a {
   a match {
     case a =>
-      if (step != 0)
-        /* c1 */
+      if (step != 0) /* c1 */
         d.name should be("dir" + step)
     case a =>
       if (step != 0 /* c1 */ )
@@ -2979,15 +2977,13 @@ object a {
         d.name should be("dir" + step)
       }
     case a =>
-      if (step != 0)
-        /* c1 */ {
-          d.name should be("dir" + step)
-        }
+      if (step != 0) /* c1 */ {
+        d.name should be("dir" + step)
+      }
     case a =>
-      if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 case 7, beforeMultiline = fold
@@ -3013,27 +3009,20 @@ object a {
 >>>
 object a {
   a match {
-    case a =>
-      if (step != 0)
-        /* c1 */
+    case a => if (step != 0) /* c1 */
         d.name should be("dir" + step)
-    case a =>
-      if (step != 0 /* c1 */ )
+    case a => if (step != 0 /* c1 */ )
         d.name should be("dir" + step)
-    case a =>
-      if (step != 0) { /* c1 */
+    case a => if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a => if (step != 0) /* c1 */ {
         d.name should be("dir" + step)
       }
     case a =>
-      if (step != 0)
-        /* c1 */ {
-          d.name should be("dir" + step)
-        }
-    case a =>
-      if (step != 0)
-        /* c1 */ { /* c2 */
-          d.name should be("dir" + step)
-        }
+      if (step != 0) /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
   }
 }
 <<< #2113 original

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2650,7 +2650,6 @@ object a {
 <<< def followed by comment, break, wrap
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int =
@@ -2667,7 +2666,6 @@ object a {
 <<< def followed by comment, break, no wrap
 maxColumn = 100
 comments.wrap = no
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int =
@@ -2685,7 +2683,6 @@ object a {
 <<< def followed by comment, no break
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   def foo(bar: Int): Int = /* comment */
@@ -2699,7 +2696,6 @@ object a {
 <<< val followed by comment, break, wrap
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int =
@@ -2716,7 +2712,6 @@ object a {
 <<< val followed by comment, break, no wrap
 maxColumn = 100
 comments.wrap = no
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int =
@@ -2734,7 +2729,6 @@ object a {
 <<< val followed by comment, no break
 maxColumn = 100
 comments.wrap = trailing
-newlines.alwaysBeforeMultilineDef = false
 ===
 object a {
   val foo: Int = /* comment */

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2990,6 +2990,52 @@ object a {
         }
   }
 }
+<<< #2113 case 7, beforeMultiline = fold
+newlines.beforeMultiline = fold
+===
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0)
+        /* c1 */ {
+          d.name should be("dir" + step)
+        }
+    case a =>
+      if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
 <<< #2113 original
 maxColumn = 80
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1543,7 +1543,7 @@ object a {
       }
     }
 }
-<<< 7.1: enumerator and guard short, for long
+<<< 7.1.1: enumerator and guard short, for long
 object a {
   def c(b: List[Int]): List[Int] =
     for {
@@ -1558,6 +1558,34 @@ object a {
       a <- b
       if (b ++ b).length >= 2
     } yield a
+}
+<<< 7.1.2: enumerators and guard short, for long, parens
+object a {
+  for (i <- 0 until n;
+        j <- 0 until n if i + j == v)
+   yield (i, j)
+}
+>>>
+object a {
+  for (
+    i <- 0 until n;
+    j <- 0 until n
+    if i + j == v
+  )
+    yield (i, j)
+}
+<<< 7.1.2: enumerator and guard short, for long, parens
+object a {
+  def a = for (a <- b; if cc < dd) yield a
+}
+>>>
+object a {
+  def a =
+    for (
+      a <- b;
+      if cc < dd
+    )
+      yield a
 }
 <<< 7.2: enumerator shoft, guard long
 maxColumn = 28
@@ -2716,4 +2744,283 @@ object a {
 object a {
   val foo: Int = /* comment */
     baz
+}
+<<< #2113 if-apply 1
+object a {
+  if (a)
+    Seq(
+      a,
+      b
+    )
+  else
+    Seq(
+      a,
+      b
+    )
+}
+>>>
+object a {
+  if (a)
+    Seq(a, b)
+  else
+    Seq(a, b)
+}
+<<< #2113 if-apply 2
+maxColumn = 30
+===
+object a {
+  if (a)
+    Seq(aaaaaaaaaa, bbbbbbbbbb)
+  else
+    Seq(aaaaaaaaaa, bbbbbbbbbb)
+}
+>>>
+object a {
+  if (a)
+    Seq(
+      aaaaaaaaaa,
+      bbbbbbbbbb
+    )
+  else
+    Seq(
+      aaaaaaaaaa,
+      bbbbbbbbbb
+    )
+}
+<<< #2113 def 1
+maxColumn = 72
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) { // c1
+      d.name should be("dir" + step)
+      validate(d.parent, step - 1)
+    }
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) { // c1
+      d.name should be("dir" + step)
+      validate(d.parent, step - 1)
+    }
+}
+<<< #2113 def 2
+maxColumn = 100
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) // c1
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0) // c1
+      d.name should be("dir" + step)
+}
+<<< #2113 def 3
+maxColumn = 70
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0)
+      /* c1 */
+      d.name should be("dir" + step)
+}
+<<< #2113 def 4
+object a {
+  def validate(d: Directory): Unit = if (step != 0)
+    d.name should be("dir" + step)
+}
+>>>
+object a {
+  def validate(d: Directory): Unit =
+    if (step != 0)
+      d.name should be("dir" + step)
+}
+<<< #2113 def 5
+maxColumn = 80
+===
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */ { /* c2 */
+    d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  def validate(d: DirectoryProxy, step: Int): Unit =
+    if (step != 0)
+      /* c1 */ { /* c2 */
+        d.name should be("dir" + step)
+      }
+}
+<<< #2113 case 1
+object a {
+  a match {
+    case a => d.name.should.be_dir("step1", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name
+        .should
+        .be_dir("step1", "step2")
+  }
+}
+<<< #2113 case 2
+object a {
+  a match {
+    case a => d.name.should.be_dir("step1", "plus", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name
+        .should
+        .be_dir(
+          "step1",
+          "plus",
+          "step2"
+        )
+  }
+}
+<<< #2113 case 3
+object a {
+  a match {
+    case a => d.name.should.be("dir").plus("step1", "step2")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name
+        .should
+        .be("dir")
+        .plus("step1", "step2")
+  }
+}
+<<< #2113 case 4
+object a {
+  a match {
+    case a => d.name should be("dir")
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name should be("dir")
+  }
+}
+<<< #2113 case 5
+object a {
+  a match {
+    case a => d.name should be("dir" + step)
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      d.name should be("dir" + step)
+  }
+}
+<<< #2113 case 6
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
+<<< #2113 case 7
+object a {
+  a match {
+    case a => if (step != 0) /* c1 */
+      d.name should be("dir" + step)
+    case a => if (step != 0 /* c1 */)
+      d.name should be("dir" + step)
+    case a => if (step != 0) { /* c1 */
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ {
+      d.name should be("dir" + step)
+    }
+    case a => if (step != 0) /* c1 */ { /* c2 */
+      d.name should be("dir" + step)
+    }
+  }
+}
+>>>
+object a {
+  a match {
+    case a =>
+      if (step != 0)
+        /* c1 */
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0 /* c1 */ )
+        d.name should be("dir" + step)
+    case a =>
+      if (step != 0) { /* c1 */
+        d.name should be("dir" + step)
+      }
+    case a =>
+      if (step != 0)
+        /* c1 */ {
+          d.name should be("dir" + step)
+        }
+    case a =>
+      if (step != 0)
+        /* c1 */ { /* c2 */
+          d.name should be("dir" + step)
+        }
+  }
+}
+<<< #2113 original
+maxColumn = 80
+===
+object a {
+  if (!someBooleanValue) Command.invalid
+  else if (someIntValue != 1) Command.invalid
+  else someCollection.get(args.head) match {
+      case it @ Some(_) =>
+        someService.setSomeValue(it)
+        Command.success
+      case None => Command.invalid
+    }
+}
+>>>
+object a {
+  if (!someBooleanValue)
+    Command.invalid
+  else if (someIntValue != 1)
+    Command.invalid
+  else
+    someCollection.get(args.head) match {
+      case it @ Some(_) =>
+        someService.setSomeValue(it)
+        Command.success
+      case None =>
+        Command.invalid
+    }
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -468,13 +468,12 @@ object a {
 }
 >>>
 object a {
-  def findAccountByAPIKey(apiKey: APIKey) =
-    byKeyCache.get(apiKey) match {
-      case None =>
-        delegate.findAccountByAPIKey(apiKey) map {
-          _ map _ tap (add(apiKey, _)) unsafePerformIO
-        }
-    }
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map {
+        _ map _ tap (add(apiKey, _)) unsafePerformIO
+      }
+  }
 }
 <<< #1633 1.3: func with placeholder and infix
 object a {
@@ -487,13 +486,12 @@ object a {
 }
 >>>
 object a {
-  def findAccountByAPIKey(apiKey: APIKey) =
-    byKeyCache.get(apiKey) match {
-      case None =>
-        delegate.findAccountByAPIKey(apiKey) map {
-          _ map (_) tap (add(apiKey, _)) unsafePerformIO (foo)
-        }
-    }
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map {
+        _ map (_) tap (add(apiKey, _)) unsafePerformIO (foo)
+      }
+  }
 }
 <<< #1633 1.4: func
 object a {
@@ -506,13 +504,12 @@ object a {
 }
 >>>
 object a {
-  def findAccountByAPIKey(apiKey: APIKey) =
-    byKeyCache.get(apiKey) match {
-      case None =>
-        delegate.findAccountByAPIKey(apiKey) map { x =>
-          x._1 map x._2 tap (add(apiKey, _)) unsafePerformIO
-        }
-    }
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map { x =>
+        x._1 map x._2 tap (add(apiKey, _)) unsafePerformIO
+      }
+  }
 }
 <<< #1633 1.5: partial func
 object a {
@@ -525,13 +522,12 @@ object a {
 }
 >>>
 object a {
-  def findAccountByAPIKey(apiKey: APIKey) =
-    byKeyCache.get(apiKey) match {
-      case None =>
-        delegate.findAccountByAPIKey(apiKey) map { case (x, y) =>
-          x map y tap (add(apiKey, _)) unsafePerformIO
-        }
-    }
+  def findAccountByAPIKey(apiKey: APIKey) = byKeyCache.get(apiKey) match {
+    case None =>
+      delegate.findAccountByAPIKey(apiKey) map { case (x, y) =>
+        x map y tap (add(apiKey, _)) unsafePerformIO
+      }
+  }
 }
 <<< #1633 2.1: function block in an if-statement
 object a {

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -183,8 +183,8 @@ object a {
 implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](
     f: Function8[
         T1, T2, T3, T4, T5, T6, T7, T8,
-        R]): scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] =
-  (x1, x2, x3, x4, x5, x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
+        R]): scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3,
+    x4, x5, x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
 <<< toFunction22 #255
   implicit def toFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](f: Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]): scala.Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22)
 >>>
@@ -211,11 +211,10 @@ def sourceMapper: js.UndefOr[js.Function1[ // scalastyle:ignore
     case _                         => th
    }
 >>>
-def unwrapJavaScriptException(th: Throwable): Any =
-  th match {
-    case js.JavaScriptException(e) => e
-    case _                         => th
-  }
+def unwrapJavaScriptException(th: Throwable): Any = th match {
+  case js.JavaScriptException(e) => e
+  case _                         => th
+}
 <<< no newline before { #305
 object RTCIceCandidateInit {
   @inline

--- a/scalafmt-tests/src/test/resources/spaces/InParentheses.stat
+++ b/scalafmt-tests/src/test/resources/spaces/InParentheses.stat
@@ -20,27 +20,24 @@ def x = ( 1, 2 )
 <<< maxColumn
 def x = (1, 2, aaaaaaaaaaaaaawwwwsssssssssswa)
 >>>
-def x =
-  (
-    1,
-    2,
-    aaaaaaaaaaaaaawwwwsssssssssswa )
+def x = (
+  1,
+  2,
+  aaaaaaaaaaaaaawwwwsssssssssswa )
 <<< maxColumn apply
 def foo = bar(aaaaaaaaaaaaa, bbbbbbbbbbbbbb, cccccccccc)
 >>>
-def foo =
-  bar(
-    aaaaaaaaaaaaa,
-    bbbbbbbbbbbbbb,
-    cccccccccc )
+def foo = bar(
+  aaaaaaaaaaaaa,
+  bbbbbbbbbbbbbb,
+  cccccccccc )
 <<< maxColumn apply 2
 def foo = bar(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbb, cccccccccc)
 >>>
-def foo =
-  bar(
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
-    bbbbbbbbbbbbbb,
-    cccccccccc )
+def foo = bar(
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+  bbbbbbbbbbbbbb,
+  cccccccccc )
 <<< brackets
 function[A](a, b, c)
 >>>

--- a/scalafmt-tests/src/test/resources/test/i1527.stat
+++ b/scalafmt-tests/src/test/resources/test/i1527.stat
@@ -15,16 +15,15 @@ object a {
 >>>
 object a {
   @tailrec
-  final def rhsOptimalToken(start: FormatToken): Token =
-    start.right match {
-      case T.Comma() | T.LeftParen() | T.RightParen() | T.RightBracket() |
-          T.Semicolon() | T.RightArrow() | T.Equals()
-          if next(start) != start &&
-            !startsNewBlock(start.right) &&
-            newlinesBetween(start.between) == 0 =>
-        rhsOptimalToken(next(start))
-      case _ => start.left
-    }
+  final def rhsOptimalToken(start: FormatToken): Token = start.right match {
+    case T.Comma() | T.LeftParen() | T.RightParen() | T.RightBracket() |
+        T.Semicolon() | T.RightArrow() | T.Equals()
+        if next(start) != start &&
+          !startsNewBlock(start.right) &&
+          newlinesBetween(start.between) == 0 =>
+      rhsOptimalToken(next(start))
+    case _ => start.left
+  }
 }
 <<< scala-native
 def genCQuoteOp(app: Apply): Val = {

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -121,14 +121,13 @@ object a {
     )(implicit
         c1: SomeType1,
         c2: SomeType2, // comment
-    ) =
-      this(
-        a1,
-        a2, // comment
-      )(
-        b1,
-        b2, // comment
-      )
+    ) = this(
+      a1,
+      a2, // comment
+    )(
+      b1,
+      b2, // comment
+    )
   }
 }
 <<< #1703

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysDanglingParens.stat
@@ -328,13 +328,12 @@ object a {
     )(implicit
         c1: SomeType1,
         c2: SomeType2, // comment
-    ) =
-      this(
-        a1,
-        a2, // comment
-      )(
-        b1,
-        b2, // comment
-      )
+    ) = this(
+      a1,
+      a2, // comment
+    )(
+      b1,
+      b2, // comment
+    )
   }
 }

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultiple.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultiple.stat
@@ -121,14 +121,13 @@ object a {
     )(implicit
         c1: SomeType1,
         c2: SomeType2, // comment
-    ) =
-      this(
-        a1,
-        a2, // comment
-      )(
-        b1,
-        b2, // comment
-      )
+    ) = this(
+      a1,
+      a2, // comment
+    )(
+      b1,
+      b2, // comment
+    )
   }
 }
 <<< #1703

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleDanglingParens.stat
@@ -328,13 +328,12 @@ object a {
     )(implicit
         c1: SomeType1,
         c2: SomeType2, // comment
-    ) =
-      this(
-        a1,
-        a2, // comment
-      )(
-        b1,
-        b2, // comment
-      )
+    ) = this(
+      a1,
+      a2, // comment
+    )(
+      b1,
+      b2, // comment
+    )
   }
 }

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasNever.stat
@@ -89,13 +89,12 @@ object a {
     )(implicit
         c1: SomeType1,
         c2: SomeType2 // comment
-    ) =
-      this(
-        a1,
-        a2 // comment
-      )(
-        b1,
-        b2 // comment
-      )
+    ) = this(
+      a1,
+      a2 // comment
+    )(
+      b1,
+      b2 // comment
+    )
   }
 }

--- a/scalafmt-tests/src/test/resources/unit/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/unit/DefDef.stat
@@ -84,10 +84,9 @@ def fill(points: Double) = x match {
 case ctx => 1
 }
 >>>
-def fill(points: Double) =
-  x match {
-    case ctx => 1
-  }
+def fill(points: Double) = x match {
+  case ctx => 1
+}
 <<< single line excluding last {} block
     def compare(): Int =
       if (startA == endA) {


### PR DESCRIPTION
Let's try to standardize formatting of the code which follows a def/val/case/if etc using an extended version of `newlines.alwaysBeforeMultilineDef`.

`scala-repos` diffs (for classic case, in which only handling of comments is different):
* Newlines: default alwaysBeforeMultilineDef = false: https://github.com/kitbellew/scala-repos/commit/c06b63b40029b6f4cea2df6fe19af91554f10d23?w=1
* Router: standard rule for body of def/if-else/case: https://github.com/kitbellew/scala-repos/commit/05b9b3e05d939643e937c7b71c930379f04c80df

For the other cases (fold, unfold, keep), unit tests describe the new functionality.

Fixes #2113.