### PR TITLE
Newlines: explicit setting for beforeTypeBounds (`:`, `<:`, `>:`, `<%`)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -784,7 +784,7 @@ package core {
 
 ### `newlines.beforeMultiline`
 
-> Since 2.7.0
+> Since v2.7.0
 
 This parameter controls whether to force a new line before a multi-line body of
 `case/if/val` and how to format it if the space is allowed. (For multi-line
@@ -855,7 +855,7 @@ a match {
 
 ### `newlines.beforeMultilineDef`
 
-> Since 2.7.0
+> Since v2.7.0
 
 This parameter applies to multi-line definitions only. It accepts the same
 values as [`newlines.beforeMultiline`](#newlinesbeforemultiline) (and defaults
@@ -919,6 +919,19 @@ def foo: String =
     x.toUpper
   }
 ```
+
+### `newlines.beforeTypeBounds`
+
+> Since v3.0.0
+
+This parameter controls formatting of bounds of type parameters: upper `<:`,
+lower `>:`, view `<%`, and context `:` bounds. It accepts the
+same values as [`newlines.source`](#newlinessource).
+
+- `classic`: simply allows no line breaks (default; can't be specified)
+- `keep`: preserves a no-break if the next bound fits on the line
+- `fold`: uses a no-break if the next bound fits on the line
+- `unfold`: puts all bounds on the same line, or breaks before each
 
 ### `newlines.alwaysBeforeElseAfterCurlyIf`
 
@@ -2903,7 +2916,7 @@ Controls what happens if a chain enclosed in parentheses is followed by
 additional selects. Those additional selects will be considered part of the
 enclosed chain if and only if this flag is false.
 
-> Since 2.6.2.
+> Since v2.6.2.
 
 ```scala mdoc:defaults
 optIn.encloseClassicChains

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -148,6 +148,7 @@ case class Newlines(
     source: SourceHints = Newlines.classic,
     @annotation.ExtraName("neverInResultType")
     avoidInResultType: Boolean = false,
+    beforeTypeBounds: SourceHints = Newlines.classic,
     neverBeforeJsNative: Boolean = false,
     sometimesBeforeColonInMethodReturnType: Boolean = true,
     penalizeSingleSelectMultiArgList: Boolean = true,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -349,6 +349,7 @@ object ScalafmtConfig {
             s"newlines.beforeMultilineDef=$x"
           )
         }
+        addIf(newlines.beforeTypeBounds eq Newlines.keep)
       }
       if (newlines.source == Newlines.unfold) {
         addIf(align.arrowEnumeratorGenerator)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -7,13 +7,11 @@ package org.scalafmt.internal
 case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
   import org.scalafmt.util.TokenOps._
 
-  def noNewlines: Seq[Split] =
-    splits.filterNot(_.isNL)
+  @inline def noNewlines: Seq[Split] =
+    Decision.noNewlineSplits(splits)
 
-  def onlyNewlinesWithFallback(default: => Split): Seq[Split] = {
-    val filtered = onlyNewlineSplits
-    if (filtered.nonEmpty) filtered else Seq(default)
-  }
+  @inline def onlyNewlinesWithFallback(default: => Split): Seq[Split] =
+    Decision.onlyNewlinesWithFallback(splits, default)
 
   def forceNewline: Seq[Split] =
     if (isAttachedSingleLineComment(formatToken))
@@ -24,9 +22,24 @@ case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
   def onlyNewlinesWithoutFallback: Seq[Split] =
     onlyNewlineSplits
 
-  private def onlyNewlineSplits: Seq[Split] =
-    splits.filter(_.isNL)
+  @inline private def onlyNewlineSplits: Seq[Split] =
+    Decision.onlyNewlineSplits(splits)
 
   def withSplits(splits: Seq[Split]): Decision = copy(splits = splits)
+
+}
+
+object Decision {
+
+  @inline def noNewlineSplits(s: Seq[Split]): Seq[Split] =
+    s.filterNot(_.isNL)
+
+  @inline def onlyNewlineSplits(s: Seq[Split]): Seq[Split] =
+    s.filter(_.isNL)
+
+  def onlyNewlinesWithFallback(s: Seq[Split], fb: => Split): Seq[Split] = {
+    val filtered = onlyNewlineSplits(s)
+    if (filtered.nonEmpty) filtered else Seq(fb)
+  }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -67,7 +67,6 @@ class FormatOps(
   import TokenOps._
   import TreeOps._
   implicit val dialect = initStyle.runner.dialect
-  def isScala3Dialect = dialect == ScalafmtRunner.Dialect.scala3
   private val ownersMap = getOwners(tree)
   val tokens: FormatTokens = FormatTokens(tree.tokens, owners)
   private[internal] val soft = new SoftKeywordClasses(dialect)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1194,6 +1194,18 @@ class Router(formatOps: FormatOps) {
           }
         )
         Seq(Split(noNLMod, 0))
+      /* Type bounds in type definitions and declarations such as:
+       * type `Tuple <: Alpha & Beta = Another` or `Tuple <: Alpha & Beta`
+       */
+      case FormatToken(_, _: T.Subtype, _)
+          if isScala3Dialect &&
+            rightOwner.is[Type.Bounds] &&
+            rightOwner.parent.exists(t => t.is[Defn.Type] || t.is[Decl.Type]) =>
+        val typeBoundEnd = rightOwner.tokens.last
+        Seq(
+          Split(Space, 0).withSingleLineNoOptimal(typeBoundEnd),
+          Split(Newline, 1).withIndent(2, typeBoundEnd, After)
+        )
 
       case FormatToken(left, _: T.Colon, _) =>
         val mod = left match {
@@ -1948,18 +1960,6 @@ class Router(formatOps: FormatOps) {
             Split(Newline, 1).withIndent(2, lastToken, After)
           )
         }
-      /* Type bounds in type definitions and declarations such as:
-       * type `Tuple <: Alpha & Beta = Another` or `Tuple <: Alpha & Beta`
-       */
-      case FormatToken(_, _: T.Subtype, _)
-          if isScala3Dialect &&
-            rightOwner.is[Type.Bounds] &&
-            rightOwner.parent.exists(t => t.is[Defn.Type] || t.is[Decl.Type]) =>
-        val typeBoundEnd = rightOwner.tokens.last
-        Seq(
-          Split(Space, 0).withSingleLineNoOptimal(typeBoundEnd),
-          Split(Newline, 1).withIndent(2, typeBoundEnd, After)
-        )
       // Interpolation
       case FormatToken(_, _: T.Interpolation.Id, _) =>
         Seq(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1188,12 +1188,15 @@ class Router(formatOps: FormatOps) {
           style.spaces.beforeContextBoundColon match {
             case SpaceBeforeContextBound.Always => true
             case SpaceBeforeContextBound.IfMultipleBounds =>
-              1 < tp.cbounds.length +
+              1 < tp.cbounds.length + tp.vbounds.length +
                 tp.tbounds.lo.size + tp.tbounds.hi.size
             case _ => false
           }
         )
         getSplitsForTypeBounds(formatToken, noNLMod, tp, _.cbounds)
+      case FormatToken(_, _: T.Viewbound, _) if rightOwner.is[Type.Param] =>
+        val tp = rightOwner.asInstanceOf[Type.Param]
+        getSplitsForTypeBounds(formatToken, Space, tp, _.vbounds)
       /* Type bounds in type definitions and declarations such as:
        * type `Tuple <: Alpha & Beta = Another` or `Tuple <: Alpha & Beta`
        */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1193,7 +1193,7 @@ class Router(formatOps: FormatOps) {
             case _ => false
           }
         )
-        Seq(Split(noNLMod, 0))
+        getSplitsForTypeBounds(formatToken, noNLMod, tp, _.cbounds)
       /* Type bounds in type definitions and declarations such as:
        * type `Tuple <: Alpha & Beta = Another` or `Tuple <: Alpha & Beta`
        */

--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -71,3 +71,227 @@ def processTypeForUpdateOrApply(
                                Option[ScalaResolveResult])] = {
   println(1)
 }
+<<< #1249 classic
+maxColumn = 30
+===
+class Foo[
+  F[_] : Bar : Sync
+       : ExecuteUnsafe,
+  T
+]
+>>>
+class Foo[
+    F[_]: Bar: Sync: ExecuteUnsafe,
+    T
+]
+<<< #1249 fold
+maxColumn = 30
+newlines.beforeTypeBounds = fold
+===
+class Foo[
+  F[_] : Bar
+       : Sync : ExecuteUnsafe,
+  T
+]
+>>>
+class Foo[
+    F[_]: Bar: Sync: ExecuteUnsafe,
+    T
+]
+<<< #1249 unfold
+maxColumn = 30
+newlines.beforeTypeBounds = unfold
+===
+class Foo[
+  F[_] : Bar
+       : Sync : ExecuteUnsafe,
+  T
+]
+>>>
+class Foo[
+    F[_]: Bar: Sync: ExecuteUnsafe,
+    T
+]
+<<< #1249 keep
+maxColumn = 30
+newlines.beforeTypeBounds = keep
+===
+class Foo[
+  F[_] : Bar
+       : Sync : ExecuteUnsafe,
+  T
+]
+>>>
+class Foo[
+    F[_]: Bar: Sync: ExecuteUnsafe,
+    T
+]
+<<< #1342 classic
+object TestScalafmt {
+  def sayHi[
+      T: HasContextA: HasContextB: HasContextB: HasContextB
+      : HasContextB: HasContextB: HasContextB: HasContextB:
+       HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
+      name: String): Unit =
+    s"my name is $name"
+}
+>>>
+object TestScalafmt {
+  def sayHi[
+      T: HasContextA: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
+      name: String): Unit =
+    s"my name is $name"
+}
+<<< #1342 fold
+newlines.beforeTypeBounds = fold
+===
+object TestScalafmt {
+  def sayHi[
+      T: HasContextA: HasContextB: HasContextB: HasContextB
+      : HasContextB: HasContextB: HasContextB: HasContextB:
+       HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
+      name: String): Unit =
+    s"my name is $name"
+}
+>>>
+object TestScalafmt {
+  def sayHi[
+      T: HasContextA: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
+      name: String): Unit =
+    s"my name is $name"
+}
+<<< #1342 unfold
+newlines.beforeTypeBounds = unfold
+===
+object TestScalafmt {
+  def sayHi[
+      T: HasContextA: HasContextB: HasContextB: HasContextB
+      : HasContextB: HasContextB: HasContextB: HasContextB:
+       HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
+      name: String): Unit =
+    s"my name is $name"
+}
+>>>
+object TestScalafmt {
+  def sayHi[
+      T: HasContextA: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
+      name: String): Unit =
+    s"my name is $name"
+}
+<<< #1342 keep
+newlines.beforeTypeBounds = keep
+===
+object TestScalafmt {
+  def sayHi[
+      T: HasContextA: HasContextB: HasContextB: HasContextB
+      : HasContextB: HasContextB: HasContextB: HasContextB:
+       HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
+      name: String): Unit =
+    s"my name is $name"
+}
+>>>
+object TestScalafmt {
+  def sayHi[
+      T: HasContextA: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
+      name: String): Unit =
+    s"my name is $name"
+}
+<<< type inside block longer, classic
+maxColumn = 60
+align.preset = none
+===
+object a {
+  def foo[
+     AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd] <% CCCCCC[cccccc]
+       <% DDDDDD[dddddd] : CCCCCC[cccccc] : DDDDDD[dddddd],
+     AAAAAAAAAAAAA >: CCCCCCCC[cccccccc]
+       <: DDDDDDDD[dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[dddddddd]
+       : CCCCCCCC[cccccccc] : DDDDDDDD[dddddddd]
+  ] = ???
+}
+>>>
+object a {
+  def foo[
+      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
+          dddddd] <% CCCCCC[cccccc] <% DDDDDD[
+          dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
+      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
+          dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
+          dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
+  ] = ???
+}
+<<< type inside block longer, keep
+maxColumn = 60
+align.preset = none
+newlines.beforeTypeBounds = keep
+===
+object a {
+  def foo[
+     AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd] <% CCCCCC[cccccc]
+       <% DDDDDD[dddddd] : CCCCCC[cccccc] : DDDDDD[dddddd],
+     AAAAAAAAAAAAA >: CCCCCCCC[cccccccc]
+       <: DDDDDDDD[dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[dddddddd]
+       : CCCCCCCC[cccccccc] : DDDDDDDD[dddddddd]
+  ] = ???
+}
+>>>
+object a {
+  def foo[
+      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
+          dddddd] <% CCCCCC[cccccc] <% DDDDDD[
+          dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
+      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
+          dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
+          dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
+  ] = ???
+}
+<<< type inside block longer, fold
+maxColumn = 60
+align.preset = none
+newlines.beforeTypeBounds = fold
+===
+object a {
+  def foo[
+     AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd] <% CCCCCC[cccccc]
+       <% DDDDDD[dddddd] : CCCCCC[cccccc] : DDDDDD[dddddd],
+     AAAAAAAAAAAAA >: CCCCCCCC[cccccccc]
+       <: DDDDDDDD[dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[dddddddd]
+       : CCCCCCCC[cccccccc] : DDDDDDDD[dddddddd]
+  ] = ???
+}
+>>>
+object a {
+  def foo[
+      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
+          dddddd] <% CCCCCC[cccccc] <% DDDDDD[
+          dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
+      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
+          dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
+          dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
+  ] = ???
+}
+<<< type inside block longer, unfold
+maxColumn = 60
+align.preset = none
+newlines.beforeTypeBounds = unfold
+===
+object a {
+  def foo[
+     AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd] <% CCCCCC[cccccc]
+       <% DDDDDD[dddddd] : CCCCCC[cccccc] : DDDDDD[dddddd],
+     AAAAAAAAAAAAA >: CCCCCCCC[cccccccc]
+       <: DDDDDDDD[dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[dddddddd]
+       : CCCCCCCC[cccccccc] : DDDDDDDD[dddddddd]
+  ] = ???
+}
+>>>
+object a {
+  def foo[
+      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
+          dddddd] <% CCCCCC[cccccc] <% DDDDDD[
+          dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
+      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
+          dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
+          dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
+  ] = ???
+}

--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -95,7 +95,8 @@ class Foo[
 ]
 >>>
 class Foo[
-    F[_]: Bar: Sync: ExecuteUnsafe,
+    F[_]: Bar: Sync
+      : ExecuteUnsafe,
     T
 ]
 <<< #1249 unfold
@@ -109,7 +110,10 @@ class Foo[
 ]
 >>>
 class Foo[
-    F[_]: Bar: Sync: ExecuteUnsafe,
+    F[_]
+      : Bar
+      : Sync
+      : ExecuteUnsafe,
     T
 ]
 <<< #1249 keep
@@ -123,7 +127,8 @@ class Foo[
 ]
 >>>
 class Foo[
-    F[_]: Bar: Sync: ExecuteUnsafe,
+    F[_]: Bar
+      : Sync: ExecuteUnsafe,
     T
 ]
 <<< #1342 classic
@@ -155,9 +160,9 @@ object TestScalafmt {
 }
 >>>
 object TestScalafmt {
-  def sayHi[
-      T: HasContextA: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
-      name: String): Unit =
+  def sayHi[T: HasContextA: HasContextB: HasContextB: HasContextB: HasContextB
+    : HasContextB: HasContextB: HasContextB: HasContextB: HasContextB
+    : HasContextB: HasContextB: HasContextB](name: String): Unit =
     s"my name is $name"
 }
 <<< #1342 unfold
@@ -173,9 +178,20 @@ object TestScalafmt {
 }
 >>>
 object TestScalafmt {
-  def sayHi[
-      T: HasContextA: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
-      name: String): Unit =
+  def sayHi[T
+    : HasContextA
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB
+    : HasContextB](name: String): Unit =
     s"my name is $name"
 }
 <<< #1342 keep
@@ -191,9 +207,9 @@ object TestScalafmt {
 }
 >>>
 object TestScalafmt {
-  def sayHi[
-      T: HasContextA: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB: HasContextB](
-      name: String): Unit =
+  def sayHi[T: HasContextA: HasContextB: HasContextB: HasContextB
+    : HasContextB: HasContextB: HasContextB: HasContextB: HasContextB
+    : HasContextB: HasContextB: HasContextB: HasContextB](name: String): Unit =
     s"my name is $name"
 }
 <<< type inside block longer, classic
@@ -238,11 +254,12 @@ object a {
 object a {
   def foo[
       AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
-          dddddd] <% CCCCCC[cccccc] <% DDDDDD[
-          dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
+          dddddd] <% CCCCCC[cccccc] <% DDDDDD[dddddd]
+        : CCCCCC[cccccc]: DDDDDD[dddddd],
       AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
           dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
-          dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
+          dddddddd]
+        : CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
   ] = ???
 }
 <<< type inside block longer, fold
@@ -263,8 +280,8 @@ object a {
 object a {
   def foo[
       AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
-          dddddd] <% CCCCCC[cccccc] <% DDDDDD[
-          dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
+          dddddd] <% CCCCCC[cccccc] <% DDDDDD[dddddd]
+        : CCCCCC[cccccc]: DDDDDD[dddddd],
       AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
           dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
           dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
@@ -288,8 +305,9 @@ object a {
 object a {
   def foo[
       AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
-          dddddd] <% CCCCCC[cccccc] <% DDDDDD[
-          dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
+          dddddd] <% CCCCCC[cccccc] <% DDDDDD[dddddd]
+        : CCCCCC[cccccc]
+        : DDDDDD[dddddd],
       AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
           dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
           dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]

--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -256,8 +256,8 @@ object a {
       AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd]
         <% CCCCCC[cccccc]
         <% DDDDDD[dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
-      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
-          dddddddd] <% CCCCCCCC[cccccccc]
+      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc]
+        <: DDDDDDDD[dddddddd] <% CCCCCCCC[cccccccc]
         <% DDDDDDDD[dddddddd]
         : CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
   ] = ???
@@ -282,8 +282,8 @@ object a {
       AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd]
         <% CCCCCC[cccccc] <% DDDDDD[dddddd]: CCCCCC[cccccc]
         : DDDDDD[dddddd],
-      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
-          dddddddd] <% CCCCCCCC[cccccccc]
+      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc]
+        <: DDDDDDDD[dddddddd] <% CCCCCCCC[cccccccc]
         <% DDDDDDDD[dddddddd]: CCCCCCCC[cccccccc]
         : DDDDDDDD[dddddddd]
   ] = ???
