### PR TITLE
Don't pass CMSClassUnloading to sbt

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -4,5 +4,4 @@
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
--XX:+CMSClassUnloadingEnabled
 -Dsbt.server.autostart=false

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,1 +1,0 @@
--J-XX:+CMSClassUnloadingEnabled


### PR DESCRIPTION
This has apparently been the default since 2013
(https://bugs.openjdk.java.net/browse/JDK-8000325)
and is no longer available on jdk15