### PR TITLE
Scala 3: Add support to format open classes.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -212,7 +212,10 @@ lazy val tests = project
       scalatest.value
     ),
     scalacOptions ++= scalacJvmOptions.value,
-    fork := true
+    // Fork in CI to hit on memory limitation issues. Disable forking locally
+    // because ScalaTest error reporting fails with serialization errors when
+    // forking is disabled.
+    fork := isCI
   )
   .dependsOn(coreJVM, dynamic, cli)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
@@ -87,10 +87,13 @@ object ScalafmtRunner {
     val scala213 = Scala213
       .withAllowTrailingCommas(true)
     val default = scala213
-      .withAllowOrTypes(true) // New feature in Dotty
-      .withAllowAndTypes(true) // New feature in Dotty
-      .withAllowTraitParameters(true) // New feature in Dotty
-      .withAllowColonForExtractorVarargs(true) // New feature in Dotty
+      // Supported Dotty features.
+      .withAllowOrTypes(true)
+      .withAllowAndTypes(true)
+      .withAllowTraitParameters(true)
+      .withAllowColonForExtractorVarargs(true)
+      .withAllowExportClause(true)
+      .withAllowOpenClass(true)
 
     implicit lazy val decoder: ConfDecoder[Dialect] = {
       ReaderUtil.oneOf[Dialect](

--- a/scalafmt-tests/src/test/resources/dotty/Open.stat
+++ b/scalafmt-tests/src/test/resources/dotty/Open.stat
@@ -1,0 +1,21 @@
+maxColumn = 40
+<<< class
+open class Foobar()
+>>>
+open class Foobar()
+<<< object
+open object Foobar
+>>>
+open object Foobar
+<<< trait
+open trait Foobar
+>>>
+open trait Foobar
+<<< implicit open
+implicit open class Foobar()
+>>>
+implicit open class Foobar()
+<<< open implicit
+open implicit class Foobar()
+>>>
+open implicit class Foobar()

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiersOpen.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiersOpen.stat
@@ -1,0 +1,11 @@
+maxColumn = 200 #to not disturb the output too much
+rewrite {
+  rules = [SortModifiers]
+  sortModifiers {
+    order = ["open", "implicit"]
+  }
+}
+<<< open implicit class
+implicit open class Foo()
+>>>
+open implicit class Foo()

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiersOpenMissing.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiersOpenMissing.stat
@@ -1,0 +1,10 @@
+rewrite {
+  rules = [SortModifiers]
+  sortModifiers {
+    order = ["implicit"]
+  }
+}
+<<< open goes to the front of the list if it's missing from the config
+implicit open class Foo()
+>>>
+open implicit class Foo()

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Default.source
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Default.source
@@ -92,3 +92,7 @@ final private[test] object Tests {
     implicit final override protected lazy val name: String = impl
   }
 }
+<<< open default
+open implicit class Test()
+>>>
+implicit open class Test()


### PR DESCRIPTION
This PR implements support to format open classes, which is a new soft
modifier in Scala 3. Details
https://dotty.epfl.ch/docs/reference/other-new-features/open-classes.html