### PR TITLE
FormatOps: optional braces in a single-stat block

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1950,7 +1950,8 @@ class FormatOps(
     ): Option[Seq[Split]] = {
       val leftOwner = ft.meta.leftOwner
       findTreeWithParentSimple(nft.meta.rightOwner)(_ eq leftOwner) match {
-        case Some(t: Term.Block) if isBlockStart(t, nft) =>
+        case Some(t: Term.Block)
+            if t.stats.lengthCompare(1) > 0 && isBlockStart(t, nft) =>
           Some(getSplitsMaybeBlock(ft, nft, t, true))
         case _ => None
       }


### PR DESCRIPTION
Actually, they are always optional, so we should fall back to existing rules to handle that.