### PR TITLE
BinPack: support indenting call sites only once

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
@@ -29,6 +29,7 @@ import metaconfig._
 case class BinPack(
     unsafeCallSite: Boolean = false,
     unsafeDefnSite: Boolean = false,
+    indentCallSiteOnce: Boolean = false,
     parentConstructors: BinPack.ParentCtors = BinPack.ParentCtors.MaybeNever,
     literalArgumentLists: Boolean = true,
     literalsIncludeSimpleExpr: Boolean = false,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1004,8 +1004,10 @@ class Router(formatOps: FormatOps) {
         val open = formatToken.left
         val close = matching(open)
         val indent = getApplyIndent(leftOwner)
+        val noSplitIndent =
+          if (style.binPack.indentCallSiteOnce) Num(0) else indent
         def baseNoSplit(implicit line: sourcecode.Line) =
-          Split(NoSplit, 0).withIndent(indent, close, Before)
+          Split(NoSplit, 0).withIndent(noSplitIndent, close, Before)
         val opensLiteralArgumentList =
           styleMap.opensLiteralArgumentList(formatToken)
         val singleLineOnly =
@@ -1161,9 +1163,12 @@ class Router(formatOps: FormatOps) {
         argumentStarts.get(hash(right)) match {
           case Some(nextArg) if isBinPack(leftOwner) =>
             val lastFT = tokens.getLast(nextArg)
+            val indentCallSiteOnce =
+              style.binPack.indentCallSiteOnce && isCallSite(leftOwner)
+            val indent = if (indentCallSiteOnce) style.indent.callSite else 0
             Seq(
               Split(Space, 0).withSingleLine(rhsOptimalToken(lastFT)),
-              Split(Newline, 1)
+              Split(Newline, 1).withIndent(indent, right, After)
             )
           case _
               if !style.newlines.formatInfix &&

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -154,6 +154,7 @@ object SharedPolicyAmounts {
 }
 <<< #2079 avoid nested indent
 binPack.preset = true
+binPack.indentCallSiteOnce = true
 continuationIndent.callSite = 4
 ===
 object a {
@@ -163,5 +164,5 @@ object a {
 >>>
 object a {
   new SimpleMethodName(validateSimpleEncodedName(name, 0, len,
-          openAngleBracketOK = false))
+      openAngleBracketOK = false))
 }

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -152,3 +152,16 @@ object SharedPolicyAmounts {
       75000, 100000, 150000, 200000, 300000, 400000, 500000, 750000, 1000000
   )
 }
+<<< #2079 avoid nested indent
+binPack.preset = true
+continuationIndent.callSite = 4
+===
+object a {
+  new SimpleMethodName(
+    validateSimpleEncodedName(name, 0, len, openAngleBracketOK = false))
+}
+>>>
+object a {
+  new SimpleMethodName(validateSimpleEncodedName(name, 0, len,
+          openAngleBracketOK = false))
+}


### PR DESCRIPTION
Instead of indenting for each level of "()" nesting, add a flag to allow indenting only once. Fixes #2079.