### PR TITLE
Remove paiges, which doesn't seem to be used anymore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,7 +208,6 @@ lazy val tests = project
     libraryDependencies ++= Seq(
       // Test dependencies
       "com.lihaoyi" %% "scalatags" % "0.9.4",
-      "org.typelevel" %% "paiges-core" % "0.3.0",
       scalametaTestkit,
       munit.value
     ),


### PR DESCRIPTION
Not sure why it was needed, but it might help us to get scalafmt on native if we remove it.