### PR TITLE
Rewrite: fix the placeholder check

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -222,7 +222,7 @@ object RewriteCtx {
             queue ++= (t.lhs +: t.args)
             iter
           case t: Term.Apply =>
-            queue += t.fun
+            queue ++= (t.fun +: t.args)
             iter
           case t: Term.Select =>
             queue += t.qual

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -960,3 +960,11 @@ object a {
   val res = new A with B { val foo = 1 }
   val res = new A with B { val foo = 1 }.foo
 }
+<<< #2426 placeholder in infix
+def main(args: Array[String]): Unit =
+  args foreach {
+    println(_)
+  }
+>>>
+def main(args: Array[String]): Unit =
+  args foreach println(_)

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -967,4 +967,6 @@ def main(args: Array[String]): Unit =
   }
 >>>
 def main(args: Array[String]): Unit =
-  args foreach println(_)
+  args foreach {
+    println(_)
+  }


### PR DESCRIPTION
Check the arguments of a Term.Apply (just like Term.ApplyInfix above) looking for a placeholder. Fixes #2426.