### PR TITLE
ScalafmtConfig: define a new `indent.main` parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,17 @@ top-level.
 
 ## Indentation
 
+### `indent.main`
+
+> Since v3.0.0.
+
+This parameter controls the primary code indentation. Various context-specific
+overrides are defined below, within this section.
+
+```scala mdoc:defaults
+indent.main
+```
+
 ### `indent.callSite`
 
 ```scala mdoc:defaults

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ top-level.
 
 ```
     preset = default
-    continuationIndent.defnSite = 2
+    indent.defnSite = 2
     optIn.configStyleArguments = false
 ```
 
@@ -114,7 +114,7 @@ top-level.
     preset = default
     binPack.preset = true
     align.ifWhileOpenParen = false
-    continuationIndent.callSite = 4
+    indent.callSite = 4
     docstrings.style = Asterisk
     importSelectors = binPack
     newlines {
@@ -130,16 +130,16 @@ top-level.
 
 ## Indentation
 
-### `continuationIndent.callSite`
+### `indent.callSite`
 
 ```scala mdoc:defaults
-continuationIndent.callSite
+indent.callSite
 ```
 
 Example:
 
 ```scala mdoc:scalafmt
-continuationIndent.callSite = 2
+indent.callSite = 2
 ---
 function(
 argument1, // indented by 2
@@ -147,31 +147,31 @@ argument1, // indented by 2
 )
 ```
 
-### `continuationIndent.defnSite`
+### `indent.defnSite`
 
 ```scala mdoc:defaults
-continuationIndent.defnSite
+indent.defnSite
 ```
 
-Same as `continuationIndent.callSite` except for definition site. Example:
+Same as `indent.callSite` except for definition site. Example:
 
 ```scala mdoc:scalafmt
-continuationIndent.defnSite = 4
+indent.defnSite = 4
 ---
 def function(
 argument1: Type1 // indented by 4
 ): ReturnType
 ```
 
-### `continuationIndent.ctorSite`
+### `indent.ctorSite`
 
 > Since v2.5.0.
 
-Applies to constructors. Defaults to `continuationIndent.defnSite`.
+Applies to constructors. Defaults to `indent.defnSite`.
 
 ```scala mdoc:scalafmt
