### PR TITLE
Tests: apply header customizations for all tests

### DIFF
--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< scalajs 1
 private def genApplyForSym(minArgc: Int, hasRestParam: Boolean,
     sym: Symbol): js.Tree = {

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< Massive 1
 List(Split(Space, 0).withPolicy(SingleLineBlock(close)),
            Split(nl, 1).withPolicy({

--- a/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/default/ApplyInfix.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< URI state explosion (for performance only, output is ugly as hell)
     "(?:" +
     lelem+"{7}"+block+"|"+                 // 1:2:3:4:5:6:7:8

--- a/scalafmt-tests/src/test/resources/default/Case.case
+++ b/scalafmt-tests/src/test/resources/default/Case.case
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< Unindent singleline
 case FormatToken(_: Ident | _: `this` | _: `_ ` | _: `(`, _: `.` | _: `#`, _) => List(
   NoSplit0

--- a/scalafmt-tests/src/test/resources/default/Case.stat
+++ b/scalafmt-tests/src/test/resources/default/Case.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< Route partial function
 val Route: PartialFunction[Decision, Decision] = {
   case FormatToken(_: Ident | _: `this` | _: `_ ` | _: `(`, _: `.` | _: `#`, _) =>

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< Long line
 class Formatter(style: ScalaStyle, tree: Tree, toks: Array[FormatToken], statementStarts: Set[Token], owners: Map[Token, Tree])
 >>>

--- a/scalafmt-tests/src/test/resources/default/Comment.stat
+++ b/scalafmt-tests/src/test/resources/default/Comment.stat
@@ -1,9 +1,7 @@
-80 columns                                                                     ##
 ## Devos BEWARE of reformatting this file, it contains essential invisible
 ## horizontal whitespace as defined by Java 8 java.util.regex.Pattern
 ## "\\h": [\x20\t\xA0\u1680\u180e\u2000-\u200a\u202f\u205f\u3000].
 ## For quick reference \x20 is ASCII space, \t is tab.
-|
 <<< keep blank lines
 {
 

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< Long line
 object a {
   /**

--- a/scalafmt-tests/src/test/resources/default/Fidelity.source
+++ b/scalafmt-tests/src/test/resources/default/Fidelity.source
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< group id
 object ScalaJSGroupID {
 

--- a/scalafmt-tests/src/test/resources/default/Fidelity.stat
+++ b/scalafmt-tests/src/test/resources/default/Fidelity.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< statement starts get newline
   {
     val lhm = factory.empty[jl.Integer, String]

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< align by superfluous (
      val weights: Map[Int, Double] = (for {
        group <- groupedWeights

--- a/scalafmt-tests/src/test/resources/default/Idempotency.stat
+++ b/scalafmt-tests/src/test/resources/default/Idempotency.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< paulp example #192
 class A {
   def traced(in: A => Unit, out: B => Unit): Fun[A, B] = ( f

--- a/scalafmt-tests/src/test/resources/default/If.stat
+++ b/scalafmt-tests/src/test/resources/default/If.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< Break before then condition
 if (between.lastOption.exists(_.isInstanceOf[`\n`])) List(Split(NoIndentNewline, 0))
 else List(Split(Newline, 0))

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< resolveLocalDef
     def withDedicatedVar: Unit = {
       def doBuildInner = {

--- a/scalafmt-tests/src/test/resources/default/SearchState.stat
+++ b/scalafmt-tests/src/test/resources/default/SearchState.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< spark
 {
   {

--- a/scalafmt-tests/src/test/resources/default/Select.stat
+++ b/scalafmt-tests/src/test/resources/default/Select.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< basic
 a .b .c
 >>>

--- a/scalafmt-tests/src/test/resources/default/Semicolon.stat
+++ b/scalafmt-tests/src/test/resources/default/Semicolon.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< keep on single line, if possible
 indent.main = 4
 ===

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< no indent multiline strings without margin
 val x = """Formatter changed AST
                 |=====================

--- a/scalafmt-tests/src/test/resources/default/Super.stat
+++ b/scalafmt-tests/src/test/resources/default/Super.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< #661 super space
 foo. super.x()
 >>>

--- a/scalafmt-tests/src/test/resources/default/TermParam.stat
+++ b/scalafmt-tests/src/test/resources/default/TermParam.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< unindent by 2 in blocks, #186
 scrut.branchSwitch(scrut.value,
                    casevals = normalcases.map { case (v, _) => v },

--- a/scalafmt-tests/src/test/resources/default/Trait.stat
+++ b/scalafmt-tests/src/test/resources/default/Trait.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< break on extends trait #109
 trait WorkerNavigator extends NavigatorID with NavigatorOnLine with NavigatorLanguage
 >>>

--- a/scalafmt-tests/src/test/resources/default/Try.stat
+++ b/scalafmt-tests/src/test/resources/default/Try.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< finally
 object Foo {
   try loop(blocks, startingImports, Imports(), wrapperIndex = 1 )

--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< val type apply formats too #117
 val xxxxxxxxxxxxxxxxxxxxxxxxx:FooBarrrrrr[BaaaaaaaaaaaazBazzzKaaaaaaaaar[ String, Option[ List[Either[ Int, Option[String] ]]] ]]
 >>>

--- a/scalafmt-tests/src/test/resources/default/TypeWith.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeWith.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< with
 { def getAnnotationOwner(
        annotationOwnerLookUp: ScLiteral => Option[

--- a/scalafmt-tests/src/test/resources/default/Unicode.stat
+++ b/scalafmt-tests/src/test/resources/default/Unicode.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< preserve the unicode literals in pattern position, see scalafix#619
 def a = (1, 2, 3) match { case (r, \u03b8, \u03c6) => r + \u03b8 + \u03c6 }
 >>>

--- a/scalafmt-tests/src/test/resources/default/Unindent.stat
+++ b/scalafmt-tests/src/test/resources/default/Unindent.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< FutureSpec akka
 {{{
       f(

--- a/scalafmt-tests/src/test/resources/default/Val.stat
+++ b/scalafmt-tests/src/test/resources/default/Val.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< Long line
 val newIndents: Vector[Indent[Num]]
       =

--- a/scalafmt-tests/src/test/resources/scala3/Macro.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Macro.stat
@@ -1,4 +1,4 @@
-maxColumn = 40
+
 <<< splice brace
 ${    locationImpl() }
 >>>

--- a/scalafmt-tests/src/test/resources/scala3/Match.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Match.stat
@@ -1,4 +1,4 @@
-maxColumn=80
+
 <<< match with dot
 def mtch(x: Int): String =
             x.match {

--- a/scalafmt-tests/src/test/resources/scala3/Open.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Open.stat
@@ -1,4 +1,4 @@
-maxColumn = 40
+
 <<< class
 open class Foobar()
 >>>

--- a/scalafmt-tests/src/test/resources/scala3/Vararg.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Vararg.stat
@@ -1,5 +1,4 @@
 
-
 <<< simple invocation
 val a = method(0, 1,"", others*)
 >>>

--- a/scalafmt-tests/src/test/resources/scalajs/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Advanced.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< scalajs 1
 private def genApplyForSym(minArgc: Int, hasRestParam: Boolean,
     sym: Symbol): js.Tree = {

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< config style #158
 function(
   a,

--- a/scalafmt-tests/src/test/resources/scalajs/Class.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Class.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< Long line
 class Formatter(style: ScalaStyle, tree: Tree, toks: Array[FormatToken], statementStarts: Set[Token], owners: Map[Token, Tree])
 >>>

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< js.native def is special #108
   def uniform4fv(location: WebGLUniformLocation, v: Float32Array): Unit = js.native
 >>>

--- a/scalafmt-tests/src/test/resources/scalajs/For.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/For.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< no align by <- #226
 val k = for {
     _ <- FutureAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA(aaaaaa, bbbbbbbbbbbb, cccccccc) if one

--- a/scalafmt-tests/src/test/resources/scalajs/If.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/If.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< while condition is like if
     while (!hasReachedEof(curr) &&
     !statementStarts.contains(hash(tokens(curr.splits.length).left))) {

--- a/scalafmt-tests/src/test/resources/scalajs/Import.source
+++ b/scalafmt-tests/src/test/resources/scalajs/Import.source
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< break #101
 import org.scalajs.dom.experimental.serviceworkers.{ServiceWorkerGlobalScope, ServiceWorkerRegistration}
 >>>

--- a/scalafmt-tests/src/test/resources/scalajs/TermApply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/TermApply.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< breaking cost #158
  object ReferrerPolicy {
   val `no-referrer-when-downgrade` = "no-referrer-when-downgrade".asInstanceOf[

--- a/scalafmt-tests/src/test/resources/scalajs/Type.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Type.stat
@@ -1,4 +1,4 @@
-80 columns                                                                     |
+
 <<< type refinement
 type ScalaJSPlugin = NscPlugin {
   def registerModuleExports(sym: ScalaJSJUnitPluginComponent.global.Symbol): Unit

--- a/scalafmt-tests/src/test/resources/unit/Advanced.source
+++ b/scalafmt-tests/src/test/resources/unit/Advanced.source
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< Rich syntax
 @ foobar("annot", {
   val x = 2

--- a/scalafmt-tests/src/test/resources/unit/Annotations.stat
+++ b/scalafmt-tests/src/test/resources/unit/Annotations.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< single line annotation
   @inline def Rule = raw.CSSRule
 >>>

--- a/scalafmt-tests/src/test/resources/unit/Apply.stat
+++ b/scalafmt-tests/src/test/resources/unit/Apply.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< SKIP incorrect indent expire
 jv.validated[AddScheduledQueryRequest]
   .disjunction leftMap { err =>

--- a/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
+++ b/scalafmt-tests/src/test/resources/unit/ApplyInfix.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< no newline after binding (
 js.Return(!(!({
 genIsScalaJSObject(obj) &&

--- a/scalafmt-tests/src/test/resources/unit/Argument.source
+++ b/scalafmt-tests/src/test/resources/unit/Argument.source
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< One argument per line
 object Object {
   val x = function(a1234567, b1234567,

--- a/scalafmt-tests/src/test/resources/unit/Basic.source
+++ b/scalafmt-tests/src/test/resources/unit/Basic.source
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< Two methods
 object a {
 

--- a/scalafmt-tests/src/test/resources/unit/Case.case
+++ b/scalafmt-tests/src/test/resources/unit/Case.case
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< Match tuple
 case (x, y) =>   x -> y
 >>>

--- a/scalafmt-tests/src/test/resources/unit/Case.stat
+++ b/scalafmt-tests/src/test/resources/unit/Case.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< No inline
 object Object {
   val x = { case 2 => 1

--- a/scalafmt-tests/src/test/resources/unit/ColumnWidth.source
+++ b/scalafmt-tests/src/test/resources/unit/ColumnWidth.source
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< Object definition fits in one line
 @foobar
 object   a   {val x:Int=1}

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< Inline comment binds left
 function(a,// comment
          b)

--- a/scalafmt-tests/src/test/resources/unit/Cond.stat
+++ b/scalafmt-tests/src/test/resources/unit/Cond.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< Split on =
 def better(other: State): Boolean = this.cost <= other.cost &&
   this.indentation <= other.indentation

--- a/scalafmt-tests/src/test/resources/unit/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/unit/DefDef.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< single line
 def log(split: Split): String = "aasplit"
 >>>

--- a/scalafmt-tests/src/test/resources/unit/Dialect.stat
+++ b/scalafmt-tests/src/test/resources/unit/Dialect.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< trailing comma
 foo(
   1,

--- a/scalafmt-tests/src/test/resources/unit/For.stat
+++ b/scalafmt-tests/src/test/resources/unit/For.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< newline for each clause
 for { f0 <- Option(a)
   filename <- f0

--- a/scalafmt-tests/src/test/resources/unit/If.stat
+++ b/scalafmt-tests/src/test/resources/unit/If.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< With curly
 if (true) {
       println(aaaaaaaaaaaaaaaaaaaaaaaaaa)

--- a/scalafmt-tests/src/test/resources/unit/Import.source
+++ b/scalafmt-tests/src/test/resources/unit/Import.source
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< One per line
 import foo.bar
 

--- a/scalafmt-tests/src/test/resources/unit/Interpolate.stat
+++ b/scalafmt-tests/src/test/resources/unit/Interpolate.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< has expression
 s"${a.foo[Bar]}"
 >>>

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< keep x to {
 lst.map { x =>
       println(x)

--- a/scalafmt-tests/src/test/resources/unit/Lit.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lit.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< long
 1l
 >>>

--- a/scalafmt-tests/src/test/resources/unit/Mod.stat
+++ b/scalafmt-tests/src/test/resources/unit/Mod.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< private this #94
   private[this] val root = 1
 >>>

--- a/scalafmt-tests/src/test/resources/unit/Package.source
+++ b/scalafmt-tests/src/test/resources/unit/Package.source
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< separate by two newlines with docstring
 package foo
 /**

--- a/scalafmt-tests/src/test/resources/unit/Symbol.stat
+++ b/scalafmt-tests/src/test/resources/unit/Symbol.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< symbols get space
 def unary_!   : Boolean = !value
 >>>

--- a/scalafmt-tests/src/test/resources/unit/Template.source
+++ b/scalafmt-tests/src/test/resources/unit/Template.source
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< extends
 class A(
   b: B)

--- a/scalafmt-tests/src/test/resources/unit/TermApply.stat
+++ b/scalafmt-tests/src/test/resources/unit/TermApply.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< one arg chained (state explosion)
 a(b).c(d).e(f).g(h).i(j).k { aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa }
 >>>

--- a/scalafmt-tests/src/test/resources/unit/TermUpdate.stat
+++ b/scalafmt-tests/src/test/resources/unit/TermUpdate.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< one arg
  sieve(1) = false
 >>>

--- a/scalafmt-tests/src/test/resources/unit/Trait.source
+++ b/scalafmt-tests/src/test/resources/unit/Trait.source
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< trait start new lines
 object A {
       val x = 1;

--- a/scalafmt-tests/src/test/resources/unit/Type.stat
+++ b/scalafmt-tests/src/test/resources/unit/Type.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< abstract defs get newline
 type ObjNotifyLike = Any {
         def notify(): Unit

--- a/scalafmt-tests/src/test/resources/unit/TypeArgument.stat
+++ b/scalafmt-tests/src/test/resources/unit/TypeArgument.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< One argument per line
 object Object {
   val x = function[a1234567, b1234567,

--- a/scalafmt-tests/src/test/resources/unit/UnaryApply.stat
+++ b/scalafmt-tests/src/test/resources/unit/UnaryApply.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< literal
 -100
 

--- a/scalafmt-tests/src/test/resources/unit/Val.stat
+++ b/scalafmt-tests/src/test/resources/unit/Val.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< Break first after =
 object a {
   val A__________________a: Int = 123456789

--- a/scalafmt-tests/src/test/resources/unit/Xml.stat
+++ b/scalafmt-tests/src/test/resources/unit/Xml.stat
@@ -1,4 +1,4 @@
-40 columns                              |
+
 <<< xml end indent
  <span>1</span> ++ <span>2</span> + 1
 >>>


### PR DESCRIPTION
Earlier, this was only done for those test suites which use the default style. Let's apply this to those which use a different style based on the folder which contains them.