@@ -305,13 +305,16 @@ object a {
 >>>
 object a {
   def foo[
-      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd]
+      AAAAAAAAAAAAA
+        >: CCCCCC[cccccc]
+        <: DDDDDD[dddddd]
         <% CCCCCC[cccccc]
         <% DDDDDD[dddddd]
         : CCCCCC[cccccc]
         : DDDDDD[dddddd],
-      AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
-          dddddddd]
+      AAAAAAAAAAAAA
+        >: CCCCCCCC[cccccccc]
+        <: DDDDDDDD[dddddddd]
         <% CCCCCCCC[cccccccc]
         <% DDDDDDDD[dddddddd]
         : CCCCCCCC[cccccccc]

--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -253,12 +253,12 @@ object a {
 >>>
 object a {
   def foo[
-      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
-          dddddd] <% CCCCCC[cccccc] <% DDDDDD[dddddd]
-        : CCCCCC[cccccc]: DDDDDD[dddddd],
+      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd]
+        <% CCCCCC[cccccc]
+        <% DDDDDD[dddddd]: CCCCCC[cccccc]: DDDDDD[dddddd],
       AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
-          dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
-          dddddddd]
+          dddddddd] <% CCCCCCCC[cccccccc]
+        <% DDDDDDDD[dddddddd]
         : CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
   ] = ???
 }
