### PR TITLE
[Scala 3] Add support for match types

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -854,7 +854,7 @@ class FormatWriter(formatOps: FormatOps) {
       def unapply(tree: Tree): Option[Tree] =
         tree match {
           case _: Source | _: Template | _: Term.Block | _: Term.Match |
-              _: Term.Function | _: Term.PartialFunction =>
+              _: Type.Match | _: Term.Function | _: Term.PartialFunction =>
             Some(tree)
           case _ => None
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/TreeSyntacticGroup.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/TreeSyntacticGroup.scala
@@ -66,6 +66,7 @@ object TreeSyntacticGroup {
       case _: Type.ByName => g.Type.ParamTyp
       case _: Type.Var => g.Type.ParamTyp
       case _: Type.Param => g.Path // ???
+      case _: Type.Match => g.Type.Typ
       // Pat
       case _: Pat.Var => g.Pat.SimplePattern
       case _: Pat.Wildcard => g.Pat.SimplePattern

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -318,6 +318,7 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
           }
 
         case Term.Match(`b`, _) => true
+        case Type.Match(`b`, _) => true
 
         case parent =>
           SyntacticGroupOps.groupNeedsParenthesis(

--- a/scalafmt-tests/src/test/resources/scala3/MatchType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/MatchType.stat
@@ -1,0 +1,126 @@
+#
+<<< simple match type
+type Elem[X] = X match {
+             case String => Char
+             case Array[t] => t
+}
+>>>
+type Elem[X] = X match {
+  case String   => Char
+  case Array[t] => t
+}
+<<< type bound match type
+type Head[X <: Tuple] = X match {
+           case (x1, ?) => 
+           x1
+         }
+>>>
+type Head[X <: Tuple] = X match {
+  case (x1, ?) =>
+    x1
+}
+<<< recursive match type
+type Len[X] <: Int = X match {
+           case Unit => 0
+           case x *: xs => S[Len[xs]]}
+>>>
+type Len[X] <: Int = X match {
+  case Unit    => 0
+  case x *: xs => S[Len[xs]]
+}
+<<< complex match type
+type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
+           case Unit => 
+          Y
+           case x1 *: xs1 => 
+          x1 *: Concat[xs1, Y]
+         }
+>>>
+type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
+  case Unit =>
+    Y
+  case x1 *: xs1 =>
+    x1 *: Concat[xs1, Y]
+}
+<<< long type bound match type
+maxColumn = 40
+===
+type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
+           case Unit => 
+          Y
+           case x1 *: xs1 => 
+          x1 *: Concat[xs1, Y]
+         }
+>>>
+type Concat[
+    X <: Tuple,
+    Y <: Tuple
+] <: Tuple = X match {
+  case Unit =>
+    Y
+  case x1 *: xs1 =>
+    x1 *: Concat[xs1, Y]
+}
+<<< even longer type bound 
+maxColumn = 40
+===
+type Concat[X, Y] <: TupleTupleTupleTupleTupleTupleTuple = X match {
+           case Unit => 
+          Y
+           case x1 *: xs1 => 
+          x1 *: Concat[xs1, Y]
+         }
+>>>
+type Concat[
+    X,
+    Y
+] <: TupleTupleTupleTupleTupleTupleTuple =
+  X match {
+    case Unit =>
+      Y
+    case x1 *: xs1 =>
+      x1 *: Concat[xs1, Y]
+  }
+<<< match type unfold
+newlines.beforeMultiline = unfold
+===
+  type Elem[X] = X match {
+    case String   => Array[AVeryLongTraitNameToTestOutSomeThings]
+    case Array[t] => 
+      t
+  }
+>>>
+type Elem[X] =
+  X match {
+    case String =>
+      Array[AVeryLongTraitNameToTestOutSomeThings]
+    case Array[t] =>
+      t
+  }
+<<< match type fold
+newlines.beforeMultiline = fold
+===
+  type Elem[X] = X match {
+    case String   => 
+      Array[AVeryLongTraitNameToTestOutSomeThings]
+    case Array[t] => t
+  }
+>>>
+type Elem[X] = X match {
+  case String   => Array[AVeryLongTraitNameToTestOutSomeThings]
+  case Array[t] => t
+}
+<<< match type keep
+newlines.beforeMultiline = keep
+===
+  type Elem[X] = X match {
+    case String   => 
+      Array[AVeryLongTraitNameToTestOutSomeThings]
+    case Array[t] => t
+  }
+>>>
+type Elem[X] = X match {
+  case String =>
+    Array[AVeryLongTraitNameToTestOutSomeThings]
+  case Array[t] => t
+}


### PR DESCRIPTION
Scala 3 allows to specify types using the match clause such as:
```scala
type T = R match{
  case Char => String
  case Array[t] => t
}
```
Implementing this required mostly copying whatever was done for normal matches.