### PR TITLE
Router: use extractors on meta to get extra values

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -73,4 +73,10 @@ object FormatToken {
     lazy val firstNL = text.indexOf('\n')
   }
 
+  class ExtractFromMeta[A](f: FormatToken.Meta => Option[A]) {
+    def unapply(meta: FormatToken.Meta): Option[A] = f(meta)
+  }
+
+  val LeftOwner = new ExtractFromMeta(x => Some(x.leftOwner))
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -67,34 +67,13 @@ object InfixApp {
 
 }
 
-/** Pattern extractor to concisely and safely query parent chain.
-  *
-  * Example:
-  * {{{
-  *   tree match {
-  *     case (_: Term) `:parent:` (_: Defn) `:parent:` (_: Source) => ???
-  *   }
-  * }}}
-  * The name is backquoted to get right associativity while using
-  * alphabetic characters
-  */
-object `:parent:` {
-  def unapply(tree: Tree): Option[(Tree, Tree)] =
-    tree.parent match {
-      case Some(parent) =>
-        Some(tree -> parent)
+object WithChain {
+  def unapply(t: Type.With): Option[Type.With] = {
+    // self types, params, val/def/var/type definitions or declarations
+    val top = TreeOps.topTypeWith(t)
+    top.parent match {
+      case Some(_: Defn | _: Decl | _: Term.Param | _: Self) => Some(top)
       case _ => None
     }
-}
-
-object WithChain {
-  def unapply(t: Type.With): Option[Type.With] =
-    TreeOps.topTypeWith(t) match {
-      // self types, params, val/def/var/type definitions or declarations
-      case (top: Type.With) `:parent:`
-          (_: Defn | _: Decl | _: Term.Param | _: Self) =>
-        Some(top)
-      case _ =>
-        None
-    }
+  }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -349,6 +349,10 @@ object TreeOps {
       case name: Term.Name => name.parent.flatMap(defDefReturnType)
       case _ => None
     }
+  val DefDefReturnTypeLeft =
+    new FormatToken.ExtractFromMeta(x => defDefReturnType(x.leftOwner))
+  val DefDefReturnTypeRight =
+    new FormatToken.ExtractFromMeta(x => defDefReturnType(x.rightOwner))
 
   /** Returns `true` if the `scala.meta.Tree` is a class, trait, enum or def
     *
@@ -506,6 +510,8 @@ object TreeOps {
     case t: Defn.Val => (t.rhs, None)
     case t: Defn.Var => (t.rhs.getOrElse(t), None) // var x: Int = _, no policy
   }
+  val SplitAssignIntoPartsLeft =
+    new FormatToken.ExtractFromMeta(x => splitAssignIntoParts.lift(x.leftOwner))
 
   /** How many parents of tree are Term.Apply?
     */


### PR DESCRIPTION
Using extractors on the entire format token, especially when it includes a match on either left or right token, is inefficient. However, in most cases an extractor match on the meta field is equivalent and allows us to extract the value once instead of twice (once in match and a second time in the case body).