### PR TITLE
[Scala 3] Add formatting for match used as an operator

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/Match.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Match.stat
@@ -1,0 +1,133 @@
+
+<<< match with dot
+def mtch(x: Int): String =
+            x.match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.trim()
+>>>
+def mtch(x: Int): String =
+  x.match {
+    case 1 => "1"
+    case _ => "ERR"
+  }.trim()
+<<< match with dot complex
+def mtch(int: Int): String =
+            int.hello().thisIsALongMethodName().match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String =
+  int
+    .hello()
+    .thisIsALongMethodName()
+    .match {
+      case 1 => "1"
+      case _ => "ERR"
+    }
+    .thisIsALongMethodName()
+    .thisIsALongMethodName()
+    .match {
+      case "1" => 1
+      case _   => 0
+    }
+<<< match with dot complex inside
+def mtch(int: Int): String =
+            int.hello().match {
+              case a =>
+                a.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+            }
+>>>
+def mtch(int: Int): String =
+  int
+    .hello()
+    .match {
+      case a =>
+        a
+          .thisIsALongMethodName()
+          .thisIsALongMethodName()
+          .match {
+            case "1" => 1
+            case _   => 0
+          }
+    }
+<<< match chain complex
+val hello = xs match {
+  case Nil => "empty"
+   case x :: xs1 => "nonempty"
+} startsWith "empty" match {
+   case true => 0
+    case false => 1
+}
+>>>
+val hello = xs match {
+  case Nil      => "empty"
+  case x :: xs1 => "nonempty"
+} startsWith "empty" match {
+  case true  => 0
+  case false => 1
+}
+<<< match chain
+xs match {
+  case Nil => "empty"
+  case x :: xs1 => "nonempty"
+} match {
+  case "empty" => 0
+  case "nonempty" => 1
+}
+>>>
+xs match {
+  case Nil      => "empty"
+  case x :: xs1 => "nonempty"
+} match {
+  case "empty"    => 0
+  case "nonempty" => 1
+}
+<<< match with dot complex keep
+newlines.source=keep
+===
+def mtch(int: Int): String =
+            int.hello().thisIsALongMethodName().match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String =
+  int.hello().thisIsALongMethodName().match {
+    case 1 => "1"
+    case _ => "ERR"
+  }.thisIsALongMethodName().thisIsALongMethodName().match {
+    case "1" => 1
+    case _   => 0
+  }
+<<< match with dot complex fold
+newlines.source=fold
+===
+def mtch(int: Int): String =
+            int
+              .hello()
+              .thisIsALongMethodName().match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String = int.hello().thisIsALongMethodName().match {
+  case 1 => "1"
+  case _ => "ERR"
+}.thisIsALongMethodName().thisIsALongMethodName().match {
+  case "1" => 1
+  case _   => 0
+}


### PR DESCRIPTION
In Scala 3 match can be used as any other operator, which means it can chained and can be invoked with an additional `.`

More details here: https://dotty.epfl.ch/docs/reference/changed-features/match-syntax.html

I tried to keep most of the changes behind the dialect, so this will only be noticed by Scala 3 dialect users