### PR TITLE
Newlines: break before params of multiline lambda

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -250,9 +250,6 @@ case class Newlines(
   lazy val avoidForSimpleOverflowTooLong: Boolean =
     avoidForSimpleOverflow.contains(AvoidForSimpleOverflow.tooLong)
 
-  lazy val neverBeforeCurlyLambdaParams = !alwaysBeforeCurlyBraceLambdaParams &&
-    (beforeCurlyLambdaParams eq BeforeCurlyLambdaParams.never)
-
   lazy val alwaysBeforeCurlyLambdaParams = alwaysBeforeCurlyBraceLambdaParams ||
     (beforeCurlyLambdaParams eq BeforeCurlyLambdaParams.always)
 
@@ -328,11 +325,13 @@ object Newlines {
   object BeforeCurlyLambdaParams {
     case object always extends BeforeCurlyLambdaParams
     case object never extends BeforeCurlyLambdaParams
+    case object multiline extends BeforeCurlyLambdaParams
     case object multilineWithCaseOnly extends BeforeCurlyLambdaParams
     implicit val codec: ConfCodec[BeforeCurlyLambdaParams] =
       ReaderUtil.oneOfCustom[BeforeCurlyLambdaParams](
         never,
         always,
+        multiline,
         multilineWithCaseOnly
       ) {
         case Conf.Bool(true) => Configured.Ok(always)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -196,7 +196,13 @@ class Router(formatOps: FormatOps) {
             case Some(owner: Term.Function) =>
               val arrow = getFuncArrow(lastLambda(owner))
               val expire = arrow.getOrElse(tokens(owner.tokens.last))
-              val nlOnly = Some(style.newlines.alwaysBeforeCurlyLambdaParams)
+              val nlOnly =
+                if (style.newlines.alwaysBeforeCurlyLambdaParams) Some(true)
+                else if (
+                  style.newlines.beforeCurlyLambdaParams eq
+                    Newlines.BeforeCurlyLambdaParams.multiline
+                ) None
+                else Some(false)
               (expire, arrow.map(_.left), 0, nlOnly)
             case Some(t: Case) if t.cond.isEmpty && (leftOwner match {
                   case Term.PartialFunction(List(`t`)) => true
@@ -206,8 +212,8 @@ class Router(formatOps: FormatOps) {
               val nlOnly =
                 if (style.newlines.alwaysBeforeCurlyLambdaParams) Some(true)
                 else if (
-                  style.newlines.beforeCurlyLambdaParams eq
-                    Newlines.BeforeCurlyLambdaParams.multilineWithCaseOnly
+                  style.newlines.beforeCurlyLambdaParams ne
+                    Newlines.BeforeCurlyLambdaParams.never
                 ) None
                 else Some(false)
               (arrow, Some(arrow.left), 0, nlOnly)

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -254,14 +254,15 @@ object a {
 object a {
   x.map { x => s"${x._1} -> ${x._2}" }
   x.map { case (c, i) => s"$c -> $i" }
-  x.zipWithIndex.map { x =>
-    s"${x._1} -> ${x._2}"
+  x.zipWithIndex.map {
+    x => s"${x._1} -> ${x._2}"
   }
-  x.zipWithIndex.map { case (c, i) =>
-    s"$c -> $i"
+  x.zipWithIndex.map {
+    case (c, i) => s"$c -> $i"
   }
-  x.zipWithIndex.map { case (c, i) =>
-    s"$c -> $i (long comment)"
+  x.zipWithIndex.map {
+    case (c, i) =>
+      s"$c -> $i (long comment)"
   }
   x.zipWithIndex.map {
     case (c, i) if c != i =>

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -239,3 +239,32 @@ object a {
       s"$c -> $i"
   }
 }
+<<< #2099 beforeCurlyLambdaParams = multiline
+newlines.beforeCurlyLambdaParams = multiline
+===
+object a {
+  x.map { x => s"${x._1} -> ${x._2}" }
+  x.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { x => s"${x._1} -> ${x._2}" }
+  x.zipWithIndex.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { case (c, i) => s"$c -> $i (long comment)" }
+  x.zipWithIndex.map { case (c, i) if c != i => s"$c -> $i" }
+}
+>>>
+object a {
+  x.map { x => s"${x._1} -> ${x._2}" }
+  x.map { case (c, i) => s"$c -> $i" }
+  x.zipWithIndex.map { x =>
+    s"${x._1} -> ${x._2}"
+  }
+  x.zipWithIndex.map { case (c, i) =>
+    s"$c -> $i"
+  }
+  x.zipWithIndex.map { case (c, i) =>
+    s"$c -> $i (long comment)"
+  }
+  x.zipWithIndex.map {
+    case (c, i) if c != i =>
+      s"$c -> $i"
+  }
+}


### PR DESCRIPTION
This option allows forgoing the break for oneline formatting, which the `always` option doesn't provide.
Fixes #2187.