@@ -279,12 +279,13 @@ object a {
 >>>
 object a {
   def foo[
-      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
-          dddddd] <% CCCCCC[cccccc] <% DDDDDD[dddddd]
-        : CCCCCC[cccccc]: DDDDDD[dddddd],
+      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd]
+        <% CCCCCC[cccccc] <% DDDDDD[dddddd]: CCCCCC[cccccc]
+        : DDDDDD[dddddd],
       AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
-          dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
-          dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
+          dddddddd] <% CCCCCCCC[cccccccc]
+        <% DDDDDDDD[dddddddd]: CCCCCCCC[cccccccc]
+        : DDDDDDDD[dddddddd]
   ] = ???
 }
 <<< type inside block longer, unfold
@@ -304,12 +305,16 @@ object a {
 >>>
 object a {
   def foo[
-      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[
-          dddddd] <% CCCCCC[cccccc] <% DDDDDD[dddddd]
+      AAAAAAAAAAAAA >: CCCCCC[cccccc] <: DDDDDD[dddddd]
+        <% CCCCCC[cccccc]
+        <% DDDDDD[dddddd]
         : CCCCCC[cccccc]
         : DDDDDD[dddddd],
       AAAAAAAAAAAAA >: CCCCCCCC[cccccccc] <: DDDDDDDD[
-          dddddddd] <% CCCCCCCC[cccccccc] <% DDDDDDDD[
-          dddddddd]: CCCCCCCC[cccccccc]: DDDDDDDD[dddddddd]
+          dddddddd]
+        <% CCCCCCCC[cccccccc]
+        <% DDDDDDDD[dddddddd]
+        : CCCCCCCC[cccccccc]
+        : DDDDDDDD[dddddddd]
   ] = ???
 }

