### PR TITLE
Support using soft keyword in parameter and argument lists

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1213,6 +1213,18 @@ something.map { x => f(x) }
 
 > Since v2.5.0.
 
+#### Newlines around `using` parameter and argument list modifier
+
+> Since v3.0.0
+
+`using` soft keyword was introduced in Scala 3 and is supported in scalafmt.
+The settings `newlines.implicitParamListModifierPrefer` and
+`newlines.implicitParamListModifierForce` are from now on aliases for
+`newlines.usingParamListModifierPrefer` and `newlines.usingParamListModifierForce`.
+By picking one of them formatting will be applied at the same time to both `implicit` and `using`.
+Besides parameter lists, `using` can also be used with argument lists hence
+provided rules will then also be applied to the argument lists.
+
 #### Prefer After (default)
 
 > Prefers newline after `implicit`. Newline will be added unless the entire

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -170,7 +170,9 @@ case class Newlines(
     @annotation.ExtraName("afterCurlyLambda")
     afterCurlyLambdaParams: AfterCurlyLambdaParams =
       AfterCurlyLambdaParams.never,
+    @annotation.ExtraName("usingParamListModifierForce")
     implicitParamListModifierForce: Seq[BeforeAfter] = Seq.empty,
+    @annotation.ExtraName("usingParamListModifierPrefer")
     implicitParamListModifierPrefer: Option[BeforeAfter] = None,
     alwaysBeforeElseAfterCurlyIf: Boolean = false,
     @annotation.DeprecatedName(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -45,6 +45,8 @@ class FormatOps(
     baseStyle: ScalafmtConfig,
     val filename: String = ""
 ) {
+  import FormatOps._
+
   val initStyle = {
     val queue = new mutable.Queue[Tree]
     queue += tree
@@ -65,6 +67,7 @@ class FormatOps(
   implicit val dialect = initStyle.runner.dialect
   private val ownersMap = getOwners(tree)
   val tokens: FormatTokens = FormatTokens(tree.tokens, owners)
+  private[internal] val soft = new SoftKeywordClasses(dialect)
   private val statementStarts = getStatementStarts(tree)
   val dequeueSpots = getDequeueSpots(tree) ++ statementStarts.keys
   private val matchingParentheses: Map[TokenHash, Token] =
@@ -882,20 +885,20 @@ class FormatOps(
   )(implicit style: ScalafmtConfig): Boolean = {
     def opensImplicit =
       (style.newlines.forceAfterImplicitParamListModifier ||
-        next(ft).hasBreak) && opensConfigStyleImplicitOrUsingParamList(ft)
+        next(ft).hasBreak) && opensConfigStyleImplicitParamList(ft)
     (ft.hasBreak || opensImplicit) && {
       val close = matching(ft.left)
       tokens(close, -1).hasBreak
     }
   }
 
-  def opensConfigStyleImplicitOrUsingParamList(
+  /** Works for `using` as well */
+  def opensConfigStyleImplicitParamList(
       formatToken: FormatToken
   )(implicit style: ScalafmtConfig): Boolean =
-    (formatToken.right
-      .is[T.KwImplicit] || formatToken.right.text == "using") &&
+    formatToken.right.is[soft.ImplicitOrUsing] &&
       style.newlines.notBeforeImplicitParamListModifier &&
-      opensImplicitOrUsingParamList(formatToken).isDefined
+      opensImplicitParamList(formatToken).isDefined
 
   def styleAt(tree: Tree): ScalafmtConfig = {
     val style = styleMap.at(tree.tokens.head)
@@ -1136,7 +1139,7 @@ class FormatOps(
         def isDefinition = ownerCheck(owners(close2))
 
         val shouldAddNewline = {
-          if (right.is[T.KwImplicit] || right.text == "using")
+          if (right.is[soft.ImplicitOrUsing])
             style.newlines.forceBeforeImplicitParamListModifier ||
             style.verticalMultiline.newlineBeforeImplicitKW
           else
@@ -1147,7 +1150,7 @@ class FormatOps(
           Split(NoSplit.orNL(!shouldAddNewline), 0)
             .withIndent(indentParam, close2, ExpiresOn.Before)
         )
-      case Decision(t @ FormatToken(T.KwImplicit() | T.Ident("using"), _, _), _)
+      case Decision(t @ FormatToken(soft.ImplicitOrUsing(), _, _), _)
           if style.newlines.forceAfterImplicitParamListModifier ||
             style.verticalMultiline.newlineAfterImplicitKW =>
         Seq(Split(Newline, 0))
@@ -1291,22 +1294,22 @@ class FormatOps(
   def getApplyArgs(
       ft: FormatToken,
       isRight: Boolean
-  )(implicit style: ScalafmtConfig): (Tree, Seq[Tree]) = {
+  )(implicit style: ScalafmtConfig): TreeArgs = {
     val paren = if (isRight) ft.right else ft.left
     val owner = if (isRight) ft.meta.rightOwner else ft.meta.leftOwner
     def getArgs(argss: Seq[Seq[Tree]]): Seq[Tree] =
       findArgsFor(paren, argss).getOrElse(Seq.empty)
     owner match {
-      case InfixApp(ia) if style.newlines.formatInfix => (ia.op, ia.rhs)
+      case InfixApp(ia) if style.newlines.formatInfix => TreeArgs(ia.op, ia.rhs)
       case t @ SplitDefnIntoParts(_, name, tparams, paramss) =>
         if (if (isRight) paren.is[T.RightParen] else paren.is[T.LeftParen])
-          (name, getArgs(paramss))
+          TreeArgs(name, getArgs(paramss))
         else
-          (name, tparams)
+          TreeArgs(name, tparams)
       case SplitCallIntoParts(tree, either) =>
         either match {
-          case Left(args) => (tree, args)
-          case Right(argss) => (tree, getArgs(argss))
+          case Left(args) => TreeArgs(tree, args)
+          case Right(argss) => TreeArgs(tree, getArgs(argss))
         }
       case _ =>
         logger.debug(s"""Unknown tree
@@ -1316,9 +1319,7 @@ class FormatOps(
     }
   }
 
-  def opensImplicitOrUsingParamList(
-      ft: FormatToken
-  ): Option[Seq[Term.Param]] = {
+  def opensImplicitParamList(ft: FormatToken): Option[Seq[Term.Param]] = {
     val paramsOpt = splitDefnIntoParts.lift(ft.meta.leftOwner).flatMap {
       case (_, _, _, paramss) =>
         findArgsFor(ft.left, paramss)
@@ -1327,14 +1328,12 @@ class FormatOps(
     paramsOpt.filter(!_.exists(TreeOps.hasExplicitImplicit))
   }
 
-  def opensImplicitOrUsingParamList(
-      ft: FormatToken,
-      args: Seq[Tree]
-  ): Boolean =
+  /** Works for `using` as well */
+  def opensImplicitParamList(ft: FormatToken, args: Seq[Tree]): Boolean =
     ft.right.is[T.KwImplicit] && args.forall {
       case t: Term.Param => !hasExplicitImplicit(t)
       case _ => true
-    } || ft.right.text == "using"
+    } || ft.right.is[soft.KwUsing]
 
   def isEnclosedInMatching(tree: Tree, open: T, close: T): Boolean =
     tree.tokens.headOption.contains(open) && (tree.tokens.last eq close)
@@ -1785,4 +1784,17 @@ class FormatOps(
     }
   }
 
+  // For using to be the soft kw it also has to be preceded by paren
+  def isRightImplicitOrUsingSoftKw(
+      ft: FormatToken,
+      soft: SoftKeywordClasses
+  ): Boolean = ft.left match {
+    case _: T.KwImplicit => true
+    case soft.KwUsing() => prevNonComment(prev(ft)).left.is[T.LeftParen]
+    case _ => false
+  }
+}
+
+object FormatOps {
+  case class TreeArgs(tree: Tree, args: Seq[Tree])
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1017,7 +1017,7 @@ class FormatWriter(formatOps: FormatOps) {
     ft.meta.rightOwner match {
       case x: Importer => x.importees.length > 1
       case _ =>
-        val args = getApplyArgs(ft, true)._2
+        val args = getApplyArgs(ft, true).args
         args.length > 1 && (args.last match {
           case _: Term.Repeated => false
           case t: Term.Param => !t.decltpe.exists(_.is[Type.Repeated])

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
@@ -1,6 +1,8 @@
 package org.scalafmt.util
 
+import scala.meta.Dialect
 import scala.meta.internal.classifiers.classifier
+import scala.meta.internal.parsers.SoftKeywords
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
 
@@ -96,4 +98,14 @@ object RightParenOrBracket {
 trait LeftParenOrBrace
 object LeftParenOrBrace {
   def unapply(tok: Token): Boolean = tok.is[LeftParen] || tok.is[LeftBrace]
+}
+
+class SoftKeywordClasses(dialect: Dialect) extends SoftKeywords(dialect) {
+  @classifier
+  trait ImplicitOrUsing
+  object ImplicitOrUsing {
+    def unapply(tok: Token): Boolean = {
+      tok.is[KwImplicit] || tok.is[KwUsing]
+    }
+  }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -222,4 +222,10 @@ object TokenOps {
     }
   }
 
+  def isRightImplicitOrUsingSoftKw(ft: FormatToken): Boolean = ft match {
+    case FormatToken(_: LeftParen, Ident("using"), _) => true
+    case FormatToken(_, _: KwImplicit, _) => true
+    case _ => false
+  }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -222,10 +222,4 @@ object TokenOps {
     }
   }
 
-  def isRightImplicitOrUsingSoftKw(ft: FormatToken): Boolean = ft match {
-    case FormatToken(_: LeftParen, Ident("using"), _) => true
-    case FormatToken(_, _: KwImplicit, _) => true
-    case _ => false
-  }
-
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -353,7 +353,7 @@ object TreeOps {
     tree match {
       case _: Term.Apply | _: Type.Apply | _: Pat.Extract | _: Term.Super |
           _: Pat.Tuple | _: Term.Tuple | _: Term.ApplyType | _: Term.Assign |
-          _: Init =>
+          _: Init | _: Term.ApplyUsing =>
         true
       case t: Term.ApplyInfix => style.newlines.formatInfix && t.args.length > 1
       case _ => false
@@ -398,6 +398,7 @@ object TreeOps {
     case t: Type.Function => (t, Left(t.params))
     case t: Type.Tuple => (t, Left(t.args))
     case t: Init => (t.tpe, Right(t.argss))
+    case t: Term.ApplyUsing => (t.fun, Left(t.args))
   }
   object SplitCallIntoParts {
     def unapply(tree: Tree): Option[CallParts] =

--- a/scalafmt-tests/src/test/resources/dotty/Using.stat
+++ b/scalafmt-tests/src/test/resources/dotty/Using.stat
@@ -244,3 +244,25 @@ val using = "aaaaaa"
 >>>
 val using =
   "aaaaaa"
+<<< comment in definition
+maxColumn = 40
+===
+def foo( /* go scala3 */ using a: String, b: String, c: String )
+>>>
+def foo(
+    /* go scala3 */ using
+    a: String,
+    b: String,
+    c: String
+)
+<<< comment in apply
+maxColumn = 40
+===
+foo( /* go scala3 */ using a: String, b: String, c: String )
+>>>
+foo(
+  /* go scala3 */ using
+  a: String,
+  b: String,
+  c: String
+)

--- a/scalafmt-tests/src/test/resources/dotty/Using.stat
+++ b/scalafmt-tests/src/test/resources/dotty/Using.stat
@@ -1,0 +1,246 @@
+<<< using parameter
+maxColumn = 40
+===
+def max[T](x: T, y: T)(using ord: Ord[T]): T = {}
+>>>
+def max[T](x: T, y: T)(using
+    ord: Ord[T]
+): T = {}
+<<< multiple using parameters
+maxColumn = 40
+===
+def max[T](x: T, y: T)(using a: A[T], b: B[T], c: C[T]): T = {}
+>>>
+def max[T](x: T, y: T)(using
+    a: A[T],
+    b: B[T],
+    c: C[T]
+): T = {}
+<<< apply method with context argument
+maxColumn = 40
+===
+max(2, 3)(using     intOrd)
+>>>
+max(2, 3)(using intOrd)
+<<< anonymous context parameter
+maxColumn = 40
+===
+def maximum[T](xs: List[T])(using Ord[T]): T = {}
+>>>
+def maximum[T](xs: List[T])(using
+    Ord[T]
+): T = {}
+<<< multiple anonymous context parameters
+maxColumn = 40
+===
+def max[T](x: T, y: T)(using A[T], B[T], C[T]): T = {}
+>>>
+def max[T](x: T, y: T)(using
+    A[T],
+    B[T],
+    C[T]
+): T = {}
+<<< nested calls with explicit context arguments
+maxColumn = 40
+===
+maximum(xs)(using descending(using listOrd(using intOrd)))
+>>>
+maximum(xs)(using
+  descending(using
+    listOrd(using intOrd)
+  )
+)
+<<< multiple using clauses
+maxColumn = 40
+===
+def f(u: Universe)(using ctx: u.Context)(using s: ctx.Symbol, k: ctx.Kind, o: ctx.Other) = {}
+>>>
+def f(
+    u: Universe
+)(using ctx: u.Context)(using
+    s: ctx.Symbol,
+    k: ctx.Kind,
+    o: ctx.Other
+) = {}
+<<< call with two using clauses
+maxColumn = 30
+===
+f(global)(using ctx)(using sym, kind)
+>>>
+f(global)(using ctx)(using
+  sym,
+  kind
+)
+<<< force newline before
+maxColumn = 60
+newlines.usingParamListModifierForce = [before]
+===
+def format(code: String, age: Int)(using ev: Parser, c: Context): String
+>>>
+def format(code: String, age: Int)(
+    using ev: Parser,
+    c: Context
+): String
+<<< newline force after
+maxColumn = 60
+newlines.usingParamListModifierForce = [after]
+===
+def format(code: String, age: Int)(using ev: Parser, c: Context): String
+>>>
+def format(code: String, age: Int)(using
+    ev: Parser,
+    c: Context
+): String
+<<< newline force before & after
+maxColumn = 60
+newlines.usingParamListModifierForce = [before, after]
+===
+def format(code: String, age: Int)(using ev: Parser, c: Context): String
+>>>
+def format(code: String, age: Int)(
+    using
+    ev: Parser,
+    c: Context
+): String
+<<< newline force before (arg list)
+maxColumn = 20
+newlines.usingParamListModifierForce = [before]
+===
+f(global)(using sym, kind)
+>>>
+f(global)(
+  using sym,
+  kind
+)
+<<< newline force after (arg list)
+maxColumn = 20
+newlines.usingParamListModifierForce = [after]
+===
+f(global)(using sym, kind)
+>>>
+f(global)(using
+  sym,
+  kind
+)
+<<< newline force before & after (arg list)
+maxColumn = 20
+newlines.usingParamListModifierForce = [before, after]
+===
+f(global)(using sym, kind)
+>>>
+f(global)(
+  using
+  sym,
+  kind
+)
+<<< newline prefer before
+maxColumn = 60
+newlines.usingParamListModifierPrefer = before
+===
+def format(code: String, age: Int)(using ev: Parser, c: Context): String
+>>>
+def format(code: String, age: Int)(
+    using ev: Parser,
+    c: Context
+): String
+<<< newline prefer after
+maxColumn = 60
+newlines.usingParamListModifierPrefer = after
+===
+def format(code: String, age: Int)(using ev: Parser, c: Context): String
+>>>
+def format(code: String, age: Int)(using
+    ev: Parser,
+    c: Context
+): String
+<<< newline prefer before (arg list)
+maxColumn = 25
+newlines.usingParamListModifierPrefer = before
+===
+f(global)(using sym, kind)
+>>>
+f(global)(
+  using sym,
+  kind
+)
+<<< newline prefer after (arg list)
+maxColumn = 25
+newlines.usingParamListModifierPrefer = after
+===
+f(global)(using sym, kind)
+>>>
+f(global)(using
+  sym,
+  kind
+)
+<<< vertical multiline, force newline before
+maxColumn = 60
+verticalMultiline.atDefnSite = true
+newlines.usingParamListModifierForce = [before]
+===
+def format(code: String, age: Int)(using ev: Parser, c: Context): String
+>>>
+def format(
+    code: String,
+    age: Int
+  )(
+    using ev: Parser,
+    c: Context
+  ): String
+<<< vertical multiline, force newline after
+maxColumn = 60
+verticalMultiline.atDefnSite = true
+newlines.usingParamListModifierForce = [after]
+===
+def format(code: String, age: Int)(using ev: Parser, c: Context): String
+>>>
+def format(
+    code: String,
+    age: Int
+  )(using
+    ev: Parser,
+    c: Context
+  ): String
+<<< vertical multiline, force newline before & after
+maxColumn = 60
+verticalMultiline.atDefnSite = true
+newlines.usingParamListModifierForce = [before,after]
+===
+def format(code: String, age: Int)(using ev: Parser, c: Context): String
+>>>
+def format(
+    code: String,
+    age: Int
+  )(
+    using
+    ev: Parser,
+    c: Context
+  ): String
+<<< config style
+optIn.configStyleArguments = true
+maxColumn=45
+===
+def method2(using a: Int, b: String, c: String): Boolean
+>>>
+def method2(using
+    a: Int,
+    b: String,
+    c: String
+): Boolean
+<<< using as identifier
+maxColumn = 20
+===
+def using(using using: using, using: using, using: using)
+>>>
+def using(using
+    using: using,
+    using: using,
+    using: using
+)
+<<< using as a val
+maxColumn = 15
+===
+val using = "aaaaaa"
+>>>
+val using =
+  "aaaaaa"


### PR DESCRIPTION
The next one based on #2216.

The `using` soft keyword in parameter lists seems to be one-to-one with the `implicit`. However, `using` can also be used within argument lists. 

We've discussed with @tgodzik that we can add aliases to `newlines.implicitParamListModifierPrefer` and `newlines.implicitParamListModifierForce`, namely `newlines.usingParamListModifierPrefer` and `newlines.usingParamListModifierForce` (and apply this existing setting to the using argument lists).

Please take a look at the changes in the docs, I put the information about the whole `implicit vs using` matter in one place. In addition, we can update every occurrence of `implicit` that applies to the `using` at the same time and replace it with `implicit or using` for the case of specificity and maybe add some additional examples. What do you think?