### PR TITLE
Fix formatting when Ident is after TypeLambdaArrow

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
@@ -39,7 +39,7 @@ object Delim {
     token.is[Underscore] || token.is[LeftParen] || token.is[RightParen] ||
     token.is[Comma] || token.is[Dot] || token.is[Semicolon] ||
     token.is[LeftBracket] || token.is[RightBracket] || token.is[LeftBrace] ||
-    token.is[RightBrace] || token.is[ContextArrow]
+    token.is[RightBrace] || token.is[ContextArrow] || token.is[TypeLambdaArrow]
   }
 }
 

--- a/scalafmt-tests/src/test/resources/scala3/TypeLambda.stat
+++ b/scalafmt-tests/src/test/resources/scala3/TypeLambda.stat
@@ -3,6 +3,10 @@
 type   Tuple   =  [  X ] =>> (X, X)
 >>>
 type Tuple = [X] =>> (X, X)
+<<< type lambda ident
+type Of[S] = [F[_]] =>>   Scoped[F, S]
+>>>
+type Of[S] = [F[_]] =>> Scoped[F, S]
 <<< type lambda long
 maxColumn = 30
 ===


### PR DESCRIPTION
Related to https://github.com/scalameta/scalafmt/issues/2216#issuecomment-823910262

Previously, we would catch the case with Delim being second for `(`.