### PR TITLE
Dependencies: upgrade scalameta to 4.3.21

### DIFF
--- a/scalafmt-tests/src/test/resources/test/Dialect.source
+++ b/scalafmt-tests/src/test/resources/test/Dialect.source
@@ -49,3 +49,17 @@ rewrite.rules = [AvoidInfix]
 #!/usr/bin/env   amm
 >>> foo.sc
 #!/usr/bin/env amm
+<<< #2104
+runner.dialect = dotty
+===
+sealed trait Foo {
+  def negate : - = -
+}
+trait -
+case object - extends -
+>>>
+sealed trait Foo {
+  def negate: - = -
+}
+trait -
+case object - extends -


### PR DESCRIPTION
Actually, the dependency has already been updated by `scala-steward`. Add the test which failed previously.

Improves dotty support in the `scalameta` parser but `scalafmt` formatter doesn't support any new syntax.

Fixes #2104.