### PR TITLE
Router: use available style to check binpack

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -889,13 +889,6 @@ class FormatOps(
       style.newlines.notBeforeImplicitParamListModifier &&
       opensImplicitParamList(formatToken).isDefined
 
-  def styleAt(tree: Tree): ScalafmtConfig = {
-    val style = styleMap.at(tree.tokens.head)
-    if (styleMap.forcedBinPack(tree)) // off-by-one
-      styleMap.setBinPack(style, callSite = true)
-    else style
-  }
-
   def getApplyIndent(
       leftOwner: Tree,
       isConfigStyle: Boolean = false
@@ -907,8 +900,7 @@ class FormatOps(
       case _ => Num(style.indent.callSite)
     }
 
-  def isBinPack(owner: Tree): Boolean = {
-    implicit val style = styleAt(owner)
+  def isBinPack(owner: Tree)(implicit style: ScalafmtConfig): Boolean = {
     (style.binPack.unsafeCallSite && isCallSite(owner)) ||
     (style.binPack.unsafeDefnSite && isDefnSite(owner))
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1156,8 +1156,7 @@ class Router(formatOps: FormatOps) {
             nextNonComment(next(tok)).right.is[RightParenOrBracket]
           Seq(Split(Space, 0), Split(Newline, 1).notIf(noNewline))
         }
-      case tok @ FormatToken(T.Comma(), right, _)
-          if leftOwner.isNot[Template] =>
+      case FormatToken(_: T.Comma, right, _) if leftOwner.isNot[Template] =>
         // TODO(olafur) DRY, see OneArgOneLine.
         argumentStarts.get(hash(right)) match {
           case Some(nextArg) if isBinPack(leftOwner) =>


### PR DESCRIPTION
The style for an intermediate token between two parentheses would have the same value for `binPack.unsafeCallSite`, so there's no need for a complex logic.