### PR TITLE
FormatOps: fix bug with space indent in ctrl body

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3187,3 +3187,53 @@ object a {
     )
   }
 }
+<<< #2400
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+>>>
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -3011,3 +3011,53 @@ object a {
   val bbb = c match { case _ => }
   bbb = c match { case _ => }
 }
+<<< #2400
+maxColumn = 25
+===
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+>>>
+class Test {
+  val a = foo(1, 2)
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3190,3 +3190,53 @@ object a {
       )
   )
 }
+<<< #2400
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+>>>
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+      111,
+      222
+    )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3226,9 +3226,9 @@ class Test {
     222
   )
   val a = /* c */ functionCall(
-      111,
-      222
-    )
+    111,
+    222
+  )
   val a = /* c */
     functionCall(
       111,

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3202,3 +3202,53 @@ object a {
       case _ =>
     }
 }
+<<< #2400
+maxColumn = 25
+===
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+>>>
+class Test {
+  val a = foo(1, 2)
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}


### PR DESCRIPTION
Some experimental and slightly convoluted logic remained which lead to an unnecessary indent in rare cases of def/val/case bodies.

P.S. `scala-repos` changes are exactly three expressions, all correctly reducing the unnecessary indent.
```
diff --git a/repos/intellij-scala/src/org/jetbrains/plugins/scala/annotator/importsTracker/ScalaRefC
ountHolder.scala b/repos/intellij-scala/src/org/jetbrains/plugins/scala/annotator/importsTracker/Sca
laRefCountHolder.scala
index cd29801c6f..cf4c05bb40 100644
--- a/repos/intellij-scala/src/org/jetbrains/plugins/scala/annotator/importsTracker/ScalaRefCountHol
der.scala
+++ b/repos/intellij-scala/src/org/jetbrains/plugins/scala/annotator/importsTracker/ScalaRefCountHol
der.scala
@@ -135,7 +135,7 @@ object ScalaRefCountHolder {
   def getInstance(file: PsiFile): ScalaRefCountHolder = {
     val myFile = /*Option(file.getViewProvider getPsi ScalaFileType.SCALA_LANGUAGE) getOrElse file
     val file2 = */ Option(
-        ScalaLanguageDerivative getScalaFileOnDerivative file) getOrElse file
+      ScalaLanguageDerivative getScalaFileOnDerivative file) getOrElse file
 
     Option(myFile getUserData SCALA_REF_COUNT_HOLDER_IN_FILE_KEY) getOrElse {
       myFile.asInstanceOf[UserDataHolderEx] putUserDataIfAbsent (
diff --git a/repos/intellij-scala/testdata/typeInference/bugs4/SCL3082.scala b/repos/intellij-scala/testdata/typeInference/bugs4/SCL3082.scala
index 1f23ec7e6e..5f4b8401bd 100644
--- a/repos/intellij-scala/testdata/typeInference/bugs4/SCL3082.scala
+++ b/repos/intellij-scala/testdata/typeInference/bugs4/SCL3082.scala
@@ -2,7 +2,7 @@ class Example {
   type PF[A, B] = PartialFunction[B, A]
 
   val x: PF[Int, String] = /*start*/ {
-      case x => x.length()
-    } /*end*/
+    case x => x.length()
+  } /*end*/
 }
 //PartialFunction[String, Int]
diff --git a/repos/scala/src/reflect/scala/reflect/internal/Symbols.scala b/repos/scala/src/reflect/scala/reflect/internal/Symbols.scala
index c6f894a9c2..52b9f57254 100644
--- a/repos/scala/src/reflect/scala/reflect/internal/Symbols.scala
+++ b/repos/scala/src/reflect/scala/reflect/internal/Symbols.scala
@@ -1011,9 +1011,9 @@ trait Symbols extends api.Symbols { self: SymbolTable =>
       *  unpleasantries like Predef.String, $iw.$iw.Foo and <empty>.Bippy.
       */
     final def isOmittablePrefix = /*!settings.debug.value &&*/ (
-        UnqualifiedOwners(skipPackageObject)
-          || isEmptyPrefix
-      )
+      UnqualifiedOwners(skipPackageObject)
+        || isEmptyPrefix
+    )
     def isEmptyPrefix =
       (
         isEffectiveRoot // has no prefix for real, <empty> or <root>
```