### PR TITLE
[Scala 3] Add tests for new wildcard imports

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/StarImport.stat
+++ b/scalafmt-tests/src/test/resources/scala3/StarImport.stat
@@ -1,0 +1,17 @@
+
+<<< simple wildcard import
+import a . b . c . *
+>>>
+import a.b.c.*
+<<< star named import
+import a . b . c . `*`
+>>>
+import a.b.c.`*`
+<<< simple wildcard export
+export a . b . c . *
+>>>
+export a.b.c.*
+<<< star named export
+export a . b . c . `*`
+>>>
+export a.b.c.`*`


### PR DESCRIPTION
It's now possible to use `*` instead of `_` for wildcard imports. More info [here](https://dotty.epfl.ch/docs/reference/changed-features/imports.html)