### PR TITLE
[Scala 3] Fix formatting for the new vararg splices

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1851,7 +1851,11 @@ class Router(formatOps: FormatOps) {
       case FormatToken(_, T.Ident("|"), _) if rightOwner.is[Pat.Alternative] =>
         val noNL = style.newlines.source.ne(Newlines.keep) || newlines == 0
         Seq(Split(Space.orNL(noNL), 0))
-
+      case FormatToken(_, T.Ident("*"), _)
+          if rightOwner.is[Term.Repeated] || rightOwner.is[Pat.Repeated] =>
+        Seq(
+          Split(NoSplit, 0)
+        )
       case FormatToken(
             T.Ident(_) | Literal() | T.Interpolation.End() | T.Xml.End(),
             T.Ident(_) | Literal() | T.Xml.Start(),

--- a/scalafmt-tests/src/test/resources/scala3/Vararg.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Vararg.stat
@@ -1,0 +1,22 @@
+
+
+<<< simple invocation
+val a = method(0, 1,"", others*)
+>>>
+val a = method(0, 1, "", others*)
+<<< old apply
+val a = method(0, 1,"", others: _*)
+>>>
+val a = method(0, 1, "", others: _*)
+<<< pattern match
+a match {case List(xs*) => 1 
+case Nil => 2}
+>>>
+a match {
+  case List(xs*) => 1
+  case Nil       => 2
+}
+<<< normal usage
+val a = List(0, 1, 1*2)
+>>>
+val a = List(0, 1, 1 * 2)


### PR DESCRIPTION
It's now possible specify arguments for vararg parameters by adding `*`:
```scala
def method(a: String, b: String*)
method(arg1, args*)
```
this also works for pattern matches.

More info about the new syntax is available [here](https://dotty.epfl.ch/docs/reference/changed-features/vararg-splices.html)