### PR TITLE
FormatOps: use common rules for a generator body

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -168,6 +168,10 @@ class FormatOps(
   final def nextNonComment(curr: FormatToken): FormatToken =
     findToken(curr, next)(!_.right.is[T.Comment]).fold(identity, identity)
 
+  final def prevNonCommentSameLine(curr: FormatToken): FormatToken =
+    findToken(curr, prev)(ft => ft.hasBreak || !ft.left.is[T.Comment])
+      .fold(identity, identity)
+
   final def prevNonComment(curr: FormatToken): FormatToken =
     findToken(curr, prev)(!_.left.is[T.Comment]).fold(identity, identity)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1621,10 +1621,10 @@ class FormatOps(
             case _ => getSlbSplits()
           }
         case InfixApp(ia) =>
-          val left = findLeftInfix(ia)
-          val (callPolicy, isCallSite) = CallSite.getFoldedPolicies(left.lhs)
+          val left = findLeftInfix(ia).lhs
+          val (callPolicy, isCallSite) = CallSite.getFoldedPolicies(left)
           if (isCallSite) getPolicySplits(0, callPolicy)
-          else getSplits(getSlbSplit(left.op.tokens.last), true)
+          else getSplits(getSlbSplit(left.tokens.last), true)
         case _ =>
           val (callPolicy, isCallSite) = CallSite.getFoldedPolicies(body)
           getPolicySplits(if (isCallSite) 0 else 1, callPolicy)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1992,13 +1992,14 @@ class Router(formatOps: FormatOps) {
 
   private def getSplitsDefValEquals(
       ft: FormatToken,
-      body: Tree
+      body: Tree,
+      spaceIndents: Seq[Indent] = Seq.empty
   )(splits: => Seq[Split])(implicit
       style: ScalafmtConfig
   ): Seq[Split] = {
     def expire = body.tokens.last
-    if (ft.right.is[T.LeftBrace])
-      Seq(Split(Space, 0)) // The block will take care of indenting by 2
+    if (ft.right.is[T.LeftBrace]) // The block will take care of indenting by 2
+      Seq(Split(Space, 0).withIndents(spaceIndents))
     else if (
       ft.right.is[T.Comment] &&
       (ft.hasBreak || nextNonCommentSameLine(next(ft)).hasBreak)

--- a/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
+++ b/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
@@ -24,11 +24,13 @@ for {
 } yield cond
 >>>
 for {
-  variable <- record.field.field1.map(
-                _.toString
-              )
-  cond <- if (variable) doSomething
-          else doAnything
+  variable <-
+    record.field.field1.map(
+      _.toString
+    )
+  cond <-
+    if (variable) doSomething
+    else doAnything
 } yield cond
 <<< split long lines, without breaks
 for {
@@ -125,9 +127,8 @@ for {
          def value = 2
        }
   y <- Int(2)
-  cond <-
-    if (variable) doSomething
-    else doAnything
+  cond <- if (variable) doSomething
+          else doAnything
 } yield x + y
 <<< keep
 newlines.source=keep
@@ -208,12 +209,10 @@ for {
 } yield x + y
 >>>
 for {
-  cond <-
-    try { Some(x) }
-    catch { case _ => None }
-  cond =
-    try { Some(x) }
-    catch { case _ => None }
+  cond <- try { Some(x) }
+          catch { case _ => None }
+  cond = try { Some(x) }
+         catch { case _ => None }
 } yield x + y
 <<< fold try with break
 newlines.source=fold
@@ -227,10 +226,8 @@ for {
 } yield x + y
 >>>
 for {
-  cond <-
-    try { Some(x) }
-    catch { case _ => None }
-  cond =
-    try { Some(x) }
-    catch { case _ => None }
+  cond <- try { Some(x) }
+          catch { case _ => None }
+  cond = try { Some(x) }
+         catch { case _ => None }
 } yield x + y

--- a/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
+++ b/scalafmt-tests/src/test/resources/align/ArrowEnumeratorGenerator.stat
@@ -14,12 +14,26 @@ for {
        }
   y <- Int(2)
 } yield x + y
-<<< split long lines
+<<< split long lines, with breaks
 for {
   variable <-
     record.field.field1.map(_.toString)
   cond <-
     if (variable) doSomething
+    else doAnything
+} yield cond
+>>>
+for {
+  variable <- record.field.field1.map(
+                _.toString
+              )
+  cond <- if (variable) doSomething
+          else doAnything
+} yield cond
+<<< split long lines, without breaks
+for {
+  variable <- record.field.field1.map(_.toString)
+  cond <- if (variable) doSomething
     else doAnything
 } yield cond
 >>>
@@ -149,4 +163,74 @@ for {
   cond <-
     if (variable) doSomething
     else doAnything
+} yield x + y
+<<< keep try without break
+newlines.source=keep
+align.arrowEnumeratorGenerator = true
+===
+for {
+  cond <- try { Some(x) } catch { case _ => None }
+  cond = try { Some(x) } catch { case _ => None }
+} yield x + y
+>>>
+for {
+  cond <- try { Some(x) }
+          catch { case _ => None }
+  cond = try { Some(x) }
+         catch { case _ => None }
+} yield x + y
+<<< keep try with break
+newlines.source=keep
+align.arrowEnumeratorGenerator = true
+===
+for {
+  cond <-
+    try { Some(x) } catch { case _ => None }
+  cond =
+    try { Some(x) } catch { case _ => None }
+} yield x + y
+>>>
+for {
+  cond <-
+    try { Some(x) }
+    catch { case _ => None }
+  cond =
+    try { Some(x) }
+    catch { case _ => None }
+} yield x + y
+<<< fold try without break
+newlines.source=fold
+align.arrowEnumeratorGenerator = true
+===
+for {
+  cond <- try { Some(x) } catch { case _ => None }
+  cond = try { Some(x) } catch { case _ => None }
+} yield x + y
+>>>
+for {
+  cond <-
+    try { Some(x) }
+    catch { case _ => None }
+  cond =
+    try { Some(x) }
+    catch { case _ => None }
+} yield x + y
+<<< fold try with break
+newlines.source=fold
+align.arrowEnumeratorGenerator = true
+===
+for {
+  cond <-
+    try { Some(x) } catch { case _ => None }
+  cond =
+    try { Some(x) } catch { case _ => None }
+} yield x + y
+>>>
+for {
+  cond <-
+    try { Some(x) }
+    catch { case _ => None }
+  cond =
+    try { Some(x) }
+    catch { case _ => None }
 } yield x + y

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -65,6 +65,26 @@ for (
         ) // test Java API
     }
 ) checkOne(looker, l, r)
+<<< multiline for with paren, no comments
+for ((l, r) ← ( Seq(
+    SelectString("a/b/c") -> None,
+    SelectString("akka://all-systems/Nobody") -> None,
+    SelectPath(system / "hallo") -> None,
+    SelectPath(looker.path child "hallo") -> None, // test Java API
+    SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+  )
+  )
+) checkOne(looker, l, r)
+>>>
+for (
+    (l, r) ← (Seq(
+          SelectString("a/b/c") -> None,
+          SelectString("akka://all-systems/Nobody") -> None,
+          SelectPath(system / "hallo") -> None,
+          SelectPath(looker.path child "hallo") -> None, // test Java API
+          SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+      ))
+) checkOne(looker, l, r)
 <<< multiline for with paren
 for ((l, r) ← /* c1 */ ( /* c2 */ Seq(
     SelectString("a/b/c") -> None,
@@ -85,6 +105,26 @@ for (
           SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
       ) // test Java API
     )
+) checkOne(looker, l, r)
+<<< multiline for with paren, no comments
+for ((l, r) ← ( Seq(
+    SelectString("a/b/c") -> None,
+    SelectString("akka://all-systems/Nobody") -> None,
+    SelectPath(system / "hallo") -> None,
+    SelectPath(looker.path child "hallo") -> None, // test Java API
+    SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+  )
+  )
+) checkOne(looker, l, r)
+>>>
+for (
+    (l, r) ← (Seq(
+          SelectString("a/b/c") -> None,
+          SelectString("akka://all-systems/Nobody") -> None,
+          SelectPath(system / "hallo") -> None,
+          SelectPath(looker.path child "hallo") -> None, // test Java API
+          SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+      ))
 ) checkOne(looker, l, r)
 <<< multiline for with paren, no align
 align.preset = none

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -56,13 +56,13 @@ for ((l, r) ← /* c1 */ { /* c2 */ Seq(
 >>>
 for (
     (l, r) ← /* c1 */ { /* c2 */
-        Seq(
-            SelectString("a/b/c") -> None,
-            SelectString("akka://all-systems/Nobody") -> None,
-            SelectPath(system / "hallo") -> None,
-            SelectPath(looker.path child "hallo") -> None, // test Java API
-            SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
-        ) // test Java API
+      Seq(
+          SelectString("a/b/c") -> None,
+          SelectString("akka://all-systems/Nobody") -> None,
+          SelectPath(system / "hallo") -> None,
+          SelectPath(looker.path child "hallo") -> None, // test Java API
+          SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+      ) // test Java API
     }
 ) checkOne(looker, l, r)
 <<< multiline for with paren, no comments
@@ -78,12 +78,12 @@ for ((l, r) ← ( Seq(
 >>>
 for (
     (l, r) ← (Seq(
-          SelectString("a/b/c") -> None,
-          SelectString("akka://all-systems/Nobody") -> None,
-          SelectPath(system / "hallo") -> None,
-          SelectPath(looker.path child "hallo") -> None, // test Java API
-          SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
-      ))
+        SelectString("a/b/c") -> None,
+        SelectString("akka://all-systems/Nobody") -> None,
+        SelectPath(system / "hallo") -> None,
+        SelectPath(looker.path child "hallo") -> None, // test Java API
+        SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+    ))
 ) checkOne(looker, l, r)
 <<< multiline for with paren
 for ((l, r) ← /* c1 */ ( /* c2 */ Seq(
@@ -119,12 +119,12 @@ for ((l, r) ← ( Seq(
 >>>
 for (
     (l, r) ← (Seq(
-          SelectString("a/b/c") -> None,
-          SelectString("akka://all-systems/Nobody") -> None,
-          SelectPath(system / "hallo") -> None,
-          SelectPath(looker.path child "hallo") -> None, // test Java API
-          SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
-      ))
+        SelectString("a/b/c") -> None,
+        SelectString("akka://all-systems/Nobody") -> None,
+        SelectPath(system / "hallo") -> None,
+        SelectPath(looker.path child "hallo") -> None, // test Java API
+        SelectPath(looker.path descendant Seq("a", "b").asJava) -> None
+    ))
 ) checkOne(looker, l, r)
 <<< multiline for with paren, no align
 align.preset = none

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3119,3 +3119,37 @@ a match {
   case (k, v) =>
     ()
 }
+<<< #2158 for with guard
+maxColumn = 70
+danglingParentheses.preset = false
+===
+object a {
+  for (method <- e.getMethods if break && method.hasModifierProperty("static")) {
+    // noop
+  }
+}
+>>>
+object a {
+  for (method <- e.getMethods
+    if break && method.hasModifierProperty("static")) {
+    // noop
+  }
+}
+<<< #2158 val and no val
+object a {
+  val bbb = c match {
+    case _ =>
+  }
+  bbb = c match {
+    case _ =>
+  }
+}
+>>>
+object a {
+  val bbb = c match {
+    case _ =>
+  }
+  bbb = c match {
+    case _ =>
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1640,11 +1640,11 @@ for {
   nu <- rand.gaussian(0, 1)
   y = nu * nu
   x = (mean
-      + mean * mean * y * 0.5 / shape
-      - 0.5 * mean / shape * math
-        .sqrt(
-          4 * mean * shape * y + mean * mean * y * y
-        ))
+    + mean * mean * y * 0.5 / shape
+    - 0.5 * mean / shape * math
+      .sqrt(
+        4 * mean * shape * y + mean * mean * y * y
+      ))
   z <- rand.uniform
 } yield {
   if (z <= mean / (mean + x))

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1438,9 +1438,9 @@ val k = for {
 val k = for {
   _ <- aaa + bbb
   if !onlyOne
-  _ <- Future(
-    aaa
-  ) if !onlyOne
+  _ <-
+    Future(aaa)
+  if !onlyOne
   _ <- Future(2)
 } yield ()
 <<< 7.5: multiple consecutive guards

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2981,3 +2981,33 @@ a match {
   case (k, v) =>
     ()
 }
+<<< #2158 for with guard
+maxColumn = 70
+danglingParentheses.preset = false
+===
+object a {
+  for (method <- e.getMethods if break && method.hasModifierProperty("static")) {
+    // noop
+  }
+}
+>>>
+object a {
+  for (method <- e.getMethods
+    if break && method.hasModifierProperty("static")) {
+    // noop
+  }
+}
+<<< #2158 val and no val
+object a {
+  val bbb = c match {
+    case _ =>
+  }
+  bbb = c match {
+    case _ =>
+  }
+}
+>>>
+object a {
+  val bbb = c match { case _ => }
+  bbb = c match { case _ => }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1550,9 +1550,8 @@ val k = for {
 val k = for {
   _ <- aaa + bbb
   if !onlyOne
-  _ <- Future(
-    aaa
-  )
+  _ <-
+    Future(aaa)
   if !onlyOne
   _ <- Future(2)
 } yield ()

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3083,3 +3083,37 @@ a match {
   case (k, v) =>
     ()
 }
+<<< #2158 for with guard
+maxColumn = 70
+danglingParentheses.preset = false
+===
+object a {
+  for (method <- e.getMethods if break && method.hasModifierProperty("static")) {
+    // noop
+  }
+}
+>>>
+object a {
+  for (method <- e.getMethods
+    if break && method.hasModifierProperty("static")) {
+    // noop
+  }
+}
+<<< #2158 val and no val
+object a {
+  val bbb = c match {
+    case _ =>
+  }
+  bbb = c match {
+    case _ =>
+  }
+}
+>>>
+object a {
+  val bbb = c match {
+    case _ =>
+  }
+  bbb = c match {
+    case _ =>
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3164,3 +3164,39 @@ a match {
   case (k, v) =>
     ()
 }
+<<< #2158 for with guard
+maxColumn = 70
+danglingParentheses.preset = false
+===
+object a {
+  for (method <- e.getMethods if break && method.hasModifierProperty("static")) {
+    // noop
+  }
+}
+>>>
+object a {
+  for (method <- e.getMethods
+    if break && method.hasModifierProperty("static")) {
+    // noop
+  }
+}
+<<< #2158 val and no val
+object a {
+  val bbb = c match {
+    case _ =>
+  }
+  bbb = c match {
+    case _ =>
+  }
+}
+>>>
+object a {
+  val bbb =
+    c match {
+      case _ =>
+    }
+  bbb =
+    c match {
+      case _ =>
+    }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1656,11 +1656,13 @@ val k =
   for {
     _ <- aa + bb
     if !onlyOne
-    _ <-
-      Future(aaa)
+    _ <- Future(
+      aaa
+    )
     if !onlyOne
-    _ <-
-      Future(2)
+    _ <- Future(
+      2
+    )
   } yield ()
 <<< 7.5: multiple consecutive guards
 maxColumn = 80

--- a/scalafmt-tests/src/test/resources/unit/For.stat
+++ b/scalafmt-tests/src/test/resources/unit/For.stat
@@ -281,8 +281,8 @@ for {
 } yield cond
 >>>
 for {
-  variable <-
-    record.field.field1.map(_.toString)
+  variable <- record.field.field1
+    .map(_.toString)
   cond <-
     if (variable) doSomething
     else doAnything
@@ -304,8 +304,8 @@ for {
 } yield cond
 >>>
 for {
-  variable <-
-    record.field.field1.map(_.toString)
+  variable <- record.field.field1
+    .map(_.toString)
   cond =
     if (variable) doSomething
     else doAnything


### PR DESCRIPTION
Follow-on to #2158. Also partial undo of #1795, since the same functionality is now available by setting `newlines.beforeMultiline = keep`.