### PR TITLE
Router: truncate indent for enclosed select chains

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1200,7 +1200,8 @@ class Router(formatOps: FormatOps) {
           findLastApplyAndNextSelect(rightOwner, enclosed)
         val thisSelect = rightOwner.asInstanceOf[Term.Select]
         val prevSelect = findPrevSelect(thisSelect, enclosed)
-        val expire = lastToken(expireTree)
+        val expireDropRight = if (isEnclosedInMatching(expireTree)) 1 else 0
+        val expire = lastToken(expireTree.tokens.dropRight(expireDropRight))
 
         def breakOnNextDot: Policy =
           nextSelect.fold(Policy.noPolicy) { tree =>
@@ -1234,9 +1235,7 @@ class Router(formatOps: FormatOps) {
             val prevChain = inSelectChain(prevSelect, thisSelect, expireTree)
             if (canStartSelectChain(thisSelect, nextSelect, expireTree)) {
               val chainExpire =
-                if (nextSelect.isEmpty) lastToken(thisSelect)
-                else if (!isEnclosedInMatching(expireTree)) expire
-                else lastToken(expireTree.tokens.dropRight(1))
+                if (nextSelect.isEmpty) lastToken(thisSelect) else expire
               val nestedPenalty =
                 nestedSelect(rightOwner) + nestedApplies(leftOwner)
               // This policy will apply to both the space and newline splits, otherwise

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3153,3 +3153,37 @@ object a {
     case _ =>
   }
 }
+<<< #2137 val, parens with select chain
+object a {
+  val baz = (
+    Bar
+      .newBuilder
+      .baz()
+  )
+}
+>>>
+object a {
+  val baz = (
+    Bar.newBuilder
+      .baz()
+    )
+}
+<<< #2137 case, parens with select chain
+object a {
+  a match {
+    case foo => (
+      Bar
+        .newBuilder
+        .baz()
+    )
+  }
+}
+>>>
+object a {
+  a match {
+    case foo => (
+      Bar.newBuilder
+        .baz()
+      )
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3166,7 +3166,7 @@ object a {
   val baz = (
     Bar.newBuilder
       .baz()
-    )
+  )
 }
 <<< #2137 case, parens with select chain
 object a {
@@ -3184,6 +3184,6 @@ object a {
     case foo => (
       Bar.newBuilder
         .baz()
-      )
+    )
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3123,7 +3123,7 @@ pubSubMessage match {
     (
       IngestionSubscriber
         .defaultServices
-      ).processEff.message()
+    ).processEff.message()
 }
 <<< #2137 tuple with ->, match
 maxColumn = 20

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix3.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix3.stat
@@ -90,7 +90,7 @@ object a {
       .read[Double]
       .and((JsPath \ "long").read[Double])
       .and((JsPath \ "anotherField").read[String])
-    )(Location.apply _)
+  )(Location.apply _)
 }
 <<< #842 1
 maxColumn = 80
@@ -111,5 +111,5 @@ object a {
       .and( // comment
         (JsPath \ "anotherField").read[String]
       )
-    )(Location.apply _)
+  )(Location.apply _)
 }


### PR DESCRIPTION
Follow-up to #2137.