### PR TITLE
FormatWriter: correct first line of docstrings for `wrap=no`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -717,8 +717,9 @@ class FormatWriter(formatOps: FormatOps) {
           while (matcher.find()) {
             val contentBeg = matcher.start(2)
             val contentEnd = matcher.end(2)
-            if (contentBeg == contentEnd) prevWasBlank = true
-            else {
+            if (contentBeg == contentEnd) {
+              if (sb.length() != sbLen) prevWasBlank = true
+            } else {
               if (sb.length() != sbLen) appendBreak()
               if (prevWasBlank) {
                 appendBreak

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -10,8 +10,7 @@ object a {
 >>>
 object a {
 
-  /**
-    * Returns True is this state will always return better formatting than other.
+  /** Returns True is this state will always return better formatting than other.
     */
   def alwaysBetter(other: State): Boolean = this.cost <= other.cost &&
     this.indentation <= other.indentation
@@ -107,8 +106,7 @@ final def getSelectChain(child: Term.Select,
       TypedPipe.from[U](pipe, fields)(flowDef, mode, conv)
     })
 >>>
-/**
-  * If any errors happen below this line, but before a groupBy, write to a TypedSink
+/** If any errors happen below this line, but before a groupBy, write to a TypedSink
   */
 def addTrap[U >: T](trapSink: Source with TypedSink[T])(implicit
     conv: TupleConverter[U]): TypedPipe[U] =

--- a/scalafmt-tests/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/src/test/resources/newlines/source.source
@@ -67,8 +67,7 @@ private[parser] trait CacheControlHeader { this: Parser with CommonRules with Co
   }
 }
 >>>
-/**
-  * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+/** Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
   */
 
 package akka.http.impl.model.parser

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -999,12 +999,22 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
 
   /** alias for [[literal]] */
   /**
+   * alias for [[literal]]
+   */
+  /**
+   * alias for [[literal]]
    * alias for [[literal]]
    */
 }
@@ -1019,12 +1029,22 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
 
   /** alias for [[literal]] */
   /** alias for [[literal]] */
+  /**
+   * alias for [[literal]]
+   * alias for [[literal]]
+   */
 }
 <<< #2028 Asterisk unfold
 docstrings.style = Asterisk
@@ -1037,6 +1057,12 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
@@ -1045,6 +1071,10 @@ object a {
    * alias for [[literal]]
    */
   /**
+   * alias for [[literal]]
+   */
+  /**
+   * alias for [[literal]]
    * alias for [[literal]]
    */
 }
@@ -1059,12 +1089,22 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
 
   /** alias for [[literal]] */
   /**
+    * alias for [[literal]]
+    */
+  /**
+    * alias for [[literal]]
     * alias for [[literal]]
     */
 }
@@ -1079,12 +1119,22 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
 
   /** alias for [[literal]] */
   /** alias for [[literal]] */
+  /**
+    * alias for [[literal]]
+    * alias for [[literal]]
+    */
 }
 <<< #2028 SpaceAsterisk unfold
 docstrings.style = SpaceAsterisk
@@ -1097,6 +1147,12 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
@@ -1104,6 +1160,10 @@ object a {
   /** alias for [[literal]]
     */
   /**
+    * alias for [[literal]]
+    */
+  /**
+    * alias for [[literal]]
     * alias for [[literal]]
     */
 }
@@ -1118,12 +1178,22 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
 
   /** alias for [[literal]] */
   /**
+   *  alias for [[literal]]
+   */
+  /**
+   *  alias for [[literal]]
    *  alias for [[literal]]
    */
 }
@@ -1138,12 +1208,22 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
 
   /** alias for [[literal]] */
   /** alias for [[literal]] */
+  /**
+   *  alias for [[literal]]
+   *  alias for [[literal]]
+   */
 }
 <<< #2028 AsteriskSpace unfold
 docstrings.style = AsteriskSpace
@@ -1156,6 +1236,12 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
@@ -1163,6 +1249,10 @@ object a {
   /** alias for [[literal]]
    */
   /**
+   *  alias for [[literal]]
+   */
+  /**
+   *  alias for [[literal]]
    *  alias for [[literal]]
    */
 }
@@ -1179,6 +1269,12 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
@@ -1190,6 +1286,11 @@ object a {
   /**
    * alias for
    * [[literal]]
+   */
+  /**
+   * alias for
+   * [[literal]] alias
+   * for [[literal]]
    */
 }
 <<< #2028 Asterisk long, keep, wrap
