### PR TITLE
[Scala3] Add inline and transparent modifiers

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
@@ -27,7 +27,9 @@ object SortSettings {
     ModKey("protected", _.is[Mod.Protected]),
     //
     ModKey("lazy", _.is[Mod.Lazy]),
-    ModKey("open", _.is[Mod.Open])
+    ModKey("open", _.is[Mod.Open]),
+    ModKey("transparent", _.is[Mod.Transparent]),
+    ModKey("inline", _.is[Mod.Inline])
   )
 
   implicit val SortSettingsModKeyReader: ConfCodec[ModKey] =

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiersInlineTransparent.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiersInlineTransparent.stat
@@ -1,0 +1,18 @@
+maxColumn = 200 #to not disturb the output too much
+rewrite {
+  rules = [SortModifiers]
+  sortModifiers {
+    order = ["inline", "transparent"]
+  }
+}
+runner.dialect = Scala3
+<<< transparent inline method
+transparent inline def choose(b: Boolean): A = {
+  if (b) { new A }
+  else { new B }
+}
+>>>
+inline transparent def choose(b: Boolean): A = {
+  if (b) { new A }
+  else { new B }
+}

--- a/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Default.source
+++ b/scalafmt-tests/src/test/resources/rewrite/SortModifiers_Default.source
@@ -95,3 +95,13 @@ final private[test] object Tests {
 open implicit class Test()
 >>>
 implicit open class Test()
+<<< transparent inline method
+transparent inline def choose(b: Boolean): A = {
+  if (b) { new A }
+  else { new B }
+}
+>>>
+transparent inline def choose(b: Boolean): A = {
+  if (b) { new A }
+  else { new B }
+}

--- a/scalafmt-tests/src/test/resources/scala3/InlineTransparent.stat
+++ b/scalafmt-tests/src/test/resources/scala3/InlineTransparent.stat
@@ -1,0 +1,32 @@
+<<< simple inline
+inline val logging =     false
+>>>
+inline val logging = false
+<<< complex inline
+inline val logging = {
+    if (a) { true}
+    else false
+}
+>>>
+inline val logging = {
+  if (a) { true }
+  else false
+}
+<<< inline transparent
+transparent inline def choose(b: Boolean): A = {if(b) {new A} else {new B}}
+>>>
+transparent inline def choose(b: Boolean): A = {
+  if (b) { new A }
+  else { new B }
+}
+<<< inline transparent break
+maxColumn = 20
+===
+transparent inline override protected def choose(b: Boolean): A = {if(b) {new A} else {new B}}
+>>>
+transparent inline override protected def choose(
+    b: Boolean
+): A = {
+  if (b) { new A }
+  else { new B }
+}


### PR DESCRIPTION
Scala 3 introduced inline and transparent modifiers that can be add to variables or definitions. More info at https://dotty.epfl.ch/docs/reference/metaprogramming/inline.html