### PR TITLE
Router: force break before multiline assignments

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -256,8 +256,8 @@ case class Newlines(
     (beforeCurlyLambdaParams eq BeforeCurlyLambdaParams.always)
 
   lazy val getBeforeMultiline = beforeMultiline.getOrElse(source)
-  lazy val getBeforeMultilineDef = beforeMultilineDef.getOrElse {
-    if (alwaysBeforeMultilineDef) Newlines.unfold else getBeforeMultiline
+  lazy val getBeforeMultilineDef = beforeMultilineDef.orElse {
+    if (alwaysBeforeMultilineDef) Some(Newlines.unfold) else None
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -195,7 +195,7 @@ case class Newlines(
       "Use newlines.beforeMultiline, newlines.forceBeforeMultilineAssign instead",
       "3.0.0"
     )
-    private[config] val beforeMultilineDef: Option[SourceHints] = None,
+    beforeMultilineDef: Option[SourceHints] = None,
     afterInfix: Option[AfterInfix] = None,
     afterInfixBreakOnNested: Boolean = false,
     afterInfixMaxCountPerExprForSome: Int = 10,
@@ -268,8 +268,12 @@ case class Newlines(
     (beforeCurlyLambdaParams eq BeforeCurlyLambdaParams.always)
 
   lazy val getBeforeMultiline = beforeMultiline.getOrElse(source)
-  lazy val getBeforeMultilineDef = beforeMultilineDef.orElse {
-    if (alwaysBeforeMultilineDef) Some(Newlines.unfold) else None
+  lazy val shouldForceBeforeMultilineAssign = {
+    forceBeforeMultilineAssign.getOrElse {
+      if (alwaysBeforeMultilineDef || beforeMultilineDef.eq(Newlines.unfold))
+        ForceBeforeMultilineAssign.`def`
+      else ForceBeforeMultilineAssign.never
+    }
   }
 
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3273,18 +3273,21 @@ class Test {
 }
 >>>
 class Test {
-  val a = foo(
-    1,
-    2
-  )
-  val a = functionCall(
-    111,
-    222
-  )
-  val a = /* c */ functionCall(
-    111,
-    222
-  )
+  val a =
+    foo(
+      1,
+      2
+    )
+  val a =
+    functionCall(
+      111,
+      222
+    )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
   val a = /* c */
     functionCall(
       111,
@@ -3319,8 +3322,9 @@ class Test {
 }
 >>>
 class Test {
-  val foo = bar +
-    baz * qux + 1 + 2
+  val foo =
+    bar +
+      baz * qux + 1 + 2
 }
 <<< #2400 nesting forceBeforeMultilineAssign = topMember
 maxColumn = 27
@@ -3349,14 +3353,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3422,14 +3428,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3451,14 +3459,16 @@ package a {
           quxQux
         )
       new a with b {
-        val foo = barBar(
-          bazBaz,
-          quxQux
-        )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        val foo =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,
@@ -3495,14 +3505,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3510,28 +3522,32 @@ package a {
         )
     }
     def d = {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
           quxQux
         )
       new a with b {
-        val foo = barBar(
-          bazBaz,
-          quxQux
-        )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        val foo =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,
@@ -3572,10 +3588,11 @@ package a {
         bazBaz,
         quxQux
       )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3587,10 +3604,11 @@ package a {
         bazBaz,
         quxQux
       )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3601,10 +3619,11 @@ package a {
           bazBaz,
           quxQux
         )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3192,7 +3192,9 @@ object a {
     )
   }
 }
-<<< #2400
+<<< #2400 forceBeforeMultilineAssign = never
+newlines.forceBeforeMultilineAssign = never
+===
 class Test {
   val a = foo(
     1,
@@ -3241,4 +3243,447 @@ class Test {
       111,
       222
     )
+}
+<<< #2400 forceBeforeMultilineAssign = any
+newlines.forceBeforeMultilineAssign = any
+===
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+>>>
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+<<< #2400 infix forceBeforeMultilineAssign = never
+newlines.forceBeforeMultilineAssign = never
+maxColumn = 25
+===
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+>>>
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+<<< #2400 infix forceBeforeMultilineAssign = any
+newlines.forceBeforeMultilineAssign = any
+maxColumn = 25
+===
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+>>>
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+<<< #2400 nesting forceBeforeMultilineAssign = topMember
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = topMember
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = anyMember
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = anyMember
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = any
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = any
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = def
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = def
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = never
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = never
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -3017,7 +3017,8 @@ object a {
   val bbb = c match { case _ => }
   bbb = c match { case _ => }
 }
-<<< #2400
+<<< #2400 forceBeforeMultilineAssign = never
+newlines.forceBeforeMultilineAssign = never
 maxColumn = 25
 ===
 class Test {
@@ -3066,4 +3067,446 @@ class Test {
       111,
       222
     )
+}
+<<< #2400 forceBeforeMultilineAssign = any
+newlines.forceBeforeMultilineAssign = any
+maxColumn = 25
+===
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+>>>
+class Test {
+  val a = foo(1, 2)
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+<<< #2400 infix forceBeforeMultilineAssign = never
+newlines.forceBeforeMultilineAssign = never
+maxColumn = 25
+===
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+>>>
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+<<< #2400 infix forceBeforeMultilineAssign = any
+newlines.forceBeforeMultilineAssign = any
+maxColumn = 25
+===
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+>>>
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+<<< #2400 nesting forceBeforeMultilineAssign = topMember
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = topMember
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = anyMember
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = anyMember
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = any
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = any
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = def
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = def
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = never
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = never
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -3099,10 +3099,11 @@ class Test {
 >>>
 class Test {
   val a = foo(1, 2)
-  val a = functionCall(
-    111,
-    222
-  )
+  val a =
+    functionCall(
+      111,
+      222
+    )
   val a = /* c */
     functionCall(
       111,
@@ -3142,8 +3143,9 @@ class Test {
 }
 >>>
 class Test {
-  val foo = bar +
-    baz * qux + 1 + 2
+  val foo =
+    bar + baz * qux + 1 +
+      2
 }
 <<< #2400 nesting forceBeforeMultilineAssign = topMember
 maxColumn = 27
@@ -3172,14 +3174,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3245,14 +3249,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3274,14 +3280,16 @@ package a {
           quxQux
         )
       new a with b {
-        val foo = barBar(
-          bazBaz,
-          quxQux
-        )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        val foo =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,
@@ -3318,14 +3326,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3333,28 +3343,32 @@ package a {
         )
     }
     def d = {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
           quxQux
         )
       new a with b {
-        val foo = barBar(
-          bazBaz,
-          quxQux
-        )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        val foo =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,
@@ -3395,10 +3409,11 @@ package a {
         bazBaz,
         quxQux
       )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3410,10 +3425,11 @@ package a {
         bazBaz,
         quxQux
       )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3424,10 +3440,11 @@ package a {
           bazBaz,
           quxQux
         )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3195,7 +3195,9 @@ object a {
       )
   )
 }
-<<< #2400
+<<< #2400 forceBeforeMultilineAssign = never
+newlines.forceBeforeMultilineAssign = never
+===
 class Test {
   val a = foo(
     1,
@@ -3244,4 +3246,447 @@ class Test {
       111,
       222
     )
+}
+<<< #2400 forceBeforeMultilineAssign = any
+newlines.forceBeforeMultilineAssign = any
+===
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+>>>
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+<<< #2400 infix forceBeforeMultilineAssign = never
+newlines.forceBeforeMultilineAssign = never
+maxColumn = 25
+===
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+>>>
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+<<< #2400 infix forceBeforeMultilineAssign = any
+newlines.forceBeforeMultilineAssign = any
+maxColumn = 25
+===
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+>>>
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+<<< #2400 nesting forceBeforeMultilineAssign = topMember
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = topMember
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = anyMember
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = anyMember
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = any
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = any
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = def
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = def
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = never
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = never
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3276,18 +3276,21 @@ class Test {
 }
 >>>
 class Test {
-  val a = foo(
-    1,
-    2
-  )
-  val a = functionCall(
-    111,
-    222
-  )
-  val a = /* c */ functionCall(
-    111,
-    222
-  )
+  val a =
+    foo(
+      1,
+      2
+    )
+  val a =
+    functionCall(
+      111,
+      222
+    )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
   val a = /* c */
     functionCall(
       111,
@@ -3322,8 +3325,9 @@ class Test {
 }
 >>>
 class Test {
-  val foo = bar +
-    baz * qux + 1 + 2
+  val foo =
+    bar +
+      baz * qux + 1 + 2
 }
 <<< #2400 nesting forceBeforeMultilineAssign = topMember
 maxColumn = 27
@@ -3352,14 +3356,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3425,14 +3431,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3454,14 +3462,16 @@ package a {
           quxQux
         )
       new a with b {
-        val foo = barBar(
-          bazBaz,
-          quxQux
-        )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        val foo =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,
@@ -3498,14 +3508,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3513,28 +3525,32 @@ package a {
         )
     }
     def d = {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
           quxQux
         )
       new a with b {
-        val foo = barBar(
-          bazBaz,
-          quxQux
-        )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        val foo =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,
@@ -3575,10 +3591,11 @@ package a {
         bazBaz,
         quxQux
       )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3590,10 +3607,11 @@ package a {
         bazBaz,
         quxQux
       )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3604,10 +3622,11 @@ package a {
           bazBaz,
           quxQux
         )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2189,6 +2189,27 @@ object a {
 }
 >>>
 object a {
+  def `media-range-def` = rule {
+    "*/*" ~ push("*") ~ push("*") |
+      `type` ~ '/' ~
+      ('*' ~ !tchar ~ push("*") | subtype) | '*' ~ push("*") ~ push("*")
+  }
+}
+<<< 8.17 with explicit beforeMultilineDef
+maxColumn = 80
+newlines.beforeMultilineDef = unfold
+===
+object a {
+   def `media-range-def` =
+     rule {
+       "*/*" ~ push("*") ~ push("*") |
+        `type` ~ '/' ~
+        ('*' ~ !tchar ~ push("*") | subtype) |
+        '*' ~ push("*") ~ push("*")
+     }
+}
+>>>
+object a {
   def `media-range-def` =
     rule {
       "*/*" ~ push("*") ~ push("*") |
@@ -2224,11 +2245,10 @@ def `day-name` =
        "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
         "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6))
 >>>
-def `day-name` =
-  rule(
-    "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
-      "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6)
-  )
+def `day-name` = rule(
+  "Sun" ~ push(0) | "Mon" ~ push(1) | "Tue" ~ push(2) | "Wed" ~ push(3) |
+    "Thu" ~ push(4) | "Fri" ~ push(5) | "Sat" ~ push(6)
+)
 <<< 8.20
 maxColumn = 80
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3309,10 +3309,11 @@ class Test {
 >>>
 class Test {
   val a = foo(1, 2)
-  val a = functionCall(
-    111,
-    222
-  )
+  val a =
+    functionCall(
+      111,
+      222
+    )
   val a = /* c */
     functionCall(
       111,
@@ -3384,14 +3385,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3457,14 +3460,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3486,14 +3491,16 @@ package a {
           quxQux
         )
       new a with b {
-        val foo = barBar(
-          bazBaz,
-          quxQux
-        )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        val foo =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,
@@ -3530,14 +3537,16 @@ package a {
 package a {
   class b {
     class c {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3545,28 +3554,32 @@ package a {
         )
     }
     def d = {
-      val foo = barBar(
-        bazBaz,
-        quxQux
-      )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      val foo =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
           quxQux
         )
       new a with b {
-        val foo = barBar(
-          bazBaz,
-          quxQux
-        )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        val foo =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,
@@ -3607,10 +3620,11 @@ package a {
         bazBaz,
         quxQux
       )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3622,10 +3636,11 @@ package a {
         bazBaz,
         quxQux
       )
-      def foo() = barBar(
-        bazBaz,
-        quxQux
-      )
+      def foo() =
+        barBar(
+          bazBaz,
+          quxQux
+        )
       def foo(q: Int) =
         barBar(
           bazBaz,
@@ -3636,10 +3651,11 @@ package a {
           bazBaz,
           quxQux
         )
-        def foo() = barBar(
-          bazBaz,
-          quxQux
-        )
+        def foo() =
+          barBar(
+            bazBaz,
+            quxQux
+          )
         def foo(q: Int) =
           barBar(
             bazBaz,

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3227,7 +3227,8 @@ object a {
       case _ =>
     }
 }
-<<< #2400
+<<< #2400 forceBeforeMultilineAssign = never
+newlines.forceBeforeMultilineAssign = never
 maxColumn = 25
 ===
 class Test {
@@ -3277,3 +3278,448 @@ class Test {
       222
     )
 }
+<<< #2400 forceBeforeMultilineAssign = any
+newlines.forceBeforeMultilineAssign = any
+maxColumn = 25
+===
+class Test {
+  val a = foo(
+    1,
+    2
+  )
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */ functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+>>>
+class Test {
+  val a = foo(1, 2)
+  val a = functionCall(
+    111,
+    222
+  )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = /* c */
+    functionCall(
+      111,
+      222
+    )
+  val a = // c
+    functionCall(
+      111,
+      222
+    )
+}
+<<< #2400 infix forceBeforeMultilineAssign = never
+newlines.forceBeforeMultilineAssign = never
+maxColumn = 25
+===
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+>>>
+class Test {
+  val foo =
+    bar + baz * qux + 1 +
+      2
+}
+<<< #2400 infix forceBeforeMultilineAssign = any
+newlines.forceBeforeMultilineAssign = any
+maxColumn = 25
+===
+class Test {
+  val foo = bar +
+    baz * qux + 1 + 2
+}
+>>>
+class Test {
+  val foo =
+    bar + baz * qux + 1 +
+      2
+}
+<<< #2400 nesting forceBeforeMultilineAssign = topMember
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = topMember
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = anyMember
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = anyMember
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = any
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = any
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = def
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = def
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+<<< #2400 nesting forceBeforeMultilineAssign = never
+maxColumn = 27
+newlines.forceBeforeMultilineAssign = never
+===
+package a {
+  class b {
+    class c {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+    }
+    def d = {
+      val foo = barBar(bazBaz, quxQux)
+      def foo() = barBar(bazBaz, quxQux)
+      def foo(q: Int) = barBar(bazBaz, quxQux)
+      new a with b {
+        val foo = barBar(bazBaz, quxQux)
+        def foo() = barBar(bazBaz, quxQux)
+        def foo(q: Int) = barBar(bazBaz, quxQux)
+      }
+    }
+  }
+}
+>>>
+package a {
+  class b {
+    class c {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+    }
+    def d = {
+      val foo = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo() = barBar(
+        bazBaz,
+        quxQux
+      )
+      def foo(q: Int) =
+        barBar(
+          bazBaz,
+          quxQux
+        )
+      new a with b {
+        val foo = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo() = barBar(
+          bazBaz,
+          quxQux
+        )
+        def foo(q: Int) =
+          barBar(
+            bazBaz,
+            quxQux
+          )
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Expand the deprecated `alwaysBeforeMultilineDef` to have more granular control. Also, if the deprecated `beforeMultilineDef` is not explicitly specified, apply the behaviour of `beforeMultiline` parameter instead.

As discussed in #2400, the option to have consistent formatting is desirable. Fixes #2400.