### PR TITLE
TokenTraverser: fix bug with traversing back

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -42,8 +42,7 @@ class TokenTraverser(tokens: Tokens, filename: String) {
 
   def nextToken(token: Token): Token = {
     tok2idx.get(token) match {
-      case Some(i) if tokens.length > i + 1 =>
-        tokens(i + 1)
+      case Some(i) if i < tokens.length - 1 => tokens(i + 1)
       case _ => token
     }
   }
@@ -53,8 +52,7 @@ class TokenTraverser(tokens: Tokens, filename: String) {
 
   def prevToken(token: Token): Token = {
     tok2idx.get(token) match {
-      case Some(i) if tokens.length > i - 1 =>
-        tokens(i - 1)
+      case Some(i) if i > 0 => tokens(i - 1)
       case _ => token
     }
   }


### PR DESCRIPTION
For consistency, also slightly rewrite the forward check.