### PR TITLE
FormatOps: mimic `{}` pairs with optional braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -20,8 +20,6 @@ private class BestFirstSearch private (
     range: Set[Range],
     formatWriter: FormatWriter
 )(implicit val formatOps: FormatOps) {
-  import Token._
-
   import LoggerOps._
   import TokenOps._
   import TreeOps._
@@ -69,15 +67,13 @@ private class BestFirstSearch private (
     if (!recurseOnBlocks || !isInsideNoOptZone(ft)) None
     else {
       val left = tokens(ft, -1)
-      if (!left.left.is[LeftBrace]) None
-      else {
-        val close = tokens.matching(left.left)
+      val closeOpt = formatOps.getEndOfBlock(left, false)(style)
+      closeOpt.filter(close =>
         // Block must span at least 3 lines to be worth recursing.
-        val ok = close != stop &&
+        close != stop &&
           distance(left.left, close) > style.maxColumn * 3 &&
           extractStatementsIfAny(left.meta.leftOwner).nonEmpty
-        if (ok) Some(close) else None
-      }
+      )
     }
 
   def stateColumnKey(state: State): StateHash = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1872,6 +1872,12 @@ class FormatOps(
 
   object OptionalBraces {
 
+    trait Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]]
+    }
+
     // Optional braces in templates after `:|with`
     // Optional braces after any token that can start indentation:
     // )  =  =>  ?=>  <-  catch  do  else  finally  for
@@ -1881,26 +1887,35 @@ class FormatOps(
     )(implicit style: ScalafmtConfig): Option[Seq[Split]] = {
       val ft = tokens(ftMeta.idx)
       val nft = nextNonComment(ft)
-      val rightOwner = nft.meta.rightOwner
-      if (nft.right.is[T.LeftBrace] || rightOwner.is[Term.Block]) None
-      else {
-        ft.left match {
-          case _: T.Colon | _: T.KwWith => unapplyTemplate(ft, nft)
-          case _: T.RightArrow => unapplyRightArrow(ft, nft)
-          case _: T.RightParen => unapplyRightParen(ft, nft)
-          case _: T.KwFor => unapplyFor(ft, nft)
-          case _: T.KwDo => unapplyDo(ft, nft)
-          case _: T.Equals => unapplyEquals(ft, nft)
-          case _: T.KwTry => unapplyTry(ft, nft)
-          case _: T.KwCatch => unapplyCatch(ft, nft)
-          case _: T.KwFinally => unapplyFinally(ft, nft)
-          case _: T.KwMatch => unapplyMatch(ft, nft)
-          case _: T.KwThen => unapplyThen(ft, nft)
-          case _: T.KwElse => unapplyElse(ft, nft)
-          case _ => unapplyBlock(ft, nft)
-        }
-      }
+      getImpl(ft, nft).flatMap(_.tryGetSplits(ft, nft))
     }
+
+    def getImpl(ft: FormatToken, nft: FormatToken)(implicit
+        style: ScalafmtConfig
+    ): Option[Impl] =
+      if (nft.right.is[T.LeftBrace]) None
+      else if (!style.runner.dialect.allowSignificantIndentation) None
+      else {
+        val impl = ft.left match {
+          case _: T.Colon | _: T.KwWith => TemplateImpl
+          case _: T.RightArrow => RightArrowImpl
+          case _: T.RightParen => RightParenImpl
+          case _: T.KwFor => ForImpl
+          case _: T.KwDo => DoImpl
+          case _: T.Equals => EqualsImpl
+          case _: T.KwTry => TryImpl
+          case _: T.KwCatch => CatchImpl
+          case _: T.KwFinally => FinallyImpl
+          case _: T.KwMatch => MatchImpl
+          case _: T.KwThen => ThenImpl
+          case _: T.KwElse => ElseImpl
+          case _: T.KwReturn | _: T.ContextArrow | _: T.LeftArrow |
+              _: T.KwThrow | _: T.KwWhile | _: T.KwYield =>
+            BlockImpl
+          case _ => null
+        }
+        Option(impl)
+      }
 
     private def getSplits(
         ft: FormatToken,
@@ -1927,171 +1942,196 @@ class FormatOps(
       }
     }
 
-    def unapplyTemplate(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] = {
-      ft.meta.leftOwner match {
-        case t: Template if templateCurly(t).contains(ft.left) =>
-          Some(getSplits(ft, t, forceNL = true))
-        case _ => None
+    object TemplateImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] = {
+        ft.meta.leftOwner match {
+          case t: Template if templateCurly(t).contains(ft.left) =>
+            Some(getSplits(ft, t, forceNL = true))
+          case _ => None
+        }
       }
     }
 
-    def unapplyBlock(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] = {
-      val leftOwner = ft.meta.leftOwner
-      findTreeWithParentSimple(nft.meta.rightOwner)(_ eq leftOwner) match {
-        case Some(t: Term.Block)
-            if t.stats.lengthCompare(1) > 0 && isBlockStart(t, nft) =>
-          Some(getSplitsMaybeBlock(ft, nft, t, true))
-        case _ => None
+    object BlockImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] = {
+        val leftOwner = ft.meta.leftOwner
+        findTreeWithParentSimple(nft.meta.rightOwner)(_ eq leftOwner) match {
+          case Some(t: Term.Block)
+              if t.stats.lengthCompare(1) > 0 && isBlockStart(t, nft) =>
+            Some(getSplitsMaybeBlock(ft, nft, t, true))
+          case _ => None
+        }
       }
     }
 
-    def unapplyRightParen(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      ft.meta.leftOwner match {
-        case Defn.ExtensionGroup(_, _, t: Term.Block) if isBlockStart(t, nft) =>
-          Some(getSplitsMaybeBlock(ft, nft, t, true))
-        case t: Term.If if (nft.right match {
-              case _: T.KwThen | _: T.LeftBrace => false
-              case _ =>
+    object RightParenImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        ft.meta.leftOwner match {
+          case Defn.ExtensionGroup(_, _, t: Term.Block)
+              if isBlockStart(t, nft) =>
+            Some(getSplitsMaybeBlock(ft, nft, t, true))
+          case t: Term.If if !nft.right.is[T.KwThen] && {
                 isTreeMultiStatBlock(t.thenp) || isElsePWithOptionalBraces(t) ||
-                  !ifWithoutElse(t) && existsBlockIfWithoutElse(t.thenp)
-            }) =>
-          Some(getSplitsForIf(ft, nft, t))
-        case _ => None
-      }
+                !ifWithoutElse(t) && existsBlockIfWithoutElse(t.thenp)
+              } =>
+            Some(getSplitsForIf(ft, nft, t))
+          case _ => None
+        }
+    }
 
-    def unapplyRightArrow(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      if (ft.meta.leftOwner.is[Case]) None // already takes care of indents etc.
-      else unapplyBlock(ft, nft)
+    object RightArrowImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        if (ft.meta.leftOwner.is[Case]) None // already behaves this way
+        else BlockImpl.tryGetSplits(ft, nft)
+    }
 
-    def unapplyFor(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      ft.meta.leftOwner match {
-        case t: Term.For => getSplitsForStats(ft, nft, t.enums, false)
-        case t: Term.ForYield => getSplitsForStats(ft, nft, t.enums, false)
-        case _ => unapplyBlock(ft, nft)
-      }
+    object ForImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        ft.meta.leftOwner match {
+          case t: Term.For => getSplitsForStats(ft, nft, t.enums, false)
+          case t: Term.ForYield => getSplitsForStats(ft, nft, t.enums, false)
+          case _ => BlockImpl.tryGetSplits(ft, nft)
+        }
+    }
 
-    def unapplyDo(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      (ft.meta.leftOwner match {
-        case t: Term.Do => Some(t.body -> true)
-        case t: Term.While => Some(t.body -> false)
-        case t: Term.For => Some(t.body -> false)
-        case _ => None
-      }).map { case (body, allowMain) =>
-        getSplitsMaybeBlock(ft, nft, body, allowMain)
-      }
+    object DoImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        (ft.meta.leftOwner match {
+          case t: Term.Do => Some(t.body -> true)
+          case t: Term.While => Some(t.body -> false)
+          case t: Term.For => Some(t.body -> false)
+          case _ => None
+        }).map { case (body, allowMain) =>
+          getSplitsMaybeBlock(ft, nft, body, allowMain)
+        }
+    }
 
-    def unapplyEquals(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      ft.meta.leftOwner match {
-        case t: Ctor.Secondary =>
-          getSplitsForStats(ft, nft, t.init, t.stats, true)
-        case _ => unapplyBlock(ft, nft)
-      }
+    object EqualsImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        ft.meta.leftOwner match {
+          case t: Ctor.Secondary =>
+            getSplitsForStats(ft, nft, t.init, t.stats, true)
+          case _ => BlockImpl.tryGetSplits(ft, nft)
+        }
+    }
 
-    def unapplyTry(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      (ft.meta.leftOwner match {
-        case t: Term.Try =>
-          val usesOB = isTreeMultiStatBlock(t.expr) ||
-            isCatchUsingOptionalBraces(t) ||
-            t.finallyp.exists(isTreeUsingOptionalBraces)
-          Some(t.expr -> usesOB)
-        case t: Term.TryWithHandler =>
-          val usesOB = isTreeMultiStatBlock(t.expr) ||
-            t.finallyp.exists(isTreeUsingOptionalBraces)
-          Some(t.expr -> usesOB)
-        case _ => None
-      }).map { case (body, usesOptionalBraces) =>
-        val forceNL = shouldBreakInOptionalBraces(nft)
-        getSplits(ft, body, forceNL, !usesOptionalBraces)
-      }
+    object TryImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        (ft.meta.leftOwner match {
+          case t: Term.Try =>
+            val usesOB = isTreeMultiStatBlock(t.expr) ||
+              isCatchUsingOptionalBraces(t) ||
+              t.finallyp.exists(isTreeUsingOptionalBraces)
+            Some(t.expr -> usesOB)
+          case t: Term.TryWithHandler =>
+            val usesOB = isTreeMultiStatBlock(t.expr) ||
+              t.finallyp.exists(isTreeUsingOptionalBraces)
+            Some(t.expr -> usesOB)
+          case _ => None
+        }).map { case (body, usesOptionalBraces) =>
+          val forceNL = shouldBreakInOptionalBraces(nft)
+          getSplits(ft, body, forceNL, !usesOptionalBraces)
+        }
+    }
 
     private def isCatchUsingOptionalBraces(tree: Term.Try): Boolean =
       tree.catchp.headOption.exists(x =>
         !nonCommentBefore(x).left.is[T.LeftBrace]
       )
 
-    def unapplyCatch(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      ft.meta.leftOwner match {
-        case t: Term.Try => getSplitsForStats(ft, nft, t.catchp, false)
-        case _ => None
-      }
+    object CatchImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        ft.meta.leftOwner match {
+          case t: Term.Try => getSplitsForStats(ft, nft, t.catchp, false)
+          case _ => None
+        }
+    }
 
-    def unapplyFinally(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      (ft.meta.leftOwner match {
-        case t: Term.Try =>
-          t.finallyp.map { x =>
-            x -> (isTreeMultiStatBlock(x) ||
-              isCatchUsingOptionalBraces(t) ||
-              isTreeUsingOptionalBraces(t.expr))
-          }
-        case t: Term.TryWithHandler =>
-          t.finallyp.map { x =>
-            x -> (isTreeMultiStatBlock(x) ||
-              isTreeUsingOptionalBraces(t.expr))
-          }
-        case _ => None
-      }).map { case (body, usesOptionalBraces) =>
-        val forceNL = shouldBreakInOptionalBraces(nft)
-        getSplits(ft, body, forceNL, !usesOptionalBraces)
-      }
+    object FinallyImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        (ft.meta.leftOwner match {
+          case t: Term.Try =>
+            t.finallyp.map { x =>
+              x -> (isTreeMultiStatBlock(x) ||
+                isCatchUsingOptionalBraces(t) ||
+                isTreeUsingOptionalBraces(t.expr))
+            }
+          case t: Term.TryWithHandler =>
+            t.finallyp.map { x =>
+              x -> (isTreeMultiStatBlock(x) ||
+                isTreeUsingOptionalBraces(t.expr))
+            }
+          case _ => None
+        }).map { case (body, usesOptionalBraces) =>
+          val forceNL = shouldBreakInOptionalBraces(nft)
+          getSplits(ft, body, forceNL, !usesOptionalBraces)
+        }
+    }
 
-    def unapplyMatch(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] = {
-      def result(tree: Tree, cases: Seq[Tree]): Option[Seq[Split]] = {
-        val ok = cases.headOption.exists(_.tokens.head eq nft.right)
-        if (ok) Some(getSplits(ft, tree, true)) else None
-      }
-      ft.meta.leftOwner match {
-        case t: Term.Match => result(t, t.cases)
-        case t: Type.Match => result(t, t.cases)
-        case _ => None
+    object MatchImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] = {
+        def result(tree: Tree, cases: Seq[Tree]): Option[Seq[Split]] = {
+          val ok = cases.headOption.exists(_.tokens.head eq nft.right)
+          if (ok) Some(getSplits(ft, tree, true)) else None
+        }
+        ft.meta.leftOwner match {
+          case t: Term.Match => result(t, t.cases)
+          case t: Type.Match => result(t, t.cases)
+          case _ => None
+        }
       }
     }
 
-    def unapplyThen(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      ft.meta.leftOwner match {
-        case t: Term.If => Some(getSplitsForIf(ft, nft, t))
-        case _ => None
-      }
+    object ThenImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        ft.meta.leftOwner match {
+          case t: Term.If => Some(getSplitsForIf(ft, nft, t))
+          case _ => None
+        }
+    }
 
-    def unapplyElse(ft: FormatToken, nft: FormatToken)(implicit
-        style: ScalafmtConfig
-    ): Option[Seq[Split]] =
-      ft.meta.leftOwner match {
-        case t: Term.If =>
-          t.elsep match {
-            case _: Term.If => None
-            case x if isTreeMultiStatBlock(x) =>
-              Some(getSplits(ft, x, true))
-            case x if isThenPWithOptionalBraces(t) =>
-              val forceNL = shouldBreakInOptionalBraces(nft)
-              Some(getSplits(ft, x, forceNL))
-            case _ => None
-          }
-        case _ => None
-      }
+    object ElseImpl extends Impl {
+      def tryGetSplits(ft: FormatToken, nft: FormatToken)(implicit
+          style: ScalafmtConfig
+      ): Option[Seq[Split]] =
+        ft.meta.leftOwner match {
+          case t: Term.If =>
+            t.elsep match {
+              case _: Term.If => None
+              case x if isTreeMultiStatBlock(x) =>
+                Some(getSplits(ft, x, true))
+              case x if isThenPWithOptionalBraces(t) =>
+                val forceNL = shouldBreakInOptionalBraces(nft)
+                Some(getSplits(ft, x, forceNL))
+              case _ => None
+            }
+          case _ => None
+        }
+    }
 
     private def getSplitsMaybeBlock(
         ft: FormatToken,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -762,7 +762,7 @@ class Router(formatOps: FormatOps) {
             }
           )
             parensTuple(args(0).tokens.last)
-          else insideBlock[T.LeftBrace](tok, close)
+          else insideBracesBlock(tok, close)
 
         val indent = getApplyIndent(leftOwner, onlyConfigStyle)
 
@@ -1027,7 +1027,7 @@ class Router(formatOps: FormatOps) {
               if (isBracket)
                 insideBlock[T.LeftBracket](formatToken, close)
               else
-                insideBlock[T.LeftBrace](formatToken, close)
+                insideBracesBlock(formatToken, close)
             val policy =
               policyWithExclude(exclude, Policy.End.Before, Policy.End.On)(
                 Policy.End.Before(close),
@@ -1405,7 +1405,7 @@ class Router(formatOps: FormatOps) {
           case Newlines.fold =>
             val end =
               nextSelect.fold(expire)(x => getLastNonTrivialToken(x.qual))
-            def exclude = insideBlock[LeftParenOrBrace](t, end)
+            def exclude = insideBracesBlock(t, end, true)
             Seq(
               Split(NoSplit, 0).withSingleLine(end, exclude),
               Split(NewlineT(alt = Some(NoSplit)), 1)
@@ -1612,7 +1612,7 @@ class Router(formatOps: FormatOps) {
           CtrlBodySplits.get(formatToken, body) {
             Split(Space, 0).withSingleLineNoOptimal(
               expire,
-              insideBlock[T.LeftBrace](formatToken, expire),
+              insideBracesBlock(formatToken, expire),
               noSyntaxNL = leftOwner.is[Term.ForYield] && right.is[T.KwYield]
             )
           }(nlSplitFunc)
@@ -1630,7 +1630,7 @@ class Router(formatOps: FormatOps) {
       case FormatToken(_, T.KwElse() | T.KwYield(), _) =>
         val expire = rhsOptimalToken(tokens.getLast(rightOwner))
         val noSpace = shouldBreak(formatToken)
-        def exclude = insideBlock[T.LeftBrace](formatToken, expire)
+        def exclude = insideBracesBlock(formatToken, expire)
         val noSyntaxNL = formatToken.right.is[T.KwYield]
         Seq(
           Split(Space, 0)
@@ -1792,7 +1792,7 @@ class Router(formatOps: FormatOps) {
 
       case tok @ FormatToken(_, cond @ T.KwIf(), _) if rightOwner.is[Case] =>
         val arrow = getCaseArrow(rightOwner.asInstanceOf[Case]).left
-        val exclude = insideBlock[T.LeftBrace](tok, arrow)
+        val exclude = insideBracesBlock(tok, arrow)
 
         Seq(
           Split(Space, 0).withSingleLineNoOptimal(arrow, exclude = exclude),
@@ -1949,7 +1949,7 @@ class Router(formatOps: FormatOps) {
           case Newlines.fold =>
             val endOfGuard = getLastToken(rightOwner)
             val exclude =
-              insideBlock[LeftParenOrBrace](formatToken, endOfGuard)
+              insideBracesBlock(formatToken, endOfGuard, true)
             Seq(
               Split(Space, 0).withSingleLine(endOfGuard, exclude = exclude),
               Split(Newline, 1)
@@ -2238,7 +2238,7 @@ class Router(formatOps: FormatOps) {
       baseSpaceSplit
         .withOptimalToken(optimal)
         .withPolicy {
-          val exclude = insideBlock[T.LeftBrace](ft, expire)
+          val exclude = insideBracesBlock(ft, expire)
           policyWithExclude(exclude, Policy.End.On, Policy.End.After)(
             Policy.End.Before(expire),
             new PenalizeAllNewlines(_, Constants.ShouldBeSingleLine)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -1,6 +1,5 @@
 package org.scalafmt.util
 
-import scala.meta.classifiers.Classifier
 import scala.meta.{Defn, Pkg, Source, Template, Term, Tree}
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
@@ -202,9 +201,6 @@ object TokenOps {
       case Newlines.fold => false
       case Newlines.unfold => true
     }
-
-  def classifyOnRight[A](cls: Classifier[Token, A])(ft: FormatToken): Boolean =
-    cls(ft.right)
 
   def findArgsFor[A <: Tree](
       token: Token,

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -727,14 +727,32 @@ object Foo:
       None
   )
 >>>
-FormatTests:53 [e]: org.scalafmt.Error$SearchStateExploded: Search state exploded on '.∙isTrue[557:563]', line 19
+object Foo:
+   def bar = process(arg match
+      case a: A if a.b =>
+        None
 
-org.scalafmt.Error$FormatterOutputDoesNotParse: Formatter output does not parse:
-          otherVarName
+      case a: A if a.c() =>
+        None
 
-        case a: A
-            if a.someField.otherField.function().exists(SomeObjectLongName
-                                                                        ^
-<input>:29: error: ) expected but end of file found
-            if a.someField.otherField.function().exists(SomeObjectLongName
-                                                                          ^
+      case a: A if a.c() =>
+        None
+
+      case a: A if a.b =>
+        Some(
+          someMethod().anotherMethod().fooBarMethod(ObjectWithLongName.method())
+        )
+
+      case a: A if a.c() =>
+        val varName =
+          a.method(a.someField.anotherField.method().map(ObjectWithLongName.A))
+        val otherVarName =
+          varName.method(a.someField.method(ObjectWithLongName.B))
+        otherVarName
+
+      case a: A
+          if a.someField.otherField
+            .function()
+            .exists(SomeObjectLongName.isTrue) =>
+        None
+   )

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -703,3 +703,38 @@ object a:
      // c1
      else if aa then aaa
 // c1
+<<< #2448
+object Foo:
+  def bar = process(arg match
+    case a: A if a.b =>
+      None
+
+    case a: A if a.c() =>
+      None
+
+    case a: A if a.c() =>
+      None
+
+    case a: A if a.b =>
+      Some(someMethod().anotherMethod().fooBarMethod(ObjectWithLongName.method()))
+
+    case a: A if a.c() =>
+      val varName = a.method(a.someField.anotherField.method().map(ObjectWithLongName.A))
+      val otherVarName = varName.method(a.someField.method(ObjectWithLongName.B))
+      otherVarName
+
+    case a: A if a.someField.otherField.function().exists(SomeObjectLongName.isTrue) =>
+      None
+  )
+>>>
+FormatTests:53 [e]: org.scalafmt.Error$SearchStateExploded: Search state exploded on '.∙isTrue[557:563]', line 19
+
+org.scalafmt.Error$FormatterOutputDoesNotParse: Formatter output does not parse:
+          otherVarName
+
+        case a: A
+            if a.someField.otherField.function().exists(SomeObjectLongName
+                                                                        ^
+<input>:29: error: ) expected but end of file found
+            if a.someField.otherField.function().exists(SomeObjectLongName
+                                                                          ^

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -686,3 +686,53 @@ object a:
      // c1
      else if aa then aaa
 // c1
+<<< #2448
+object Foo:
+  def bar = process(arg match
+    case a: A if a.b =>
+      None
+
+    case a: A if a.c() =>
+      None
+
+    case a: A if a.c() =>
+      None
+
+    case a: A if a.b =>
+      Some(someMethod().anotherMethod().fooBarMethod(ObjectWithLongName.method()))
+
+    case a: A if a.c() =>
+      val varName = a.method(a.someField.anotherField.method().map(ObjectWithLongName.A))
+      val otherVarName = varName.method(a.someField.method(ObjectWithLongName.B))
+      otherVarName
+
+    case a: A if a.someField.otherField.function().exists(SomeObjectLongName.isTrue) =>
+      None
+  )
+>>>
+object Foo:
+   def bar = process(
+     arg match
+        case a: A if a.b => None
+
+        case a: A if a.c() => None
+
+        case a: A if a.c() => None
+
+        case a: A if a.b =>
+          Some(
+            someMethod().anotherMethod()
+              .fooBarMethod(ObjectWithLongName.method())
+          )
+
+        case a: A if a.c() =>
+          val varName = a
+            .method(a.someField.anotherField.method().map(ObjectWithLongName.A))
+          val otherVarName = varName
+            .method(a.someField.method(ObjectWithLongName.B))
+          otherVarName
+
+        case a: A
+            if a.someField.otherField.function()
+              .exists(SomeObjectLongName.isTrue) => None
+   )

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -729,3 +729,56 @@ object a:
      else if aa then
         aaa
 // c1
+<<< #2448
+object Foo:
+  def bar = process(arg match
+    case a: A if a.b =>
+      None
+
+    case a: A if a.c() =>
+      None
+
+    case a: A if a.c() =>
+      None
+
+    case a: A if a.b =>
+      Some(someMethod().anotherMethod().fooBarMethod(ObjectWithLongName.method()))
+
+    case a: A if a.c() =>
+      val varName = a.method(a.someField.anotherField.method().map(ObjectWithLongName.A))
+      val otherVarName = varName.method(a.someField.method(ObjectWithLongName.B))
+      otherVarName
+
+    case a: A if a.someField.otherField.function().exists(SomeObjectLongName.isTrue) =>
+      None
+  )
+>>>
+object Foo:
+   def bar = process(arg match
+      case a: A if a.b =>
+        None
+
+      case a: A if a.c() =>
+        None
+
+      case a: A if a.c() =>
+        None
+
+      case a: A if a.b =>
+        Some(
+          someMethod().anotherMethod().fooBarMethod(ObjectWithLongName.method())
+        )
+
+      case a: A if a.c() =>
+        val varName =
+          a.method(a.someField.anotherField.method().map(ObjectWithLongName.A))
+        val otherVarName =
+          varName.method(a.someField.method(ObjectWithLongName.B))
+        otherVarName
+
+      case a: A
+          if a.someField.otherField.function().exists(
+            SomeObjectLongName.isTrue
+          ) =>
+        None
+   )

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -768,3 +768,61 @@ object a:
      else if aa then
         aaa
 // c1
+<<< #2448
+object Foo:
+  def bar = process(arg match
+    case a: A if a.b =>
+      None
+
+    case a: A if a.c() =>
+      None
+
+    case a: A if a.c() =>
+      None
+
+    case a: A if a.b =>
+      Some(someMethod().anotherMethod().fooBarMethod(ObjectWithLongName.method()))
+
+    case a: A if a.c() =>
+      val varName = a.method(a.someField.anotherField.method().map(ObjectWithLongName.A))
+      val otherVarName = varName.method(a.someField.method(ObjectWithLongName.B))
+      otherVarName
+
+    case a: A if a.someField.otherField.function().exists(SomeObjectLongName.isTrue) =>
+      None
+  )
+>>>
+object Foo:
+   def bar = process(
+     arg match
+        case a: A if a.b =>
+          None
+
+        case a: A if a.c() =>
+          None
+
+        case a: A if a.c() =>
+          None
+
+        case a: A if a.b =>
+          Some(
+            someMethod()
+              .anotherMethod()
+              .fooBarMethod(ObjectWithLongName.method())
+          )
+
+        case a: A if a.c() =>
+          val varName = a
+            .method(a.someField.anotherField.method().map(ObjectWithLongName.A))
+          val otherVarName = varName
+            .method(a.someField.method(ObjectWithLongName.B))
+          otherVarName
+
+        case a: A
+            if a
+              .someField
+              .otherField
+              .function()
+              .exists(SomeObjectLongName.isTrue) =>
+          None
+   )


### PR DESCRIPTION
With optional braces, we are missing the physical indication that the formatter has come to expect with some of its optimizations.

The BestFirstSearch algorithm has an optimization which recurses into a block and doesn't backtrack. Some split policies skip matching pairs of braces when applying a single-line constraint.

In the absence of any other indicators (like Indent/Outdent tokens), we need to identify cases where braces are optional.

Fixes #2448.