### PR TITLE
[Scala 3] Add tests for given exports

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV  = "4.4.6"
+  val scalametaV  = "4.4.7"
   val scalacheckV = "1.15.2"
   val coursier    = "1.0.3"
   val munitV      = "0.7.20"

--- a/scalafmt-tests/src/test/resources/scala3/ExportGivens.stat
+++ b/scalafmt-tests/src/test/resources/scala3/ExportGivens.stat
@@ -1,0 +1,55 @@
+<<< wildcard import
+object B {
+  export A._
+  export A.given}
+>>>
+object B {
+  export A._
+  export A.given
+}
+<<< merged export clauses
+object B {
+  export A.{given, _}
+}
+>>>
+object B {
+  export A.{given, _}
+}
+<<< export given of type
+maxColumn = 20
+===
+export A.{given T1, given T2, given T3}
+>>>
+export A.{
+  given T1,
+  given T2,
+  given T3
+}
+<<< export given of type doesn't break
+maxColumn = 10
+===
+export A.{given T1, given T2, given T3}
+>>>
+export A.{
+  given T1,
+  given T2,
+  given T3
+}
+<<< with wildcard argument
+maxColumn = 20
+===
+export Instances.{given Ordering[?], given ExecutionContext}
+>>>
+export Instances.{
+  given Ordering[?],
+  given ExecutionContext
+}
+<<< by-type mixed with by-name
+maxColumn = 20
+===
+export Instances.{im, given Ordering[?]}
+>>>
+export Instances.{
+  im,
+  given Ordering[?]
+}


### PR DESCRIPTION
It seems that after recent changes in Scala 3, given exports are easily handled by the same logic that does imports.