### PR TITLE
FormatOps: fix bug with `{` or `then` in `if`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -305,9 +305,7 @@ class FormatOps(
   def defnSiteLastToken(close: FormatToken, tree: Tree): Token = {
     tree match {
       // TODO(olafur) scala.meta should make this easier.
-      case procedure: Defn.Def
-          if procedure.decltpe.isDefined &&
-            procedure.decltpe.get.tokens.isEmpty =>
+      case procedure: Defn.Def if procedure.decltpe.exists(_.tokens.isEmpty) =>
         procedure.body.tokens.find(_.is[T.LeftBrace])
       case t: Defn.Def if t.body.is[Term.Block] =>
         t.body.tokens.headOption
@@ -1640,9 +1638,9 @@ class FormatOps(
       def hasStateColumn = spaceIndents.exists(_.hasStateColumn)
       val (spaceSplit, nlSplit) = body match {
         case t: Term.If if ifWithoutElse(t) || hasStateColumn =>
-          val thenIsBlock = t.thenp.is[Term.Block]
           val thenBeg = tokens(t.thenp.tokens.head)
-          val end = if (thenIsBlock) thenBeg else prevNonComment(prev(thenBeg))
+          val thenHasLB = thenBeg.left.is[T.LeftBrace]
+          val end = if (thenHasLB) thenBeg else prevNonComment(prev(thenBeg))
           getSplits(getSlbSplit(end.left))
         case _: Term.If => getSlbSplits()
         case _: Term.Try | _: Term.TryWithHandler =>

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -485,15 +485,27 @@ object a:
      for x <- y
      yield foo
 <<< complex "block" expression
-def foo =
-   if cond then
+object a:
+  def foo =
+    if cond then
         sb.append(doc.text.substring(offset, end))
         sb.append(doc.text.substring(offset, end))
+  def foo =
+    if (cond) {
+        sb.append(doc.text.substring(offset, end))
+        sb.append(doc.text.substring(offset, end))
+    }
 >>>
-def foo =
-  if cond then
-     sb.append(doc.text.substring(offset, end))
-     sb.append(doc.text.substring(offset, end))
+object a:
+   def foo =
+     if cond then
+        sb.append(doc.text.substring(offset, end))
+        sb.append(doc.text.substring(offset, end))
+   def foo =
+     if (cond) {
+       sb.append(doc.text.substring(offset, end))
+       sb.append(doc.text.substring(offset, end))
+     }
 <<< lambda with =>
 object a:
   val func: A => B = (a: A) =>

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -479,15 +479,26 @@ object a:
         bar
    def foo = for x <- y yield foo
 <<< complex "block" expression
-def foo =
-   if cond then
+object a:
+  def foo =
+    if cond then
         sb.append(doc.text.substring(offset, end))
         sb.append(doc.text.substring(offset, end))
+  def foo =
+    if (cond) {
+        sb.append(doc.text.substring(offset, end))
+        sb.append(doc.text.substring(offset, end))
+    }
 >>>
-def foo =
-  if cond then
+object a:
+   def foo =
+     if cond then
+        sb.append(doc.text.substring(offset, end))
+        sb.append(doc.text.substring(offset, end))
+   def foo = if (cond) {
      sb.append(doc.text.substring(offset, end))
      sb.append(doc.text.substring(offset, end))
+   }
 <<< lambda with =>
 object a:
   val func: A => B = (a: A) =>

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -491,10 +491,9 @@ object a:
     }
 >>>
 object a:
-   def foo =
-     if cond then
-        sb.append(doc.text.substring(offset, end))
-        sb.append(doc.text.substring(offset, end))
+   def foo = if cond then
+      sb.append(doc.text.substring(offset, end))
+      sb.append(doc.text.substring(offset, end))
    def foo = if (cond) {
      sb.append(doc.text.substring(offset, end))
      sb.append(doc.text.substring(offset, end))

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -497,15 +497,27 @@ object a:
         x <- y
      yield foo
 <<< complex "block" expression
-def foo =
-   if cond then
+object a:
+  def foo =
+    if cond then
         sb.append(doc.text.substring(offset, end))
         sb.append(doc.text.substring(offset, end))
+  def foo =
+    if (cond) {
+        sb.append(doc.text.substring(offset, end))
+        sb.append(doc.text.substring(offset, end))
+    }
 >>>
-def foo =
-  if cond then
-     sb.append(doc.text.substring(offset, end))
-     sb.append(doc.text.substring(offset, end))
+object a:
+   def foo =
+     if cond then
+        sb.append(doc.text.substring(offset, end))
+        sb.append(doc.text.substring(offset, end))
+   def foo =
+     if (cond) {
+       sb.append(doc.text.substring(offset, end))
+       sb.append(doc.text.substring(offset, end))
+     }
 <<< lambda with =>
 object a:
   val func: A => B = (a: A) =>

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -528,15 +528,27 @@ object a:
         x <- y
      yield foo
 <<< complex "block" expression
-def foo =
-   if cond then
+object a:
+  def foo =
+    if cond then
         sb.append(doc.text.substring(offset, end))
         sb.append(doc.text.substring(offset, end))
+  def foo =
+    if (cond) {
+        sb.append(doc.text.substring(offset, end))
+        sb.append(doc.text.substring(offset, end))
+    }
 >>>
-def foo =
-  if cond then
-     sb.append(doc.text.substring(offset, end))
-     sb.append(doc.text.substring(offset, end))
+object a:
+   def foo =
+     if cond then
+        sb.append(doc.text.substring(offset, end))
+        sb.append(doc.text.substring(offset, end))
+   def foo =
+     if (cond) {
+       sb.append(doc.text.substring(offset, end))
+       sb.append(doc.text.substring(offset, end))
+     }
 <<< lambda with =>
 object a:
   val func: A => B = (a: A) =>


### PR DESCRIPTION
With optional braces, the body of `if` can be a block but not include a left brace. Let's expire on `{` if it's there, otherwise on the token just before `thenp` part.
