### PR TITLE
[Scala 3] Add formatting for polymorphic functions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -356,6 +356,7 @@ class Router(formatOps: FormatOps) {
 
       case FormatToken(T.RightArrow() | T.ContextArrow(), right, _)
           if leftOwner.is[Term.FunctionTerm] ||
+            leftOwner.is[Term.PolyFunction] ||
             (leftOwner.is[Template] &&
               leftOwner.parent.exists(_.is[Term.NewAnonymous])) =>
         val (endOfFunction, expiresOn) = leftOwner match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/TreeSyntacticGroup.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/TreeSyntacticGroup.scala
@@ -33,6 +33,7 @@ object TreeSyntacticGroup {
       case _: Term.Try => g.Term.Expr1
       case _: Term.TryWithHandler => g.Term.Expr1
       case _: Term.FunctionTerm => g.Term.Expr
+      case _: Term.PolyFunction => g.Term.Expr
       case _: Term.PartialFunction => g.Term.SimpleExpr
       case _: Term.While => g.Term.Expr1
       case _: Term.Do => g.Term.Expr1
@@ -52,6 +53,7 @@ object TreeSyntacticGroup {
       case _: Type.Apply => g.Type.SimpleTyp
       case t: Type.ApplyInfix => g.Type.InfixTyp(t.op.value)
       case _: Type.FunctionType => g.Type.Typ
+      case _: Type.PolyFunction => g.Type.Typ
       case _: Type.Tuple => g.Type.SimpleTyp
       case _: Type.With => g.Type.WithTyp
       case _: Type.And => g.Type.InfixTyp("&")

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -342,6 +342,7 @@ object TreeOps {
           _: Defn.EnumCase | _: Defn.ExtensionGroup =>
         true
       case _: Term.FunctionTerm | _: Type.FunctionType => true
+      case _: Term.PolyFunction | _: Type.PolyFunction => true
       case x: Ctor.Primary => x.parent.exists(isDefnSite)
       case _ => false
     }
@@ -418,7 +419,9 @@ object TreeOps {
     case t: Term.ApplyType => (t.fun, Left(t.targs))
     case t: Term.Tuple => (t, Left(t.args))
     case t: Term.FunctionTerm => (t, Left(t.params))
+    case t: Term.PolyFunction => (t, Left(t.tparams))
     case t: Type.FunctionType => (t, Left(t.params))
+    case t: Type.PolyFunction => (t, Left(t.tparams))
     case t: Type.Tuple => (t, Left(t.args))
     case t: Init => (t.tpe, Right(t.argss))
     case t: Term.ApplyUsing => (t.fun, Left(t.args))

--- a/scalafmt-tests/src/test/resources/scala3/PolyFunction.stat
+++ b/scalafmt-tests/src/test/resources/scala3/PolyFunction.stat
@@ -1,0 +1,67 @@
+
+<<< simple polymorphic function
+val t0 = [T] => (ts: List[T]) =>     ts.headOption
+>>>
+val t0 = [T] => (ts: List[T]) => ts.headOption
+<<< long polymorphic function
+maxColumn = 30
+===
+val thisIsAPolymorphicFunction = [PolymorphicFunctionTypeParam] => (polymorphicFunctionParam: List[T]) =>     ts.headOption
+>>>
+val thisIsAPolymorphicFunction =
+  [
+      PolymorphicFunctionTypeParam
+  ] =>
+    (polymorphicFunctionParam: List[
+      T
+    ]) => ts.headOption
+<<< complex polymorphic function
+maxColumn = 15
+===
+val t1 = [F[_], G[_], T] => (ft: F[T], f: F[T] => G[T]) => f(ft)
+>>>
+val t1 = [F[
+    _
+], G[_], T] =>
+  (
+      ft: F[T],
+      f: F[
+        T
+      ] => G[T]
+  ) => f(ft)
+<<< simple polymorphic function type
+type F0 = [T] => List[T]   =>    Option[T]
+>>>
+type F0 = [T] => List[T] => Option[T]
+<<< long polymorphic function type
+maxColumn = 30
+===
+type ThisIsAPolymorphicFunctionType = [PolymorphicFunctionTypeParam] => List[T] =>     Option[T]
+>>>
+type ThisIsAPolymorphicFunctionType =
+  [
+      PolymorphicFunctionTypeParam
+  ] => List[T] => Option[T]
+<<< long polymorphic context function type
+maxColumn = 30
+===
+type ThisIsAPolymorphicFunctionType = [PolymorphicFunctionTypeParam] => List[T] ?=>     Option[T]
+>>>
+type ThisIsAPolymorphicFunctionType =
+  [
+      PolymorphicFunctionTypeParam
+  ] => List[T] ?=> Option[T]
+<<< complex polymorphic function type
+maxColumn = 15
+===
+type T1 = [F[_], G[_], T] => (F[T], F[T] => G[T]) => F[T]
+>>>
+type T1 =
+  [F[_], G[
+      _
+  ], T] => (
+      F[T],
+      F[
+        T
+      ] => G[T]
+  ) => F[T]


### PR DESCRIPTION
Polymorphic types are a way to define a function parametrized by a type, complementary to `def method[T]`

More information here: http://dotty.epfl.ch/docs/reference/new-types/polymorphic-function-types.html

I was also looking at fold/unfold, but polymorphic function types cannot have curly braces around their body, so this will not make much sense.