### PR TITLE
Router: handle optional braces in this/catch/match/for-do/for-yield

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -179,9 +179,7 @@ class Router(formatOps: FormatOps) {
             _,
             OptionalBracesTemplate(owner)
           ) if dialect.allowSignificantIndentation =>
-        val indent = style.indent.getSignificant
-        val mod = NewlineT(formatToken.hasBlankLine)
-        Seq(Split(mod, 0).withIndent(indent, lastToken(owner), After))
+        getOptionalBracesSplits(formatToken, owner)
 
       // optional braces: block follows
       case FormatToken(
@@ -193,9 +191,7 @@ class Router(formatOps: FormatOps) {
             _,
             OptionalBracesBlock(owner)
           ) if dialect.allowSignificantIndentation =>
-        val indent = style.indent.getSignificant
-        val mod = NewlineT(formatToken.hasBlankLine)
-        Seq(Split(mod, 0).withIndent(indent, lastToken(owner), After))
+        getOptionalBracesSplits(formatToken, owner)
 
       // { ... } Blocks
       case tok @ FormatToken(open @ T.LeftBrace(), right, between) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -181,11 +181,42 @@ class Router(formatOps: FormatOps) {
           ) if dialect.allowSignificantIndentation =>
         getOptionalBracesSplits(formatToken, owner)
 
+      // optional braces: catch
+      case FormatToken(
+            _: T.KwCatch,
+            _,
+            OptionalBracesCatch(owner)
+          ) if dialect.allowSignificantIndentation =>
+        getOptionalBracesSplits(formatToken, owner)
+
+      // optional braces: match
+      case FormatToken(
+            _: T.KwMatch,
+            _,
+            OptionalBracesMatch(owner)
+          ) if dialect.allowSignificantIndentation =>
+        getOptionalBracesSplits(formatToken, owner)
+
+      // optional braces: equals
+      case FormatToken(
+            _: T.Equals,
+            _,
+            OptionalBracesEquals(owner)
+          ) if dialect.allowSignificantIndentation =>
+        getOptionalBracesSplits(formatToken, owner)
+
+      // optional braces: for
+      case FormatToken(
+            _: T.KwFor,
+            _,
+            OptionalBracesFor(owner)
+          ) if dialect.allowSignificantIndentation =>
+        getOptionalBracesSplits(formatToken, owner)
+
       // optional braces: block follows
       case FormatToken(
-            _: T.Equals | _: T.RightArrow | _: T.ContextArrow | _: T.LeftArrow |
-            _: T.KwCatch | _: T.KwDo | _: T.KwElse | _: T.KwFinally |
-            _: T.KwFor | _: T.KwMatch | _: T.KwReturn | _: T.KwThen |
+            _: T.RightArrow | _: T.ContextArrow | _: T.LeftArrow | _: T.KwDo |
+            _: T.KwElse | _: T.KwFinally | _: T.KwReturn | _: T.KwThen |
             _: T.KwThrow | _: T.KwTry | _: T.KwWhile | _: T.KwYield |
             _: T.RightParen,
             _,

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -302,15 +302,14 @@ class a(vi: Int, vs: String):
     foo
   end this
 >>>
-org.scalafmt.Error$FormatterChangedAST: Formatter changed AST
 class a(vi: Int, vs: String):
    def this() =
-     this(0, "")
-   foo
+      this(0, "")
+      foo
    end this
    def this(vi: Int) =
-     this(vi, "")
-   foo
+      this(vi, "")
+      foo
    end this
 <<< match
 object a:
@@ -329,15 +328,15 @@ object a:
 object a:
    def foo =
      this match
-     case A =>
-       that match
-       case b => bb
-       case c => cc
-       end match
-     case B =>
-       that match
-       case c => cc
-       case _ => dd
+        case A =>
+          that match
+             case b => bb
+             case c => cc
+          end match
+        case B =>
+          that match
+             case c => cc
+             case _ => dd
 <<< match type
 object a:
   type foo[x] = x match
@@ -352,14 +351,14 @@ object a:
 >>>
 object a:
    type foo[x] = x match
-   case A =>
-     that match
-     case b => bb
-     case c => cc
-   case B =>
-     that match
-     case c => cc
-     case _ => dd
+      case A =>
+        that match
+           case b => bb
+           case c => cc
+      case B =>
+        that match
+           case c => cc
+           case _ => dd
 <<< catch one
 object a:
   def foo =
@@ -369,8 +368,7 @@ object a:
 object a:
    def foo =
      try foo
-     catch
-     case A => foo
+     catch case A => foo
 <<< catch multiple
 object a:
   def foo =
@@ -386,22 +384,19 @@ object a:
             case c => cc
             case _ => dd
 >>>
-<input>:10: error: outdent expected but case found
-     case B =>
-     ^
 object a:
    def foo =
      try foo
      catch
-     case A =>
-       that match
-       case b => bb
-       case c => cc
-       end match
-     case B =>
-       that match
-       case c => cc
-       case _ => dd
+        case A =>
+          that match
+             case b => bb
+             case c => cc
+          end match
+        case B =>
+          that match
+             case c => cc
+             case _ => dd
 <<< for
 object a:
   def foo =
@@ -419,8 +414,10 @@ object a:
 >>>
 object a:
    def foo =
-     for x <- y
-     x <- y do
+     for
+        x <- y
+        x <- y
+     do
         foo
         bar
    def foo =
@@ -443,9 +440,10 @@ object a:
 >>>
 object a:
    def foo =
-     for x <- y
-     x = y
-     if x
+     for
+        x <- y
+        x = y
+        if x
      yield
         foo
         bar

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -291,3 +291,164 @@ object a {
      end cond
   end A
 }
+<<< ctor this
+class a(vi: Int, vs: String):
+  def this() =
+    this(0, "")
+    foo
+  end this
+  def this(vi: Int) =
+    this(vi, "")
+    foo
+  end this
+>>>
+org.scalafmt.Error$FormatterChangedAST: Formatter changed AST
+class a(vi: Int, vs: String):
+   def this() =
+     this(0, "")
+   foo
+   end this
+   def this(vi: Int) =
+     this(vi, "")
+   foo
+   end this
+<<< match
+object a:
+  def foo =
+    this match
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+         end match
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+object a:
+   def foo =
+     this match
+     case A =>
+       that match
+       case b => bb
+       case c => cc
+       end match
+     case B =>
+       that match
+       case c => cc
+       case _ => dd
+<<< match type
+object a:
+  type foo[x] = x match
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+object a:
+   type foo[x] = x match
+   case A =>
+     that match
+     case b => bb
+     case c => cc
+   case B =>
+     that match
+     case c => cc
+     case _ => dd
+<<< catch one
+object a:
+  def foo =
+    try foo
+    catch case A => foo
+>>>
+object a:
+   def foo =
+     try foo
+     catch
+     case A => foo
+<<< catch multiple
+object a:
+  def foo =
+    try foo
+    catch
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+         end match
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+<input>:10: error: outdent expected but case found
+     case B =>
+     ^
+object a:
+   def foo =
+     try foo
+     catch
+     case A =>
+       that match
+       case b => bb
+       case c => cc
+       end match
+     case B =>
+       that match
+       case c => cc
+       case _ => dd
+<<< for
+object a:
+  def foo =
+    for
+      x <- y
+      x <- y
+    do
+      foo
+      bar
+  def foo =
+    for
+      x <- y
+    do
+      bar
+>>>
+object a:
+   def foo =
+     for x <- y
+     x <- y do
+        foo
+        bar
+   def foo =
+     for x <- y do bar
+<<< for-yield
+object a:
+  def foo =
+    for
+      x <- y
+      x = y
+      if x
+    yield
+      foo
+      bar
+  def foo =
+    for
+      x <- y
+    yield
+      foo
+>>>
+object a:
+   def foo =
+     for x <- y
+     x = y
+     if x
+     yield
+        foo
+        bar
+   def foo =
+     for x <- y
+     yield foo

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -300,13 +300,14 @@ class a(vi: Int, vs: String):
     foo
   end this
 >>>
-Formatter changed AST
 class a(vi: Int, vs: String):
-   def this() = this(0, "")
-   foo
+   def this() =
+      this(0, "")
+      foo
    end this
-   def this(vi: Int) = this(vi, "")
-   foo
+   def this(vi: Int) =
+      this(vi, "")
+      foo
    end this
 <<< match
 object a:
@@ -325,15 +326,15 @@ object a:
 object a:
    def foo =
      this match
-     case A =>
-       that match
-       case b => bb
-       case c => cc
-       end match
-     case B =>
-       that match
-       case c => cc
-       case _ => dd
+        case A =>
+          that match
+             case b => bb
+             case c => cc
+          end match
+        case B =>
+          that match
+             case c => cc
+             case _ => dd
 <<< match type
 object a:
   type foo[x] = x match
@@ -349,14 +350,14 @@ object a:
 object a:
    type foo[x] =
      x match
-     case A =>
-       that match
-       case b => bb
-       case c => cc
-     case B =>
-       that match
-       case c => cc
-       case _ => dd
+        case A =>
+          that match
+             case b => bb
+             case c => cc
+        case B =>
+          that match
+             case c => cc
+             case _ => dd
 <<< catch one
 object a:
   def foo =
@@ -366,8 +367,7 @@ object a:
 object a:
    def foo =
      try foo
-     catch
-     case A => foo
+     catch case A => foo
 <<< catch multiple
 object a:
   def foo =
@@ -383,24 +383,19 @@ object a:
             case c => cc
             case _ => dd
 >>>
-<input>:10: error: outdent expected but case found
-     case B =>
-     ^
-       that match
-       case c => cc
 object a:
    def foo =
      try foo
      catch
-     case A =>
-       that match
-       case b => bb
-       case c => cc
-       end match
-     case B =>
-       that match
-       case c => cc
-       case _ => dd
+        case A =>
+          that match
+             case b => bb
+             case c => cc
+          end match
+        case B =>
+          that match
+             case c => cc
+             case _ => dd
 <<< for
 object a:
   def foo =
@@ -417,8 +412,10 @@ object a:
       bar
 >>>
 object a:
-   def foo = for x <- y
-   x <- y do
+   def foo = for
+      x <- y
+      x <- y
+   do
       foo
       bar
    def foo = for x <- y do bar
@@ -440,8 +437,9 @@ object a:
 >>>
 object a:
    def foo =
-     for x <- y
-     x = y if x
+     for
+        x <- y
+        x = y if x
      yield
         foo
         bar

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1,0 +1,448 @@
+indent.significant = 3
+newlines.source = fold
+<<< simple value equals
+val test = // comm
+    val a = ""
+     a  +    ""
+>>>
+val test = // comm
+   val a = ""
+   a + ""
+<<< if else with comment before colon
+trait A /* comm */ :
+  val cond =
+   if true then
+    stat1
+    stat2
+   else { // c1
+     stat3
+     stat4
+     }
+   end if
+>>>
+trait A /* comm */:
+   val cond =
+      if true then
+         stat1
+         stat2
+      else { // c1
+        stat3
+        stat4
+      }
+      end if
+<<< nested class with end marker
+trait A /* comm */ :
+  class B:
+    val a = ""
+  end B
+>>>
+trait A /* comm */:
+   class B:
+      val a = ""
+   end B
+<<< object
+object Obj:
+  def hello = 
+      1
+       2
+  end hello
+>>>
+object Obj:
+   def hello =
+      1
+      2
+   end hello
+<<< object with braces
+object Obj{
+  def hello = 
+    1
+    2
+}
+>>>
+object Obj {
+  def hello =
+     1
+     2
+}
+<<< extension method
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) 
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](
+    a: Map[A, Foooooooooooooooo[B]]
+)
+   def add(b: A) = a + b
+   def add2(b: A) = a + b
+
+   def add3(b: A) = a + b
+<<< extension multi
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) (using b: Map[A, Foooooooooooooooo[B]])
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](
+    a: Map[A, Foooooooooooooooo[B]]
+)(using b: Map[A, Foooooooooooooooo[B]])
+   def add(b: A) = a + b
+   def add2(b: A) = a + b
+
+   def add3(b: A) = a + b
+<<< if(cond) indentation 
+trait A:
+  val cond =
+    if (true)
+        stat1
+         stat2
+    else
+       stat3
+       stat4
+>>>
+trait A:
+   val cond =
+     if (true)
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+<<< given with
+given intOrd: Ord[Int] with Eq[Int] with // c1
+    /* c2 */
+     def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+     def compare2(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+>>>
+given intOrd: Ord[Int] with Eq[Int] with // c1
+   /* c2 */
+   def compare(x: Int, y: Int) = if x < y then -1 else if x > y then +1 else 0
+   def compare2(x: Int, y: Int) = if x < y then -1 else if x > y then +1 else 0
+<<< given with and a blank
+given intOrd: Ord[Int] with Eq[Int] with
+
+     def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+>>>
+given intOrd: Ord[Int] with Eq[Int] with
+
+   def compare(x: Int, y: Int) = if x < y then -1 else if x > y then +1 else 0
+<<< derived trait, val-end, if-end
+trait A extends B:
+  val cond1 =
+    if true then
+
+     stat1
+     stat2
+    else
+
+     stat3
+     stat4
+    end if
+  end cond1
+>>>
+trait A extends B:
+   val cond1 =
+      if true then
+
+         stat1
+         stat2
+      else
+
+         stat3
+         stat4
+      end if
+   end cond1
+<<< derived trait, val-end, if-noend
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+  end cond1
+>>>
+trait A extends B:
+   val cond1 =
+     if true then
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+   end cond1
+<<< derived trait, val-noend, if-end
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+    end if
+>>>
+trait A extends B:
+   val cond1 =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+<<< derived trait, val-noend, if-noend
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+>>>
+trait A extends B:
+   val cond1 =
+     if true then
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+<<< derived trait with self
+trait A extends B:
+
+  self: C =>
+  val cond =
+   if true then
+    stat1
+    stat2
+   else
+     stat3
+     stat4
+   end if
+>>>
+trait A extends B:
+
+   self: C =>
+   val cond =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+<<< lots of end markers
+object a {
+ trait A:
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+    end if
+  end cond
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+    end if
+  end cond
+ end A
+}
+>>>
+object a {
+  trait A:
+     val cond =
+        if true then
+           stat1
+           stat2
+        else
+           stat3
+           stat4
+        end if
+     end cond
+     val cond =
+        if true then
+           stat1
+           stat2
+        else
+           stat3
+           stat4
+        end if
+     end cond
+  end A
+}
+<<< ctor this
+class a(vi: Int, vs: String):
+  def this() =
+    this(0, "")
+    foo
+  end this
+  def this(vi: Int) =
+    this(vi, "")
+    foo
+  end this
+>>>
+Formatter changed AST
+class a(vi: Int, vs: String):
+   def this() = this(0, "")
+   foo
+   end this
+   def this(vi: Int) = this(vi, "")
+   foo
+   end this
+<<< match
+object a:
+  def foo =
+    this match
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+         end match
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+object a:
+   def foo =
+     this match
+     case A =>
+       that match
+       case b => bb
+       case c => cc
+       end match
+     case B =>
+       that match
+       case c => cc
+       case _ => dd
+<<< match type
+object a:
+  type foo[x] = x match
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+object a:
+   type foo[x] =
+     x match
+     case A =>
+       that match
+       case b => bb
+       case c => cc
+     case B =>
+       that match
+       case c => cc
+       case _ => dd
+<<< catch one
+object a:
+  def foo =
+    try foo
+    catch case A => foo
+>>>
+object a:
+   def foo =
+     try foo
+     catch
+     case A => foo
+<<< catch multiple
+object a:
+  def foo =
+    try foo
+    catch
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+         end match
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+<input>:10: error: outdent expected but case found
+     case B =>
+     ^
+       that match
+       case c => cc
+object a:
+   def foo =
+     try foo
+     catch
+     case A =>
+       that match
+       case b => bb
+       case c => cc
+       end match
+     case B =>
+       that match
+       case c => cc
+       case _ => dd
+<<< for
+object a:
+  def foo =
+    for
+      x <- y
+      x <- y
+    do
+      foo
+      bar
+  def foo =
+    for
+      x <- y
+    do
+      bar
+>>>
+object a:
+   def foo = for x <- y
+   x <- y do
+      foo
+      bar
+   def foo = for x <- y do bar
+<<< for-yield
+object a:
+  def foo =
+    for
+      x <- y
+      x = y
+      if x
+    yield
+      foo
+      bar
+  def foo =
+    for
+      x <- y
+    yield
+      foo
+>>>
+object a:
+   def foo =
+     for x <- y
+     x = y if x
+     yield
+        foo
+        bar
+   def foo = for x <- y yield foo

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -307,15 +307,14 @@ class a(vi: Int, vs: String):
     foo
   end this
 >>>
-Formatter changed AST
 class a(vi: Int, vs: String):
    def this() =
-     this(0, "")
-   foo
+      this(0, "")
+      foo
    end this
    def this(vi: Int) =
-     this(vi, "")
-   foo
+      this(vi, "")
+      foo
    end this
 <<< match
 object a:
@@ -334,15 +333,15 @@ object a:
 object a:
    def foo =
      this match
-     case A =>
-       that match
-       case b => bb
-       case c => cc
-       end match
-     case B =>
-       that match
-       case c => cc
-       case _ => dd
+        case A =>
+          that match
+             case b => bb
+             case c => cc
+          end match
+        case B =>
+          that match
+             case c => cc
+             case _ => dd
 <<< match type
 object a:
   type foo[x] = x match
@@ -358,14 +357,14 @@ object a:
 object a:
    type foo[x] =
      x match
-     case A =>
-       that match
-       case b => bb
-       case c => cc
-     case B =>
-       that match
-       case c => cc
-       case _ => dd
+        case A =>
+          that match
+             case b => bb
+             case c => cc
+        case B =>
+          that match
+             case c => cc
+             case _ => dd
 <<< catch one
 object a:
   def foo =
@@ -375,8 +374,7 @@ object a:
 object a:
    def foo =
      try foo
-     catch
-     case A => foo
+     catch case A => foo
 <<< catch multiple
 object a:
   def foo =
@@ -392,24 +390,19 @@ object a:
             case c => cc
             case _ => dd
 >>>
-<input>:10: error: outdent expected but case found
-     case B =>
-     ^
-       that match
-       case c => cc
 object a:
    def foo =
      try foo
      catch
-     case A =>
-       that match
-       case b => bb
-       case c => cc
-       end match
-     case B =>
-       that match
-       case c => cc
-       case _ => dd
+        case A =>
+          that match
+             case b => bb
+             case c => cc
+          end match
+        case B =>
+          that match
+             case c => cc
+             case _ => dd
 <<< for
 object a:
   def foo =
@@ -427,8 +420,10 @@ object a:
 >>>
 object a:
    def foo =
-     for x <- y
-     x <- y do
+     for
+        x <- y
+        x <- y
+     do
         foo
         bar
    def foo =
@@ -451,9 +446,10 @@ object a:
 >>>
 object a:
    def foo =
-     for x <- y
-     x = y
-     if x
+     for
+        x <- y
+        x = y
+        if x
      yield
         foo
         bar

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1,0 +1,462 @@
+indent.significant = 3
+newlines.source = keep
+<<< simple value equals
+val test = // comm
+    val a = ""
+     a  +    ""
+>>>
+val test = // comm
+   val a = ""
+   a + ""
+<<< if else with comment before colon
+trait A /* comm */ :
+  val cond =
+   if true then
+    stat1
+    stat2
+   else { // c1
+     stat3
+     stat4
+     }
+   end if
+>>>
+trait A /* comm */:
+   val cond =
+      if true then
+         stat1
+         stat2
+      else { // c1
+        stat3
+        stat4
+      }
+      end if
+<<< nested class with end marker
+trait A /* comm */ :
+  class B:
+    val a = ""
+  end B
+>>>
+trait A /* comm */:
+   class B:
+      val a = ""
+   end B
+<<< object
+object Obj:
+  def hello = 
+      1
+       2
+  end hello
+>>>
+object Obj:
+   def hello =
+      1
+      2
+   end hello
+<<< object with braces
+object Obj{
+  def hello = 
+    1
+    2
+}
+>>>
+object Obj {
+  def hello =
+     1
+     2
+}
+<<< extension method
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) 
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](a: Map[
+  A,
+  Foooooooooooooooo[B]
+])
+   def add(b: A) = a + b
+   def add2(b: A) = a + b
+
+   def add3(b: A) = a + b
+<<< extension multi
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) (using b: Map[A, Foooooooooooooooo[B]])
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](a: Map[
+  A,
+  Foooooooooooooooo[B]
+])(using
+    b: Map[A, Foooooooooooooooo[B]]
+)
+   def add(b: A) = a + b
+   def add2(b: A) = a + b
+
+   def add3(b: A) = a + b
+<<< if(cond) indentation 
+trait A:
+  val cond =
+    if (true)
+        stat1
+         stat2
+    else
+       stat3
+       stat4
+>>>
+trait A:
+   val cond =
+     if (true)
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+<<< given with
+given intOrd: Ord[Int] with Eq[Int] with // c1
+    /* c2 */
+     def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+     def compare2(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+>>>
+given intOrd: Ord[Int] with Eq[Int] with // c1
+   /* c2 */
+   def compare(x: Int, y: Int) =
+     if x < y then -1 else if x > y then +1 else 0
+   def compare2(x: Int, y: Int) =
+     if x < y then -1 else if x > y then +1 else 0
+<<< given with and a blank
+given intOrd: Ord[Int] with Eq[Int] with
+
+     def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+>>>
+given intOrd: Ord[Int] with Eq[Int] with
+
+   def compare(x: Int, y: Int) =
+     if x < y then -1 else if x > y then +1 else 0
+<<< derived trait, val-end, if-end
+trait A extends B:
+  val cond1 =
+    if true then
+
+     stat1
+     stat2
+    else
+
+     stat3
+     stat4
+    end if
+  end cond1
+>>>
+trait A extends B:
+   val cond1 =
+      if true then
+
+         stat1
+         stat2
+      else
+
+         stat3
+         stat4
+      end if
+   end cond1
+<<< derived trait, val-end, if-noend
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+  end cond1
+>>>
+trait A extends B:
+   val cond1 =
+     if true then
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+   end cond1
+<<< derived trait, val-noend, if-end
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+    end if
+>>>
+trait A extends B:
+   val cond1 =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+<<< derived trait, val-noend, if-noend
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+>>>
+trait A extends B:
+   val cond1 =
+     if true then
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+<<< derived trait with self
+trait A extends B:
+
+  self: C =>
+  val cond =
+   if true then
+    stat1
+    stat2
+   else
+     stat3
+     stat4
+   end if
+>>>
+trait A extends B:
+
+   self: C =>
+   val cond =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+<<< lots of end markers
+object a {
+ trait A:
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+    end if
+  end cond
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+    end if
+  end cond
+ end A
+}
+>>>
+object a {
+  trait A:
+     val cond =
+        if true then
+           stat1
+           stat2
+        else
+           stat3
+           stat4
+        end if
+     end cond
+     val cond =
+        if true then
+           stat1
+           stat2
+        else
+           stat3
+           stat4
+        end if
+     end cond
+  end A
+}
+<<< ctor this
+class a(vi: Int, vs: String):
+  def this() =
+    this(0, "")
+    foo
+  end this
+  def this(vi: Int) =
+    this(vi, "")
+    foo
+  end this
+>>>
+Formatter changed AST
+class a(vi: Int, vs: String):
+   def this() =
+     this(0, "")
+   foo
+   end this
+   def this(vi: Int) =
+     this(vi, "")
+   foo
+   end this
+<<< match
+object a:
+  def foo =
+    this match
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+         end match
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+object a:
+   def foo =
+     this match
+     case A =>
+       that match
+       case b => bb
+       case c => cc
+       end match
+     case B =>
+       that match
+       case c => cc
+       case _ => dd
+<<< match type
+object a:
+  type foo[x] = x match
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+object a:
+   type foo[x] =
+     x match
+     case A =>
+       that match
+       case b => bb
+       case c => cc
+     case B =>
+       that match
+       case c => cc
+       case _ => dd
+<<< catch one
+object a:
+  def foo =
+    try foo
+    catch case A => foo
+>>>
+object a:
+   def foo =
+     try foo
+     catch
+     case A => foo
+<<< catch multiple
+object a:
+  def foo =
+    try foo
+    catch
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+         end match
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+<input>:10: error: outdent expected but case found
+     case B =>
+     ^
+       that match
+       case c => cc
+object a:
+   def foo =
+     try foo
+     catch
+     case A =>
+       that match
+       case b => bb
+       case c => cc
+       end match
+     case B =>
+       that match
+       case c => cc
+       case _ => dd
+<<< for
+object a:
+  def foo =
+    for
+      x <- y
+      x <- y
+    do
+      foo
+      bar
+  def foo =
+    for
+      x <- y
+    do
+      bar
+>>>
+object a:
+   def foo =
+     for x <- y
+     x <- y do
+        foo
+        bar
+   def foo =
+     for x <- y do bar
+<<< for-yield
+object a:
+  def foo =
+    for
+      x <- y
+      x = y
+      if x
+    yield
+      foo
+      bar
+  def foo =
+    for
+      x <- y
+    yield
+      foo
+>>>
+object a:
+   def foo =
+     for x <- y
+     x = y
+     if x
+     yield
+        foo
+        bar
+   def foo =
+     for x <- y
+     yield foo

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1,0 +1,475 @@
+indent.significant = 3
+newlines.source = unfold
+<<< simple value equals
+val test = // comm
+    val a = ""
+     a  +    ""
+>>>
+val test = // comm
+   val a = ""
+   a + ""
+<<< if else with comment before colon
+trait A /* comm */ :
+  val cond =
+   if true then
+    stat1
+    stat2
+   else { // c1
+     stat3
+     stat4
+     }
+   end if
+>>>
+trait A /* comm */:
+   val cond =
+      if true then
+         stat1
+         stat2
+      else { // c1
+        stat3
+        stat4
+      }
+      end if
+<<< nested class with end marker
+trait A /* comm */ :
+  class B:
+    val a = ""
+  end B
+>>>
+trait A /* comm */:
+   class B:
+      val a = ""
+   end B
+<<< object
+object Obj:
+  def hello = 
+      1
+       2
+  end hello
+>>>
+object Obj:
+   def hello =
+      1
+      2
+   end hello
+<<< object with braces
+object Obj{
+  def hello = 
+    1
+    2
+}
+>>>
+object Obj {
+  def hello =
+     1
+     2
+}
+<<< extension method
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) 
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](
+    a: Map[A, Foooooooooooooooo[B]]
+)
+   def add(b: A) = a + b
+   def add2(b: A) = a + b
+
+   def add3(b: A) = a + b
+<<< extension multi
+maxColumn = 40
+===
+extension [A](a: Map[A, Foooooooooooooooo[B]]) (using b: Map[A, Foooooooooooooooo[B]])
+    def add(b: A) = a + b
+     def add2(b: A) = a + b
+  
+    def add3(b: A) = a + b
+>>>
+extension [A](
+    a: Map[A, Foooooooooooooooo[B]]
+)(using b: Map[A, Foooooooooooooooo[B]])
+   def add(b: A) = a + b
+   def add2(b: A) = a + b
+
+   def add3(b: A) = a + b
+<<< if(cond) indentation 
+trait A:
+  val cond =
+    if (true)
+        stat1
+         stat2
+    else
+       stat3
+       stat4
+>>>
+trait A:
+   val cond =
+     if (true)
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+<<< given with
+given intOrd: Ord[Int] with Eq[Int] with // c1
+    /* c2 */
+     def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+     def compare2(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+>>>
+given intOrd: Ord[Int] with Eq[Int] with // c1
+   /* c2 */
+   def compare(x: Int, y: Int) =
+     if x < y then -1
+     else if x > y then +1
+     else
+       0
+   def compare2(x: Int, y: Int) =
+     if x < y then -1
+     else if x > y then +1
+     else
+       0
+<<< given with and a blank
+given intOrd: Ord[Int] with Eq[Int] with
+
+     def compare(x: Int, y: Int) =
+      if x < y then -1 else if x > y then +1 else 0
+>>>
+given intOrd: Ord[Int] with Eq[Int] with
+
+   def compare(x: Int, y: Int) =
+     if x < y then -1
+     else if x > y then +1
+     else
+       0
+<<< derived trait, val-end, if-end
+trait A extends B:
+  val cond1 =
+    if true then
+
+     stat1
+     stat2
+    else
+
+     stat3
+     stat4
+    end if
+  end cond1
+>>>
+trait A extends B:
+   val cond1 =
+      if true then
+
+         stat1
+         stat2
+      else
+
+         stat3
+         stat4
+      end if
+   end cond1
+<<< derived trait, val-end, if-noend
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+  end cond1
+>>>
+trait A extends B:
+   val cond1 =
+     if true then
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+   end cond1
+<<< derived trait, val-noend, if-end
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+    end if
+>>>
+trait A extends B:
+   val cond1 =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+<<< derived trait, val-noend, if-noend
+trait A extends B:
+  val cond1 =
+    if true then
+     stat1
+     stat2
+    else
+     stat3
+     stat4
+>>>
+trait A extends B:
+   val cond1 =
+     if true then
+        stat1
+        stat2
+     else
+        stat3
+        stat4
+<<< derived trait with self
+trait A extends B:
+
+  self: C =>
+  val cond =
+   if true then
+    stat1
+    stat2
+   else
+     stat3
+     stat4
+   end if
+>>>
+trait A extends B:
+
+   self: C =>
+   val cond =
+      if true then
+         stat1
+         stat2
+      else
+         stat3
+         stat4
+      end if
+<<< lots of end markers
+object a {
+ trait A:
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+    end if
+  end cond
+  val cond =
+    if true then
+      stat1
+      stat2
+    else
+      stat3
+      stat4
+    end if
+  end cond
+ end A
+}
+>>>
+object a {
+  trait A:
+     val cond =
+        if true then
+           stat1
+           stat2
+        else
+           stat3
+           stat4
+        end if
+     end cond
+     val cond =
+        if true then
+           stat1
+           stat2
+        else
+           stat3
+           stat4
+        end if
+     end cond
+  end A
+}
+<<< ctor this
+class a(vi: Int, vs: String):
+  def this() =
+    this(0, "")
+    foo
+  end this
+  def this(vi: Int) =
+    this(vi, "")
+    foo
+  end this
+>>>
+Formatter changed AST
+class a(vi: Int, vs: String):
+   def this() = this(0, "")
+   foo
+   end this
+   def this(vi: Int) = this(vi, "")
+   foo
+   end this
+<<< match
+object a:
+  def foo =
+    this match
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+         end match
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+object a:
+   def foo =
+     this match
+     case A =>
+       that match
+       case b =>
+         bb
+       case c =>
+         cc
+       end match
+     case B =>
+       that match
+       case c =>
+         cc
+       case _ =>
+         dd
+<<< match type
+object a:
+  type foo[x] = x match
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+object a:
+   type foo[x] =
+     x match
+     case A =>
+       that match
+       case b =>
+         bb
+       case c =>
+         cc
+     case B =>
+       that match
+       case c =>
+         cc
+       case _ =>
+         dd
+<<< catch one
+object a:
+  def foo =
+    try foo
+    catch case A => foo
+>>>
+object a:
+   def foo =
+     try foo
+     catch
+     case A =>
+       foo
+<<< catch multiple
+object a:
+  def foo =
+    try foo
+    catch
+      case A =>
+         that match
+            case b => bb
+            case c => cc
+         end match
+      case B =>
+         that match
+            case c => cc
+            case _ => dd
+>>>
+<input>:12: error: outdent expected but case found
+     case B =>
+     ^
+       that match
+       case c =>
+object a:
+   def foo =
+     try foo
+     catch
+     case A =>
+       that match
+       case b =>
+         bb
+       case c =>
+         cc
+       end match
+     case B =>
+       that match
+       case c =>
+         cc
+       case _ =>
+         dd
+<<< for
+object a:
+  def foo =
+    for
+      x <- y
+      x <- y
+    do
+      foo
+      bar
+  def foo =
+    for
+      x <- y
+    do
+      bar
+>>>
+object a:
+   def foo =
+     for x <- y
+     x <- y do
+        foo
+        bar
+   def foo = for x <- y do bar
+<<< for-yield
+object a:
+  def foo =
+    for
+      x <- y
+      x = y
+      if x
+    yield
+      foo
+      bar
+  def foo =
+    for
+      x <- y
+    yield
+      foo
+>>>
+object a:
+   def foo =
+     for x <- y
+     x = y
+     if x
+     yield
+        foo
+        bar
+   def foo = for x <- y yield foo

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -312,13 +312,14 @@ class a(vi: Int, vs: String):
     foo
   end this
 >>>
-Formatter changed AST
 class a(vi: Int, vs: String):
-   def this() = this(0, "")
-   foo
+   def this() =
+      this(0, "")
+      foo
    end this
-   def this(vi: Int) = this(vi, "")
-   foo
+   def this(vi: Int) =
+      this(vi, "")
+      foo
    end this
 <<< match
 object a:
@@ -337,19 +338,19 @@ object a:
 object a:
    def foo =
      this match
-     case A =>
-       that match
-       case b =>
-         bb
-       case c =>
-         cc
-       end match
-     case B =>
-       that match
-       case c =>
-         cc
-       case _ =>
-         dd
+        case A =>
+          that match
+             case b =>
+               bb
+             case c =>
+               cc
+          end match
+        case B =>
+          that match
+             case c =>
+               cc
+             case _ =>
+               dd
 <<< match type
 object a:
   type foo[x] = x match
@@ -365,18 +366,18 @@ object a:
 object a:
    type foo[x] =
      x match
-     case A =>
-       that match
-       case b =>
-         bb
-       case c =>
-         cc
-     case B =>
-       that match
-       case c =>
-         cc
-       case _ =>
-         dd
+        case A =>
+          that match
+             case b =>
+               bb
+             case c =>
+               cc
+        case B =>
+          that match
+             case c =>
+               cc
+             case _ =>
+               dd
 <<< catch one
 object a:
   def foo =
@@ -387,8 +388,8 @@ object a:
    def foo =
      try foo
      catch
-     case A =>
-       foo
+       case A =>
+         foo
 <<< catch multiple
 object a:
   def foo =
@@ -404,28 +405,23 @@ object a:
             case c => cc
             case _ => dd
 >>>
-<input>:12: error: outdent expected but case found
-     case B =>
-     ^
-       that match
-       case c =>
 object a:
    def foo =
      try foo
      catch
-     case A =>
-       that match
-       case b =>
-         bb
-       case c =>
-         cc
-       end match
-     case B =>
-       that match
-       case c =>
-         cc
-       case _ =>
-         dd
+        case A =>
+          that match
+             case b =>
+               bb
+             case c =>
+               cc
+          end match
+        case B =>
+          that match
+             case c =>
+               cc
+             case _ =>
+               dd
 <<< for
 object a:
   def foo =
@@ -443,8 +439,10 @@ object a:
 >>>
 object a:
    def foo =
-     for x <- y
-     x <- y do
+     for
+        x <- y
+        x <- y
+     do
         foo
         bar
    def foo = for x <- y do bar
@@ -466,9 +464,10 @@ object a:
 >>>
 object a:
    def foo =
-     for x <- y
-     x = y
-     if x
+     for
+        x <- y
+        x = y
+        if x
      yield
         foo
         bar


### PR DESCRIPTION
These two keywords are not followed by a block, hence the existing logic doesn't work for them.