### PR TITLE
Various changes to prepare to rewrite optional braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -72,7 +72,7 @@ private class BestFirstSearch private (
       else {
         val close = matching(left.left)
         // Block must span at least 3 lines to be worth recursing.
-        val ok = close != stop &&
+        val ok = close.start < stop.start &&
           distance(left.left, close) > style.maxColumn * 3 &&
           extractStatementsIfAny(left.meta.leftOwner).nonEmpty
         if (ok) Some(close) else None
@@ -128,7 +128,7 @@ private class BestFirstSearch private (
 
       val splitToken = tokens(curr.depth)
       if (
-        splitToken.left.start >= stop.start &&
+        splitToken.right.start > stop.start &&
         splitToken.left.start < splitToken.left.end
       ) {
         return curr

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -252,7 +252,7 @@ class FormatWriter(formatOps: FormatOps) {
         ): Option[FormatToken] = {
           def owner = tok.meta.rightOwner
 
-          val nextNonCommentTok = nextNonComment(tok)
+          val nextNonCommentTok = tokens.nextNonComment(tok)
           val skip = nextNonCommentTok.meta.idx - tok.meta.idx
           val right = nextNonCommentTok.right
           def isNewline =
@@ -1091,7 +1091,7 @@ class FormatWriter(formatOps: FormatOps) {
 
     def checkTopLevelStatement: Boolean =
       topLevelHeadTokens.contains(formatToken.meta.idx) && {
-        val nextNonCommentTok = nextNonComment(formatToken)
+        val nextNonCommentTok = tokens.nextNonComment(formatToken)
         val distance = nextNonCommentTok.meta.idx - formatToken.meta.idx
         val nonCommentOwner = nextNonCommentTok.meta.rightOwner match {
           case mod: Mod => mod.parent.get

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -64,6 +64,15 @@ class Router(formatOps: FormatOps) {
   import FormatOps._
   import formatOps._
 
+  import tokens.{
+    prev,
+    next,
+    prevNonComment,
+    nextNonComment,
+    prevNonCommentSameLine,
+    nextNonCommentSameLine
+  }
+
   private def getSplitsImpl(formatToken: FormatToken): Seq[Split] = {
     implicit val style = styleMap.at(formatToken)
     val leftOwner = formatToken.meta.leftOwner

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -76,14 +76,14 @@ final case class State(
 
     val overflow = columnOnCurrentLine - style.maxColumn
     val nextPolicy: PolicySummary =
-      policy.combine(nextSplit.policy, fops.next(tok))
+      policy.combine(nextSplit.policy, fops.tokens.next(tok))
 
     val (penalty, nextDelayedPenalty) =
       if (
         overflow <= 0 || right.is[Token.Comment] && {
           val rtext = tok.meta.right.text
           nextSplit.isNL && rtext.length >= (style.maxColumn - nextIndent) ||
-          fops.next(tok).hasBreak && {
+          fops.tokens.next(tok).hasBreak && {
             if (TokenOps.isDocstring(rtext))
               (style.docstrings.wrap ne Docstrings.Wrap.no) && nextSplit.isNL
             else
@@ -241,7 +241,7 @@ final case class State(
       val ok = {
         // comment could be preceded by a comma
         isComment && ft.left.is[Token.Comma] &&
-        (fops.prev(ft).meta.leftOwner eq lineOwner)
+        (fops.tokens.prev(ft).meta.leftOwner eq lineOwner)
       } ||
         TreeOps
           .findTreeOrParentSimple(ft.meta.leftOwner)(_ eq lineOwner)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/CanRunTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/CanRunTests.scala
@@ -23,10 +23,11 @@ trait CanRunTests extends FunSuite with HasTests {
             try {
               run.apply(t, parse)
             } catch {
-              case e: ParseException =>
+              case FormatException(e: ParseException, code) =>
                 fail(
                   "test does not parse\n" +
-                    parseException2Message(e, t.original)
+                    parseException2Message(e, code),
+                  e
                 )
             }
           case None => fail(s"Found no parse for filename $filename")

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/FormatException.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/FormatException.scala
@@ -1,0 +1,3 @@
+package org.scalafmt.util
+
+case class FormatException(exc: Throwable, code: String) extends Exception(exc)


### PR DESCRIPTION
- Indent: slightly modify how expiration is detected
- CanRunTests: print the code which failed parsing
- FormatOps: move traversal methods to FormatTokens
- BestFirstSearch: use stop token position only