### PR TITLE
Router: preserve breaks for source.keep in `case`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1918,12 +1918,16 @@ class Router(formatOps: FormatOps) {
         Seq(
           Split(NoSplit, 0)
         )
-      case FormatToken(_, T.RightParen(), _) =>
-        val mod =
-          Space(style.spaces.inParentheses && isDefnOrCallSite(rightOwner))
-        Seq(
-          Split(mod, 0)
-        )
+      case FormatToken(_, close: T.RightParen, _) =>
+        def modNoNL = {
+          def allowSpace = rightOwner match {
+            case _: Term.If | _: Term.While | _: Term.For | _: Term.ForYield =>
+              isLastToken(close, rightOwner)
+            case _ => true
+          }
+          Space(style.spaces.inParentheses && allowSpace)
+        }
+        Seq(Split(modNoNL, 0))
 
       case FormatToken(left, _: T.KwCatch | _: T.KwFinally, _)
           if style.newlines.alwaysBeforeElseAfterCurlyIf

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -345,10 +345,17 @@ object TreeOps {
   def isSuperfluousParenthesis(open: LeftParen, owner: Tree): Boolean =
     !isTuple(owner) && owner.tokens.headOption.contains(open)
 
-  def isFirstOrLastToken(token: Token, owner: Tree): Boolean = {
-    owner.tokens.headOption.contains(token) ||
+  @inline
+  def isFirstOrLastToken(token: Token, owner: Tree): Boolean =
+    isFirstToken(token, owner) || isLastToken(token, owner)
+
+  @inline
+  def isFirstToken(token: Token, owner: Tree): Boolean =
+    owner.tokens.headOption.contains(token)
+
+  @inline
+  def isLastToken(token: Token, owner: Tree): Boolean =
     owner.tokens.lastOption.contains(token)
-  }
 
   def isCallSite(tree: Tree)(implicit style: ScalafmtConfig): Boolean =
     tree match {

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3156,11 +3156,11 @@ a match {
 >>>
 a match {
   case ( Root / "foo" | Root / "bar" |
-      Root / "baz" / _ / "qux") =>
-    ( if (foo) ( foo) + bar
-      else foo + ( bar)) + ( baz)
+      Root / "baz" / _ / "qux" ) =>
+    ( if (foo) ( foo ) + bar
+      else foo + ( bar ) ) + ( baz )
   case ( Root / "foo" | Root / "bar" |
-      Root / "baz" / _ / "qux") => (
+      Root / "baz" / _ / "qux" ) => (
     foo
   )
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3130,12 +3130,15 @@ a match {
 }
 >>>
 a match {
-  case (Root / "foo" | Root / "bar" |
-      Root / "baz" / _ / "qux") =>
+  case (Root / "foo"
+      | Root / "bar"
+      | Root / "baz" / _ / "qux"
+      ) =>
     (if (foo) (foo) + bar
      else foo + (bar)) + (baz)
-  case (Root / "foo" | Root / "bar" |
-      Root / "baz" / _ / "qux") => (
+  case (Root / "foo"
+      | Root / "bar"
+      | Root / "baz" / _ / "qux") => (
     foo
   )
 }
@@ -3155,12 +3158,15 @@ a match {
 }
 >>>
 a match {
-  case ( Root / "foo" | Root / "bar" |
-      Root / "baz" / _ / "qux" ) =>
+  case ( Root / "foo"
+      | Root / "bar"
+      | Root / "baz" / _ / "qux"
+      ) =>
     ( if (foo) ( foo ) + bar
       else foo + ( bar ) ) + ( baz )
-  case ( Root / "foo" | Root / "bar" |
-      Root / "baz" / _ / "qux" ) => (
+  case ( Root / "foo"
+      | Root / "bar"
+      | Root / "baz" / _ / "qux" ) => (
     foo
   )
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3116,3 +3116,51 @@ object a {
     case _ =>
   }
 }
+<<< #2219
+a match {
+  case ( Root / "foo"
+       | Root / "bar"
+       | Root / "baz" / _ / "qux"
+       ) =>
+    (if (foo) (foo) + bar
+    else foo + (bar)) + (baz)
+  case ( Root / "foo"
+       | Root / "bar"
+       | Root / "baz" / _ / "qux" ) => (foo)
+}
+>>>
+a match {
+  case (Root / "foo" | Root / "bar" |
+      Root / "baz" / _ / "qux") =>
+    (if (foo) (foo) + bar
+     else foo + (bar)) + (baz)
+  case (Root / "foo" | Root / "bar" |
+      Root / "baz" / _ / "qux") => (
+    foo
+  )
+}
+<<< #2219 with spaces
+spaces.inParentheses = true
+===
+a match {
+  case (Root / "foo"
+       | Root / "bar"
+       | Root / "baz" / _ / "qux"
+       ) =>
+    (if (foo) (foo) + bar
+    else foo + (bar)) + (baz)
+  case (Root / "foo"
+       | Root / "bar"
+       | Root / "baz" / _ / "qux") => (foo)
+}
+>>>
+a match {
+  case ( Root / "foo" | Root / "bar" |
+      Root / "baz" / _ / "qux") =>
+    ( if (foo) ( foo) + bar
+      else foo + ( bar)) + ( baz)
+  case ( Root / "foo" | Root / "bar" |
+      Root / "baz" / _ / "qux") => (
+    foo
+  )
+}


### PR DESCRIPTION
Also, fix closing paren when `spaces.inParentheses` is set. Currently, one case is excluded for the opening paren (`if`/`while`/etc.), but a completely different one (`isDefnOrCallSite`) applies to the closing paren. Let's fix that.

Fixes #2219.