### PR TITLE
Add tests for windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* eol=lf
+*.png eol=autocrlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         java: [adopt@1.8, adopt@1.11]
-    runs-on: ubuntu-latest
+        os: [windows-latest, ubuntu-latest]
+        exclude:
+          - os: windows-latest
+            java: adopt@1.8
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v10
@@ -26,8 +30,11 @@ jobs:
           # for GitOps tests	
           git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"
       - run: TEST="2.11" sbt ci-test
+        shell: bash
       - run: TEST="2.12" sbt ci-test
+        shell: bash
       - run: TEST="2.13" sbt ci-test
+        shell: bash
   formatting:
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -213,6 +213,7 @@ lazy val tests = project
       scalatest.value
     ),
     scalacOptions ++= scalacJvmOptions.value,
+    javaOptions += "-Dfile.encoding=UTF8",
     // Fork in CI to avoid memory limitation issues. Disable forking locally
     // because ScalaTest error reporting fails with cryptic serialization errors
     // when forking is enabled.

--- a/scalafmt-tests/src/test/scala/org/scalafmt/EmptyFileTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/EmptyFileTest.scala
@@ -3,13 +3,14 @@ package org.scalafmt
 import java.lang.System.lineSeparator
 
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalafmt.util.DiffAssertions
 
-class EmptyFileTest extends AnyFunSuite {
+class EmptyFileTest extends AnyFunSuite with DiffAssertions {
   test("empty tree formats to newline") {
     Seq("", lineSeparator, "", s"   $lineSeparator  ").foreach { original =>
-      val expected = lineSeparator
+      val expected = "\n"
       val obtained = Scalafmt.format(original).get
-      assert(obtained == expected)
+      assertNoDiff(obtained, expected)
     }
   }
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/GitOpsTest.scala
@@ -31,7 +31,15 @@ class GitOpsTest extends funsuite.FixtureAnyFunSuite {
     add(initF)(ops)
     commit(ops)
     try withFixture(test.toNoArgTest(ops))
-    finally deleteTree(f)
+    finally {
+      try {
+        deleteTree(f)
+      } catch {
+        case t: Throwable =>
+          println("Unable to delete test files")
+          t.printStackTrace()
+      }
+    }
   }
 
   def touch(


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalafmt/issues/2288

Additionally, to help with some [cryptic errors](https://github.com/scalatest/scalatest/issues/556) I got back to munit (reverted https://github.com/scalameta/scalafmt/pull/1697). The support in Intellij is much better now, so I think it's worth keeeping. There was a recent release with some nice changes in Intellij - https://blog.jetbrains.com/scala/2020/12/01/intellij-scala-plugin-2020-3/#munit-support

What do you think?

I commented on parts that are related to windows failures.

