### PR TITLE
BestFirstSearch: partially undo the last commit

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -72,7 +72,7 @@ private class BestFirstSearch private (
       else {
         val close = matching(left.left)
         // Block must span at least 3 lines to be worth recursing.
-        val ok = close.start < stop.start &&
+        val ok = close != stop &&
           distance(left.left, close) > style.maxColumn * 3 &&
           extractStatementsIfAny(left.meta.leftOwner).nonEmpty
         if (ok) Some(close) else None


### PR DESCRIPTION
The patch being undone is causing changes in `scala-repos`, will be investigated separately.