### PR TITLE
[Scala 3] Format export clauses

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -16,7 +16,6 @@ import scala.meta.{
   Case,
   Defn,
   Enumerator,
-  Import,
   Importer,
   Init,
   Lit,
@@ -28,7 +27,8 @@ import scala.meta.{
   Tree,
   Type,
   TypeCase,
-  CaseTree
+  CaseTree,
+  ImportExportStat
 }
 
 object Constants {
@@ -131,11 +131,11 @@ class Router(formatOps: FormatOps) {
         )
       // Import
       case FormatToken(_: T.Dot, _, _)
-          if existsParentOfType[Import](rightOwner) =>
+          if existsParentOfType[ImportExportStat](rightOwner) =>
         Seq(Split(NoSplit, 0))
       // Import left brace
       case FormatToken(open: T.LeftBrace, _, _)
-          if existsParentOfType[Import](leftOwner) =>
+          if existsParentOfType[ImportExportStat](leftOwner) =>
         val close = matching(open)
         val policy = SingleLineBlock(
           close,
@@ -161,7 +161,7 @@ class Router(formatOps: FormatOps) {
             .withIndent(2, close, Before)
         )
       case FormatToken(_, _: T.RightBrace, _)
-          if existsParentOfType[Import](rightOwner) =>
+          if existsParentOfType[ImportExportStat](rightOwner) =>
         Seq(Split(Space(style.spaces.inImportCurlyBraces), 0))
 
       // Interpolated string left brace

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortImports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortImports.scala
@@ -23,7 +23,8 @@ sealed abstract class SortImports(implicit ctx: RewriteCtx)
 
   override def rewrite(tree: Tree): Unit =
     tree match {
-      case Import(imports) =>
+      case stat: ImportExportStat =>
+        val imports = stat.importers
         val builder = Seq.newBuilder[TokenPatch]
         imports.foreach { `import` =>
           val importees = `import`.importees

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
@@ -12,18 +12,19 @@ object Keyword {
   def unapply(token: Token): Boolean = {
     token.is[KwAbstract] || token.is[KwCase] || token.is[KwCatch] ||
     token.is[KwClass] || token.is[KwDef] || token.is[KwDo] ||
-    token.is[KwElse] || token.is[KwEnum] || token.is[KwExtends] ||
-    token.is[KwFalse] || token.is[KwFinal] || token.is[KwFinally] ||
-    token.is[KwFor] || token.is[KwForsome] || token.is[KwGiven] ||
-    token.is[KwIf] || token.is[KwImplicit] || token.is[KwImport] ||
-    token.is[KwLazy] || token.is[KwMatch] || token.is[KwMacro] ||
-    token.is[KwNew] || token.is[KwNull] || token.is[KwObject] ||
-    token.is[KwOverride] || token.is[KwPackage] || token.is[KwPrivate] ||
-    token.is[KwProtected] || token.is[KwReturn] || token.is[KwSealed] ||
-    token.is[KwSuper] || token.is[KwThis] || token.is[KwThrow] ||
-    token.is[KwTrait] || token.is[KwTrue] || token.is[KwTry] ||
-    token.is[KwType] || token.is[KwVal] || token.is[KwVar] ||
-    token.is[KwWhile] || token.is[KwWith] || token.is[KwYield]
+    token.is[KwElse] || token.is[KwEnum] || token.is[KwExport] ||
+    token.is[KwExtends] || token.is[KwFalse] || token.is[KwFinal] ||
+    token.is[KwFinally] || token.is[KwFor] || token.is[KwForsome] ||
+    token.is[KwGiven] || token.is[KwIf] || token.is[KwImplicit] ||
+    token.is[KwImport] || token.is[KwLazy] || token.is[KwMatch] ||
+    token.is[KwMacro] || token.is[KwNew] || token.is[KwNull] ||
+    token.is[KwObject] || token.is[KwOverride] || token.is[KwPackage] ||
+    token.is[KwPrivate] || token.is[KwProtected] || token.is[KwReturn] ||
+    token.is[KwSealed] || token.is[KwSuper] || token.is[KwThis] ||
+    token.is[KwThrow] || token.is[KwTrait] || token.is[KwTrue] ||
+    token.is[KwTry] || token.is[KwType] || token.is[KwVal] ||
+    token.is[KwVar] || token.is[KwWhile] || token.is[KwWith] ||
+    token.is[KwYield]
   }
 }
 

--- a/scalafmt-tests/src/test/resources/scala3/Export.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Export.stat
@@ -1,0 +1,120 @@
+<<< simple
+export     scanUnit.scan
+>>>
+export scanUnit.scan
+<<< braces
+export A.{ 
+     b, c, d, _ }
+>>>
+export A.{b, c, d, _}
+<<< rename
+export   printUnit.  {status  => _, _}
+>>>
+export printUnit.{status => _, _}
+<<< multiline
+maxColumn = 20
+===
+export   printUnit.  {status  => S, Tree}
+>>>
+export printUnit.{
+  status => S,
+  Tree
+}
+<<< ascii sorting
+rewrite.rules = [AsciiSortImports]
+===
+export a.{
+  ~>,
+  lowercase,
+  Uppercase,
+  `symbol`
+}
+>>>
+export a.{Uppercase, `symbol`, lowercase, ~>}
+<<< sorting
+rewrite.rules = [SortImports]
+===
+export a.b.{
+  c,
+  a,
+  b
+}, k.{
+  g, f
+}
+>>>
+export a.b.{a, b, c}, k.{f, g}
+<<< spaces in braces
+spaces.inImportCurlyBraces=true
+===
+export A.{ 
+     b, c, d, _ }
+>>>
+export A.{ b, c, d, _ }
+<<< expand selectors
+rewrite.rules = [ExpandImportSelectors]
+maxColumn = 30
+===
+object e {
+  export a.{
+    b,
+    c
+  }, h.{
+    k, l
+  }
+  export d.e.{f, g}
+}
+>>>
+object e {
+  export a.b
+  export a.c
+  export h.k
+  export h.l
+  export d.e.f
+  export d.e.g
+}
+<<< expand selectors rename/unimport
+rewrite.rules = [ExpandImportSelectors]
+maxColumn = 30
+===
+object e {
+  export a.{
+    foo => bar,
+    zzzz => _,
+    baz
+  }
+}
+>>>
+object e {
+  export a.{foo => bar}
+  export a.{zzzz => _}
+  export a.baz
+}
+<<< export binpack single line
+importSelectors = singleLine
+maxColumn = 30
+===
+export packagename.{AVeryLongClass1, AVeryLongClass2, AVeryLongClass3, AVeryLongClass4}
+>>>
+export packagename.{AVeryLongClass1, AVeryLongClass2, AVeryLongClass3, AVeryLongClass4}
+<<< export binpack noBinPack
+importSelectors = noBinPack
+maxColumn = 30
+===
+export packagename.{AVeryLongClass1, AVeryLongClass2, AVeryLongClass3, AVeryLongClass4}
+>>>
+export packagename.{
+  AVeryLongClass1,
+  AVeryLongClass2,
+  AVeryLongClass3,
+  AVeryLongClass4
+}
+<<< export binpack binPack
+importSelectors = binPack
+maxColumn = 50
+===
+export packagename.{AVeryLongClass1, AVeryLongClass2, AVeryLongClass3, AVeryLongClass4}
+>>>
+export packagename.{
+  AVeryLongClass1, AVeryLongClass2,
+  AVeryLongClass3, AVeryLongClass4
+}


### PR DESCRIPTION
Scala 3 has a complimentary structure to imports, which is the export cluase: https://dotty.epfl.ch/docs/reference/other-new-features/export.html

All of the existing options for import make sense in case of export.

Not sure if it makes sense to add aliases to all of the import options or whether to separate them. I left it as is for now.