### PR TITLE
[Scala 3] Add support for optional braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
@@ -88,10 +88,6 @@ object ScalafmtRunner {
       .withAllowTrailingCommas(true)
     val default = scala213
     val scala3 = Scala3
-      // Disable significant indentation because the exact syntax is still under
-      // development and is likely to change soon. See discussions at
-      // https://contributors.scala-lang.org/t/feedback-sought-optional-braces/4702
-      .withAllowSignificantIndentation(false)
 
     implicit lazy val decoder: ConfDecoder[Dialect] = {
       ReaderUtil.oneOf[Dialect](

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
@@ -21,6 +21,7 @@ object Keyword {
     token.is[KwObject] || token.is[KwOverride] || token.is[KwPackage] ||
     token.is[KwPrivate] || token.is[KwProtected] || token.is[KwReturn] ||
     token.is[KwSealed] || token.is[KwSuper] || token.is[KwThis] ||
+    token.is[KwThen] ||
     token.is[KwThrow] || token.is[KwTrait] || token.is[KwTrue] ||
     token.is[KwTry] || token.is[KwType] || token.is[KwVal] ||
     token.is[KwVar] || token.is[KwWhile] || token.is[KwWith] ||
@@ -117,4 +118,18 @@ class SoftKeywordClasses(dialect: Dialect) extends SoftKeywords(dialect) {
       tok.is[KwExtends] || tok.is[KwDerives]
     }
   }
+}
+
+/*
+=  =>  ?=>  <-  catch  do  else  finally  for
+if  match  return  then  throw  try  while  yield
+ */
+@classifier
+trait CanStartIndent {
+  def unapply(tok: Token): Boolean =
+    tok.is[Equals] || tok.is[RightArrow] || tok.is[ContextArrow] ||
+      tok.is[LeftArrow] || tok.is[KwCatch] || tok.is[KwDo] || tok.is[KwElse] ||
+      tok.is[KwElse] || tok.is[KwFinally] || tok.is[KwFor] || tok.is[KwMatch] ||
+      tok.is[KwReturn] || tok.is[KwThen] || tok.is[KwThrow] || tok.is[KwTry] ||
+      tok.is[KwWhile] || tok.is[KwYield]
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1,0 +1,112 @@
+
+<<< simple value equals
+val test = 
+    val a = ""
+     a  +    ""
+>>>
+val test =
+  val a = ""
+  a + ""
+<<< if else
+trait A:
+  val cond = if true then
+    stat1
+    stat2
+  else
+      stat3
+      stat4
+>>>
+trait A:
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+<<< object
+object Obj:
+  def hello = 
+      1
+       2
+>>>
+object Obj:
+  def hello =
+    1
+    2
+<<< object with braces
+object Obj{
+  def hello = 
+    1
+    2
+}
+>>>
+object Obj {
+  def hello =
+    1
+    2
+}
+<<< extension method
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) 
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](
+    a: Map[A, Foooooooooooooooo[B]]
+)
+  def add(b: A) = a + b
+  def add2(b: A) = a + b
+
+  def add3(b: A) = a + b
+<<< extension multi
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) (using b: Map[A, Foooooooooooooooo[B]])
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](
+    a: Map[A, Foooooooooooooooo[B]]
+)(using b: Map[A, Foooooooooooooooo[B]])
+  def add(b: A) = a + b
+  def add2(b: A) = a + b
+
+  def add3(b: A) = a + b
+<<< if(cond) indentation 
+trait A:
+  val cond =
+    if (true)
+        stat1
+         stat2
+    else
+       stat3
+       stat4
+>>>
+trait A:
+  val cond =
+    if (true)
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+<<< given with
+given intOrd: Ord[Int] with Eq[Int] with
+    def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+     def compare2(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+>>>
+given intOrd: Ord[Int]
+  with Eq[Int]
+  with
+    def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+    def compare2(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0


### PR DESCRIPTION
Optional braces are discussed in depth here https://dotty.epfl.ch/docs/reference/other-new-features/indentation.html

There 4 different ways indentation can start:
- after a keyword token such as:
```
=  =>  ?=>  <-  catch  do  else  finally  for
if  match  return  then  throw  try  while  yield
```
- after `:` at end of line in templates
- after `)` in if or an extension group
- after `with` for given definitions

I created a PR just in case someone wanted to take a look at it. Otherwise, I should be able to finish it by the next week. 

I still need to do:
- [ ] use indent from https://github.com/scalameta/scalafmt/pull/2401
- [ ] more tests!
- [ ] try to figure out if some settings can break optional braces