--- a/scalafmt-tests/src/test/resources/scala3/MatchType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/MatchType.stat
@@ -44,6 +44,7 @@ type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
 }
 <<< long type bound match type
 maxColumn = 40
+newlines.beforeTypeBounds = fold
 ===
 type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
            case Unit => 
@@ -59,7 +60,8 @@ type Concat[X <: Tuple, Y <: Tuple]
   case x1 *: xs1 =>
     x1 *: Concat[xs1, Y]
 }
-<<< even longer type bound 
+<<< even longer type bound
+newlines.beforeTypeBounds = fold
 maxColumn = 40
 ===
 type Concat[X, Y] <: TupleTupleTupleTupleTupleTupleTuple = X match {

--- a/scalafmt-tests/src/test/resources/scala3/OpaqueType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OpaqueType.stat
@@ -12,6 +12,7 @@ opaque type HelloIAmAnOpaqueTypeTerry =
   NiceToMeetYouTerry
 <<< opaque type bounds
 maxColumn = 15
+newlines.beforeTypeBounds = fold
 ===
 opaque type VeryLongClassName <: AType = AB
 >>>

--- a/scalafmt-tests/src/test/resources/scala3/UnionIntersectionType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/UnionIntersectionType.stat
@@ -131,6 +131,7 @@ def hello(
 }
 <<< opaque type bounds
 maxColumn = 20
+newlines.beforeTypeBounds = unfold
 ===
 opaque type VeryLongClassName <: Alpha & Beta & Gamma = AB
 >>>
@@ -139,6 +140,7 @@ opaque type VeryLongClassName
     Gamma = AB
 <<< single split type bounds
 maxColumn = 20
+newlines.beforeTypeBounds = unfold
 ===
 opaque type VeryLongClassName <: Alpha & Beta = AB
 >>>
@@ -147,6 +149,7 @@ opaque type VeryLongClassName
   AB
 <<< single split type decl bounds
 maxColumn = 20
+newlines.beforeTypeBounds = fold
 ===
 type VeryLongClassName <: Alpha & Beta
 >>>


### PR DESCRIPTION
Fixes #1249. Follow-on to #2351.