-continuationIndent.ctorSite = 4
-continuationIndent.defnSite = 2
+indent.ctorSite = 4
+indent.defnSite = 2
 ---
 class A(
  field1: Type1 // indented by 4
@@ -182,19 +182,19 @@ class A(
 }
 ```
 
-### `continuationIndent.caseSite`
+### `indent.caseSite`
 
 > Since v3.0.0.
 
 Applies indentation to case values before arrow.
 
 ```scala mdoc:defaults
-continuationIndent.caseSite
+indent.caseSite
 ```
 
 ```scala mdoc:scalafmt
 maxColumn = 20
-continuationIndent.caseSite = 5
+indent.caseSite = 5
 ---
 x match {
   case _: Aaaaaa |
@@ -203,17 +203,17 @@ x match {
 }
 ```
 
-### `continuationIndent.extendSite`
+### `indent.extendSite`
 
 ```scala mdoc:defaults
-continuationIndent.extendSite
-continuationIndent.withSiteRelativeToExtends
+indent.extendSite
+indent.withSiteRelativeToExtends
 ```
 
 ```scala mdoc:scalafmt
-continuationIndent.extendSite = 4
+indent.extendSite = 4
 # this one added in v2.5.0
-continuationIndent.withSiteRelativeToExtends = 2
+indent.withSiteRelativeToExtends = 2
 maxColumn = 30
 ---
 trait Foo extends A with B with C with D with E {
@@ -221,21 +221,21 @@ trait Foo extends A with B with C with D with E {
 }
 ```
 
-### `continuationIndent.commaSiteRelativeToExtends`
+### `indent.commaSiteRelativeToExtends`
 
 > Since v3.0.0
 
 Added to support Scala 3, which allows to specify multiple parents with a comma.
 
 ```scala mdoc:defaults
-continuationIndent.extendSite
-continuationIndent.commaSiteRelativeToExtends
+indent.extendSite
+indent.commaSiteRelativeToExtends
 ```
 
 ```scala mdoc:scalafmt
 runner.dialect = scala3
-continuationIndent.extendSite = 4
-continuationIndent.commaSiteRelativeToExtends = 4
+indent.extendSite = 4
+indent.commaSiteRelativeToExtends = 4
 maxColumn = 20
 ---
 trait Foo extends A, B, C, D, E {
@@ -1400,7 +1400,7 @@ danglingParentheses.exclude
 ```
 
 ```scala mdoc:scalafmt
-continuationIndent.defnSite = 2
+indent.defnSite = 2
 danglingParentheses.defnSite = true
 danglingParentheses.exclude = [def]
 ---
@@ -1949,9 +1949,9 @@ method3(
 Since: v1.6.0.
 
 If enabled this formats methods such that parameters are on their own line
-indented by [`continuationIndent.defnSite`](#continuationindentdefnsite).
+indented by [`indent.defnSite`](#continuationindentdefnsite).
 Separation between parameter groups are indented by two spaces less than
-`continuationIndent.defnSite`. The return type is on its own line at the end.
+`indent.defnSite`. The return type is on its own line at the end.
 
 > This formatting is only triggered if the method definition exceeds the
 > maxColumn value in width or if the number of arguments to the method exceeds
@@ -1982,7 +1982,7 @@ verticalMultiline.newlineAfterOpenParen
 ```
 
 ```scala mdoc:scalafmt
-continuationIndent.defnSite = 2
+indent.defnSite = 2
 verticalMultiline.atDefnSite = true
 verticalMultiline.arityThreshold = 2
 verticalMultiline.newlineAfterOpenParen = true
@@ -2003,7 +2003,7 @@ verticalMultiline.excludeDanglingParens
 ```
 
 ```scala mdoc:scalafmt
-continuationIndent.defnSite = 2
+indent.defnSite = 2
 verticalMultiline.excludeDanglingParens = [def]
 verticalMultiline.atDefnSite = true
 verticalMultiline.arityThreshold = 2

--- a/readme/src/main/scala/org/scalafmt/readme/Readme.scala
+++ b/readme/src/main/scala/org/scalafmt/readme/Readme.scala
@@ -285,8 +285,7 @@ object Readme {
   )
 
   val multilineNewlineAfterParen = ScalafmtConfig.default.copy(
-    continuationIndent =
-      ScalafmtConfig.default.continuationIndent.copy(defnSite = 2),
+    indent = ScalafmtConfig.default.indent.copy(defnSite = 2),
     verticalMultiline = VerticalMultiline(
       atDefnSite = true,
       arityThreshold = 2,
@@ -295,8 +294,7 @@ object Readme {
   )
 
   val multilineDanglingParens = ScalafmtConfig.default.copy(
-    continuationIndent =
-      ScalafmtConfig.default.continuationIndent.copy(defnSite = 2),
+    indent = ScalafmtConfig.default.indent.copy(defnSite = 2),
     verticalMultiline = VerticalMultiline(
       atDefnSite = true,
       arityThreshold = 2,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
@@ -2,7 +2,8 @@ package org.scalafmt.config
 
 import metaconfig._
 
-/** @param defnSite indentation around class/def
+/** @param main the primary indentation used in the code
+  * @param defnSite indentation around class/def
   * @param ctorSite indentation around class constructor parameters
   * @param caseSite indentation for case values before arrow
   * @param callSite indentation around function calls, etc.
@@ -11,6 +12,7 @@ import metaconfig._
   * @param commaSiteRelativeToExtends additional indentation before in the line after extends with a comma
   */
 case class Indents(
+    main: Int = 2,
     callSite: Int = 2,
     defnSite: Int = 4,
     caseSite: Int = 4,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
@@ -10,7 +10,7 @@ import metaconfig._
   * @param withSiteRelativeToExtends additional indentation before `with`
   * @param commaSiteRelativeToExtends additional indentation before in the line after extends with a comma
   */
-case class ContinuationIndent(
+case class Indents(
     callSite: Int = 2,
     defnSite: Int = 4,
     caseSite: Int = 4,
@@ -20,7 +20,7 @@ case class ContinuationIndent(
     withSiteRelativeToExtends: Int = 0,
     commaSiteRelativeToExtends: Int = 2
 ) {
-  implicit val reader: ConfDecoder[ContinuationIndent] =
+  implicit val reader: ConfDecoder[Indents] =
     generic.deriveDecoder(this).noTypos
 
   def getDefnSite(tree: meta.Tree): Int =
@@ -30,9 +30,9 @@ case class ContinuationIndent(
     }).getOrElse(defnSite)
 }
 
-object ContinuationIndent {
-  implicit lazy val surface: generic.Surface[ContinuationIndent] =
+object Indents {
+  implicit lazy val surface: generic.Surface[Indents] =
     generic.deriveSurface
-  implicit lazy val encoder: ConfEncoder[ContinuationIndent] =
+  implicit lazy val encoder: ConfEncoder[Indents] =
     generic.deriveEncoder
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
@@ -14,7 +14,7 @@ case class Indents(
     callSite: Int = 2,
     defnSite: Int = 4,
     caseSite: Int = 4,
-    ctorSite: Option[Int] = None,
+    private[config] val ctorSite: Option[Int] = None,
     @annotation.ExtraName("deriveSite")
     extendSite: Int = 4,
     withSiteRelativeToExtends: Int = 0,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -381,6 +381,7 @@ object ScalafmtConfig {
         "binPack.unsafeXXX && newlines.implicitParamListModifierXXX (not implemented)"
       )
       checkPositive(
+        indent.main,
         indent.callSite,
         indent.defnSite,
         indent.commaSiteRelativeToExtends

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -105,7 +105,8 @@ case class ScalafmtConfig(
     comments: Comments = Comments(),
     optIn: OptIn = OptIn(),
     binPack: BinPack = BinPack(),
-    continuationIndent: ContinuationIndent = ContinuationIndent(),
+    @annotation.ExtraName("continuationIndent")
+    indent: Indents = Indents(),
     align: Align = Align(),
     spaces: Spaces = Spaces(),
     literals: Literals = Literals(),
@@ -151,7 +152,7 @@ case class ScalafmtConfig(
   private implicit def spacesReader = spaces.reader
   private implicit def literalsReader = literals.reader
   private implicit def xmlLiteralsDecoder = xmlLiterals.decoder
-  private implicit def continuationIndentReader = continuationIndent.reader
+  private implicit def indentReader = indent.reader
   private implicit def binpackReader = binPack.decoder
   private implicit def newlinesReader = newlines.reader
   private implicit def optInReader = optIn.reader
@@ -236,7 +237,7 @@ object ScalafmtConfig {
   val default = ScalafmtConfig()
 
   val intellij: ScalafmtConfig = default.copy(
-    continuationIndent = ContinuationIndent(2, 2),
+    indent = Indents(callSite = 2, defnSite = 2),
     align = default.align.copy(openParenCallSite = false),
     optIn = default.optIn.copy(
       configStyleArguments = false
@@ -261,7 +262,7 @@ object ScalafmtConfig {
       unsafeCallSite = true,
       parentConstructors = BinPack.ParentCtors.Always
     ),
-    continuationIndent = ContinuationIndent(4, 4),
+    indent = Indents(callSite = 4, defnSite = 4),
     importSelectors = ImportSelectors.binPack,
     newlines = default.newlines.copy(
       avoidInResultType = true,
@@ -379,7 +380,7 @@ object ScalafmtConfig {
         },
         "binPack.unsafeXXX && newlines.implicitParamListModifierXXX (not implemented)"
       )
-      addIfNegative(continuationIndent.callSite, continuationIndent.defnSite)
+      addIfNegative(indent.callSite, indent.defnSite)
     }
     if (allErrors.isEmpty) Configured.ok(cfg)
     else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -380,7 +380,19 @@ object ScalafmtConfig {
         },
         "binPack.unsafeXXX && newlines.implicitParamListModifierXXX (not implemented)"
       )
-      addIfNegative(indent.callSite, indent.defnSite)
+      checkPositive(
+        indent.callSite,
+        indent.defnSite,
+        indent.commaSiteRelativeToExtends
+      )
+      checkNonNeg(
+        indent.caseSite,
+        indent.extendSite,
+        indent.withSiteRelativeToExtends
+      )
+      checkPositiveOpt(
+        indent.ctorSite
+      )
     }
     if (allErrors.isEmpty) Configured.ok(cfg)
     else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -919,8 +919,8 @@ class FormatOps(
     leftOwner match {
       case x if isDefnSite(x) && !x.isInstanceOf[Type.Apply] =>
         if (style.binPack.unsafeDefnSite && !isConfigStyle) Num(0)
-        else Num(style.continuationIndent.getDefnSite(x))
-      case _ => Num(style.continuationIndent.callSite)
+        else Num(style.indent.getDefnSite(x))
+      case _ => Num(style.indent.callSite)
     }
 
   def isBinPack(owner: Tree): Boolean = {
@@ -1105,7 +1105,7 @@ class FormatOps(
 
     val FormatToken(open, r, _) = ft
     val close = matching(open)
-    val indentParam = Num(style.continuationIndent.getDefnSite(owner))
+    val indentParam = Num(style.indent.getDefnSite(owner))
     val indentSep = Num((indentParam.n - 2).max(0))
     val isBracket = open.is[T.LeftBracket]
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1809,7 +1809,8 @@ class FormatOps(
         style: ScalafmtConfig
     ): Split =
       asInfixApp(body).fold {
-        nlSplit.withIndent(Num(2), body.tokens.last, ExpiresOn.After)
+        val expire = body.tokens.last
+        nlSplit.withIndent(Num(style.indent.main), expire, ExpiresOn.After)
       }(app => InfixSplits(app, ft).withNLIndent(nlSplit))
 
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -555,10 +555,11 @@ class FormatOps(
     }
 
     private val fullIndent: Indent = {
-      val expire = assignBodyExpire.fold(fullExpire) { x =>
-        if (beforeLhs) x else fullExpire
+      val expire = assignBodyExpire match {
+        case Some(x) if beforeLhs => x
+        case _ => fullExpire
       }
-      Indent(Num(2), expire, ExpiresOn.After)
+      Indent(Num(style.indent.main), expire, ExpiresOn.After)
     }
 
     private val (nlIndent, nlPolicy) = {
@@ -656,8 +657,8 @@ class FormatOps(
         if (isFirstOp) (fullExpire, if (skip) Indent.Empty else fullIndent)
         else {
           val expire = expires.head._1
-          val indent =
-            if (skip) Indent.Empty else Indent(Num(2), expire, ExpiresOn.After)
+          val indentLen = if (skip) 0 else style.indent.main
+          val indent = Indent(Num(indentLen), expire, ExpiresOn.After)
           (expire, indent)
         }
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1879,7 +1879,7 @@ class FormatOps(
   )(implicit style: ScalafmtConfig): Seq[Split] = {
     val typeEnd = lastToken(typeOwner)
     val boundEnd = boundEndOpt.getOrElse(typeEnd)
-    def indent = Indent(Num(2), boundEnd, ExpiresOn.After)
+    def indent = Indent(Num(style.indent.main), boundEnd, ExpiresOn.After)
     def unfoldPolicy = typeOwner match {
       case tparam: Type.Param =>
         Policy.on(typeEnd) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -660,7 +660,7 @@ class Router(formatOps: FormatOps) {
           Seq(
             Split(Newline, 0)
               .withPolicyOpt(newlinePolicy)
-              .withIndent(style.continuationIndent.callSite, close, Before)
+              .withIndent(style.indent.callSite, close, Before)
           )
         else {
           val newlinePenalty = 3 + nestedApplies(leftOwner)
@@ -671,7 +671,7 @@ class Router(formatOps: FormatOps) {
             if (noMultiline) Split.ignored else multilineSpaceSplit,
             Split(Newline, newlinePenalty)
               .withPolicyOpt(newlinePolicy)
-              .withIndent(style.continuationIndent.callSite, close, Before)
+              .withIndent(style.indent.callSite, close, Before)
           )
         }
 
@@ -920,7 +920,7 @@ class Router(formatOps: FormatOps) {
           if style.binPack.unsafeDefnSite && isDefnSite(leftOwner) =>
         val close = matching(open)
         val isBracket = open.is[T.LeftBracket]
-        val indent = Num(style.continuationIndent.getDefnSite(leftOwner))
+        val indent = Num(style.indent.getDefnSite(leftOwner))
         if (isTuple(leftOwner)) {
           Seq(
             Split(NoSplit, 0).withPolicy(SingleLineBlock(close, okSLC = true))
@@ -1041,7 +1041,7 @@ class Router(formatOps: FormatOps) {
         val penalizeNewlines =
           PenalizeAllNewlines(expire, Constants.BracketPenalty)
         val sameLineSplit = Space(endsWithSymbolIdent(left))
-        val indent = style.continuationIndent.getDefnSite(leftOwner)
+        val indent = style.indent.getDefnSite(leftOwner)
         Seq(
           Split(sameLineSplit, 0).withPolicy(penalizeNewlines),
           // Spark style guide allows this:
@@ -1150,7 +1150,7 @@ class Router(formatOps: FormatOps) {
           case _ =>
             val indent = leftOwner match {
               case _: Defn.Val | _: Defn.Var =>
-                style.continuationIndent.getDefnSite(leftOwner)
+                style.indent.getDefnSite(leftOwner)
               case _ =>
                 0
             }
@@ -1435,7 +1435,7 @@ class Router(formatOps: FormatOps) {
         binPackParentConstructorSplits(
           Set(rightOwner),
           lastToken,
-          style.continuationIndent.extendSite,
+          style.indent.extendSite,
           enumCase.inits.length > 1
         )
 
@@ -1453,7 +1453,7 @@ class Router(formatOps: FormatOps) {
         binPackParentConstructorSplits(
           template.toSet,
           lastToken,
-          style.continuationIndent.extendSite,
+          style.indent.extendSite,
           template.exists(_.inits.length > 1)
         )
 
@@ -1467,7 +1467,7 @@ class Router(formatOps: FormatOps) {
         )
         val ident =
           if (firstDerives || isFirstInit(template, prevOwner))
-            style.continuationIndent.commaSiteRelativeToExtends
+            style.indent.commaSiteRelativeToExtends
           else 0
         typeTemplateSplits(template, ident, firstDerives)
 
@@ -1488,7 +1488,7 @@ class Router(formatOps: FormatOps) {
             val prev = prevNonComment(formatToken)
             val indent =
               if (!isFirstInit(template, prev.meta.leftOwner)) 0
-              else style.continuationIndent.withSiteRelativeToExtends
+              else style.indent.withSiteRelativeToExtends
             typeTemplateSplits(template, indent)
           case t @ WithChain(top) =>
             splitWithChain(
@@ -1497,7 +1497,7 @@ class Router(formatOps: FormatOps) {
               top.tokens.last
             )
           case enumCase: Defn.EnumCase =>
-            val indent = style.continuationIndent.withSiteRelativeToExtends
+            val indent = style.indent.withSiteRelativeToExtends
             val expire = enumCase.tokens.last
             Seq(
               Split(Space, 0).withIndent(indent, expire, ExpiresOn.After),
@@ -1519,14 +1519,14 @@ class Router(formatOps: FormatOps) {
           Seq(
             Split(NoSplit, 0).withSingleLine(close),
             Split(Newline, 1)
-              .withIndent(style.continuationIndent.callSite, close, Before)
+              .withIndent(style.indent.callSite, close, Before)
               .withPolicy(penalizeNewlines)
               .andPolicy(decideNewlinesOnlyBeforeClose(close))
           )
         else {
           val indent: Length =
             if (style.align.ifWhileOpenParen) StateColumn
-            else style.continuationIndent.callSite
+            else style.indent.callSite
           Seq(
             Split(NoSplit, 0)
               .withIndent(indent, close, Before)
@@ -1666,7 +1666,7 @@ class Router(formatOps: FormatOps) {
             else decideNewlinesOnlyBeforeClose(close)
           Split(Newline, cost)
             .withPolicy(policy)
-            .withIndent(style.continuationIndent.callSite, close, Before)
+            .withIndent(style.indent.callSite, close, Before)
         }
         if (isSingleLineComment(right))
           Seq(newlineSplit(0, isConfig))
@@ -1756,7 +1756,7 @@ class Router(formatOps: FormatOps) {
           Split(Space, 0, policy = policy)
             .withIndent(entireClauseIndent, expire, After)
             .withIndent(
-              style.continuationIndent.caseSite - entireClauseIndent,
+              style.indent.caseSite - entireClauseIndent,
               arrow,
               After
             )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -164,7 +164,7 @@ class Router(formatOps: FormatOps) {
           Split(Newline, 1)
             .onlyIf(style.importSelectors != ImportSelectors.singleLine)
             .withPolicy(newlinePolicy)
-            .withIndent(2, close, Before)
+            .withIndent(style.indent.main, close, Before)
         )
       case FormatToken(_, _: T.RightBrace, _)
           if existsParentOfType[ImportExportStat](rightOwner) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -105,11 +105,12 @@ class Router(formatOps: FormatOps) {
         val split = Split(NoSplit, 0).withPolicy(policy)
         Seq(
           if (getStripMarginChar(formatToken).isEmpty) split
-          else if (!style.align.stripMargin) split.withIndent(2, end, After)
-          else // statecolumn - 1 because of margin characters |
+          else if (style.align.stripMargin)
             split
               .withIndent(StateColumn, end, After)
-              .withIndent(-1, end, After)
+              .withIndent(-1, end, After) // -1 because of margin characters |
+          else
+            split.withIndent(style.indent.main, end, After)
         )
       // Interpolation
       case FormatToken(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1852,11 +1852,13 @@ class Router(formatOps: FormatOps) {
             (value == "&" && leftOwner.is[Type.And]) =>
         if (style.newlines.source eq Newlines.keep)
           Seq(Split(Space.orNL(newlines == 0), 0))
-        else
+        else {
+          val indent = style.indent.main
           Seq(
             Split(Space, 0),
-            Split(Newline, 1).withIndent(2, lastToken(leftOwner), After)
+            Split(Newline, 1).withIndent(indent, lastToken(leftOwner), After)
           )
+        }
 
       // Pattern alternatives
       case FormatToken(T.Ident("|"), _, _) if leftOwner.is[Pat.Alternative] =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -45,11 +45,6 @@ object Constants {
   val ExceedColumnPenalty = 1000
   // Breaking a line like s"aaaaaaa${111111 + 22222}" should be last resort.
   val BreakSingleLineInterpolatedString = 10 * ExceedColumnPenalty
-  // when converting new A with B with C to
-  // new A
-  //   with B
-  //   with C
-  val IndentForWithChains = 2
 }
 
 /** Assigns splits to format tokens.
@@ -2103,7 +2098,7 @@ class Router(formatOps: FormatOps) {
       binPackParentConstructorSplits(
         owners,
         lastToken,
-        IndentForWithChains,
+        style.indent.main,
         extendsThenWith
       )
     } else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/ValidationOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/ValidationOps.scala
@@ -4,12 +4,38 @@ import scala.collection.mutable
 
 object ValidationOps {
 
-  def addIfNegative(
+  def checkNonNeg(
       ns: sourcecode.Text[Int]*
   )(implicit errors: mutable.Buffer[String]): Unit =
     ns.foreach { n =>
       if (n.value < 0)
         errors += s"${n.source} must be non-negative, was ${n.value}"
+    }
+
+  def checkPositive(
+      ns: sourcecode.Text[Int]*
+  )(implicit errors: mutable.Buffer[String]): Unit =
+    ns.foreach { n =>
+      if (n.value <= 0)
+        errors += s"${n.source} must be positive, was ${n.value}"
+    }
+
+  def checkNonNegOpt(
+      ns: sourcecode.Text[Option[Int]]*
+  )(implicit errors: mutable.Buffer[String]): Unit =
+    ns.foreach { n =>
+      n.value.foreach { nv =>
+        if (nv < 0) errors += s"${n.source} must be non-negative, was $nv"
+      }
+    }
+
+  def checkPositiveOpt(
+      ns: sourcecode.Text[Option[Int]]*
+  )(implicit errors: mutable.Buffer[String]): Unit =
+    ns.foreach { n =>
+      n.value.foreach { nv =>
+        if (nv <= 0) errors += s"${n.source} must be positive, was $nv"
+      }
     }
 
   def addIf(

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflectConfig.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflectConfig.scala
@@ -27,15 +27,6 @@ class ScalafmtReflectConfig private[dynamic] (
 
   private val rewriteRulesMethod = Try(targetCls.getMethod("rewrite")).toOption
 
-  private val continuationIndentMethod =
-    Try(targetCls.getMethod("continuationIndent")).toOption
-  private val continuationIndentCallSiteMethod =
-    Try(targetCls.getMethod("continuationIndentCallSite")).toOption
-  private val continuationIndentDefnSiteMethod =
-    Try(targetCls.getMethod("continuationIndentDefnSite")).toOption
-  private val DefaultIndentCallSite = 2
-  private val DefaultIndentDefnSite = 4
-
   val version: String = {
     target.invokeAs[String]("version").trim
   }
@@ -84,36 +75,6 @@ class ScalafmtReflectConfig private[dynamic] (
         !rewriteSettings.invoke("rules").invokeAs[Boolean]("isEmpty")
       case None =>
         false
-    }
-  }
-
-  val continuationIndentCallSite: Int = {
-    continuationIndentMethod match {
-      case Some(method) => // scalafmt >= v0.4
-        val indentsObj = method.invoke(target)
-        indentsObj.invokeAs[Int]("callSite")
-      case None =>
-        continuationIndentCallSiteMethod match {
-          case Some(method) => // scalafmt >= v0.2.0
-            method.invoke(target).asInstanceOf[Int]
-          case None =>
-            DefaultIndentCallSite
-        }
-    }
-  }
-
-  val continuationIndentDefnSite: Int = {
-    continuationIndentMethod match {
-      case Some(method) =>
-        val indentsObj = method.invoke(target)
-        indentsObj.invokeAs[Int]("defnSite")
-      case None =>
-        continuationIndentDefnSiteMethod match {
-          case Some(method) =>
-            method.invoke(target).asInstanceOf[Int]
-          case None =>
-            DefaultIndentDefnSite
-        }
     }
   }
 

--- a/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
+++ b/scalafmt-tests/src/test/resources/align/AlignByRightName.stat
@@ -1,5 +1,7 @@
 align.preset = most
 <<< Align = with <-
+indent.main = 4
+===
 for {
   _ <- f1
   someValue <- f2
@@ -8,10 +10,10 @@ for {
 } yield ()
 >>>
 for {
-  _         <- f1
-  someValue <- f2
-  _          = doLogs
-  _         <- f3
+    _         <- f1
+    someValue <- f2
+    _          = doLogs
+    _         <- f3
 } yield ()
 <<< align sbt deps
 libraryDependencies ++= Seq(

--- a/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
+++ b/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
@@ -18,6 +18,7 @@ trait SampleTrait
 }
 <<< #370 scala211
 runner.dialect = scala211
+indent.main = 4
 ===
 trait SampleTrait extends A with B with C with D with E{
   self: LongNameMixin with B with C with D with EEEEEEEEE =>
@@ -29,8 +30,8 @@ trait SampleTrait
     extends A with B with C with D
     with E {
   self: LongNameMixin
-    with B with C with D
-    with EEEEEEEEE =>
+      with B with C with D
+      with EEEEEEEEE =>
 
   def foo: Boolean = true
 }

--- a/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
+++ b/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
@@ -29,9 +29,9 @@ trait SampleTrait extends A with B with C with D with E{
 trait SampleTrait
     extends A with B with C with D
     with E {
-  self: LongNameMixin
-      with B with C with D
-      with EEEEEEEEE =>
+    self: LongNameMixin
+        with B with C with D
+        with EEEEEEEEE =>
 
-  def foo: Boolean = true
+    def foo: Boolean = true
 }

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -326,8 +326,8 @@ case class Foo(
     ???
 }
 <<< #1487
-continuationIndent.defnSite = 2
-continuationIndent.ctorSite = 4
+indent.defnSite = 2
+indent.ctorSite = 4
 ===
 abstract class A(
  b: Int

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -185,7 +185,7 @@ else
   }
 <<< #1190 1 if
 danglingParentheses.ctrlSite = true
-continuationIndent.callSite = 2
+indent.callSite = 2
 maxColumn = 45
 ===
 object a {
@@ -215,7 +215,7 @@ object a {
 }
 <<< #1190 2 while
 danglingParentheses.ctrlSite = true
-continuationIndent.callSite = 2
+indent.callSite = 2
 maxColumn = 45
 ===
 object a {

--- a/scalafmt-tests/src/test/resources/default/Semicolon.stat
+++ b/scalafmt-tests/src/test/resources/default/Semicolon.stat
@@ -1,5 +1,7 @@
 80 columns                                                                     |
 <<< keep on single line, if possible
+indent.main = 4
+===
       text.charAt(pos) match {
         case '<' => handle("&lt;"); prev = pos + 1
         case '<' => handle("&lt;"); prev = pos + 1 // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -10,14 +12,14 @@
         }
 >>>
 text.charAt(pos) match {
-  case '<' => handle("&lt;"); prev = pos + 1
-  case '<' =>
-    handle("&lt;");
-    prev = pos + 1 // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  case '<' =>
-    handle("&lt;");
-    prev = pos + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  case '<' =>
-    handle("&lt;");
-    prev = pos + 1 // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    case '<' => handle("&lt;"); prev = pos + 1
+    case '<' =>
+        handle("&lt;");
+        prev = pos + 1 // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    case '<' =>
+        handle("&lt;");
+        prev = pos + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    case '<' =>
+        handle("&lt;");
+        prev = pos + 1 // aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 }

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -175,7 +175,7 @@ object a {
   }
 }
 <<< #1505 4
-continuationIndent.callSite = 2
+indent.callSite = 2
 newlines.avoidForSimpleOverflow = [toolong]
 ===
 object RemoteRestartedQuarantinedSpec extends MultiNodeConfig {

--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -305,20 +305,20 @@ object a {
 }
 >>>
 object a {
-  def foo[
-      AAAAAAAAAAAAA
-          >: CCCCCC[cccccc]
-          <: DDDDDD[dddddd]
-          <% CCCCCC[cccccc]
-          <% DDDDDD[dddddd]
-          : CCCCCC[cccccc]
-          : DDDDDD[dddddd],
-      AAAAAAAAAAAAA
-          >: CCCCCCCC[cccccccc]
-          <: DDDDDDDD[dddddddd]
-          <% CCCCCCCC[cccccccc]
-          <% DDDDDDDD[dddddddd]
-          : CCCCCCCC[cccccccc]
-          : DDDDDDDD[dddddddd]
-  ] = ???
+    def foo[
+        AAAAAAAAAAAAA
+            >: CCCCCC[cccccc]
+            <: DDDDDD[dddddd]
+            <% CCCCCC[cccccc]
+            <% DDDDDD[dddddd]
+            : CCCCCC[cccccc]
+            : DDDDDD[dddddd],
+        AAAAAAAAAAAAA
+            >: CCCCCCCC[cccccccc]
+            <: DDDDDDDD[dddddddd]
+            <% CCCCCCCC[cccccccc]
+            <% DDDDDDDD[dddddddd]
+            : CCCCCCCC[cccccccc]
+            : DDDDDDDD[dddddddd]
+    ] = ???
 }

--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -292,6 +292,7 @@ object a {
 maxColumn = 60
 align.preset = none
 newlines.beforeTypeBounds = unfold
+indent.main = 4
 ===
 object a {
   def foo[
@@ -306,18 +307,18 @@ object a {
 object a {
   def foo[
       AAAAAAAAAAAAA
-        >: CCCCCC[cccccc]
-        <: DDDDDD[dddddd]
-        <% CCCCCC[cccccc]
-        <% DDDDDD[dddddd]
-        : CCCCCC[cccccc]
-        : DDDDDD[dddddd],
+          >: CCCCCC[cccccc]
+          <: DDDDDD[dddddd]
+          <% CCCCCC[cccccc]
+          <% DDDDDD[dddddd]
+          : CCCCCC[cccccc]
+          : DDDDDD[dddddd],
       AAAAAAAAAAAAA
-        >: CCCCCCCC[cccccccc]
-        <: DDDDDDDD[dddddddd]
-        <% CCCCCCCC[cccccccc]
-        <% DDDDDDDD[dddddddd]
-        : CCCCCCCC[cccccccc]
-        : DDDDDDDD[dddddddd]
+          >: CCCCCCCC[cccccccc]
+          <: DDDDDDDD[dddddddd]
+          <% CCCCCCCC[cccccccc]
+          <% DDDDDDDD[dddddddd]
+          : CCCCCCCC[cccccccc]
+          : DDDDDDDD[dddddddd]
   ] = ???
 }

--- a/scalafmt-tests/src/test/resources/default/TypeWith.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeWith.stat
@@ -10,15 +10,17 @@
           PsiAnnotationOwner with PsiElement]): Option[PsiAnnotationOwner] = 1
 }
 <<< #1133
+indent.main = 4
+===
 implicit val catsStdInstancesForOption
    : Traverse[Option] with MonadError[Option, Unit] with Alternative[Option]
        with CommutativeMonad[Option] with CoflatMap[Option] = ???
 >>>
 implicit val catsStdInstancesForOption: Traverse[Option]
-  with MonadError[Option, Unit]
-  with Alternative[Option]
-  with CommutativeMonad[Option]
-  with CoflatMap[Option] = ???
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option] = ???
 <<< with-chain types #1125
 type RequiredServices = Bag with
   SomeOtherService.RequiredServices

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2377,6 +2377,8 @@ class Foo {
     .ddd()
 }
 <<< #1334 4: continue chain indent after a comment with apply, longer
+indent.main = 4
+===
 class Foo {
   val vv = v.aaa //
   .bbb() //
@@ -2386,9 +2388,9 @@ class Foo {
 >>>
 class Foo {
   val vv = v.aaa //
-    .bbb() //
-    .ccc() //
-    .ddd()
+      .bbb() //
+      .ccc() //
+      .ddd()
 }
 <<< #1334 5: select and a block apply after a comment
      val a: Vector[Array[Double]] = b.c

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1664,7 +1664,7 @@ val a =
 val a =
     1 + 2 * 3 && 4 ^ 5 || 6 op
         7 map {
-          8 % 9
+            8 % 9
         }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
@@ -1681,7 +1681,7 @@ val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 >>>
 val a =
    1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-     8 % 9
+      8 % 9
    }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
@@ -2390,10 +2390,10 @@ class Foo {
 }
 >>>
 class Foo {
-  val vv = v.aaa //
-      .bbb() //
-      .ccc() //
-      .ddd()
+    val vv = v.aaa //
+        .bbb() //
+        .ccc() //
+        .ddd()
 }
 <<< #1334 5: select and a block apply after a comment
      val a: Vector[Array[Double]] = b.c

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1653,6 +1653,8 @@ for {
     mean * mean / x
 }
 <<< 8.1: infix with longer left ||
+indent.main = 4
+===
 val a =
   1 + 2 * 3 && 4 ^ 5 || 6 op
     7 map {
@@ -1660,10 +1662,10 @@ val a =
     }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op
-    7 map {
-      8 % 9
-    }
+    1 + 2 * 3 && 4 ^ 5 || 6 op
+        7 map {
+          8 % 9
+        }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
 >>>
@@ -1673,13 +1675,14 @@ val a =
   }
 <<< 8.3: infix with longer left ||, narrow
 maxColumn = 20
+indent.main = 3
 ===
 val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-    8 % 9
-  }
+   1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+     8 % 9
+   }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2491,7 +2491,7 @@ object a {
 }
 <<< #1973 1
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   object Foo
@@ -2505,7 +2505,7 @@ object a {
 }
 <<< #1973 2
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   case class Foo(
@@ -2527,7 +2527,7 @@ object a {
 }
 <<< #1973 3
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   trait Foo

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1588,6 +1588,8 @@ val a = new A {
   def f = b
 }
 <<< 8.1: infix with longer left ||
+indent.main = 4
+===
 val a =
   1 + 2 * 3 && 4 ^ 5 || 6 op
     7 map {
@@ -1595,7 +1597,7 @@ val a =
     }
 >>>
 val a = 1 + 2 * 3 && 4 ^ 5 || 6 op
-  7 map { 8 % 9 }
+    7 map { 8 % 9 }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
 >>>
@@ -1603,13 +1605,15 @@ val a = 1 + 2 * 3 || 4 ^ 5 && 6 op
   7 map { 8 % 9 }
 <<< 8.3: infix with longer left ||, narrow
 maxColumn = 20
+indent.main = 3
 ===
 val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 >>>
-val a =
-  1 + 2 * 3 && 4 ^
-    5 || 6 op
-    7 map { 8 % 9 }
+val a = 1 +
+   2 * 3 && 4 ^ 5 ||
+   6 op 7 map {
+     8 % 9
+   }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2381,7 +2381,7 @@ object a {
 }
 <<< #1973 1
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   object Foo
@@ -2395,7 +2395,7 @@ object a {
 }
 <<< #1973 2
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   case class Foo(
@@ -2416,7 +2416,7 @@ object a {
 }
 <<< #1973 3
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   trait Foo

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2240,6 +2240,8 @@ class Foo {
     .ddd()
 }
 <<< #1334 4: continue chain indent after a comment with apply, longer
+indent.main = 4
+===
 class Foo {
   val vv = v.aaa //
   .bbb() //
@@ -2249,9 +2251,9 @@ class Foo {
 >>>
 class Foo {
   val vv = v.aaa //
-    .bbb() //
-    .ccc() //
-    .ddd()
+      .bbb() //
+      .ccc() //
+      .ddd()
 }
 <<< #1334 5: select and a block apply after a comment
      val a: Vector[Array[Double]] = b.c

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1612,7 +1612,7 @@ val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 val a = 1 +
    2 * 3 && 4 ^ 5 ||
    6 op 7 map {
-     8 % 9
+      8 % 9
    }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
@@ -2254,10 +2254,10 @@ class Foo {
 }
 >>>
 class Foo {
-  val vv = v.aaa //
-      .bbb() //
-      .ccc() //
-      .ddd()
+    val vv = v.aaa //
+        .bbb() //
+        .ccc() //
+        .ddd()
 }
 <<< #1334 5: select and a block apply after a comment
      val a: Vector[Array[Double]] = b.c

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2490,7 +2490,7 @@ object a {
 }
 <<< #1973 1
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   object Foo
@@ -2504,7 +2504,7 @@ object a {
 }
 <<< #1973 2
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   case class Foo(
@@ -2526,7 +2526,7 @@ object a {
 }
 <<< #1973 3
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   trait Foo

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1674,6 +1674,8 @@ val foo = Bar { () =>
   f(42)
 }
 <<< 8.1: infix with longer left ||
+indent.main = 4
+===
 val a =
   1 + 2 * 3 && 4 ^ 5 || 6 op
     7 map {
@@ -1681,10 +1683,10 @@ val a =
     }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op
-    7 map {
-      8 % 9
-    }
+    1 + 2 * 3 && 4 ^ 5 || 6 op
+        7 map {
+          8 % 9
+        }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
 >>>
@@ -1694,13 +1696,14 @@ val a =
   }
 <<< 8.3: infix with longer left ||, narrow
 maxColumn = 20
+indent.main = 3
 ===
 val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-    8 % 9
-  }
+   1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+     8 % 9
+   }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2376,6 +2376,8 @@ class Foo {
     .ddd()
 }
 <<< #1334 4: continue chain indent after a comment with apply, longer
+indent.main = 4
+===
 class Foo {
   val vv = v.aaa //
   .bbb() //
@@ -2385,9 +2387,9 @@ class Foo {
 >>>
 class Foo {
   val vv = v.aaa //
-    .bbb() //
-    .ccc() //
-    .ddd()
+      .bbb() //
+      .ccc() //
+      .ddd()
 }
 <<< #1334 5: select and a block apply after a comment
      val a: Vector[Array[Double]] = b.c

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1685,7 +1685,7 @@ val a =
 val a =
     1 + 2 * 3 && 4 ^ 5 || 6 op
         7 map {
-          8 % 9
+            8 % 9
         }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
@@ -1702,7 +1702,7 @@ val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 >>>
 val a =
    1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-     8 % 9
+      8 % 9
    }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
@@ -2389,10 +2389,10 @@ class Foo {
 }
 >>>
 class Foo {
-  val vv = v.aaa //
-      .bbb() //
-      .ccc() //
-      .ddd()
+    val vv = v.aaa //
+        .bbb() //
+        .ccc() //
+        .ddd()
 }
 <<< #1334 5: select and a block apply after a comment
      val a: Vector[Array[Double]] = b.c

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2615,7 +2615,7 @@ object a {
 }
 <<< #1973 1
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   object Foo
@@ -2629,7 +2629,7 @@ object a {
 }
 <<< #1973 2
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   case class Foo(
@@ -2651,7 +2651,7 @@ object a {
 }
 <<< #1973 3
 maxColumn = 25
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 ===
 object a {
   trait Foo

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2488,6 +2488,8 @@ class Foo {
     .ddd()
 }
 <<< #1334 4: continue chain indent after a comment with apply, longer
+indent.main = 4
+===
 class Foo {
   val vv = v.aaa //
   .bbb() //
@@ -2497,10 +2499,10 @@ class Foo {
 >>>
 class Foo {
   val vv = v
-    .aaa //
-    .bbb() //
-    .ccc() //
-    .ddd()
+      .aaa //
+      .bbb() //
+      .ccc() //
+      .ddd()
 }
 <<< #1334 5: select and a block apply after a comment
      val a: Vector[Array[Double]] = b.c

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1795,6 +1795,8 @@ val foo = Bar { () =>
   f(42)
 }
 <<< 8.1: infix with longer left ||
+indent.main = 4
+===
 val a =
   1 + 2 * 3 && 4 ^ 5 || 6 op
     7 map {
@@ -1802,9 +1804,9 @@ val a =
     }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-    8 % 9
-  }
+    1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
+      8 % 9
+    }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
 >>>
@@ -1814,15 +1816,16 @@ val a =
   }
 <<< 8.3: infix with longer left ||, narrow
 maxColumn = 20
+indent.main = 3
 ===
 val a = 1 + 2 * 3 && 4 ^ 5 || 6 op 7 map { 8 % 9 }
 >>>
 val a =
-  1 + 2 * 3 && 4 ^
-    5 || 6 op
-    7 map {
-      8 % 9
-    }
+   1 + 2 * 3 && 4 ^
+      5 || 6 op
+      7 map {
+        8 % 9
+      }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
 indentOperator.topLevelOnly = false

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1805,7 +1805,7 @@ val a =
 >>>
 val a =
     1 + 2 * 3 && 4 ^ 5 || 6 op 7 map {
-      8 % 9
+        8 % 9
     }
 <<< 8.2: infix with shorter left ||
 val a = 1 + 2 * 3 || 4 ^ 5 && 6 op 7 map { 8 % 9 }
@@ -1824,7 +1824,7 @@ val a =
    1 + 2 * 3 && 4 ^
       5 || 6 op
       7 map {
-        8 % 9
+         8 % 9
       }
 <<< 8.4: infix with shorter left ||, narrow
 maxColumn = 17
@@ -2501,11 +2501,11 @@ class Foo {
 }
 >>>
 class Foo {
-  val vv = v
-      .aaa //
-      .bbb() //
-      .ccc() //
-      .ddd()
+    val vv = v
+        .aaa //
+        .bbb() //
+        .ccc() //
+        .ddd()
 }
 <<< #1334 5: select and a block apply after a comment
      val a: Vector[Array[Double]] = b.c

--- a/scalafmt-tests/src/test/resources/scala3/Derives.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Derives.stat
@@ -165,9 +165,9 @@ class A(alphaParam : Int, betaParam : Int)  extends Alpha, Beta, Gamma, Delta, E
 class A(alphaParam: Int, betaParam: Int)
     extends Alpha, Beta, Gamma, Delta, Epsilon
     derives Alpha, Beta, Gamma, Delta, Epsilon
-<<< continuationIndent `deriveSite`
+<<< indent `deriveSite`
 binPack.parentConstructors = Oneline
-continuationIndent.deriveSite = 1
+indent.deriveSite = 1
 maxColumn = 50
 ===
 class A(alphaParam : Int, betaParam : Int)  extends Alpha, Beta, Gamma, Delta, Epsilon derives Alpha, Beta, Gamma, Delta, Epsilon

--- a/scalafmt-tests/src/test/resources/scala3/ExportGivens.stat
+++ b/scalafmt-tests/src/test/resources/scala3/ExportGivens.stat
@@ -36,20 +36,22 @@ export A.{
   given T3
 }
 <<< with wildcard argument
-maxColumn = 20
+maxColumn = 25
+indent.main = 4
 ===
 export Instances.{given Ordering[?], given ExecutionContext}
 >>>
 export Instances.{
-  given Ordering[?],
-  given ExecutionContext
+    given Ordering[?],
+    given ExecutionContext
 }
 <<< by-type mixed with by-name
-maxColumn = 20
+maxColumn = 25
+indent.main = 4
 ===
 export Instances.{im, given Ordering[?]}
 >>>
 export Instances.{
-  im,
-  given Ordering[?]
+    im,
+    given Ordering[?]
 }

--- a/scalafmt-tests/src/test/resources/scala3/ExtendsComma.stat
+++ b/scalafmt-tests/src/test/resources/scala3/ExtendsComma.stat
@@ -139,8 +139,8 @@ enum Enum2(val a: String, val b: String) {
       Y
 }
 <<< #143
-continuationIndent.commaSiteRelativeToExtends = 4
-continuationIndent.withSiteRelativeToExtends = 2
+indent.commaSiteRelativeToExtends = 4
+indent.withSiteRelativeToExtends = 2
 maxColumn = 30
 ===
 class A extends AVeryLongName1, AVeryLongName2, AVeryLongName3 { self: A with B with C with D with E =>

--- a/scalafmt-tests/src/test/resources/scala3/ExtendsComma.stat
+++ b/scalafmt-tests/src/test/resources/scala3/ExtendsComma.stat
@@ -151,11 +151,11 @@ class A
     extends AVeryLongName1,
         AVeryLongName2,
         AVeryLongName3 {
-  self: A
-     with B
-     with C
-     with D
-     with E =>
+   self: A
+      with B
+      with C
+      with D
+      with E =>
 }
 <<< comment between inits
 maxColumn = 30

--- a/scalafmt-tests/src/test/resources/scala3/ExtendsComma.stat
+++ b/scalafmt-tests/src/test/resources/scala3/ExtendsComma.stat
@@ -139,6 +139,7 @@ enum Enum2(val a: String, val b: String) {
       Y
 }
 <<< #143
+indent.main = 3
 indent.commaSiteRelativeToExtends = 4
 indent.withSiteRelativeToExtends = 2
 maxColumn = 30
@@ -151,10 +152,10 @@ class A
         AVeryLongName2,
         AVeryLongName3 {
   self: A
-    with B
-    with C
-    with D
-    with E =>
+     with B
+     with C
+     with D
+     with E =>
 }
 <<< comment between inits
 maxColumn = 30

--- a/scalafmt-tests/src/test/resources/scala3/Given.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Given.stat
@@ -25,14 +25,14 @@ given intOrd: Ord[Int]
     with Eq[T]
     with Sort[T]
     with {
-  def compare(
-      x: Int,
-      y: Int
-  ) = {
-    if (x < y) -1
-    else if (x > y) +1
-    else 0
-  }
+    def compare(
+        x: Int,
+        y: Int
+    ) = {
+        if (x < y) -1
+        else if (x > y) +1
+        else 0
+    }
 }
 <<< given with body and multi parents single line
 given intOrd: Ord[Int] with Eq[T] with Sort[T] with {}

--- a/scalafmt-tests/src/test/resources/scala3/Given.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Given.stat
@@ -216,7 +216,7 @@ given xx(using
     otherParameter: String)
     : Int = ???
 <<< dangling parens exclude
-continuationIndent.defnSite = 5
+indent.defnSite = 5
 danglingParentheses.defnSite = true
 danglingParentheses.exclude = [given]
 maxColumn = 30

--- a/scalafmt-tests/src/test/resources/scala3/Given.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Given.stat
@@ -17,13 +17,14 @@ object Order {
 }
 <<< given with body and multi parents
 maxColumn = 30
+indent.main = 4
 ===
 given intOrd: Ord[Int] with Eq[T] with Sort[T] with {def compare(x: Int, y: Int) = {if (x < y) -1 else if (x > y) +1 else 0 }}
 >>>
 given intOrd: Ord[Int]
-  with Eq[T]
-  with Sort[T]
-  with {
+    with Eq[T]
+    with Sort[T]
+    with {
   def compare(
       x: Int,
       y: Int

--- a/scalafmt-tests/src/test/resources/scala3/ImportingGivens.stat
+++ b/scalafmt-tests/src/test/resources/scala3/ImportingGivens.stat
@@ -36,20 +36,22 @@ import A.{
   given T3
 }
 <<< with wildcard argument
-maxColumn = 20
+maxColumn = 25
+indent.main = 4
 ===
 import Instances.{given Ordering[?], given ExecutionContext}
 >>>
 import Instances.{
-  given Ordering[?],
-  given ExecutionContext
+    given Ordering[?],
+    given ExecutionContext
 }
 <<< by-type mixed with by-name
-maxColumn = 20
+maxColumn = 25
+indent.main = 4
 ===
 import Instances.{im, given Ordering[?]}
 >>>
 import Instances.{
-  im,
-  given Ordering[?]
+    im,
+    given Ordering[?]
 }

--- a/scalafmt-tests/src/test/resources/scala3/MatchType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/MatchType.stat
@@ -45,6 +45,7 @@ type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
 <<< long type bound match type
 maxColumn = 40
 newlines.beforeTypeBounds = fold
+indent.main = 4
 ===
 type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
            case Unit => 
@@ -54,7 +55,7 @@ type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
          }
 >>>
 type Concat[X <: Tuple, Y <: Tuple]
-  <: Tuple = X match {
+    <: Tuple = X match {
   case Unit =>
     Y
   case x1 *: xs1 =>

--- a/scalafmt-tests/src/test/resources/scala3/MatchType.stat
+++ b/scalafmt-tests/src/test/resources/scala3/MatchType.stat
@@ -56,10 +56,10 @@ type Concat[X <: Tuple, Y <: Tuple] <: Tuple = X match {
 >>>
 type Concat[X <: Tuple, Y <: Tuple]
     <: Tuple = X match {
-  case Unit =>
-    Y
-  case x1 *: xs1 =>
-    x1 *: Concat[xs1, Y]
+    case Unit =>
+        Y
+    case x1 *: xs1 =>
+        x1 *: Concat[xs1, Y]
 }
 <<< even longer type bound
 newlines.beforeTypeBounds = fold

--- a/scalafmt-tests/src/test/resources/test/ContinuationIndent.stat
+++ b/scalafmt-tests/src/test/resources/test/ContinuationIndent.stat
@@ -1,7 +1,7 @@
-continuationIndent.callSite = 5
-continuationIndent.defnSite = 3
-continuationIndent.extendSite = 2
-continuationIndent.withSiteRelativeToExtends = 2
+indent.callSite = 5
+indent.defnSite = 3
+indent.extendSite = 2
+indent.withSiteRelativeToExtends = 2
 maxColumn = 39
 <<< #143
 def foo(
@@ -40,7 +40,7 @@ class ExtendTest
 }
 <<< comment between inits
 maxColumn = 30
-continuationIndent.withSiteRelativeToExtends = 2
+indent.withSiteRelativeToExtends = 2
 ===
 class A extends AVeryLongName1 /* comment */ with AVeryLongName2 with AVeryLongName3
 >>>

--- a/scalafmt-tests/src/test/resources/test/ContinuationIndentCaseSite0.stat
+++ b/scalafmt-tests/src/test/resources/test/ContinuationIndentCaseSite0.stat
@@ -1,4 +1,4 @@
-continuationIndent.caseSite = 0
+indent.caseSite = 0
 <<< Long if
 val Route: PartialFunction[Decision, Decision] = {
 case token if (token match { case Left("xml") => true; case Right(_) => false }) => List( NoSplit0 )

--- a/scalafmt-tests/src/test/resources/test/ContinuationIndentCaseSite1.stat
+++ b/scalafmt-tests/src/test/resources/test/ContinuationIndentCaseSite1.stat
@@ -1,4 +1,4 @@
-continuationIndent.caseSite = 1
+indent.caseSite = 1
 <<< Long if
 val Route: PartialFunction[Decision, Decision] = {
 case token if (token match { case Left("xml") => true; case Right(_) => false }) => List( NoSplit0 )

--- a/scalafmt-tests/src/test/resources/test/ContinuationIndentCaseSite5.stat
+++ b/scalafmt-tests/src/test/resources/test/ContinuationIndentCaseSite5.stat
@@ -1,4 +1,4 @@
-continuationIndent.caseSite = 5
+indent.caseSite = 5
 <<< Long if
 val Route: PartialFunction[Decision, Decision] = {
 case token if (token match { case Left("xml") => true; case Right(_) => false }) => List( NoSplit0 )

--- a/scalafmt-tests/src/test/resources/test/ContinuationIndentNoDanglingParens.stat
+++ b/scalafmt-tests/src/test/resources/test/ContinuationIndentNoDanglingParens.stat
@@ -1,6 +1,6 @@
-continuationIndent.callSite   = 2
-continuationIndent.defnSite   = 4
-continuationIndent.extendSite = 4
+indent.callSite   = 2
+indent.defnSite   = 4
+indent.extendSite = 4
 danglingParentheses.preset = false
 maxColumn = 50
 <<< Type Annotation Site

--- a/scalafmt-tests/src/test/resources/test/Dangling.stat
+++ b/scalafmt-tests/src/test/resources/test/Dangling.stat
@@ -1,6 +1,6 @@
 preset = intellij
 maxColumn = 40
-continuationIndent.callSite = 4
+indent.callSite = 4
 <<< single line still works
 function(aaaaaaaa, bbbbbbbb)
 >>>

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -76,6 +76,8 @@ val x = """Formatter changed AST
         """
   .stripMargin('?')
 <<< Align | margin 1 | interpolate, different char
+indent.main = 4
+===
 val x = s"""Formatter changed AST
       |=====================
       |$diff
@@ -90,8 +92,10 @@ val x = s"""Formatter changed AST
            ?=====================
            ?$diff
         """
-  .stripMargin('?')
+    .stripMargin('?')
 <<< Align | margin 1 | interpolate, different char, starts string
+indent.main = 4
+===
 val x = s"""?Formatter changed AST
       |=====================
       |$diff
@@ -106,9 +110,10 @@ val x = s"""?Formatter changed AST
             ?=====================
             ?$diff
         """
-  .stripMargin('?')
+    .stripMargin('?')
 <<< No align | margin 1 | interpolate, different char
 align.stripMargin = false
+indent.main = 4
 ===
 val x = f"""Formatter changed AST
       |=====================
@@ -121,10 +126,10 @@ val x = f"""Formatter changed AST
 val x = f"""Formatter changed AST
       |=====================
       |$diff
-  ?=====================
-  ?$diff
+    ?=====================
+    ?$diff
         """
-  .stripMargin('?')
+    .stripMargin('?')
 <<< No rewrite | margin 1 | interpolate, different char
 assumeStandardLibraryStripMargin = false
 ===
@@ -174,12 +179,13 @@ val x =
    |second""".stripMargin
 <<< pipe char on first line #324, no align
 align.stripMargin = false
+indent.main = 4
 ===
 """|first
   |second""".stripMargin
 >>>
 """|first
-  |second""".stripMargin
+    |second""".stripMargin
 <<< no align, complex interpolation
 align.stripMargin = false
 ===

--- a/scalafmt-tests/src/test/resources/test/arityThreshold.source
+++ b/scalafmt-tests/src/test/resources/test/arityThreshold.source
@@ -3,7 +3,7 @@ verticalMultiline = {
     atDefnSite = true
     arityThreshold = 2
 }
-continuationIndent.defnSite = 2
+indent.defnSite = 2
 <<< Verify that verticalMultiline.arityThreshold works as expected
 case class Foo(x: String)
 case class Bar(x: String, y: String)

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -151,17 +151,17 @@ object blah {
   // format: off
   import a.{
     // format: on
-      foo => bar,
-      zzzz => _,
-      baz
-  }
-  // format is not off
-  import a.{
-      // format is not on
-      foo => bar,
-      zzzz => _,
-      baz
-  }
+        foo => bar,
+        zzzz => _,
+        baz
+    }
+    // format is not off
+    import a.{
+        // format is not on
+        foo => bar,
+        zzzz => _,
+        baz
+    }
 }
 <<< rename/unimport (partial format:off 2)
 indent.main = 4
@@ -184,18 +184,18 @@ object blah {
 }
 >>>
 object blah {
-  import a.{
+    import a.{
     // format: off
     foo => bar,
     zzzz => _,
     // format: on
-      baz
-  }
-  import a.{
-      // format is not off
-      foo => bar,
-      zzzz => _,
-      // format is not on
-      baz
-  }
+        baz
+    }
+    import a.{
+        // format is not off
+        foo => bar,
+        zzzz => _,
+        // format is not on
+        baz
+    }
 }

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -128,6 +128,8 @@ package a.b.c
 
 import d.e.f
 <<< rename/unimport (partial format:off 1)
+indent.main = 4
+===
 object blah {
   // format: off
   import a.{
@@ -149,19 +151,21 @@ object blah {
   // format: off
   import a.{
     // format: on
-    foo => bar,
-    zzzz => _,
-    baz
+      foo => bar,
+      zzzz => _,
+      baz
   }
   // format is not off
   import a.{
-    // format is not on
-    foo => bar,
-    zzzz => _,
-    baz
+      // format is not on
+      foo => bar,
+      zzzz => _,
+      baz
   }
 }
 <<< rename/unimport (partial format:off 2)
+indent.main = 4
+===
 object blah {
   import a.{
     // format: off
@@ -185,13 +189,13 @@ object blah {
     foo => bar,
     zzzz => _,
     // format: on
-    baz
+      baz
   }
   import a.{
-    // format is not off
-    foo => bar,
-    zzzz => _,
-    // format is not on
-    baz
+      // format is not off
+      foo => bar,
+      zzzz => _,
+      // format is not on
+      baz
   }
 }

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -2,8 +2,8 @@ maxColumn = 80
 verticalMultiline = {
     atDefnSite = true
 }
-continuationIndent.defnSite = 2
-<<< Work with continuationIndent.defnSite = 2
+indent.defnSite = 2
+<<< Work with indent.defnSite = 2
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
 >>>
 def format_![T <: Tree](

--- a/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/afterImplicitKW.stat
@@ -1,8 +1,8 @@
 maxColumn = 80
 newlines.implicitParamListModifierForce = [after]
 verticalMultiline.atDefnSite = true
-continuationIndent.defnSite = 2
-continuationIndent.extendSite = 0
+indent.defnSite = 2
+indent.extendSite = 0
 
 <<< should add a newline after implicit keyword in function definitions
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String

--- a/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/beforeImplicitKW.stat
@@ -1,8 +1,8 @@
 maxColumn = 80
 newlines.implicitParamListModifierForce = [before,after]
 verticalMultiline.atDefnSite = true
-continuationIndent.defnSite = 2
-continuationIndent.extendSite = 0
+indent.defnSite = 2
+indent.extendSite = 0
 
 <<< should add a newline after implicit keyword in function definitions
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String

--- a/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/newlineAfterOpenParen.stat
@@ -1,5 +1,5 @@
 maxColumn = 80
-continuationIndent.defnSite = 2
+indent.defnSite = 2
 verticalMultiline = {
     atDefnSite = true
     arityThreshold = 2 // Used here to force reformatting.

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -2,7 +2,7 @@ verticalMultiline = {
     atDefnSite = true
 }
 maxColumn = 80
-continuationIndent.extendSite = 2
+indent.extendSite = 2
 <<< curried function over maxColumn
 def format_![T <: Tree](code: String, foo: Int)(f: A => B, k: D)(implicit ev: Parse[T], ev2: EC): String
 >>>

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDangling.source
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultilineDangling.source
@@ -1,5 +1,5 @@
 maxColumn = 80
-continuationIndent.defnSite = 2
+indent.defnSite = 2
 verticalMultiline = {
     atDefnSite = true
     arityThreshold = 2

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -281,10 +281,8 @@ class DynamicSuite extends FunSuite {
         |version=$latest
         |""".stripMargin
     )
-    f.assertThrows[ScalafmtDynamicError.ConfigParseError](
-      """|error: path/.scalafmt.conf: Invalid config: Invalid field: max. Expected one of version, maxColumn, docstrings, optIn, binPack, continuationIndent, align, spaces, literals, lineEndings, rewriteTokens, rewrite, indentOperator, newlines, runner, indentYieldKeyword, importSelectors, unindentTopLevelOperators, includeCurlyBraceInSelectChains, includeNoParensInSelectChains, assumeStandardLibraryStripMargin, danglingParentheses, poorMansTrailingCommasInConfigStyle, trailingCommas, verticalMultilineAtDefinitionSite, verticalMultilineAtDefinitionSiteArityThreshold, verticalMultiline, onTestFailure, encoding, project
-        |""".stripMargin
-    )
+    val thrown = f.assertThrows[ScalafmtDynamicError.ConfigParseError]()
+    assert(thrown.getMessage.contains("Invalid config: Invalid field: max."))
   }
 
   check("config-cache") { f =>
@@ -383,10 +381,8 @@ class DynamicSuite extends FunSuite {
 
   check("no-config") { f =>
     Files.delete(f.config)
-    f.assertThrows[ScalafmtDynamicError.ConfigDoesNotExist](
-      """|error: path/.scalafmt.conf: Missing config
-        |""".stripMargin
-    )
+    val thrown = f.assertThrows[ScalafmtDynamicError.ConfigDoesNotExist]()
+    assert(thrown.getMessage.contains("Missing config"))
   }
 
   check("intellij-default-config") { f: Format =>

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -12,7 +12,7 @@ import org.scalafmt.{Debug, Scalafmt}
 import org.scalafmt.config.FormatEvent._
 import org.scalafmt.config.{
   Config,
-  ContinuationIndent,
+  Indents,
   DanglingParentheses,
   ScalafmtConfig,
   ScalafmtRunner
@@ -227,7 +227,7 @@ object HasTests {
   )
 
   val unitTest80 = testing.copy(
-    continuationIndent = ContinuationIndent(4, 4)
+    indent = Indents(callSite = 4, defnSite = 4)
   )
 
   val unitTest40 = unitTest80.copy(maxColumn = 39)


### PR DESCRIPTION
Fixes #2385. Fixes #1493.