### PR TITLE
[Scala 3] Format import/export when using `as` soft keyword

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/RenameImportExport.stat
+++ b/scalafmt-tests/src/test/resources/scala3/RenameImportExport.stat
@@ -1,0 +1,81 @@
+
+<<< single import
+import scala   as  java
+>>>
+import scala as java
+<<< select import
+import java.util.List   as  `J-List`
+>>>
+import java.util.List as `J-List`
+<<< multiple imports
+import java.util.{List   as  `J-List`, LinkedList as Linked}
+>>>
+import java.util.{List as `J-List`, LinkedList as Linked}
+<<< multiple imports multiline
+maxColumn = 20
+===
+import java.util.{List   as  `J-List`, LinkedList as Linked}
+>>>
+import java.util.{
+  List as `J-List`,
+  LinkedList as Linked
+}
+<<< redundant braces
+import java.util.{List   as  `J-List`}
+>>>
+import java.util.{List as `J-List`}
+<<< remove redundant braces in import 
+rewrite.rules = [RedundantBraces]
+===
+import java.util.{List   as  `J-List`}
+>>>
+import java.util.List as `J-List`
+<<< remove redundant braces old syntax
+rewrite.rules = [RedundantBraces]
+===
+import java.util.{List   =>  `J-List`}
+>>>
+import java.util.{List => `J-List`}
+<<< no redundant braces in import 
+rewrite.rules = [RedundantBraces]
+===
+import java.util.List   as  `J-List`
+>>>
+import java.util.List as `J-List`
+<<< single export
+export scala   as  java
+>>>
+export scala as java
+<<< select export
+export java.util.List   as  `J-List`
+>>>
+export java.util.List as `J-List`
+<<< multiple exports
+export java.util.{List   as  `J-List`, LinkedList as Linked}
+>>>
+export java.util.{List as `J-List`, LinkedList as Linked}
+<<< multiple exports multiline
+maxColumn = 20
+===
+export java.util.{List   as  `J-List`, LinkedList as Linked}
+>>>
+export java.util.{
+  List as `J-List`,
+  LinkedList as Linked
+}
+<<< redundant braces export
+export java.util.{List   as  `J-List`}
+>>>
+export java.util.{List as `J-List`}
+<<< remove redundant braces in export
+rewrite.rules = [RedundantBraces]
+===
+export java.util.{List   as  _}
+>>>
+export java.util.List as _
+<<< no redundant braces in export
+rewrite.rules = [RedundantBraces]
+===
+export java.util.List   as  `J-List`
+>>>
+export java.util.List as `J-List`


### PR DESCRIPTION
Previously, renames could only be done using `=>`, now it's also possible to use `as`. This also makes it possible to not use braces when doing a single rename/unimport.

More information can be found [here](https://dotty.epfl.ch/docs/reference/changed-features/imports.html)