### PR TITLE
ModExt: use split width with StateColumn indents

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
@@ -46,6 +46,36 @@ case class ModExt(
     copy(indents = newIndents.filter(_ ne Indent.Empty))
   }
 
+  /**
+    * This gap is necessary for pretty alignment multiline expressions
+    * on the right-side of enumerator.
+    * Without:
+    * ```
+    * for {
+    *    a <- new Integer {
+    *          value = 1
+    *        }
+    *   x <- if (variable) doSomething
+    *       else doAnything
+    * }
+    * ```
+    *
+    * With:
+    * ```
+    * for {
+    *    a <- new Integer {
+    *           value = 1
+    *         }
+    *   x <- if (variable) doSomething
+    *        else doAnything
+    * }
+    * ```
+    */
+  def getActualIndents(offset: Int): Seq[ActualIndent] = {
+    val adjustedOffset = if (mod eq Space) offset + 1 else offset
+    indents.flatMap(_.withStateOffset(adjustedOffset))
+  }
+
 }
 
 object ModExt {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2171,7 +2171,9 @@ class Router(formatOps: FormatOps) {
   )(implicit style: ScalafmtConfig): Seq[Split] =
     asInfixApp(ft.meta.rightOwner, style.newlines.formatInfix).fold {
       val expire = lastToken(body)
-      val spaceIndents = arrowEnumeratorGeneratorAlignIndents(expire)
+      val spaceIndents =
+        if (!style.align.arrowEnumeratorGenerator) Seq.empty
+        else Seq(Indent(StateColumn, expire, After))
       getSplitsDefValEquals(ft, body, spaceIndents) {
         CtrlBodySplits.get(ft, body, spaceIndents) {
           if (spaceIndents.nonEmpty)
@@ -2188,42 +2190,5 @@ class Router(formatOps: FormatOps) {
         }(Split(Newline, _).withIndent(2, expire, After))
       }
     }(getInfixSplitsBeforeLhs(_, ft))
-
-  private def arrowEnumeratorGeneratorAlignIndents(
-      expire: Token
-  )(implicit style: ScalafmtConfig) =
-    if (style.align.arrowEnumeratorGenerator) {
-      Seq(
-        Indent(StateColumn, expire, After),
-        /**
-          * This gap is necessary for pretty alignment multiline expressions
-          * on the right-side of enumerator.
-          * Without:
-          * ```
-          * for {
-          *    a <- new Integer {
-          *          value = 1
-          *        }
-          *   x <- if (variable) doSomething
-          *       else doAnything
-          * }
-          * ```
-          *
-          * With:
-          * ```
-          * for {
-          *    a <- new Integer {
-          *           value = 1
-          *         }
-          *   x <- if (variable) doSomething
-          *        else doAnything
-          * }
-          * ```
-          */
-        Indent(Num(1), expire, After)
-      )
-    } else {
-      Seq.empty
-    }
 
 }

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -33,6 +33,29 @@ List(Split(Space,
            policy = { case Decision(t @ FormatToken(_, `close`, _), s) =>
              Decision(t, List(Split(Newline, 0)))
            }))
+<<< Massive 2 with spaces inside parens
+spaces.inParentheses = true
+===
+ List(Split(Space,
+            0,
+            policy = SingleLineBlock(close),
+            ignoreIf = blockSize > style.maxColumn),
+      Split(nl,
+            1,
+            policy = {
+            case Decision(t@FormatToken(_, `close`, _), s) =>
+            Decision(t, List(Split(Newline, 0)))
+            }))
+>>>
+List( Split( Space,
+            0,
+            policy = SingleLineBlock( close ),
+            ignoreIf = blockSize > style.maxColumn ),
+     Split( nl,
+           1,
+           policy = { case Decision( t @ FormatToken( _, `close`, _ ), s ) =>
+             Decision( t, List( Split( Newline, 0 ) ) )
+           } ) )
 <<< Massive (good API) 3
 Split(Space, 0).withPolicy {
     // Following case:

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -48,14 +48,14 @@ spaces.inParentheses = true
             }))
 >>>
 List( Split( Space,
-            0,
-            policy = SingleLineBlock( close ),
-            ignoreIf = blockSize > style.maxColumn ),
-     Split( nl,
-           1,
-           policy = { case Decision( t @ FormatToken( _, `close`, _ ), s ) =>
-             Decision( t, List( Split( Newline, 0 ) ) )
-           } ) )
+             0,
+             policy = SingleLineBlock( close ),
+             ignoreIf = blockSize > style.maxColumn ),
+      Split( nl,
+             1,
+             policy = { case Decision( t @ FormatToken( _, `close`, _ ), s ) =>
+               Decision( t, List( Split( Newline, 0 ) ) )
+             } ) )
 <<< Massive (good API) 3
 Split(Space, 0).withPolicy {
     // Following case:


### PR DESCRIPTION
Supersedes the special-case handling for aligned indent after the left arrow in generator expressions.