### PR TITLE
[Scala 3] Add support for union and intersection types

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1821,7 +1821,19 @@ class Router(formatOps: FormatOps) {
             Seq(Split(Space.orNL(noNL), 0))
         }
 
-      // Pat
+      // Union/Intersection types
+      case FormatToken(T.Ident(value), _, _)
+          if (value == "|" && leftOwner.is[Type.Or]) ||
+            (value == "&" && leftOwner.is[Type.And]) =>
+        if (style.newlines.source eq Newlines.keep)
+          Seq(Split(Space.orNL(newlines == 0), 0))
+        else
+          Seq(
+            Split(Space, 0),
+            Split(Newline, 1).withIndent(2, lastToken(leftOwner), After)
+          )
+
+      // Pattern alternatives
       case FormatToken(T.Ident("|"), _, _) if leftOwner.is[Pat.Alternative] =>
         if (style.newlines.source eq Newlines.keep)
           Seq(Split(Space.orNL(newlines == 0), 0))

--- a/scalafmt-tests/src/test/resources/scala3/UnionIntersectionType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/UnionIntersectionType.stat
@@ -1,0 +1,131 @@
+
+<<< simple intersection
+maxColumn = 30
+===
+def hello(): A & B = {
+    val a  : A & B
+}
+>>>
+def hello(): A & B = {
+  val a: A & B
+}
+<<< simple union
+maxColumn = 30
+===
+def hello(): A | B = {
+    val a  : A | B
+}
+>>>
+def hello(): A | B = {
+  val a: A | B
+}
+<<< long intersection
+maxColumn = 30
+===
+def hello(): FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType & ThirdTypeInTheInterSectionType = {
+    val a  : FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType 
+}
+>>>
+def hello(): FirstTypeInTheInterSectionType &
+  SecondTypeInTheInterSectionType &
+  ThirdTypeInTheInterSectionType = {
+  val a: FirstTypeInTheInterSectionType &
+    SecondTypeInTheInterSectionType
+}
+<<< long union
+maxColumn = 30
+===
+def hello(): FirstTypeInTheInterSectionType | SecondTypeInTheInterSectionType |  ThirdTypeInTheInterSectionType = {
+    val a  : A | B
+}
+>>>
+def hello(): FirstTypeInTheInterSectionType |
+  SecondTypeInTheInterSectionType |
+  ThirdTypeInTheInterSectionType = {
+  val a: A | B
+}
+<<< long intersection keep
+maxColumn = 30
+newlines.source=keep
+===
+def hello(): FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType & ThirdTypeInTheInterSectionType = {
+    val a  : FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType 
+}
+>>>
+def hello()
+    : FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType & ThirdTypeInTheInterSectionType = {
+  val a: FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType
+}
+<<< long union keep
+maxColumn = 30
+newlines.source=keep
+===
+def hello(): FirstTypeInTheInterSectionType | SecondTypeInTheInterSectionType |  ThirdTypeInTheInterSectionType = {
+    val a  : A | B
+}
+>>>
+def hello()
+    : FirstTypeInTheInterSectionType | SecondTypeInTheInterSectionType | ThirdTypeInTheInterSectionType = {
+  val a: A | B
+}
+<<< long intersection param
+maxColumn = 30
+===
+def hello(aNumberOfpossibleTypes: FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType & ThirdTypeInTheInterSectionType) = {
+    val a  : FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType 
+}
+>>>
+def hello(
+    aNumberOfpossibleTypes: FirstTypeInTheInterSectionType &
+      SecondTypeInTheInterSectionType &
+      ThirdTypeInTheInterSectionType
+) = {
+  val a: FirstTypeInTheInterSectionType &
+    SecondTypeInTheInterSectionType
+}
+<<< long union
+maxColumn = 30
+===
+def hello(aNumberOfpossibleTypes : FirstTypeInTheInterSectionType | SecondTypeInTheInterSectionType |  ThirdTypeInTheInterSectionType) = {
+    val a  : A | B
+}
+>>>
+def hello(
+    aNumberOfpossibleTypes: FirstTypeInTheInterSectionType |
+      SecondTypeInTheInterSectionType |
+      ThirdTypeInTheInterSectionType
+) = {
+  val a: A | B
+}
+<<< long union in type
+maxColumn = 30
+===
+def hello(aNumberOfpossibleTypes : Type[FirstTypeInTheInterSectionType | SecondTypeInTheInterSectionType |  ThirdTypeInTheInterSectionType]) = {
+    val a  : A | B
+}
+>>>
+def hello(
+    aNumberOfpossibleTypes: Type[
+      FirstTypeInTheInterSectionType |
+        SecondTypeInTheInterSectionType |
+        ThirdTypeInTheInterSectionType
+    ]
+) = {
+  val a: A | B
+}
+<<< long intersection in type
+maxColumn = 30
+===
+def hello(aNumberOfpossibleTypes : Type[FirstTypeInTheInterSectionType & SecondTypeInTheInterSectionType &  ThirdTypeInTheInterSectionType]) = {
+    val a  : A & B
+}
+>>>
+def hello(
+    aNumberOfpossibleTypes: Type[
+      FirstTypeInTheInterSectionType &
+        SecondTypeInTheInterSectionType &
+        ThirdTypeInTheInterSectionType
+    ]
+) = {
+  val a: A & B
+}


### PR DESCRIPTION
Intersection and union types are defined respectively by `&` and `|`, you might read more about it here http://dotty.epfl.ch/docs/reference/new-types/union-types.html and http://dotty.epfl.ch/docs/reference/new-types/intersection-types.html

Since, they both look pretty similar to alternatives, that's what I based my implementation on.