### PR TITLE
StyleMap: use binary search on change positions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -68,7 +68,7 @@ class FormatOps(
   import TreeOps._
   implicit val dialect = initStyle.runner.dialect
   private val ownersMap = getOwners(tree)
-  val tokens: FormatTokens = FormatTokens(tree.tokens, owners)
+  val (tokens, styleMap) = FormatTokens(tree.tokens, owners)(initStyle)
   import tokens.{
     matching,
     matchingOpt,
@@ -85,7 +85,6 @@ class FormatOps(
   private[internal] val soft = new SoftKeywordClasses(dialect)
   private val statementStarts = getStatementStarts(tree, tokens(_).left, soft)
   val dequeueSpots = getDequeueSpots(usedTokens) ++ statementStarts.keys
-  val styleMap = new StyleMap(tokens, initStyle)
   // Maps token to number of non-whitespace bytes before the token's position.
   private final val nonWhitespaceOffset: Map[Token, Int] = {
     val resultB = Map.newBuilder[Token, Int]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -5,6 +5,8 @@ import scala.meta.Tree
 import scala.meta.tokens.Token
 import scala.meta.tokens.Tokens
 
+import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.util.StyleMap
 import org.scalafmt.util.TokenOps
 import org.scalafmt.util.TreeOps
 import org.scalafmt.util.Whitespace
@@ -127,7 +129,9 @@ object FormatTokens {
     * Since tokens might be very large, we try to allocate as
     * little memory as possible.
     */
-  def apply(tokens: Tokens, owner: Token => Tree): FormatTokens = {
+  def apply(tokens: Tokens, owner: Token => Tree)(implicit
+      style: ScalafmtConfig
+  ): (FormatTokens, StyleMap) = {
     var left: Token = null
     var lmeta: FormatToken.TokenMeta = null
     val result = Array.newBuilder[FormatToken]
@@ -160,7 +164,11 @@ object FormatTokens {
           tokIdx += 1
           wsIdx = tokIdx
       }
-    new FormatTokens(result.result)
+
+    val ftoks = new FormatTokens(result.result)
+    val styleMap = new StyleMap(ftoks, style)
+
+    ftoks -> styleMap
   }
 
   @inline

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -764,8 +764,7 @@ class FormatWriter(formatOps: FormatOps) {
     // TODO(olafur) Refactor implementation to make it maintainable. It's super
     // imperative and error-prone right now.
     private def alignmentTokens: Map[Int, Int] = {
-      lazy val noAlignTokens = initStyle.align.tokens.isEmpty &&
-        styleMap.tok2style.values.forall(_.align.tokens.isEmpty)
+      lazy val noAlignTokens = styleMap.forall(_.align.tokens.isEmpty)
       if (locations.length != tokens.length || noAlignTokens)
         Map.empty[Int, Int]
       else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -147,4 +147,6 @@ class StyleMap(
   def at(token: Token): ScalafmtConfig =
     tok2style.getOrElse(hash(token), init)
 
+  private[util] def numEntries: Int = tok2style.size
+
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -110,10 +110,19 @@ class StyleMapTest extends FunSuite {
       """.stripMargin.parse[Source].get
     val fops1 = new FormatOps(code, ScalafmtConfig.default)
     val fops2 = new FormatOps(code, ScalafmtConfig(binPack = BinPack.enabled))
-    // all tokens starting with first "("
-    assertEquals(fops1.styleMap.numEntries, 43)
-    // all tokens starting with "// scalafmt:" override
-    assertEquals(fops2.styleMap.numEntries, 16)
+    /*
+     * - 1: initial style
+     * - 6: all 3 pairs of "()"
+     * - "// scalafmt:" override does nothing, since the value doesn't change
+     */
+    assertEquals(fops1.styleMap.numEntries, 7)
+    /*
+     * - 1: initial style
+     * - 1: "// scalafmt:" override
+     * - 2: last pair of "()"
+     * - the first two pairs of () do nothing, since the value doesn't change
+     */
+    assertEquals(fops2.styleMap.numEntries, 4)
   }
 
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -112,8 +112,8 @@ class StyleMapTest extends FunSuite {
     val fops2 = new FormatOps(code, ScalafmtConfig(binPack = BinPack.enabled))
     // all tokens starting with first "("
     assertEquals(fops1.styleMap.numEntries, 43)
-    // all tokens starting with first "("
-    assertEquals(fops2.styleMap.numEntries, 43)
+    // all tokens starting with "// scalafmt:" override
+    assertEquals(fops2.styleMap.numEntries, 16)
   }
 
 }


### PR DESCRIPTION
The purpose of this change is twofold:
- when tokens are rewritten, the original logic of looking up by a token would stop working, as new tokens wouldn't be registered in the `StyleMap`; instead, we need to use the token position rather than the actual token
- since format overrides are fairly rare, using binary search on a handful of change positions is cheaper than using a hashmap containing hundreds or even thousands of tokens following the first override