### PR TITLE
RedundantParens: use AvoidInfix matcher correctly

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
@@ -8,11 +8,10 @@ case class Pattern(
     excludeFilters: Seq[String]
 ) {
   val reader: ConfDecoder[Pattern] = generic.deriveDecoder(this).noTypos
-  def toMatcher: FilterMatcher =
-    new FilterMatcher(
-      FilterMatcher.mkRegexp(includeFilters),
-      FilterMatcher.mkRegexp(excludeFilters, true)
-    )
+  lazy val matcher: FilterMatcher = new FilterMatcher(
+    FilterMatcher.mkRegexp(includeFilters),
+    FilterMatcher.mkRegexp(excludeFilters, true)
+  )
 }
 
 object Pattern {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -2,14 +2,21 @@ package org.scalafmt.rewrite
 
 import scala.meta._
 
+import org.scalafmt.config.FilterMatcher
+
 object AvoidInfix extends Rewrite {
+
   override def create(implicit ctx: RewriteCtx): RewriteSession =
     new AvoidInfix
+
+  def getMatcher(ctx: RewriteCtx): FilterMatcher =
+    ctx.style.rewrite.neverInfix.matcher
+
 }
 
 class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
 
-  private val matcher = ctx.style.rewrite.neverInfix.toMatcher
+  private val matcher = AvoidInfix.getMatcher(ctx)
 
   // In a perfect world, we could just use
   // Tree.transform {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -12,6 +12,10 @@ object AvoidInfix extends Rewrite {
   def getMatcher(ctx: RewriteCtx): FilterMatcher =
     ctx.style.rewrite.neverInfix.matcher
 
+  def getMatcherIfEnabled(ctx: RewriteCtx): Option[FilterMatcher] =
+    if (ctx.style.rewrite.rules.contains(AvoidInfix)) Some(getMatcher(ctx))
+    else None
+
 }
 
 class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -429,9 +429,9 @@ object a {
 }
 >>>
 object a {
-  the[Exception].thrownBy(a).should(have) message ("b")
-  the[Exception].thrownBy(a).should(have) message (s"b")
-  the[Exception].thrownBy(a).should(have) message (f"b")
+  the[Exception].thrownBy(a).should(have) message "b"
+  the[Exception].thrownBy(a).should(have) message s"b"
+  the[Exception].thrownBy(a).should(have) message f"b"
 }
 <<< parens for infix with interpolate with AvoidInfix/neverInfix
 rewrite.rules = [RedundantParens, AvoidInfix]
@@ -444,7 +444,7 @@ object a {
 }
 >>>
 object a {
-  the[Exception] thrownBy a should have message ("b")
-  the[Exception] thrownBy a should have message (s"b")
-  the[Exception] thrownBy a should have message (f"b")
+  the[Exception] thrownBy a should have message "b"
+  the[Exception] thrownBy a should have message s"b"
+  the[Exception] thrownBy a should have message f"b"
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -418,3 +418,33 @@ object a {
   the[Exception] thrownBy a should have message s"b"
   the[Exception] thrownBy a should have message f"b"
 }
+<<< parens for infix with interpolate with AvoidInfix
+rewrite.rules = [RedundantParens, AvoidInfix]
+rewrite.neverInfix.excludeFilters = [message]
+===
+object a {
+  the[Exception] thrownBy a should have message("b")
+  the[Exception] thrownBy a should have message(s"b")
+  the[Exception] thrownBy a should have message(f"b")
+}
+>>>
+object a {
+  the[Exception].thrownBy(a).should(have) message ("b")
+  the[Exception].thrownBy(a).should(have) message (s"b")
+  the[Exception].thrownBy(a).should(have) message (f"b")
+}
+<<< parens for infix with interpolate with AvoidInfix/neverInfix
+rewrite.rules = [RedundantParens, AvoidInfix]
+rewrite.neverInfix.excludeFilters = [message, thrownBy, should]
+===
+object a {
+  the[Exception] thrownBy a should have message("b")
+  the[Exception] thrownBy a should have message(s"b")
+  the[Exception] thrownBy a should have message(f"b")
+}
+>>>
+object a {
+  the[Exception] thrownBy a should have message ("b")
+  the[Exception] thrownBy a should have message (s"b")
+  the[Exception] thrownBy a should have message (f"b")
+}


### PR DESCRIPTION
Follow-on to #2199.