### PR TITLE
Prepare for scala3 rewrites (new syntax, optional braces)

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -39,7 +39,7 @@ private class BestFirstSearch private (
     tokens.foreach { t => result += router.getSplits(t) }
     result.result()
   }
-  val noOptimizations = noOptimizationZones(tree)
+  val noOptimizations = noOptimizationZones()
   var explored = 0
   var deepestYet = State.start
   val best = mutable.Map.empty[Int, State]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -29,6 +29,7 @@ private class BestFirstSearch private (
   import formatOps.runner.optimizer._
 
   implicit val stateOrdering = State.Ordering
+  implicit val tokens = formatOps.tokens
 
   /** Precomputed table of splits for each token.
     */
@@ -70,7 +71,7 @@ private class BestFirstSearch private (
       val left = tokens(ft, -1)
       if (!left.left.is[LeftBrace]) None
       else {
-        val close = matching(left.left)
+        val close = tokens.matching(left.left)
         // Block must span at least 3 lines to be worth recursing.
         val ok = close != stop &&
           distance(left.left, close) > style.maxColumn * 3 &&

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -85,8 +85,7 @@ class FormatOps(
   private[internal] val soft = new SoftKeywordClasses(dialect)
   private val statementStarts = getStatementStarts(tree, tokens(_).left, soft)
   val dequeueSpots = getDequeueSpots(usedTokens) ++ statementStarts.keys
-  val styleMap =
-    new StyleMap(tokens, initStyle, ownersMap, matchingOpt)
+  val styleMap = new StyleMap(tokens, initStyle)
   // Maps token to number of non-whitespace bytes before the token's position.
   private final val nonWhitespaceOffset: Map[Token, Int] = {
     val resultB = Map.newBuilder[Token, Int]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -80,7 +80,7 @@ class FormatOps(
   }
 
   private[internal] val soft = new SoftKeywordClasses(dialect)
-  private val statementStarts = getStatementStarts(tree, soft)
+  private val statementStarts = getStatementStarts(tree, tokens(_).left, soft)
   val dequeueSpots = getDequeueSpots(tree) ++ statementStarts.keys
   private val matchingParentheses: Map[TokenHash, Token] =
     getMatchingParentheses(tree.tokens)
@@ -255,6 +255,7 @@ class FormatOps(
   @inline
   final def startsStatement(token: Token): Option[Tree] =
     statementStarts.get(hash(token))
+  val StartsStatementRight = new ExtractFromMeta[Tree](startsStatement)
 
   def parensTuple(token: Token): TokenRanges =
     matchingOpt(token).fold(TokenRanges.empty) { other =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1102,7 +1102,7 @@ class FormatOps(
 
     @tailrec
     def loop(token: Token): FormatToken = {
-      val f = tokens(token)
+      val f = tokens.after(token)
       f.right match {
         case x: T.LeftParen => loop(matching(x))
         // modifier for constructor if class definition has type parameters: [class A[T, K, C] private (a: Int)]
@@ -1315,7 +1315,7 @@ class FormatOps(
         }
       }
       .orElse {
-        val headToken = tokens(term.tokens.head)
+        val headToken = tokens.after(term.tokens.head)
         findFirst(headToken, term.tokens.last)(_.left.is[T.RightArrow])
       }
 
@@ -1640,7 +1640,7 @@ class FormatOps(
       def hasStateColumn = spaceIndents.exists(_.hasStateColumn)
       val (spaceSplit, nlSplit) = body match {
         case t: Term.If if ifWithoutElse(t) || hasStateColumn =>
-          val thenBeg = tokens(t.thenp.tokens.head)
+          val thenBeg = tokens.after(t.thenp.tokens.head)
           val thenHasLB = thenBeg.left.is[T.LeftBrace]
           val end = if (thenHasLB) thenBeg else prevNonComment(prev(thenBeg))
           getSplits(getSlbSplit(end.left))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -6,6 +6,7 @@ import scala.meta.tokens.Token
 import scala.meta.tokens.Tokens
 
 import org.scalafmt.util.TokenOps
+import org.scalafmt.util.TreeOps
 import org.scalafmt.util.Whitespace
 
 class FormatTokens(val arr: Array[FormatToken])
@@ -18,6 +19,9 @@ class FormatTokens(val arr: Array[FormatToken])
     result += FormatTokens.thash(arr.last.right) -> arr.last.meta.idx
     result.result()
   }
+
+  private lazy val matchingParentheses: Map[TokenOps.TokenHash, Token] =
+    TreeOps.getMatchingParentheses(arr.view.map(_.right))
 
   override def length: Int = arr.length
   override def apply(idx: Int): FormatToken = arr(idx)
@@ -56,6 +60,15 @@ class FormatTokens(val arr: Array[FormatToken])
 
   @inline def prev(ft: FormatToken): FormatToken = apply(ft, -1)
   @inline def next(ft: FormatToken): FormatToken = apply(ft, 1)
+
+  @inline def matching(token: Token): Token =
+    matchingParentheses(TokenOps.hash(token))
+  @inline def matchingOpt(token: Token): Option[Token] =
+    matchingParentheses.get(TokenOps.hash(token))
+  @inline def hasMatching(token: Token): Boolean =
+    matchingParentheses.contains(TokenOps.hash(token))
+  @inline def areMatching(t1: Token)(t2: Token): Boolean =
+    matchingOpt(t1).contains(t2)
 
   @tailrec
   final def findTokenWith[A](

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -73,6 +73,18 @@ class FormatTokens(val arr: Array[FormatToken])
   final def prevNonComment(curr: FormatToken): FormatToken =
     findToken(curr, prev)(!_.left.is[Token.Comment]).fold(identity, identity)
 
+  def getLast(tree: Tree): FormatToken =
+    apply(TokenOps.findLastVisibleToken(tree.tokens))
+
+  def getLastOpt(tree: Tree): Option[FormatToken] =
+    TokenOps.findLastVisibleTokenOpt(tree.tokens).map(apply)
+
+  def getLastNonTrivial(tree: Tree): FormatToken =
+    apply(TokenOps.findLastNonTrivialToken(tree.tokens))
+
+  def getLastNonTrivialOpt(tree: Tree): Option[FormatToken] =
+    TokenOps.findLastNonTrivialTokenOpt(tree.tokens).map(apply)
+
 }
 
 object FormatTokens {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -121,7 +121,7 @@ class FormatWriter(formatOps: FormatOps) {
                     TreeOps.isSingleElement(ta.args, b)
                   case _ => false
                 } && RedundantBraces.canRewriteWithParens(b) =>
-              val beg = tokens(matching(rb))
+              val beg = tokens(tokens.matching(rb))
               lookup.update(beg.meta.idx, tok.meta.idx -> loc.leftLineId)
             case _ =>
           }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1042,7 +1042,7 @@ class FormatWriter(formatOps: FormatOps) {
           case t: Template => super.apply(t.stats) // skip inits
           case TreeOps.MaybeTopLevelStat(t) =>
             val leading = leadingComment(tokens(t.tokens.head, -1)).meta.idx
-            val trailing = tokens(t.tokens.last).meta.idx
+            val trailing = tokens.getLast(t).meta.idx
             headBuffer += leading
             lastBuffer += trailing -> leading
             super.apply(tree)
@@ -1059,9 +1059,9 @@ class FormatWriter(formatOps: FormatOps) {
       toks: Array[FormatLocation],
       i: Int
   ): Boolean = {
-    @tailrec def isMultiline(end: Token, i: Int, minLines: Int): Boolean =
+    @tailrec def isMultiline(end: FormatToken, i: Int, minLines: Int): Boolean =
       if (minLines <= 0) true
-      else if (i >= toks.length || toks(i).formatToken.left == end) false
+      else if (i >= toks.length || toks(i).formatToken == end) false
       else {
         val hasNL = toks(i).state.split.isNL
         isMultiline(end, i + 1, if (hasNL) minLines - 1 else minLines)
@@ -1085,7 +1085,7 @@ class FormatWriter(formatOps: FormatOps) {
         }
         .flatten
         .map {
-          case pkg: Pkg => tokens(pkg.ref.tokens.last).right.is[T.LeftBrace]
+          case pkg: Pkg => tokens.getLast(pkg.ref).right.is[T.LeftBrace]
           case _ => true
         }
 
@@ -1098,7 +1098,7 @@ class FormatWriter(formatOps: FormatOps) {
           case x => x
         }
         isMultiline(
-          nonCommentOwner.tokens.last,
+          tokens.getLast(nonCommentOwner),
           i + distance + 1,
           initStyle.newlines.topLevelStatementsMinBreaks
         )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -850,7 +850,7 @@ class FormatWriter(formatOps: FormatOps) {
     }
 
     private def isEarlierLine(t: Tree)(implicit fl: FormatLocation): Boolean = {
-      val idx = tokens(t.tokens.head).meta.idx + 1
+      val idx = tokens.after(t.tokens.head).meta.idx + 1
       idx <= fl.formatToken.meta.idx && // e.g., leading comments
       locations(idx).leftLineId != fl.leftLineId
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -65,6 +65,8 @@ class Router(formatOps: FormatOps) {
   import formatOps._
 
   import tokens.{
+    matching,
+    matchingOpt,
     prev,
     next,
     prevNonComment,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -479,12 +479,12 @@ class Router(formatOps: FormatOps) {
           else CtrlBodySplits.folded(ft, body)(nlSplit(ft))
         }
       // New statement
-      case tok @ FormatToken(T.Semicolon(), right, _)
-          if newlines == 0 && startsStatement(right).isDefined =>
+      case tok @ FormatToken(_: T.Semicolon, _, StartsStatementRight(stmt))
+          if newlines == 0 =>
         val spaceSplit =
           if (style.newlines.source eq Newlines.unfold) Split.ignored
           else {
-            val expire = startsStatement(right).get.tokens.last
+            val expire = stmt.tokens.last
             Split(Space, 0).withSingleLine(expire)
           }
         Seq(
@@ -504,8 +504,7 @@ class Router(formatOps: FormatOps) {
           Split(Newline, 1).withIndent(style.indent.main, expireToken, After)
         )
 
-      case tok @ FormatToken(left, right, _)
-          if startsStatement(right).isDefined =>
+      case tok @ FormatToken(left, right, StartsStatementRight(_)) =>
         val expire = rightOwner.tokens
           .find(_.is[T.Equals])
           .map { equalsToken =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -209,9 +209,9 @@ object TokenOps {
   def findArgsFor[A <: Tree](
       token: Token,
       argss: Seq[Seq[A]],
-      matching: Map[TokenHash, Token]
+      matchingOpt: Token => Option[Token]
   ): Option[Seq[A]] =
-    matching.get(hash(token)).flatMap { other =>
+    matchingOpt(token).flatMap { other =>
       // find the arg group starting with given format token
       val beg = math.min(token.start, other.start)
       argss

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -64,16 +64,23 @@ object TokenOps {
   def findLast[A](seq: Seq[A])(cond: A => Boolean): Option[A] =
     seq.reverseIterator.find(cond)
 
-  def lastTokenOpt(tokens: Tokens): Option[Token] =
+  def findLastNonTrivialTokenOpt(tokens: Tokens): Option[Token] =
     findLast(tokens) {
       case Trivia() | _: EOF => false
       case _ => true
     }
 
-  def lastToken(tokens: Tokens): Token =
-    lastTokenOpt(tokens).getOrElse(tokens.last)
+  def findLastNonTrivialToken(tokens: Tokens): Token =
+    findLastNonTrivialTokenOpt(tokens).getOrElse(tokens.last)
 
-  def lastToken(tree: Tree): Token = lastToken(tree.tokens)
+  def findLastVisibleTokenOpt(tokens: Tokens): Option[Token] =
+    findLast(tokens) {
+      case Whitespace() | _: EOF => false
+      case _ => true
+    }
+
+  def findLastVisibleToken(tokens: Tokens): Token =
+    findLastNonTrivialTokenOpt(tokens).getOrElse(tokens.last)
 
   def endsWithNoIndent(between: Seq[Token]): Boolean =
     between.lastOption.exists(_.is[LF])

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -196,7 +196,7 @@ object TreeOps {
     *
     * Contains lookup keys in both directions, opening [({ and closing })].
     */
-  def getMatchingParentheses(tokens: Tokens): Map[TokenHash, Token] = {
+  def getMatchingParentheses(tokens: Iterable[Token]): Map[TokenHash, Token] = {
     val ret = Map.newBuilder[TokenHash, Token]
     var stack = List.empty[Token]
     tokens.foreach {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -96,9 +96,9 @@ object TreeOps {
       case _ => Seq.empty[Tree]
     }
 
-  def getDequeueSpots(tree: Tree): Set[TokenHash] = {
+  def getDequeueSpots(tokens: Iterable[Token]): Set[TokenHash] = {
     val ret = Set.newBuilder[TokenHash]
-    tree.tokens.foreach {
+    tokens.foreach {
       case t @ KwElse() =>
         ret += hash(t)
       case _ =>


### PR DESCRIPTION
- FormatTokens: allow to look up an ealier token
- FormatOps: get stmt differently in rewritten block
- FormatTokens: move matchingParens from FormatOps
- FormatOps: use tokens from FormatTokens, not tree
- FormatWriter: recognize blk rewrites in `a{} -> a()`