### PR TITLE
FormatOps: improve isCaseBodyEnclosedAsBlock

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -20,6 +20,7 @@ import scala.meta.{
   Defn,
   Import,
   Init,
+  Lit,
   Pat,
   Pkg,
   Template,
@@ -1699,10 +1700,16 @@ class FormatOps(
   ): Boolean = {
     val body = caseStat.body
     (ft.noBreak || style.newlines.getBeforeMultiline.ignoreSourceSplit) &&
-    body.eq(ft.meta.rightOwner) && !body.is[Term.Tuple] && {
+    body.eq(ft.meta.rightOwner) && (body match {
+      case _: Lit.Unit | _: Term.Tuple => false
+      case t: Term.ApplyInfix =>
+        val op = t.op.value
+        op != "->" && op != "→"
+      case _ => true
+    }) && {
       val btoks = body.tokens
       btoks.headOption.exists { head =>
-        head.is[Token.LeftParen] && btoks.last.is[Token.RightParen]
+        head.is[Token.LeftParen] && matchingOpt(head).contains(btoks.last)
       }
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1693,4 +1693,18 @@ class FormatOps(
       }
   }
 
+  // Redundant () delims around case statements
+  def isCaseBodyEnclosedAsBlock(ft: FormatToken, caseStat: Case)(implicit
+      style: ScalafmtConfig
+  ): Boolean = {
+    val body = caseStat.body
+    (ft.noBreak || style.newlines.getBeforeMultiline.ignoreSourceSplit) &&
+    body.eq(ft.meta.rightOwner) && !body.is[Term.Tuple] && {
+      val btoks = body.tokens
+      btoks.headOption.exists { head =>
+        head.is[Token.LeftParen] && btoks.last.is[Token.RightParen]
+      }
+    }
+  }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -689,18 +689,4 @@ object TreeOps {
   def isCaseBodyABlock(ft: FormatToken, caseStat: Case): Boolean =
     ft.right.is[Token.LeftBrace] && (caseStat.body eq ft.meta.rightOwner)
 
-  // Redundant () delims around case statements
-  def isCaseBodyEnclosedAsBlock(ft: FormatToken, caseStat: Case)(implicit
-      style: ScalafmtConfig
-  ): Boolean = {
-    val body = caseStat.body
-    (ft.noBreak || style.newlines.getBeforeMultiline.ignoreSourceSplit) &&
-    body.eq(ft.meta.rightOwner) && !body.is[Term.Tuple] && {
-      val btoks = body.tokens
-      btoks.headOption.exists { head =>
-        head.is[Token.LeftParen] && btoks.last.is[Token.RightParen]
-      }
-    }
-  }
-
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3067,3 +3067,45 @@ pubSubMessage match {
       IngestionSubscriber.defaultServices
     ).processEff.message()
 }
+<<< #2137 tuple with ->, match
+maxColumn = 20
+===
+a match {
+  case (k, v) => (k -> v)
+}
+>>>
+a match {
+  case (k, v) => (
+    k -> v
+  )
+}
+<<< #2137 tuple with ->, partial func
+maxColumn = 20
+===
+a {
+  case (k, v) => (k -> v)
+}
+>>>
+a {
+  case (k, v) => (
+    k -> v
+  )
+}
+<<< #2137 non-matching parens
+a match {
+  case (k, v) => () => k(v)
+}
+>>>
+a match {
+  case (k, v) => () => k(v)
+}
+<<< #2137 empty parens
+maxColumn = 17
+===
+a match {
+  case (k, v) => ()
+}
+>>>
+BestFirstSearch:330 Failed to format
+UNABLE TO FORMAT,
+tok==>∙([26:28]

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3075,9 +3075,8 @@ a match {
 }
 >>>
 a match {
-  case (k, v) => (
-    k -> v
-  )
+  case (k, v) =>
+    (k -> v)
 }
 <<< #2137 tuple with ->, partial func
 maxColumn = 20
@@ -3086,10 +3085,8 @@ a {
   case (k, v) => (k -> v)
 }
 >>>
-a {
-  case (k, v) => (
-    k -> v
-  )
+a { case (k, v) =>
+  (k -> v)
 }
 <<< #2137 non-matching parens
 a match {
@@ -3106,6 +3103,7 @@ a match {
   case (k, v) => ()
 }
 >>>
-BestFirstSearch:330 Failed to format
-UNABLE TO FORMAT,
-tok==>∙([26:28]
+a match {
+  case (k, v) =>
+    ()
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2940,9 +2940,8 @@ a match {
 }
 >>>
 a match {
-  case (k, v) => (
-    k -> v
-  )
+  case (k, v) =>
+    (k -> v)
 }
 <<< #2137 tuple with ->, partial func
 maxColumn = 20
@@ -2951,10 +2950,8 @@ a {
   case (k, v) => (k -> v)
 }
 >>>
-a {
-  case (k, v) => (
-    k -> v
-  )
+a { case (k, v) =>
+  (k -> v)
 }
 <<< #2137 non-matching parens
 a match {
@@ -2969,6 +2966,7 @@ a match {
   case (k, v) => ()
 }
 >>>
-BestFirstSearch:330 Failed to format
-UNABLE TO FORMAT,
-tok==>∙([26:28]
+a match {
+  case (k, v) =>
+    ()
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2932,3 +2932,43 @@ pubSubMessage match {
       .defaultServices).processEff
     .message()
 }
+<<< #2137 tuple with ->, match
+maxColumn = 20
+===
+a match {
+  case (k, v) => (k -> v)
+}
+>>>
+a match {
+  case (k, v) => (
+    k -> v
+  )
+}
+<<< #2137 tuple with ->, partial func
+maxColumn = 20
+===
+a {
+  case (k, v) => (k -> v)
+}
+>>>
+a {
+  case (k, v) => (
+    k -> v
+  )
+}
+<<< #2137 non-matching parens
+a match {
+  case (k, v) => () => k(v)
+}
+>>>
+a match { case (k, v) => () => k(v) }
+<<< #2137 empty parens
+maxColumn = 17
+===
+a match {
+  case (k, v) => ()
+}
+>>>
+BestFirstSearch:330 Failed to format
+UNABLE TO FORMAT,
+tok==>∙([26:28]

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3038,9 +3038,8 @@ a match {
 }
 >>>
 a match {
-  case (k, v) => (
-    k -> v
-  )
+  case (k, v) =>
+    (k -> v)
 }
 <<< #2137 tuple with ->, partial func
 maxColumn = 20
@@ -3050,9 +3049,8 @@ a {
 }
 >>>
 a {
-  case (k, v) => (
-    k -> v
-  )
+  case (k, v) =>
+    (k -> v)
 }
 <<< #2137 non-matching parens
 a match {
@@ -3069,6 +3067,7 @@ a match {
   case (k, v) => ()
 }
 >>>
-BestFirstSearch:330 Failed to format
-UNABLE TO FORMAT,
-tok==>∙([26:28]
+a match {
+  case (k, v) =>
+    ()
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3030,3 +3030,45 @@ pubSubMessage match {
       IngestionSubscriber.defaultServices
     ).processEff.message()
 }
+<<< #2137 tuple with ->, match
+maxColumn = 20
+===
+a match {
+  case (k, v) => (k -> v)
+}
+>>>
+a match {
+  case (k, v) => (
+    k -> v
+  )
+}
+<<< #2137 tuple with ->, partial func
+maxColumn = 20
+===
+a {
+  case (k, v) => (k -> v)
+}
+>>>
+a {
+  case (k, v) => (
+    k -> v
+  )
+}
+<<< #2137 non-matching parens
+a match {
+  case (k, v) => () => k(v)
+}
+>>>
+a match {
+  case (k, v) => () => k(v)
+}
+<<< #2137 empty parens
+maxColumn = 17
+===
+a match {
+  case (k, v) => ()
+}
+>>>
+BestFirstSearch:330 Failed to format
+UNABLE TO FORMAT,
+tok==>∙([26:28]

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3101,9 +3101,8 @@ a match {
 }
 >>>
 a match {
-  case (k, v) => (
-    k -> v
-  )
+  case (k, v) =>
+    (k -> v)
 }
 <<< #2137 tuple with ->, partial func
 maxColumn = 20
@@ -3112,10 +3111,8 @@ a {
   case (k, v) => (k -> v)
 }
 >>>
-a {
-  case (k, v) => (
-    k -> v
-  )
+a { case (k, v) =>
+  (k -> v)
 }
 <<< #2137 non-matching parens
 a match {
@@ -3123,7 +3120,8 @@ a match {
 }
 >>>
 a match {
-  case (k, v) => () => k(v)
+  case (k, v) =>
+    () => k(v)
 }
 <<< #2137 empty parens
 maxColumn = 17
@@ -3132,6 +3130,7 @@ a match {
   case (k, v) => ()
 }
 >>>
-BestFirstSearch:330 Failed to format
-UNABLE TO FORMAT,
-tok==>∙([26:28]
+a match {
+  case (k, v) =>
+    ()
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3093,3 +3093,45 @@ pubSubMessage match {
         .defaultServices
       ).processEff.message()
 }
+<<< #2137 tuple with ->, match
+maxColumn = 20
+===
+a match {
+  case (k, v) => (k -> v)
+}
+>>>
+a match {
+  case (k, v) => (
+    k -> v
+  )
+}
+<<< #2137 tuple with ->, partial func
+maxColumn = 20
+===
+a {
+  case (k, v) => (k -> v)
+}
+>>>
+a {
+  case (k, v) => (
+    k -> v
+  )
+}
+<<< #2137 non-matching parens
+a match {
+  case (k, v) => () => k(v)
+}
+>>>
+a match {
+  case (k, v) => () => k(v)
+}
+<<< #2137 empty parens
+maxColumn = 17
+===
+a match {
+  case (k, v) => ()
+}
+>>>
+BestFirstSearch:330 Failed to format
+UNABLE TO FORMAT,
+tok==>∙([26:28]


### PR DESCRIPTION
Follow-on to #2165, fixing a couple of bugs: avoid empty parens, "->" tuple and properly match parens.