### PR TITLE
[Scala 3] Allow to use commas instead of with for multiple parents

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,6 +200,28 @@ trait Foo extends A with B with C with D with E {
 }
 ```
 
+### `continuationIndent.commaSiteRelativeToExtends`
+
+> Since v3.0.0
+
+Added to support Scala 3, which allows to specify multiple parents with a comma.
+
+```scala mdoc:defaults
+continuationIndent.extendSite
+continuationIndent.commaSiteRelativeToExtends
+```
+
+```scala mdoc:scalafmt
+runner.dialect = scala3
+continuationIndent.extendSite = 4
+continuationIndent.commaSiteRelativeToExtends = 4
+maxColumn = 20
+---
+trait Foo extends A, B, C, D, E {
+  def foo: Boolean = true
+}
+```
+
 ### `indentOperator`
 
 Normally, the first eligible break _inside_ a chain of infix operators is

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV  = "4.4.5"
+  val scalametaV  = "4.4.6"
   val scalacheckV = "1.15.2"
   val coursier    = "1.0.3"
   val munitV      = "0.7.20"

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ContinuationIndent.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ContinuationIndent.scala
@@ -7,13 +7,15 @@ import metaconfig._
   * @param callSite indentation around function calls, etc.
   * @param extendSite indentation before `extends`
   * @param withSiteRelativeToExtends additional indentation before `with`
+  * @param commaSiteRelativeToExtends additional indentation before in the line after extends with a comma
   */
 case class ContinuationIndent(
     callSite: Int = 2,
     defnSite: Int = 4,
     ctorSite: Option[Int] = None,
     extendSite: Int = 4,
-    withSiteRelativeToExtends: Int = 0
+    withSiteRelativeToExtends: Int = 0,
+    commaSiteRelativeToExtends: Int = 2
 ) {
   implicit val reader: ConfDecoder[ContinuationIndent] =
     generic.deriveDecoder(this).noTypos

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -714,4 +714,11 @@ object TreeOps {
     }
   }
 
+  def isFirstInit(t: Template, owner: Tree) =
+    t.inits.headOption.exists { init =>
+      // [init.tpe == leftOwner] part is about expressions like [new A with B]
+      // [leftOwner.is[Init] && init == leftOwner] part is about expressions like [new A(x) with B]
+      owner.is[Init] && init == owner || init.tpe == owner
+    }
+
 }

--- a/scalafmt-tests/src/test/resources/scala3/ExtendsComma.stat
+++ b/scalafmt-tests/src/test/resources/scala3/ExtendsComma.stat
@@ -1,0 +1,167 @@
+<<< class
+class A extends XX,XY,XZ
+>>>
+class A extends XX, XY, XZ
+<<< class long
+maxColumn = 40
+===
+class A extends AVeryLongName1, AVeryLongName2, AVeryLongName3
+>>>
+class A
+    extends AVeryLongName1,
+      AVeryLongName2,
+      AVeryLongName3
+<<< class long params
+class A(abc: Int) extends AVeryLongName1(abc), AVeryLongName2(abc), AVeryLongName3(abc)
+>>>
+class A(abc: Int)
+    extends AVeryLongName1(abc),
+      AVeryLongName2(abc),
+      AVeryLongName3(abc)
+<<< parent constructors `never`
+binPack.parentConstructors = Never
+maxColumn = 40
+===
+trait A(a : Int, b : Int) extends Alpha, Beta, Gamma, Delta, Epsilon {
+  def a = ???
+}
+>>>
+trait A(a: Int, b: Int)
+    extends Alpha,
+      Beta,
+      Gamma,
+      Delta,
+      Epsilon {
+  def a = ???
+}
+<<< parent constructors `always`
+binPack.parentConstructors = Always
+maxColumn = 30
+===
+trait A(a : Int, b : Int) extends Alpha, Beta, Gamma, Delta, Epsilon {
+  def a = ???
+}
+>>>
+trait A(a: Int, b: Int)
+    extends Alpha, Beta,
+      Gamma, Delta, Epsilon {
+  def a = ???
+}
+<<< parent constructors `oneline`
+binPack.parentConstructors = Oneline
+maxColumn = 40
+===
+trait A extends Alpha, Beta, Gamma, Delta {
+  def a = ???
+}
+>>>
+trait A
+    extends Alpha, Beta, Gamma, Delta {
+  def a = ???
+}
+<<< parent constructors `onelineIfPrimaryOneline`
+binPack.parentConstructors = OnelineIfPrimaryOneline
+maxColumn = 40
+===
+trait A(alphaParam : Int, betaParam : Int) extends Alpha, Beta, Gamma, Delta {
+  def a = ???
+}
+>>>
+trait A(alphaParam: Int, betaParam: Int)
+    extends Alpha, Beta, Gamma, Delta {
+  def a = ???
+}
+<<< enum case with constructor and parent constructors with and `never`
+binPack.parentConstructors = Never
+maxColumn = 30
+===
+enum Enum2(val i: Int) {
+  case A(val s: String) extends Enum2(1), A
+}
+>>>
+enum Enum2(val i: Int) {
+  case A(val s: String)
+      extends Enum2(1),
+      A
+}
+<<< enum case with constructor and parent constructors `always`
+binPack.parentConstructors = Always
+maxColumn = 27
+===
+enum Enum2(val i: Int) {
+  case A(val s: String) extends Enum2(1), X, Y
+}
+>>>
+enum Enum2(val i: Int) {
+  case A(val s: String)
+      extends Enum2(1), X,
+      Y
+}
+<<< enum case with constructor and parent constructors `oneline`
+binPack.parentConstructors = Oneline
+maxColumn = 45
+===
+enum Enum2(val a: String, val b: String) {
+  case A(val s: String) extends Enum2("a", "b"), X, Y
+
+  case B(val s1: String, val s2: String) extends Enum2("aaaaaaaa", "bbbbbbbb"), X, Y
+}
+>>>
+enum Enum2(val a: String, val b: String) {
+  case A(val s: String)
+      extends Enum2("a", "b"), X, Y
+
+  case B(val s1: String, val s2: String)
+      extends Enum2("aaaaaaaa", "bbbbbbbb"),
+      X,
+      Y
+}
+<<< enum case with constructor and parent constructors `onelineIfPrimaryOneline`
+binPack.parentConstructors = OnelineIfPrimaryOneline
+maxColumn = 45
+===
+enum Enum2(val a: String, val b: String) {
+  case A(val s: String) extends Enum2("a", "b"), X, Y
+
+  case B(val s1: String, val s2: String, val s3: String) extends Enum2("aaaaaaaa", "bbbbbbbb"), X, Y
+}
+>>>
+enum Enum2(val a: String, val b: String) {
+  case A(val s: String)
+      extends Enum2("a", "b"), X, Y
+
+  case B(
+      val s1: String,
+      val s2: String,
+      val s3: String
+  ) extends Enum2("aaaaaaaa", "bbbbbbbb"),
+      X,
+      Y
+}
+<<< #143
+continuationIndent.commaSiteRelativeToExtends = 4
+continuationIndent.withSiteRelativeToExtends = 2
+maxColumn = 30
+===
+class A extends AVeryLongName1, AVeryLongName2, AVeryLongName3 { self: A with B with C with D with E =>
+}
+>>>
+class A
+    extends AVeryLongName1,
+        AVeryLongName2,
+        AVeryLongName3 {
+  self: A
+    with B
+    with C
+    with D
+    with E =>
+}
+<<< comment between inits
+maxColumn = 30
+===
+class A extends AVeryLongName1 /* comment */ ,AVeryLongName2, AVeryLongName3
+>>>
+class A
+    extends AVeryLongName1 /* comment */,
+      AVeryLongName2,
+      AVeryLongName3

--- a/scalafmt-tests/src/test/resources/test/ContinuationIndent.stat
+++ b/scalafmt-tests/src/test/resources/test/ContinuationIndent.stat
@@ -38,3 +38,13 @@ class ExtendTest
     with D
     with E =>
 }
+<<< comment between inits
+maxColumn = 30
+continuationIndent.withSiteRelativeToExtends = 2
+===
+class A extends AVeryLongName1 /* comment */ with AVeryLongName2 with AVeryLongName3
+>>>
+class A
+  extends AVeryLongName1 /* comment */
+    with AVeryLongName2
+    with AVeryLongName3


### PR DESCRIPTION
Scala 3 allows for using `,` instead of `with` when declaring multiple parents.