### PR TITLE
Upgrade dependencies

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -6,3 +6,4 @@
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
 -XX:+CMSClassUnloadingEnabled
+-Dsbt.server.autostart=false

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ def localSnapshotVersion: String = s"$parseTagVersion-SNAPSHOT"
 def isCI = System.getenv("CI") != null
 
 def scala211 = "2.11.12"
-def scala212 = "2.12.8"
-def scala213 = "2.13.1"
+def scala212 = "2.12.12"
+def scala213 = "2.13.3"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,8 @@ lazy val tests = project
       scalametaTestkit,
       scalatest.value
     ),
-    scalacOptions ++= scalacJvmOptions.value
+    scalacOptions ++= scalacJvmOptions.value,
+    fork := true
   )
   .dependsOn(coreJVM, dynamic, cli)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV  = "4.3.24"
+  val scalametaV  = "4.4.1"
   val scalatestV  = "3.2.3"
   val scalacheckV = "1.15.1"
   val coursier    = "1.0.3"
@@ -21,7 +21,10 @@ object Dependencies {
   val scalametaTestkit = "org.scalameta" %% "testkit" % scalametaV
 
   val scalacheck = "org.scalacheck" %% "scalacheck" % scalacheckV
-  val scalatest  = Def.setting("org.scalatest" %%% "scalatest" % scalatestV)
+  // NOTE(olafur): this repo uses only ScalaTest FunSuite with asserts. Matchers
+  // are intentionally not included in the build because they rely on "multiple
+  // infix" syntax, which is deprecated in the latest Scala version.
+  val scalatest = Def.setting("org.scalatest" %%% "scalatest-funsuite" % scalatestV)
   val scalameta = Def.setting {
     scalaBinaryVersion.value match {
       case "2.11" =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.4.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,9 +8,6 @@ addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.12")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
-addSbtPlugin(
-  "io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version
-)
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Patch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Patch.scala
@@ -2,7 +2,6 @@ package org.scalafmt.rewrite
 
 import org.scalafmt.rewrite.TokenPatch.{Add, Remove}
 
-import scala.meta._
 import scala.meta.tokens.Token
 
 sealed abstract class Patch

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/Tabulator.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/Tabulator.scala
@@ -36,7 +36,5 @@ object Tabulator {
   }
 
   def rowSeparator(colSizes: Seq[Int]) =
-    colSizes map {
-      "-" * _
-    } mkString ("+", "+", "+")
+    colSizes.map(size => "-" * size).mkString("+", "+", "+")
 }


### PR DESCRIPTION
* Latest Scala.
* Latest sbt, disable BSP server because it doesn't work well with Metals.
* Latest Scalameta.
* Use only ScalaTest FunSuite because matchers introduce compile errors
  in 2.13.3 due to "multiple infix" deprecation warnings.
* Remove unnecessary sbt-coursier dependency because it's included with sbt.