### PR TITLE
Router: format ()-enclosed case clause as a block

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -200,7 +200,8 @@ case class Newlines(
 
   val reader: ConfDecoder[Newlines] = generic.deriveDecoder(this).noTypos
 
-  val sourceIgnored: Boolean = source.in(Newlines.fold, Newlines.unfold)
+  @inline
+  def sourceIgnored: Boolean = source.ignoreSourceSplit
 
   val breakAfterInfix: AfterInfix =
     afterInfix.getOrElse {
@@ -265,18 +266,18 @@ object Newlines {
   implicit lazy val surface: Surface[Newlines] = generic.deriveSurface
   implicit lazy val encoder: ConfEncoder[Newlines] = generic.deriveEncoder
 
-  sealed abstract class SourceHints {
+  sealed abstract class SourceHints(val ignoreSourceSplit: Boolean) {
     @inline
     final def in(hints: SourceHints*): Boolean = hints.contains(this)
   }
   // the classic handler of source newlines
-  case object classic extends SourceHints
+  case object classic extends SourceHints(ignoreSourceSplit = false)
   // try to keep newlines
-  case object keep extends SourceHints
+  case object keep extends SourceHints(ignoreSourceSplit = false)
   // try to fold newlines into spaces (but not semicolons)
-  case object fold extends SourceHints
+  case object fold extends SourceHints(ignoreSourceSplit = true)
   // try to turn spaces and semicolons into newlines
-  case object unfold extends SourceHints
+  case object unfold extends SourceHints(ignoreSourceSplit = true)
 
   object SourceHints {
     // NB: don't allow specifying classic, only by default

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -689,4 +689,18 @@ object TreeOps {
   def isCaseBodyABlock(ft: FormatToken, caseStat: Case): Boolean =
     ft.right.is[Token.LeftBrace] && (caseStat.body eq ft.meta.rightOwner)
 
+  // Redundant () delims around case statements
+  def isCaseBodyEnclosedAsBlock(ft: FormatToken, caseStat: Case)(implicit
+      style: ScalafmtConfig
+  ): Boolean = {
+    val body = caseStat.body
+    (ft.noBreak || style.newlines.getBeforeMultiline.ignoreSourceSplit) &&
+    body.eq(ft.meta.rightOwner) && !body.is[Term.Tuple] && {
+      val btoks = body.tokens
+      btoks.headOption.exists { head =>
+        head.is[Token.LeftParen] && btoks.last.is[Token.RightParen]
+      }
+    }
+  }
+
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3048,14 +3048,14 @@ pubSubMessage match {
 }
 >>>
 pubSubMessage match {
-  case message: IngestionMessage =>
-    (
-      foo.bar.baz
-    ) /* very long winded comment */
+  case message: IngestionMessage => (
+    foo.bar.baz
+  ) /* very long winded comment */
   case message: IngestionMessage =>
     (foo) /* comment */
-  case message: IngestionMessage =>
-    (foo.bar.baz)
+  case message: IngestionMessage => (
+    foo.bar.baz
+  )
   case message: UploadMessage => {
     val services = makeUploadServices()
 

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3029,3 +3029,41 @@ object a {
       case None => Command.invalid
     }
 }
+<<< #2137
+pubSubMessage match {
+  case message: IngestionMessage => (
+    foo.bar.baz
+  ) /* very long winded comment */
+  case message: IngestionMessage =>
+    (foo) /* comment */
+  case message: IngestionMessage => (foo.bar.baz)
+  case message: UploadMessage => {
+    val services = makeUploadServices()
+
+    UploadSubscriber(services).processEff(message)
+  }
+  case message: IngestionMessage => (
+      IngestionSubscriber.defaultServices
+    ).processEff.message()
+}
+>>>
+pubSubMessage match {
+  case message: IngestionMessage =>
+    (
+      foo.bar.baz
+    ) /* very long winded comment */
+  case message: IngestionMessage =>
+    (foo) /* comment */
+  case message: IngestionMessage =>
+    (foo.bar.baz)
+  case message: UploadMessage => {
+    val services = makeUploadServices()
+
+    UploadSubscriber(services)
+      .processEff(message)
+  }
+  case message: IngestionMessage =>
+    (
+      IngestionSubscriber.defaultServices
+    ).processEff.message()
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2912,13 +2912,15 @@ pubSubMessage match {
 }
 >>>
 pubSubMessage match {
-  case message: IngestionMessage =>
-    (foo.bar
-      .baz) /* very long winded comment */
-  case message: IngestionMessage =>
-    (foo) /* comment */
-  case message: IngestionMessage =>
-    (foo.bar.baz)
+  case message: IngestionMessage => (
+    foo.bar.baz
+  ) /* very long winded comment */
+  case message: IngestionMessage => (
+    foo
+  ) /* comment */
+  case message: IngestionMessage => (
+    foo.bar.baz
+  )
   case message: UploadMessage => {
     val services = makeUploadServices()
 

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2893,3 +2893,40 @@ object a {
     case None => Command.invalid
   }
 }
+<<< #2137
+pubSubMessage match {
+  case message: IngestionMessage => (
+    foo.bar.baz
+  ) /* very long winded comment */
+  case message: IngestionMessage =>
+    (foo) /* comment */
+  case message: IngestionMessage => (foo.bar.baz)
+  case message: UploadMessage => {
+    val services = makeUploadServices()
+
+    UploadSubscriber(services).processEff(message)
+  }
+  case message: IngestionMessage => (
+      IngestionSubscriber.defaultServices
+    ).processEff.message()
+}
+>>>
+pubSubMessage match {
+  case message: IngestionMessage =>
+    (foo.bar
+      .baz) /* very long winded comment */
+  case message: IngestionMessage =>
+    (foo) /* comment */
+  case message: IngestionMessage =>
+    (foo.bar.baz)
+  case message: UploadMessage => {
+    val services = makeUploadServices()
+
+    UploadSubscriber(services)
+      .processEff(message)
+  }
+  case message: IngestionMessage =>
+    (IngestionSubscriber
+      .defaultServices).processEff
+    .message()
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3012,12 +3012,13 @@ pubSubMessage match {
 >>>
 pubSubMessage match {
   case message: IngestionMessage => (
-      foo.bar.baz
-    ) /* very long winded comment */
+    foo.bar.baz
+  ) /* very long winded comment */
   case message: IngestionMessage =>
     (foo) /* comment */
-  case message: IngestionMessage =>
-    (foo.bar.baz)
+  case message: IngestionMessage => (
+    foo.bar.baz
+  )
   case message: UploadMessage => {
     val services = makeUploadServices()
 

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2992,3 +2992,40 @@ object a {
     case None => Command.invalid
   }
 }
+<<< #2137
+pubSubMessage match {
+  case message: IngestionMessage => (
+    foo.bar.baz
+  ) /* very long winded comment */
+  case message: IngestionMessage =>
+    (foo) /* comment */
+  case message: IngestionMessage => (foo.bar.baz)
+  case message: UploadMessage => {
+    val services = makeUploadServices()
+
+    UploadSubscriber(services).processEff(message)
+  }
+  case message: IngestionMessage => (
+      IngestionSubscriber.defaultServices
+    ).processEff.message()
+}
+>>>
+pubSubMessage match {
+  case message: IngestionMessage => (
+      foo.bar.baz
+    ) /* very long winded comment */
+  case message: IngestionMessage =>
+    (foo) /* comment */
+  case message: IngestionMessage =>
+    (foo.bar.baz)
+  case message: UploadMessage => {
+    val services = makeUploadServices()
+
+    UploadSubscriber(
+      services
+    ).processEff(message)
+  }
+  case message: IngestionMessage => (
+      IngestionSubscriber.defaultServices
+    ).processEff.message()
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3053,3 +3053,42 @@ object a {
         Command.invalid
     }
 }
+<<< #2137
+pubSubMessage match {
+  case message: IngestionMessage => (
+    foo.bar.baz
+  ) /* very long winded comment */
+  case message: IngestionMessage =>
+    (foo) /* comment */
+  case message: IngestionMessage => (foo.bar.baz)
+  case message: UploadMessage => {
+    val services = makeUploadServices()
+
+    UploadSubscriber(services).processEff(message)
+  }
+  case message: IngestionMessage => (
+      IngestionSubscriber.defaultServices
+    ).processEff.message()
+}
+>>>
+pubSubMessage match {
+  case message: IngestionMessage =>
+    (
+      foo.bar.baz
+    ) /* very long winded comment */
+  case message: IngestionMessage =>
+    (foo) /* comment */
+  case message: IngestionMessage =>
+    (foo.bar.baz)
+  case message: UploadMessage => {
+    val services = makeUploadServices()
+
+    UploadSubscriber(services)
+      .processEff(message)
+  }
+  case message: IngestionMessage =>
+    (
+      IngestionSubscriber
+        .defaultServices
+      ).processEff.message()
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3072,14 +3072,15 @@ pubSubMessage match {
 }
 >>>
 pubSubMessage match {
-  case message: IngestionMessage =>
-    (
-      foo.bar.baz
-    ) /* very long winded comment */
-  case message: IngestionMessage =>
-    (foo) /* comment */
-  case message: IngestionMessage =>
-    (foo.bar.baz)
+  case message: IngestionMessage => (
+    foo.bar.baz
+  ) /* very long winded comment */
+  case message: IngestionMessage => (
+    foo
+  ) /* comment */
+  case message: IngestionMessage => (
+    foo.bar.baz
+  )
   case message: UploadMessage => {
     val services = makeUploadServices()
 


### PR DESCRIPTION
That includes keeping the opening paren on the first line and avoiding extra indentation. Fixes #2137.