### PR TITLE
Dedicated sbt sessions for release and docs publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: olafurpg/setup-gpg@v3
       - run: git fetch --tags --unshallow -f
       - name: Publish ${{ github.ref }}
-        run: sbt ci-release docs/docusaurusPublishGhpages
+        run: sbt ci-release; sbt docs/docusaurusPublishGhpages
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
Something broken after sbt update to 1.4.x https://github.com/scalameta/scalafmt/pull/2272

Looks like it passes invalid scala version to docs generation stage