### PR TITLE
Router: keep a blank between comma and comment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1108,7 +1108,8 @@ class Router(formatOps: FormatOps) {
         )
       // These are mostly filtered out/modified by policies.
       case tok @ FormatToken(_: T.Comma, c: T.Comment, _) =>
-        if (isSingleLineComment(c)) Seq(Split(Space.orNL(tok.noBreak), 0))
+        if (isSingleLineComment(c))
+          Seq(Split(getModCheckIndent(tok, newlines), 0))
         else if (tok.meta.right.firstNL >= 0) Seq(Split(Newline, 0))
         else {
           val noNewline = newlines == 0 &&

--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -116,6 +116,7 @@ private def scalaJSStageSettings = Seq(
     usesScalaJSLinkerTag in key := {
       Tags
     },
+
     // Prevent this linker from being used concurrently
     concurrentRestrictions in Global +=
       Tags.limit((usesScalaJSLinkerTag in key).value, 1)

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -426,8 +426,10 @@ val a = Seq(
 >>>
 val a = Seq(
     a,
+
 // b,
     c,
+
     // comment
     d
 )

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -413,3 +413,21 @@ object a {
    */
   WED = Value
 }
+<<< #2137 keep blanks between comma and comment
+val a = Seq(
+  a,
+
+// b,
+  c,
+
+  // comment
+  d
+)
+>>>
+val a = Seq(
+    a,
+// b,
+    c,
+    // comment
+    d
+)


### PR DESCRIPTION
Fixes #2317.