### PR TITLE
[Scala 3] Add tests for modified extension methods

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/Extension.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Extension.stat
@@ -167,3 +167,94 @@ extension [A, B](a: A) /* foo */ (using
 )
   /* baz */
   def a = 1
+<<< multiple using clauses
+maxColumn = 40
+===
+extension (using longName1: AVeryLongName1)(mainParameter: MainParameter)(using longName2: AVeryLongName2)(using AnEvenLongerVeryLongName) 
+  def add[TypeParameter1, TypeParameter2, TypeParameter3](b: A) = a + b
+>>>
+extension (using
+    longName1: AVeryLongName1
+)(mainParameter: MainParameter)(using
+    longName2: AVeryLongName2
+)(using AnEvenLongerVeryLongName)
+  def add[
+      TypeParameter1,
+      TypeParameter2,
+      TypeParameter3
+  ](b: A) = a + b
+<<< multiple using clauses with newline before using
+newlines.implicitParamListModifierForce = [before]
+maxColumn = 40
+===
+extension (using longName1: AVeryLongName1)(mainParameter: MainParameter)(using longName2: AVeryLongName2)(using AnEvenLongerVeryLongName) 
+  def add[TypeParameter1, TypeParameter2, TypeParameter3](b: A) = a + b
+>>>
+extension (
+    using longName1: AVeryLongName1
+)(mainParameter: MainParameter)(
+    using longName2: AVeryLongName2
+)(
+    using AnEvenLongerVeryLongName
+)
+  def add[
+      TypeParameter1,
+      TypeParameter2,
+      TypeParameter3
+  ](b: A) = a + b
+<<< multiple using clauses with newline before and after using
+newlines.implicitParamListModifierForce = [after, before]
+maxColumn = 40
+===
+extension (using longName1: AVeryLongName1)(mainParameter: MainParameter)(using longName2: AVeryLongName2)(using AnEvenLongerVeryLongName) 
+  def add[TypeParameter1, TypeParameter2, TypeParameter3](b: A) = a + b
+>>>
+extension (
+    using
+    longName1: AVeryLongName1
+)(mainParameter: MainParameter)(
+    using
+    longName2: AVeryLongName2
+)(
+    using
+    AnEvenLongerVeryLongName
+)
+  def add[
+      TypeParameter1,
+      TypeParameter2,
+      TypeParameter3
+  ](b: A) = a + b
+<<< multiple using clauses with newline preffered before using
+newlines.implicitParamListModifierPrefer = before
+maxColumn = 40
+===
+extension (using longName1: AVeryLongName1)(mainParameter: MainParameter)(using longName2: AVeryLongName2)(using AnEvenLongerVeryLongName) 
+  def add[TypeParameter1, TypeParameter2, TypeParameter3](b: A) = a + b
+>>>
+extension (
+    using longName1: AVeryLongName1
+)(mainParameter: MainParameter)(
+    using longName2: AVeryLongName2
+)(using AnEvenLongerVeryLongName)
+  def add[
+      TypeParameter1,
+      TypeParameter2,
+      TypeParameter3
+  ](b: A) = a + b
+<<< multiple using clauses with newline preffered after using
+newlines.implicitParamListModifierPrefer = after
+maxColumn = 40
+===
+extension (using longName1: AVeryLongName1)(mainParameter: MainParameter)(using longName2: AVeryLongName2)(using AnEvenLongerVeryLongName) 
+  def add[TypeParameter1, TypeParameter2, TypeParameter3](b: A) = a + b
+>>>
+extension (using
+    longName1: AVeryLongName1
+)(mainParameter: MainParameter)(using
+    longName2: AVeryLongName2
+)(using AnEvenLongerVeryLongName)
+  def add[
+      TypeParameter1,
+      TypeParameter2,
+      TypeParameter3
+  ](b: A) = a + b


### PR DESCRIPTION
Previously, extension methods could not have `using` clauses before the main parameter or type params in definitions, which is now possible.