@@ -1205,6 +1306,12 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
@@ -1216,6 +1323,11 @@ object a {
   /**
    * alias for
    * [[literal]]
+   */
+  /**
+   * alias for
+   * [[literal]] alias
+   * for [[literal]]
    */
 }
 <<< #2028 Asterisk long, fold, !wrap
@@ -1231,12 +1343,22 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
 
   /** alias for [[literal]] */
   /** alias for [[literal]] */
+  /**
+   * alias for [[literal]]
+   * alias for [[literal]]
+   */
 }
 <<< #2028 Asterisk long, keep, !wrap
 docstrings.style = Asterisk
@@ -1251,12 +1373,22 @@ object a {
    * alias for [[literal]]
    *
    */
+  /**
+   *
+   * alias for [[literal]]
+   * alias for [[literal]]
+   *
+   */
 }
 >>>
 object a {
 
   /** alias for [[literal]] */
   /** alias for [[literal]] */
+  /**
+   * alias for [[literal]]
+   * alias for [[literal]]
+   */
 }
 <<< #2043
 object Day extends Enumeration {

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -83,8 +83,7 @@ docstrings.style = SpaceAsterisk
     */
 class Main
 >>>
-/**
-  * Main entry-point.
+/** Main entry-point.
   */
 class Main
 <<< #1403 1: AsteriskSpace 1
@@ -99,8 +98,7 @@ docstrings.style = AsteriskSpace
     */
 class Main
 >>>
-/**
- *  Indent0
+/** Indent0
  *  Indent1
  *  Indent2
  *   Indent3
@@ -1100,11 +1098,9 @@ object a {
 object a {
 
   /** alias for [[literal]] */
-  /**
-    * alias for [[literal]]
+  /** alias for [[literal]]
     */
-  /**
-    * alias for [[literal]]
+  /** alias for [[literal]]
     * alias for [[literal]]
     */
 }
@@ -1131,8 +1127,7 @@ object a {
 
   /** alias for [[literal]] */
   /** alias for [[literal]] */
-  /**
-    * alias for [[literal]]
+  /** alias for [[literal]]
     * alias for [[literal]]
     */
 }
@@ -1159,11 +1154,9 @@ object a {
 
   /** alias for [[literal]]
     */
-  /**
-    * alias for [[literal]]
+  /** alias for [[literal]]
     */
-  /**
-    * alias for [[literal]]
+  /** alias for [[literal]]
     * alias for [[literal]]
     */
 }
@@ -1189,11 +1182,9 @@ object a {
 object a {
 
   /** alias for [[literal]] */
-  /**
-   *  alias for [[literal]]
+  /** alias for [[literal]]
    */
-  /**
-   *  alias for [[literal]]
+  /** alias for [[literal]]
    *  alias for [[literal]]
    */
 }
@@ -1220,8 +1211,7 @@ object a {
 
   /** alias for [[literal]] */
   /** alias for [[literal]] */
-  /**
-   *  alias for [[literal]]
+  /** alias for [[literal]]
    *  alias for [[literal]]
    */
 }
@@ -1248,11 +1238,9 @@ object a {
 
   /** alias for [[literal]]
    */
-  /**
-   *  alias for [[literal]]
+  /** alias for [[literal]]
    */
-  /**
-   *  alias for [[literal]]
+  /** alias for [[literal]]
    *  alias for [[literal]]
    */
 }

--- a/scalafmt-tests/src/test/resources/unit/Basic.source
+++ b/scalafmt-tests/src/test/resources/unit/Basic.source
@@ -25,13 +25,11 @@ object a {
 >>>
 object a {
 
-  /**
-    * One
+  /** One
     */
   def one = 1
 
-  /**
-    * Two
+  /** Two
     */
   def two = 2
 }

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -20,8 +20,7 @@ object a
 import foo.bar
 import kaz.bar
 
-/**
-  * Docstring
+/** Docstring
   */
 object a
 <<< Rename
@@ -109,8 +108,7 @@ import d.e.f
 >>>
 package a.b.c
 
-/**
-  * docstring
+/** docstring
   */
 
 import d.e.f
@@ -125,8 +123,7 @@ package a.b.c
 import d.e.f
 >>>
 package a.b.c
-/**
-  * docstring
+/** docstring
   */
 
 import d.e.f

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -8,8 +8,7 @@ object a
 >>>
 package foo
 
-/**
-  * comment
+/** comment
   */
 object a
 


### PR DESCRIPTION
Fixes #2215.