### PR TITLE
Decodable: disable top-level presets, error out

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -79,7 +79,7 @@ case class Align(
       "Enumerator.Generator" -> "for",
       "Enumerator.Val" -> "for"
     )
-) extends Decodable[Align] {
+) extends Decodable[Align]("align") {
   override protected[config] def baseDecoder =
     generic.deriveDecoder(this).noTypos
   implicit def alignReader: ConfDecoder[Seq[AlignToken]] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
@@ -36,7 +36,7 @@ case class BinPack(
     literalsMinArgCount: Int = 5,
     literalsInclude: Seq[String] = Seq(".*"),
     literalsExclude: Seq[String] = Seq("String", "Term.Name")
-) extends Decodable[BinPack] {
+) extends Decodable[BinPack]("binPack") {
   override protected[config] def baseDecoder =
     generic.deriveDecoder(this).noTypos
   def literalsRegex: FilterMatcher =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/DanglingParentheses.scala
@@ -7,7 +7,7 @@ case class DanglingParentheses(
     defnSite: Boolean,
     ctrlSite: Boolean = true,
     exclude: List[DanglingParentheses.Exclude] = Nil
-) extends Decodable[DanglingParentheses] {
+) extends Decodable[DanglingParentheses]("danglingParentheses") {
   override protected[config] def baseDecoder =
     generic.deriveDecoder(this).noTypos
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Decodable.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Decodable.scala
@@ -8,7 +8,7 @@ object Decodable {
 
 }
 
-abstract class Decodable[A] { self: A =>
+abstract class Decodable[A](sectionName: String = null) { self: A =>
   type T = A
   protected[config] def baseDecoder: ConfDecoder[A]
 
@@ -45,12 +45,11 @@ abstract class Decodable[A] { self: A =>
           case x =>
             ConfError.message(s"$me: unsupported preset: $x").notOk
         }
-      case presetsMatch(x) =>
-        Console.err.println(
-          s"$me: top-level presets deprecated; " +
-            s"use '${Decodable.presetKey}' subsection"
-        )
-        Some(Configured.ok(x, null))
+      case presetsMatch(_) =>
+        val section = Option(sectionName).fold("subsection '")(x => s"'$x.")
+        val err = s"$me: top-level presets removed since v3.0.0; " +
+          s"use $section${Decodable.presetKey} = $conf' instead"
+        Some(ConfError.message(err).notOk)
       case _ => None
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ImportSelectors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ImportSelectors.scala
@@ -38,29 +38,15 @@ import metaconfig._
   *   import org.{Aaaa, Bbbb, C, D, Eeee}
   * }}}
   */
-sealed abstract class ImportSelectors extends Decodable[ImportSelectors] {
-  override protected[config] def baseDecoder = ImportSelectors.reader
-}
+sealed abstract class ImportSelectors
 
 object ImportSelectors {
 
-  val reader: ConfCodec[ImportSelectors] =
-    ReaderUtil.oneOf[ImportSelectors](noBinPack, binPack, singleLine)
-
-  implicit val encoder: ConfEncoder[ImportSelectors] = reader
-
-  // This reader is backwards compatible with the old import selector
-  // configuration, which used the boolean flag binPackImportSelectors to
-  // decide between (what are now) the `binPack` and `noBinPack` strategies.
-  // It is defined here to keep the `ConfDecoder.instance[T} {}` lambda in a
-  // separate file from the @DeriveConfDecoder macro annotation; this is due to
-  // limitations in the current version of scalameta/paradise, but these will
-  // likely be fixed in the future, at which point this reader could be moved
-  // to ScalafmtConfig
-  implicit val preset: PartialFunction[Conf, ImportSelectors] = {
-    case Conf.Bool(true) => ImportSelectors.binPack
-    case Conf.Bool(false) => ImportSelectors.noBinPack
-  }
+  implicit val codec: ConfCodec[ImportSelectors] =
+    ReaderUtil.oneOfCustom[ImportSelectors](noBinPack, binPack, singleLine) {
+      case Conf.Bool(true) => Configured.ok(ImportSelectors.binPack)
+      case Conf.Bool(false) => Configured.ok(ImportSelectors.noBinPack)
+    }
 
   case object noBinPack extends ImportSelectors
   case object binPack extends ImportSelectors

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -53,7 +53,7 @@ case class IndentOperator(
     topLevelOnly: Boolean = true,
     include: String = ".*",
     exclude: String = "^(&&|\\|\\|)$"
-) extends Decodable[IndentOperator] {
+) extends Decodable[IndentOperator]("indentOperator") {
   override protected[config] def baseDecoder =
     generic.deriveDecoder(this).noTypos
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -160,7 +160,6 @@ case class ScalafmtConfig(
   private implicit def alignDecoder = align.decoder
   private implicit def danglingParenthesesReader = danglingParentheses.decoder
   private implicit def indentOperatorReader = indentOperator.decoder
-  private implicit def importSelectorsReader = importSelectors.decoder
   private implicit def docstringsDecoder = docstrings.decoder
   private implicit def commentsDecoder = comments.decoder
   lazy val alignMap: Map[String, regex.Pattern] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SpaceBeforeContextBound.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/SpaceBeforeContextBound.scala
@@ -1,28 +1,16 @@
 package org.scalafmt.config
 
 import metaconfig._
-import org.scalafmt.config.SpaceBeforeContextBound.{Always, IfMultipleBounds}
 
 sealed abstract class SpaceBeforeContextBound
-    extends Decodable[SpaceBeforeContextBound] {
-  override protected[config] def baseDecoder = SpaceBeforeContextBound.decoder
-
-  def isIfMultipleBounds = this == IfMultipleBounds
-  def isAlways = this == Always
-}
 
 object SpaceBeforeContextBound {
 
-  val codec: ConfCodec[SpaceBeforeContextBound] =
-    ReaderUtil.oneOf[SpaceBeforeContextBound](Always, Never, IfMultipleBounds)
-
-  implicit val encoder: ConfEncoder[SpaceBeforeContextBound] = codec
-  implicit val decoder: ConfDecoder[SpaceBeforeContextBound] = codec
-
-  implicit val preset: PartialFunction[Conf, SpaceBeforeContextBound] = {
-    case Conf.Bool(true) => Always
-    case Conf.Bool(false) => Never
-  }
+  implicit val codec: ConfCodec[SpaceBeforeContextBound] = ReaderUtil
+    .oneOfCustom[SpaceBeforeContextBound](Always, Never, IfMultipleBounds) {
+      case Conf.Bool(true) => Configured.ok(Always)
+      case Conf.Bool(false) => Configured.ok(Never)
+    }
 
   case object Always extends SpaceBeforeContextBound
   case object Never extends SpaceBeforeContextBound

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
@@ -37,7 +37,6 @@ case class Spaces(
     inByNameTypes: Boolean = true,
     afterSymbolicDefs: Boolean = false
 ) {
-  implicit val spaceBeforeContextBoundReader = beforeContextBoundColon.decoder
   implicit val reader: ConfDecoder[Spaces] = generic.deriveDecoder(this).noTypos
 }
 

--- a/scalafmt-tests/src/test/resources/spaces/BeforeContextBoundColonTrue.stat
+++ b/scalafmt-tests/src/test/resources/spaces/BeforeContextBoundColonTrue.stat
@@ -1,4 +1,4 @@
-spaces.beforeContextBoundColon.preset = true
+spaces.beforeContextBoundColon = true
 <<< space before colon #180
 def map[T: Class](f: N => T): S[T]
 >>>


### PR DESCRIPTION
It's been a while since we deprecated `binPack = true` in favor of `binPack.preset = true`, since the former always causes confusion if `binPack.parentConstructors` setting is also added. Let's now completely disable this usage.