### PR TITLE
Docstrings fix: first token may not start at 0

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1215,7 +1215,8 @@ object FormatWriter {
   ) {
     def hasBreakAfter: Boolean = state.split.isNL
     def hasBreakBefore: Boolean =
-      state.prev.split.isNL || formatToken.left.start == 0
+      // first token is BOF
+      formatToken.meta.idx <= 1 || state.prev.split.isNL
     def isStandalone: Boolean = hasBreakAfter && hasBreakBefore
   }
 

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1660,8 +1660,8 @@ docstrings.wrap = yes
    */
  val a = 1
 >>>
-Idempotency violated
 /**
- * If any errors happen below this line, but before a groupBy, write to a TypedSink
+ * If any errors happen below this line, but before a groupBy, write to a
+ * TypedSink
  */
 val a = 1

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1652,3 +1652,16 @@ object a {
 
   /** */
 }
+<<< wrap long docstring with leading space at start of document
+docstrings.wrap = yes
+===
+ /**
+   * If any errors happen below this line, but before a groupBy, write to a TypedSink
+   */
+ val a = 1
+>>>
+Idempotency violated
+/**
+ * If any errors happen below this line, but before a groupBy, write to a TypedSink
+ */
+val a = 1


### PR DESCRIPTION
Look at the format token index instead. Covers cases when docstring is the first non-BOF token but is preceded by leading whitespace.