### PR TITLE
Fix Macros after fixes in scalameta

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -527,8 +527,7 @@ class Router(formatOps: FormatOps) {
       // Opening ( with no leading space.
       case FormatToken(
             RightParenOrBracket() | T.KwSuper() | T.KwThis() | T.Ident(_) |
-            T.RightBrace() | T.Underscore() | T.MacroQuotedIdent(_) |
-            T.MacroSplicedIdent(_),
+            T.RightBrace() | T.Underscore() | T.Constant.Symbol(_),
             LeftParenOrBracket(),
             _
           ) if noSpaceBeforeOpeningParen(rightOwner) && {

--- a/scalafmt-tests/src/test/resources/dotty/Macro.stat
+++ b/scalafmt-tests/src/test/resources/dotty/Macro.stat
@@ -8,9 +8,13 @@ ${ locationImpl() }
 >>>
 '{ new Location() }
 <<< quote expr
+${
 val x   = 'expr
+}
 >>>
-val x = 'expr
+${
+  val x = 'expr
+}
 <<< splice expr
 val x   = $expr
 >>>
@@ -32,9 +36,9 @@ throw new AssertionError(s"failed assertion: ${${ showExpr(expr) }}")
 >>>
 (x: Expr[T]) => '{ $f($x) }
 <<< functions quoted
-(  x: Expr[T]) => 'f('x)
+(  x: Expr[T]) =>   ${  'f ('x) }
 >>>
-(x: Expr[T]) => 'f('x)
+(x: Expr[T]) => ${ 'f('x) } 
 <<< line wrap brace
 val xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = ${    locationImpl(Foooooooooooooooooooooooo()) }
 >>>


### PR DESCRIPTION
We recently merged the support for Macros together with an update to scalameta, which caused the master to stop compiling due to removal of two token types in scalameta. This should fix the issue. 

I also needed to fix some tests, since `'identifier` is only allowed within splices or quotes.