### PR TITLE
BFS: keep policies and indents for provided splits

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/ExpandImportSelectors.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/ExpandImportSelectors.stat
@@ -65,13 +65,15 @@ object blah {
     baz
   }
 }
-
 >>>
 object blah {
   // format: off
   import a.{
     // format: on
-    foo => bar, zzzz => _, baz}
+    foo => bar,
+    zzzz => _,
+    baz
+  }
 }
 <<< rename/unimport (partial format:off 2)
 object blah {

--- a/scalafmt-tests/src/test/resources/rewrite/SortImports.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/SortImports.stat
@@ -41,6 +41,11 @@ import a.b.{
 object a {
 import a.b.{
   c,
+// format is not off
+  b
+}
+import a.b.{
+  c,
 // format: off
   b
 }
@@ -48,6 +53,11 @@ import a.b.{
 
 >>>
 object a {
+  import a.b.{
+    b,
+// format is not off
+    c
+  }
   import a.b.{
     c,
 // format: off

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -127,3 +127,68 @@ package a.b.c
   */
 
 import d.e.f
+<<< rename/unimport (partial format:off 1)
+object blah {
+  // format: off
+  import a.{
+    // format: on
+    foo => bar,
+    zzzz => _,
+    baz
+  }
+  // format is not off
+  import a.{
+    // format is not on
+    foo => bar,
+    zzzz => _,
+    baz
+  }
+}
+>>>
+object blah {
+  // format: off
+  import a.{
+    // format: on
+    foo => bar, zzzz => _, baz}
+  // format is not off
+  import a.{
+    // format is not on
+    foo => bar,
+    zzzz => _,
+    baz
+  }
+}
+<<< rename/unimport (partial format:off 2)
+object blah {
+  import a.{
+    // format: off
+    foo => bar,
+    zzzz => _,
+    // format: on
+    baz
+  }
+  import a.{
+    // format is not off
+    foo => bar,
+    zzzz => _,
+    // format is not on
+    baz
+  }
+}
+>>>
+object blah {
+  import a.{
+    // format: off
+    foo => bar,
+    zzzz => _,
+    // format: on
+    baz
+  }
+  import a.{
+    // format is not off
+    foo => bar,
+    zzzz => _,
+    // format is not on
+    baz
+  }
+}

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -149,7 +149,10 @@ object blah {
   // format: off
   import a.{
     // format: on
-    foo => bar, zzzz => _, baz}
+    foo => bar,
+    zzzz => _,
+    baz
+  }
   // format is not off
   import a.{
     // format is not on


### PR DESCRIPTION
Otherwise, we were using an incorrect split which doesn't work outside of the `format:off` area, by losing any policies and indents the original split had.

We now also no longer need the special handling of `{...}`.

In `scala-repos`, only one file is modified, one that `scalafmt` couldn't format before.