### PR TITLE
[Scala 3] Add formatting for match used as an operator

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -707,8 +707,8 @@ object TreeOps {
   @inline
   def ifWithoutElse(t: Term.If) = t.elsep.is[Lit.Unit]
 
-  def cannotStartSelectChain(select: Term.Select): Boolean =
-    select.qual match {
+  def cannotStartSelectChainOnExpr(expr: Term): Boolean =
+    expr match {
       case _: Term.Placeholder => true
       case t: Term.Name => isSymbolicName(t.value)
       case t: Term.Select => isSymbolicName(t.name.value)

--- a/scalafmt-tests/src/test/resources/scala3/Match.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Match.stat
@@ -7,7 +7,7 @@ def mtch(x: Int): String =
             }.trim()
 >>>
 def mtch(x: Int): String =
-  x. match {
+  x.match {
     case 1 => "1"
     case _ => "ERR"
   }.trim()
@@ -22,13 +22,19 @@ def mtch(int: Int): String =
             }
 >>>
 def mtch(int: Int): String =
-  int.hello().thisIsALongMethodName(). match {
-    case 1 => "1"
-    case _ => "ERR"
-  }.thisIsALongMethodName().thisIsALongMethodName(). match {
-    case "1" => 1
-    case _   => 0
-  }
+  int
+    .hello()
+    .thisIsALongMethodName()
+    .match {
+      case 1 => "1"
+      case _ => "ERR"
+    }
+    .thisIsALongMethodName()
+    .thisIsALongMethodName()
+    .match {
+      case "1" => 1
+      case _   => 0
+    }
 <<< match with dot complex inside
 maxColumn = 50
 ===
@@ -42,10 +48,10 @@ def mtch(int: Int): String =
             }
 >>>
 def mtch(int: Int): String =
-  int.hello(). match {
-    case a =>
-      a.thisIsALongMethodName()
-        .thisIsALongMethodName(). match {
+  int.hello().match { case a =>
+    a.thisIsALongMethodName()
+      .thisIsALongMethodName()
+      .match {
         case "1" => 1
         case _   => 0
       }
@@ -132,10 +138,10 @@ def mtch(int: Int): String =
             }
 >>>
 def mtch(int: Int): String =
-  int.hello().thisIsALongMethodName(). match {
+  int.hello().thisIsALongMethodName().match {
     case 1 => "1"
     case _ => "ERR"
-  }.thisIsALongMethodName().thisIsALongMethodName(). match {
+  }.thisIsALongMethodName().thisIsALongMethodName().match {
     case "1" => 1
     case _   => 0
   }
@@ -173,10 +179,10 @@ def mtch(int: Int): String =
               case _ => 0
             }
 >>>
-def mtch(int: Int): String = int.hello().thisIsALongMethodName(). match {
+def mtch(int: Int): String = int.hello().thisIsALongMethodName().match {
   case 1 => "1"
   case _ => "ERR"
-}.thisIsALongMethodName().thisIsALongMethodName(). match {
+}.thisIsALongMethodName().thisIsALongMethodName().match {
   case "1" => 1
   case _   => 0
 }
@@ -194,10 +200,10 @@ val mtch =
               case _ => 0
             }
 >>>
-val mtch = int.hello().thisIsALongMethodName(). match {
+val mtch = int.hello().thisIsALongMethodName().match {
   case 1 => "1"
   case _ => "ERR"
-}.thisIsALongMethodName().thisIsALongMethodName(). match {
+}.thisIsALongMethodName().thisIsALongMethodName().match {
   case "1" => 1
   case _   => 0
 }

--- a/scalafmt-tests/src/test/resources/scala3/Match.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Match.stat
@@ -1,0 +1,287 @@
+maxColumn=80
+<<< match with dot
+def mtch(x: Int): String =
+            x.match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.trim()
+>>>
+def mtch(x: Int): String =
+  x. match {
+    case 1 => "1"
+    case _ => "ERR"
+  }.trim()
+<<< match with dot complex
+def mtch(int: Int): String =
+            int.hello().thisIsALongMethodName().match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String =
+  int.hello().thisIsALongMethodName(). match {
+    case 1 => "1"
+    case _ => "ERR"
+  }.thisIsALongMethodName().thisIsALongMethodName(). match {
+    case "1" => 1
+    case _   => 0
+  }
+<<< match with dot complex inside
+maxColumn = 50
+===
+def mtch(int: Int): String =
+            int.hello().match {
+              case a =>
+                a.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+            }
+>>>
+def mtch(int: Int): String =
+  int.hello(). match {
+    case a =>
+      a.thisIsALongMethodName()
+        .thisIsALongMethodName(). match {
+        case "1" => 1
+        case _   => 0
+      }
+  }
+<<< select with dot complex inside
+maxColumn = 50
+===
+def mtch(int: Int): String =
+            int.hello().matc {
+              case a =>
+                a.thisIsALongMethodName().thisIsALongMethodName().matc {
+              case "1" => 1
+              case _ => 0
+            }
+            }
+>>>
+def mtch(int: Int): String =
+  int.hello().matc { case a =>
+    a.thisIsALongMethodName()
+      .thisIsALongMethodName()
+      .matc {
+        case "1" => 1
+        case _   => 0
+      }
+  }
+<<< match chain complex
+val hello = xs match {
+  case Nil => "empty"
+   case x :: xs1 => "nonempty"
+} startsWith "empty" match {
+   case true => 0
+    case false => 1
+}
+>>>
+val hello = xs match {
+  case Nil      => "empty"
+  case x :: xs1 => "nonempty"
+} startsWith "empty" match {
+  case true  => 0
+  case false => 1
+}
+<<< infix chain complex
+val hello = xs match {
+  case Nil => "empty"
+   case x :: xs1 => "nonempty"
+} startsWith "empty" match {
+   case true => 0
+    case false => 1
+}
+>>>
+val hello = xs match {
+  case Nil      => "empty"
+  case x :: xs1 => "nonempty"
+} startsWith "empty" match {
+  case true  => 0
+  case false => 1
+}
+<<< match chain
+xs match {
+  case Nil => "empty"
+  case x :: xs1 => "nonempty"
+} match {
+  case "empty" => 0
+  case "nonempty" => 1
+}
+>>>
+xs match {
+  case Nil      => "empty"
+  case x :: xs1 => "nonempty"
+} match {
+  case "empty"    => 0
+  case "nonempty" => 1
+}
+<<< match with dot complex keep
+newlines.source=keep
+===
+def mtch(int: Int): String =
+            int.hello().thisIsALongMethodName().match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String =
+  int.hello().thisIsALongMethodName(). match {
+    case 1 => "1"
+    case _ => "ERR"
+  }.thisIsALongMethodName().thisIsALongMethodName(). match {
+    case "1" => 1
+    case _   => 0
+  }
+<<< match infix complex keep
+newlines.source=keep
+===
+def mtch(int: Int): String =
+            int.hello().thisIsALongMethodName() match {
+             case 1 => "1"
+              case _ => "ERR"
+            } thisIsALongMethodName thisIsALongMethodName match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String =
+  int.hello().thisIsALongMethodName() match {
+    case 1 => "1"
+    case _ => "ERR"
+  } thisIsALongMethodName thisIsALongMethodName match {
+    case "1" => 1
+    case _   => 0
+  }
+<<< match with dot complex fold
+newlines.source=fold
+===
+def mtch(int: Int): String =
+            int
+              .hello()
+              .thisIsALongMethodName().match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String = int.hello().thisIsALongMethodName(). match {
+  case 1 => "1"
+  case _ => "ERR"
+}.thisIsALongMethodName().thisIsALongMethodName(). match {
+  case "1" => 1
+  case _   => 0
+}
+<<< match with dot complex fold val
+newlines.source=fold
+===
+val mtch =
+            int
+              .hello()
+              .thisIsALongMethodName().match {
+             case 1 => "1"
+              case _ => "ERR"
+            }.thisIsALongMethodName().thisIsALongMethodName().match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+val mtch = int.hello().thisIsALongMethodName(). match {
+  case 1 => "1"
+  case _ => "ERR"
+}.thisIsALongMethodName().thisIsALongMethodName(). match {
+  case "1" => 1
+  case _   => 0
+}
+<<< select with dot complex fold
+newlines.source=fold
+===
+def mtch(int: Int): String =
+            int
+              .hello()
+              .thisIsALongMethodName().matc {
+             case 1 => "1"
+              case _ => "ERR"
+            }.thisIsALongMethodName().thisIsALongMethodName().matc {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String = int.hello().thisIsALongMethodName().matc {
+  case 1 => "1"
+  case _ => "ERR"
+}.thisIsALongMethodName().thisIsALongMethodName().matc {
+  case "1" => 1
+  case _   => 0
+}
+<<< match infix complex fold
+newlines.source=fold
+===
+def mtch(int: Int): String =
+            int
+              .hello()
+              .thisIsALongMethodName() match {
+             case 1 => "1"
+              case _ => "ERR"
+            } thisIsALongMethodName thisIsALongMethodName match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String = int.hello().thisIsALongMethodName() match {
+  case 1 => "1"
+  case _ => "ERR"
+} thisIsALongMethodName thisIsALongMethodName match {
+  case "1" => 1
+  case _   => 0
+}
+<<< match infix complex fold val
+newlines.source=fold
+===
+val mtch =
+            int
+              .hello()
+              .thisIsALongMethodName() match {
+             case 1 => "1"
+              case _ => "ERR"
+            } thisIsALongMethodName thisIsALongMethodName match {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+val mtch = int.hello().thisIsALongMethodName() match {
+  case 1 => "1"
+  case _ => "ERR"
+} thisIsALongMethodName thisIsALongMethodName match {
+  case "1" => 1
+  case _   => 0
+}
+<<< select infix complex fold
+newlines.source=fold
+===
+def mtch(int: Int): String =
+            int
+              .hello()
+              .thisIsALongMethodName() matc {
+             case 1 => "1"
+              case _ => "ERR"
+            } thisIsALongMethodName thisIsALongMethodName matc {
+              case "1" => 1
+              case _ => 0
+            }
+>>>
+def mtch(int: Int): String = int.hello().thisIsALongMethodName() matc {
+  case 1 => "1"
+  case _ => "ERR"
+} thisIsALongMethodName thisIsALongMethodName matc {
+  case "1" => 1
+  case _   => 0
+}


### PR DESCRIPTION
Based on #2376 from @tgodzik:

*In Scala 3 match can be used as any other operator, which means it can chained and can be invoked with an additional `"."`*

*More details here: https://dotty.epfl.ch/docs/reference/changed-features/match-syntax.html*

*I tried to keep most of the changes behind the dialect, so this will only be noticed by Scala 3 dialect users*

This approach applies the formatting rules used for `Term.Select` to appropriate `Term.Match` expressions.