### PR TITLE
RedundantParens: look for NL before nested infix ops

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -299,7 +299,5 @@ object a {
 val map = (Map("A" -> 1) - "Test" - "Test" - "Test" - "Test" - "Test"
     - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" + "B" -> 2)
 >>>
-test does not parse
-val map = Map("A" -> 1) - "Test" - "Test" - "Test" - "Test" - "Test"
-    - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" + "B" -> 2
-    ^
+val map = (Map("A" -> 1) - "Test" - "Test" - "Test" - "Test" - "Test"
+  - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" + "B" -> 2)

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -295,3 +295,11 @@ object a {
     case a if a =>
   }
 }
+<<< #2163
+val map = (Map("A" -> 1) - "Test" - "Test" - "Test" - "Test" - "Test"
+    - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" + "B" -> 2)
+>>>
+test does not parse
+val map = Map("A" -> 1) - "Test" - "Test" - "Test" - "Test" - "Test"
+    - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" - "Test" + "B" -> 2
+    ^


### PR DESCRIPTION
Previously, we were only looking for a break before an infix op once but we should also recurse into left and right sides.

Fixes #2163.