### PR TITLE
Update Scalameta to 4.4.8 and add formatting for type bounds

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.9.10"
-  val scalametaV  = "4.4.7"
+  val scalametaV  = "4.4.8"
   val scalacheckV = "1.15.2"
   val coursier    = "1.0.3"
   val munitV      = "0.7.21"

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -67,6 +67,7 @@ class FormatOps(
   import TokenOps._
   import TreeOps._
   implicit val dialect = initStyle.runner.dialect
+  def isScala3Dialect = dialect == ScalafmtRunner.Dialect.scala3
   private val ownersMap = getOwners(tree)
   val tokens: FormatTokens = FormatTokens(tree.tokens, owners)
   private[internal] val soft = new SoftKeywordClasses(dialect)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -14,6 +14,7 @@ import scala.meta.tokens.{Token, Tokens}
 import scala.meta.tokens.{Token => T}
 import scala.meta.{
   Case,
+  Decl,
   Defn,
   Enumerator,
   Importer,
@@ -1908,6 +1909,18 @@ class Router(formatOps: FormatOps) {
             Split(Newline, 1).withIndent(2, lastToken, After)
           )
         }
+      /* Type bounds in type definitions and declarations such as:
+       * type `Tuple <: Alpha & Beta = Another` or `Tuple <: Alpha & Beta`
+       */
+      case FormatToken(_, _: T.Subtype, _)
+          if isScala3Dialect &&
+            rightOwner.is[Type.Bounds] &&
+            rightOwner.parent.exists(t => t.is[Defn.Type] || t.is[Decl.Type]) =>
+        val typeBoundEnd = rightOwner.tokens.last
+        Seq(
+          Split(Space, 0).withSingleLineNoOptimal(typeBoundEnd),
+          Split(Newline, 1).withIndent(2, typeBoundEnd, After)
+        )
       // Interpolation
       case FormatToken(_, _: T.Interpolation.Id, _) =>
         Seq(

--- a/scalafmt-tests/src/test/resources/scala3/MatchType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/MatchType.stat
@@ -52,10 +52,8 @@ type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
           x1 *: Concat[xs1, Y]
          }
 >>>
-type Concat[
-    X <: Tuple,
-    Y <: Tuple
-] <: Tuple = X match {
+type Concat[X <: Tuple, Y <: Tuple]
+  <: Tuple = X match {
   case Unit =>
     Y
   case x1 *: xs1 =>
@@ -71,10 +69,8 @@ type Concat[X, Y] <: TupleTupleTupleTupleTupleTupleTuple = X match {
           x1 *: Concat[xs1, Y]
          }
 >>>
-type Concat[
-    X,
-    Y
-] <: TupleTupleTupleTupleTupleTupleTuple =
+type Concat[X, Y]
+  <: TupleTupleTupleTupleTupleTupleTuple =
   X match {
     case Unit =>
       Y

--- a/scalafmt-tests/src/test/resources/scala3/OpaqueType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OpaqueType.stat
@@ -13,10 +13,10 @@ opaque type HelloIAmAnOpaqueTypeTerry =
 <<< opaque type bounds
 maxColumn = 15
 ===
-opaque type VeryLongClassName <: A & B = AB
+opaque type VeryLongClassName <: AType = AB
 >>>
-opaque type VeryLongClassName <: A & B =
-  AB
+opaque type VeryLongClassName
+  <: AType = AB
 <<< mixed modifiers
 private opaque   type T =   List[Int] 
 >>>

--- a/scalafmt-tests/src/test/resources/scala3/UnionIntersectionType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/UnionIntersectionType.stat
@@ -129,3 +129,26 @@ def hello(
 ) = {
   val a: A & B
 }
+<<< opaque type bounds
+maxColumn = 20
+===
+opaque type VeryLongClassName <: Alpha & Beta & Gamma = AB
+>>>
+opaque type VeryLongClassName
+  <: Alpha & Beta &
+    Gamma = AB
+<<< single split type bounds
+maxColumn = 20
+===
+opaque type VeryLongClassName <: Alpha & Beta = AB
+>>>
+opaque type VeryLongClassName
+  <: Alpha & Beta =
+  AB
+<<< single split type decl bounds
+maxColumn = 20
+===
+type VeryLongClassName <: Alpha & Beta
+>>>
+type VeryLongClassName
+  <: Alpha & Beta


### PR DESCRIPTION
Previously, we would not split on type bounds which might sometimes be useful especially with the new Scala 3 types. Now, I added a separate case of type bounds in type declarations and definitions.

This also popped up due to the fixes done recently in scalameta. Not super sure about the changes, it is in a way similar to extends now, but none of it looks perfect.

We could remove the case and go back to having type bounds only ever split by space. 