### PR TITLE
[Scala 3] Add formatting for dependent function types

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/TreeSyntacticGroup.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/TreeSyntacticGroup.scala
@@ -32,7 +32,7 @@ object TreeSyntacticGroup {
       case _: Term.Match => g.Term.Expr1
       case _: Term.Try => g.Term.Expr1
       case _: Term.TryWithHandler => g.Term.Expr1
-      case _: Term.Function => g.Term.Expr
+      case _: Term.FunctionTerm => g.Term.Expr
       case _: Term.PartialFunction => g.Term.SimpleExpr
       case _: Term.While => g.Term.Expr1
       case _: Term.Do => g.Term.Expr1
@@ -45,12 +45,13 @@ object TreeSyntacticGroup {
       case _: Term.Param => g.Path // ???
       // Type
       case _: Type.Name => g.Path
+      case _: Type.TypedParam => g.Type.SimpleTyp
       case _: Type.Select => g.Type.SimpleTyp
       case _: Type.Project => g.Type.SimpleTyp
       case _: Type.Singleton => g.Type.SimpleTyp
       case _: Type.Apply => g.Type.SimpleTyp
       case t: Type.ApplyInfix => g.Type.InfixTyp(t.op.value)
-      case _: Type.Function => g.Type.Typ
+      case _: Type.FunctionType => g.Type.Typ
       case _: Type.Tuple => g.Type.SimpleTyp
       case _: Type.With => g.Type.WithTyp
       case _: Type.And => g.Type.InfixTyp("&")

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -341,7 +341,7 @@ object TreeOps {
           _: Type.Apply | _: Type.Param | _: Type.Tuple | _: Defn.Enum |
           _: Defn.EnumCase | _: Defn.ExtensionGroup =>
         true
-      case _: Term.Function | _: Type.Function => true
+      case _: Term.FunctionTerm | _: Type.FunctionType => true
       case x: Ctor.Primary => x.parent.exists(isDefnSite)
       case _ => false
     }
@@ -417,8 +417,8 @@ object TreeOps {
     case t: Type.Apply => (t.tpe, Left(t.args))
     case t: Term.ApplyType => (t.fun, Left(t.targs))
     case t: Term.Tuple => (t, Left(t.args))
-    case t: Term.Function => (t, Left(t.params))
-    case t: Type.Function => (t, Left(t.params))
+    case t: Term.FunctionTerm => (t, Left(t.params))
+    case t: Type.FunctionType => (t, Left(t.params))
     case t: Type.Tuple => (t, Left(t.args))
     case t: Init => (t.tpe, Right(t.argss))
     case t: Term.ApplyUsing => (t.fun, Left(t.args))

--- a/scalafmt-tests/src/test/resources/scala3/DependentFunction.stat
+++ b/scalafmt-tests/src/test/resources/scala3/DependentFunction.stat
@@ -1,0 +1,61 @@
+
+<<< simple dependent function
+val extractor:   (e: Entry) => e.Key =    extractKey
+>>>
+val extractor: (e: Entry) => e.Key = extractKey
+<<< simple dependent function term
+type T = 
+ (e: Entry) 
+=> e.Key
+>>>
+type T =
+  (e: Entry) => e.Key
+<<< long dependent function
+maxColumn = 30
+===
+val extractor: (entryWithALongName: EntryWithALongName) => e.KeyOfALongName = extractKey
+>>>
+val extractor: (
+    entryWithALongName: EntryWithALongName
+) => e.KeyOfALongName =
+  extractKey
+<<< dependent function multiple params
+maxColumn = 30
+===
+val extractor: (entryWithALongName1: EntryWithALongName1, entryWithALongName2: EntryWithALongName2) => e.KeyOfALongName = extractKey
+>>>
+val extractor: (
+    entryWithALongName1: EntryWithALongName1,
+    entryWithALongName2: EntryWithALongName2
+) => e.KeyOfALongName =
+  extractKey
+<<< dependent function term multiple params
+maxColumn = 30
+===
+type Type[T <: LongName] = (entryWithALongName1: EntryWithALongName1, entryWithALongName2: EntryWithALongName2[? <: T]) => e.KeyOfALongName
+>>>
+type Type[T <: LongName] = (
+    entryWithALongName1: EntryWithALongName1,
+    entryWithALongName2: EntryWithALongName2[
+      ? <: T
+    ]
+) => e.KeyOfALongName
+<<< simple context dependent function
+val extractor:   (e: Entry) ?=> e.Key =    extractKey
+>>>
+val extractor: (e: Entry) ?=> e.Key = extractKey
+<<< context dependent function term
+type T = 
+ (e: Entry)    ?=> e.Key
+>>>
+type T =
+  (e: Entry) ?=> e.Key
+<<< long context dependent function
+maxColumn = 30
+===
+val extractor: (entryWithALongName: EntryWithALongName) ?=> e.KeyOfALongName = extractKey
+>>>
+val extractor: (
+    entryWithALongName: EntryWithALongName
+) ?=> e.KeyOfALongName =
+  extractKey


### PR DESCRIPTION
Dependent functions allow us to use named parameters in function types and base their return types on the type of that parameter.

They are defined here: http://dotty.epfl.ch/docs/reference/new-types/dependent-function-types.html