### PR TITLE
FormatOps: templateDerivesOrCurly with FormatToken

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -75,7 +75,7 @@ class Router(formatOps: FormatOps) {
     nextNonCommentSameLine
   }
 
-  private def getSplitsImpl(formatToken: FormatToken): Seq[Split] = {
+  private def getSplitsImpl(implicit formatToken: FormatToken): Seq[Split] = {
     implicit val style = styleMap.at(formatToken)
     val leftOwner = formatToken.meta.leftOwner
     val rightOwner = formatToken.meta.rightOwner
@@ -1464,24 +1464,20 @@ class Router(formatOps: FormatOps) {
       // Enum Case
       case FormatToken(_, T.KwExtends(), _)
           if rightOwner.isInstanceOf[Defn.EnumCase] =>
-        val lastToken = getLastToken(rightOwner)
         val enumCase = rightOwner.asInstanceOf[Defn.EnumCase]
         binPackParentConstructorSplits(
           Set(rightOwner),
-          lastToken,
+          getLastToken(rightOwner),
           style.indent.extendSite,
           enumCase.inits.length > 1
         )
 
       // Template
-      case FormatToken(_, right @ soft.ExtendsOrDerives(), _) =>
+      case ft @ FormatToken(_, soft.ExtendsOrDerives(), _) =>
         val template = defnTemplate(rightOwner)
-        val lastToken = template
-          .flatMap {
-            if (right.is[soft.KwDerives]) templateCurly
-            else templateDerivesOrCurly
-          }
-          .getOrElse(getLastToken(template.getOrElse(rightOwner)))
+        def lastToken = template.fold(getLastToken(rightOwner)) { x =>
+          templateDerivesOrCurly(x).getOrElse(getLastToken(x))
+        }
 
         binPackParentConstructorSplits(
           template.toSet,
@@ -1491,20 +1487,11 @@ class Router(formatOps: FormatOps) {
         )
 
       // trait A extends B, C, D, E
-      case FormatToken(T.Comma(), right, _) if leftOwner.is[Template] =>
+      case FormatToken(_: T.Comma, _, _) if leftOwner.is[Template] =>
         val template = leftOwner.asInstanceOf[Template]
-        val prevOwner = prevNonComment(prev(formatToken)).meta.leftOwner
-        val firstDerives = isFirstDerives(
-          template,
-          prevOwner
-        )
-        val ident =
-          if (firstDerives || isFirstInit(template, prevOwner))
-            style.indent.commaSiteRelativeToExtends
-          else 0
-        typeTemplateSplits(template, ident, firstDerives)
+        typeTemplateSplits(template, style.indent.commaSiteRelativeToExtends)
 
-      case FormatToken(_, T.KwWith(), _) =>
+      case FormatToken(_, _: T.KwWith, _) =>
         rightOwner match {
           // something like new A with B with C
           case template: Template if template.parent.exists { p =>
@@ -1518,11 +1505,7 @@ class Router(formatOps: FormatOps) {
             )
           // trait A extends B with C with D with E
           case template: Template =>
-            val prev = prevNonComment(formatToken)
-            val indent =
-              if (!isFirstInit(template, prev.meta.leftOwner)) 0
-              else style.indent.withSiteRelativeToExtends
-            typeTemplateSplits(template, indent)
+            typeTemplateSplits(template, style.indent.withSiteRelativeToExtends)
           case t @ WithChain(top) =>
             splitWithChain(
               !t.lhs.is[Type.With],

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -805,11 +805,13 @@ object TreeOps {
       owner.is[Init] && init == owner || init.tpe == owner
     }
 
-  def isFirstDerives(t: Template, owner: Tree) =
-    owner.is[Type] && t.derives.headOption.contains(owner)
-
   def getStartOfTemplateBody(template: Template): Option[Token] =
     template.self.tokens.headOption
+      .filter { x =>
+        template.derives.lastOption
+          .orElse(template.inits.lastOption)
+          .forall(y => y.pos.end < x.start)
+      }
       .orElse(template.stats.headOption.flatMap(_.tokens.headOption))
 
   def getAndOrTypeRhs(tree: Tree): Option[Type] = tree match {

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -365,9 +365,6 @@ object ValueTypes:
   case object Private
       extends ClassificationValue
       with ConstantText
-------Idempotency violated
-      with
-        ConstantText
 <<< #2441 template handling in scala3
 runner.dialect = scala3
 ===
@@ -378,8 +375,3 @@ object ValueTypes:
 >>>
 object ValueTypes:
   case object Private extends ClassificationValue with ConstantText
---Idempotency violated
-  case object Private
-      extends ClassificationValue
-      with
-        ConstantText

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -352,3 +352,34 @@ abstract class A(
     x: Int
   ): Int
 }
+<<< #2441 template handling in scala3, short
+runner.dialect = scala3
+maxColumn = 40
+===
+object ValueTypes:
+    case object Private
+        extends ClassificationValue
+        with ConstantText
+>>>
+object ValueTypes:
+  case object Private
+      extends ClassificationValue
+      with ConstantText
+------Idempotency violated
+      with
+        ConstantText
+<<< #2441 template handling in scala3
+runner.dialect = scala3
+===
+object ValueTypes:
+    case object Private
+        extends ClassificationValue
+        with ConstantText
+>>>
+object ValueTypes:
+  case object Private extends ClassificationValue with ConstantText
+--Idempotency violated
+  case object Private
+      extends ClassificationValue
+      with
+        ConstantText


### PR DESCRIPTION
Find the right init/derive and expiration token based on the current position. Fixes #2441.