### PR TITLE
Bump deps coursier,sbt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ intellij/out
 docs/xx.md
 
 # metals
+project/metals.sbt
 .metals/
 .bloop/
+.bsp/
 
 node_modules/

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,10 +6,10 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV  = "4.3.22"
+  val scalametaV  = "4.3.24"
   val scalatestV  = "3.2.2"
   val scalacheckV = "1.14.3"
-  val coursier    = "1.0.3"
+  val coursier    = "2.0.4"
 
   val scalapb = Def.setting {
     ExclusionRule(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,9 +8,6 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.9")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-addSbtPlugin(
-  "io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version
-)
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")


### PR DESCRIPTION
Current coursier version fails to parse non SemVer version deps.
You cannot build e.g. scalameta SNAPSHOT and test it with scalafmt.
It is fixed in latest coursier.
But latest coursier conflicts with sbt 1.3.x
And latest sbt already contains sbt-coursier.

Fun stuff :)

Previously:
`Ignoring unparsed versions: Vector(4.3.24+30-63c1bd76-SNAPSHOT)`

Now works fine:
`val scalametaV  = "4.3.24+30-63c1bd76-SNAPSHOT"`