### PR TITLE
State: move format:off detection to FormatToken

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -238,7 +238,7 @@ private class BestFirstSearch private (
 
   private def getActiveSplits(state: State, maxCost: Int): Seq[Split] = {
     val ft = tokens(state.depth)
-    val useProvided = state.formatOff || !ft.inside(range)
+    val useProvided = ft.meta.formatOff || !ft.inside(range)
     val active = state.policy
       .execute(Decision(ft, routes(state.depth)))
       .splits

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -53,10 +53,12 @@ object FormatToken {
 
   /** @param between The whitespace tokens between left and right.
     * @param idx The token's index in the FormatTokens array
+    * @param formatOff if true, between and right should not be formatted
     */
   case class Meta(
       between: Array[Token],
       idx: Int,
+      formatOff: Boolean,
       left: TokenMeta,
       right: TokenMeta
   ) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -4,6 +4,7 @@ import scala.meta.Tree
 import scala.meta.tokens.Token
 import scala.meta.tokens.Tokens
 
+import org.scalafmt.util.TokenOps
 import org.scalafmt.util.Whitespace
 
 class FormatTokens(val arr: Array[FormatToken])
@@ -48,12 +49,17 @@ object FormatTokens {
     var ftIdx = 0
     var wsIdx = 0
     var tokIdx = 0
+    var fmtWasOff = false
     val arr = tokens.toArray
     def process(right: Token): Unit = {
       val rmeta = FormatToken.TokenMeta(owner(right), right.syntax)
-      if (left ne null) {
-        val meta =
-          FormatToken.Meta(arr.slice(wsIdx, tokIdx), ftIdx, lmeta, rmeta)
+      if (left eq null) {
+        fmtWasOff = TokenOps.isFormatOff(right)
+      } else {
+        val between = arr.slice(wsIdx, tokIdx)
+        val fmtIsOff = fmtWasOff || TokenOps.isFormatOff(right)
+        fmtWasOff = if (fmtWasOff) !TokenOps.isFormatOn(right) else fmtIsOff
+        val meta = FormatToken.Meta(between, ftIdx, fmtIsOff, lmeta, rmeta)
         result += FormatToken(left, right, meta)
         ftIdx += 1
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -24,8 +24,7 @@ final case class State(
     pushes: Seq[ActualIndent],
     column: Int,
     allAltAreNL: Boolean,
-    delayedPenalty: Int, // apply if positive, ignore otherwise
-    formatOff: Boolean
+    delayedPenalty: Int // apply if positive, ignore otherwise
 ) {
 
   override def toString = s"State($cost, $depth)"
@@ -104,10 +103,6 @@ final case class State(
       }
     val splitWithPenalty = nextSplit.withPenalty(penalty)
 
-    val nextFormatOff =
-      if (formatOff) !TokenOps.isFormatOn(right)
-      else TokenOps.isFormatOff(right)
-
     State(
       cost + splitWithPenalty.cost,
       // TODO(olafur) expire policy, see #18.
@@ -119,8 +114,7 @@ final case class State(
       nextIndents,
       nextStateColumn,
       nextAllAltAreNL,
-      nextDelayedPenalty,
-      nextFormatOff
+      nextDelayedPenalty
     )
   }
 
@@ -270,8 +264,7 @@ object State {
     Seq.empty,
     0,
     false,
-    0,
-    formatOff = false
+    0
   )
 
   // this is not best state, it's higher priority for search

--- a/scalafmt-tests/src/test/resources/test/Unicode.stat
+++ b/scalafmt-tests/src/test/resources/test/Unicode.stat
@@ -23,7 +23,7 @@ object Foo {
 }
 >>>
 object Foo {
-  // format: off
+   // format: off
    val nbsp = "\u00A0"
    val test = s"${nbsp}\uD83D"
    // format: on


### PR DESCRIPTION
This logic does not depend on the splits (hence, no state dependency) and requires only access to the tokens.

Also, make sure that `format:off` applies to the split just before it while `format:on` only applies to the split just after it.