### PR TITLE
upgrade to Scalameta 4.3.24

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV  = "4.3.22"
+  val scalametaV  = "4.3.24"
   val scalatestV  = "3.2.2"
   val scalacheckV = "1.14.3"
   val coursier    = "1.0.3"


### PR DESCRIPTION
context: I'm trying to get the Scala community build onto a newer version of Scalameta over at https://github.com/scala/community-build/pull/1278

not sure yet if this upgrade would help me, but it's one of the paths I'm exploring, so let's see what CI has to say