### PR TITLE
[Scala 3] Add formatting for opaque types

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SortSettings.scala
@@ -30,7 +30,8 @@ object SortSettings {
     ModKey("open", _.is[Mod.Open]),
     ModKey("transparent", _.is[Mod.Transparent]),
     ModKey("inline", _.is[Mod.Inline]),
-    ModKey("infix", _.is[Mod.Infix])
+    ModKey("infix", _.is[Mod.Infix]),
+    ModKey("opaque", _.is[Mod.Opaque])
   )
 
   implicit val SortSettingsModKeyReader: ConfCodec[ModKey] =

--- a/scalafmt-tests/src/test/resources/scala3/OpaqueType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OpaqueType.stat
@@ -1,0 +1,38 @@
+
+<<< simple opaque type
+opaque   type F = X
+>>>
+opaque type F = X
+<<< long opaque type
+maxColumn = 20
+===
+opaque   type HelloIAmAnOpaqueTypeTerry = NiceToMeetYouTerry
+>>>
+opaque type HelloIAmAnOpaqueTypeTerry =
+  NiceToMeetYouTerry
+<<< opaque type bounds
+maxColumn = 15
+===
+opaque type VeryLongClassName <: A & B = AB
+>>>
+opaque type VeryLongClassName <: A & B =
+  AB
+<<< mixed modifiers
+private opaque   type T =   List[Int] 
+>>>
+private opaque type T = List[Int] 
+<<< rewrite modifiers default
+rewrite.rules = [SortModifiers]
+===
+opaque private    type T =   List[Int] 
+>>>
+private opaque type T = List[Int] 
+<<< rewrite modifiers
+rewrite.rules = [SortModifiers]
+rewrite.sortModifiers {
+  order = ["opaque", "private"]
+}
+===
+opaque private    type T =   List[Int] 
+>>>
+opaque private type T = List[Int] 


### PR DESCRIPTION
More information about opaque types here: http://dotty.epfl.ch/docs/reference/other-new-features/opaques.html