### PR TITLE
RedundantBraces: fix method block as apply arg

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
@@ -87,8 +87,12 @@ object a {
     })
 }
 >>>
-test does not parse
 object a {
-  foo(0, { x =>
+  foo(
+    0,
+    { x =>
       val y = x
-    ^
+      y
+    }
+  )
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces2.stat
@@ -77,3 +77,18 @@ object A {
   }
   def x = 2
 }
+<<< #2138
+rewrite.redundantBraces.methodBodies = false
+===
+object a {
+  foo(0, { x =>
+      val y = x
+      y
+    })
+}
+>>>
+test does not parse
+object a {
+  foo(0, { x =>
+      val y = x
+    ^


### PR DESCRIPTION
We failed to take into account the maxLines parameter when determining if the method block as apply arg would be rewritten.

Fixes #2138.