### PR TITLE
TreeOps: don't extract single stmt in block

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -74,7 +74,7 @@ private class BestFirstSearch private (
         // Block must span at least 3 lines to be worth recursing.
         val ok = close.start < stop.start &&
           distance(left.left, close) > style.maxColumn * 3 &&
-          extractStatementsIfAny(left.meta.leftOwner).nonEmpty
+          extractStatementsIfAny(left.meta.leftOwner, true).nonEmpty
         if (ok) Some(close) else None
       }
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -77,9 +77,12 @@ object TreeOps {
       case _ => false
     }
 
-  def extractStatementsIfAny(tree: Tree): Seq[Tree] =
+  def extractStatementsIfAny(tree: Tree, all: Boolean): Seq[Tree] =
     tree match {
-      case b: Term.Block => b.stats
+      case b: Term.Block =>
+        val ok = all || b.stats.length != 1 ||
+          b.stats.head.is[Term.FunctionTerm]
+        if (ok) b.stats else Seq.empty
       case b: Term.FunctionTerm if isBlockFunction(b) => b.body :: Nil
       case t: Pkg => t.stats
       // TODO(olafur) would be nice to have an abstract "For" superclass.
@@ -174,7 +177,7 @@ object TreeOps {
           addDefn[KwDef](t.mods, t)
           addAll(t.stats)
         case t => // Nothing
-          addAll(extractStatementsIfAny(t))
+          addAll(extractStatementsIfAny(t, false))
       }
       x.children.foreach(loop)
     }

--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -381,9 +381,7 @@ testAsync("Resource.make is equivalent to a partially applied bracket") { implic
 >>>
 testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
   check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String] /* c1 */ ) /* c2 */ =>
-    { /*c3*/
-      acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f)
-    }
+    { /*c3*/ acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f) }
   }
 }
 <<< #448


### PR DESCRIPTION
This method is used to identify the points where new statements start,
specifically in order to figure out where one statement ends and a new
one begins.

With the exception of special handling for lambdas, let's not "start" a
new statement when it's the only one, as there's no previous statement
to separate from.

This allows with rewriting of optional braces, when the LeftBrace token
is dropped but the block around it remains, which leads to triggering
an earlier, incorrect rule.