### PR TITLE
[Scala 3] Add support for optional braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
@@ -3,6 +3,7 @@ package org.scalafmt.config
 import metaconfig._
 
 /** @param main the primary indentation used in the code
+  * @param significant the indentation used when optional braces are omitted
   * @param defnSite indentation around class/def
   * @param ctorSite indentation around class constructor parameters
   * @param caseSite indentation for case values before arrow
@@ -13,6 +14,7 @@ import metaconfig._
   */
 case class Indents(
     main: Int = 2,
+    private[config] val significant: Option[Int] = None,
     callSite: Int = 2,
     defnSite: Int = 4,
     caseSite: Int = 4,
@@ -24,6 +26,8 @@ case class Indents(
 ) {
   implicit val reader: ConfDecoder[Indents] =
     generic.deriveDecoder(this).noTypos
+
+  lazy val getSignificant = significant.getOrElse(main)
 
   def getDefnSite(tree: meta.Tree): Int =
     (tree match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -392,6 +392,7 @@ object ScalafmtConfig {
         indent.withSiteRelativeToExtends
       )
       checkPositiveOpt(
+        indent.significant,
         indent.ctorSite
       )
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
@@ -88,10 +88,6 @@ object ScalafmtRunner {
       .withAllowTrailingCommas(true)
     val default = scala213
     val scala3 = Scala3
-      // Disable significant indentation because the exact syntax is still under
-      // development and is likely to change soon. See discussions at
-      // https://contributors.scala-lang.org/t/feedback-sought-optional-braces/4702
-      .withAllowSignificantIndentation(false)
 
     implicit lazy val decoder: ConfDecoder[Dialect] = {
       ReaderUtil.oneOf[Dialect](

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1907,6 +1907,30 @@ class FormatOps(
     }
   }
 
+  // Optional braces in templates after `:|with`
+  object OptionalBracesTemplate {
+    def unapply(meta: FormatToken.Meta): Option[Template] =
+      meta.leftOwner match {
+        case t: Template if templateCurly(t).contains(tokens(meta.idx).left) =>
+          Some(t)
+        case _ => None
+      }
+  }
+
+  // Optional braces after any token that can start indentation:
+  // )  =  =>  ?=>  <-  catch  do  else  finally  for
+  // if  match  return  then  throw  try  while  yield
+  object OptionalBracesBlock {
+    def unapply(meta: FormatToken.Meta): Option[Term.Block] = {
+      val nft = nextNonComment(tokens(meta.idx))
+      nft.meta.rightOwner.parent match {
+        case Some(t: Term.Block) if t.tokens.headOption.contains(nft.right) =>
+          Some(t)
+        case _ => None
+      }
+    }
+  }
+
 }
 
 object FormatOps {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -173,6 +173,28 @@ class Router(formatOps: FormatOps) {
           if rightOwner.is[SomeInterpolate] =>
         Seq(Split(Space(style.spaces.inInterpolatedStringCurlyBraces), 0))
 
+      // optional braces: template follows
+      case FormatToken(
+            _: T.Colon | _: T.KwWith,
+            _,
+            OptionalBracesTemplate(owner)
+          ) if dialect.allowSignificantIndentation =>
+        val indent = style.indent.getSignificant
+        Seq(Split(Newline, 0).withIndent(indent, lastToken(owner), After))
+
+      // optional braces: block follows
+      case FormatToken(
+            _: T.Equals | _: T.RightArrow | _: T.ContextArrow | _: T.LeftArrow |
+            _: T.KwCatch | _: T.KwDo | _: T.KwElse | _: T.KwFinally |
+            _: T.KwFor | _: T.KwMatch | _: T.KwReturn | _: T.KwThen |
+            _: T.KwThrow | _: T.KwTry | _: T.KwWhile | _: T.KwYield |
+            _: T.RightParen,
+            _,
+            OptionalBracesBlock(owner)
+          ) if dialect.allowSignificantIndentation =>
+        val indent = style.indent.getSignificant
+        Seq(Split(Newline, 0).withIndent(indent, lastToken(owner), After))
+
       // { ... } Blocks
       case tok @ FormatToken(open @ T.LeftBrace(), right, between) =>
         val close = matching(open)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
@@ -21,6 +21,7 @@ object Keyword {
     token.is[KwObject] || token.is[KwOverride] || token.is[KwPackage] ||
     token.is[KwPrivate] || token.is[KwProtected] || token.is[KwReturn] ||
     token.is[KwSealed] || token.is[KwSuper] || token.is[KwThis] ||
+    token.is[KwThen] ||
     token.is[KwThrow] || token.is[KwTrait] || token.is[KwTrue] ||
     token.is[KwTry] || token.is[KwType] || token.is[KwVal] ||
     token.is[KwVar] || token.is[KwWhile] || token.is[KwWith] ||

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1,0 +1,277 @@
+indent.significant = 3
+<<< simple value equals
+val test = // comm
+    val a = ""
+     a  +    ""
+>>>
+val test = // comm
+   val a = ""
+   a + ""
+<<< if else with comment before colon
+trait A /* comm */ :
+  val cond =
+   if true then
+    stat1
+    stat2
+   else { // c1
+     stat3
+     stat4
+     }
+   end if
+>>>
+trait A /* comm */:
+   val cond =
+      if true then
+         stat1
+         stat2
+      else { // c1
+        stat3
+        stat4
+      }
+      end if
+<<< nested class with end marker
+trait A /* comm */ :
+  class B:
+    val a = ""
+  end B
+>>>
+trait A /* comm */:
+   class B:
+      val a = ""
+   end B
+<<< object
+object Obj:
+  def hello = 
+      1
+       2
+  end hello
+>>>
+object Obj:
+   def hello =
+      1
+      2
+   end hello
+<<< object with braces
+object Obj{
+  def hello = 
+    1
+    2
+}
+>>>
+object Obj {
+  def hello =
+     1
+     2
+}
+<<< extension method
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) 
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](
+    a: Map[A, Foooooooooooooooo[B]]
+)
+   def add(b: A) = a + b
+   def add2(b: A) = a + b
+
+   def add3(b: A) = a + b
+<<< extension multi
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) (using b: Map[A, Foooooooooooooooo[B]])
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](
+    a: Map[A, Foooooooooooooooo[B]]
+)(using b: Map[A, Foooooooooooooooo[B]])
+   def add(b: A) = a + b
+   def add2(b: A) = a + b
+
+   def add3(b: A) = a + b
+<<< if(cond) indentation 
+trait A:
+  val cond =
+    if (true)
+        stat1
+         stat2
+    else
+       stat3
+       stat4
+>>>
+trait A:
+   val cond =
+     if (true)
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+<<< given with
+given intOrd: Ord[Int] with Eq[Int] with // c1
+    /* c2 */
+     def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+     def compare2(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+>>>
+given intOrd: Ord[Int] with Eq[Int] with // c1
+   /* c2 */
+   def compare(x: Int, y: Int) =
+     if x < y then -1 else if x > y then +1 else 0
+   def compare2(x: Int, y: Int) =
+     if x < y then -1 else if x > y then +1 else 0
+<<< derived trait, val-end, if-end
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+    end if
+  end cond1
+>>>
+trait A extends B:
+   val cond1 =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+   end cond1
+<<< derived trait, val-end, if-noend
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+  end cond1
+>>>
+trait A extends B:
+   val cond1 =
+     if true then
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+   end cond1
+<<< derived trait, val-noend, if-end
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+    end if
+>>>
+trait A extends B:
+   val cond1 =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+<<< derived trait, val-noend, if-noend
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+>>>
+trait A extends B:
+   val cond1 =
+     if true then
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+<<< derived trait with self
+trait A extends B:
+  self: C =>
+  val cond =
+   if true then
+    stat1
+    stat2
+   else
+     stat3
+     stat4
+   end if
+>>>
+trait A extends B:
+   self: C =>
+   val cond =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+<<< lots of end markers
+object a {
+ trait A:
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+    end if
+  end cond
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+    end if
+  end cond
+ end A
+}
+>>>
+object a {
+  trait A:
+     val cond =
+        if true then
+           stat1
+           stat2
+        else
+           stat3
+           stat4
+        end if
+     end cond
+     val cond =
+        if true then
+           stat1
+           stat2
+        else
+           stat3
+           stat4
+        end if
+     end cond
+  end A
+}


### PR DESCRIPTION
Optional braces are discussed in depth in
https://dotty.epfl.ch/docs/reference/other-new-features/indentation.html

There 4 different ways indentation can start:
- after a keyword token such as:
```
=  =>  ?=>  <-  catch  do  else  finally  for
if  match  return  then  throw  try  while  yield
```
- after `:` at end of line in templates
- after `)` in if or an extension group
- after `with` for given definitions