### PR TITLE
FormatOps: use `keep` in binPackParentCtorSplits

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2801,9 +2801,9 @@ from a boolean to a wider set of options in v2.6.0.
 binPack.parentConstructors
 ```
 
-> Keep in mind that explicitly specifying the default value might change
-> behaviour; other parameters, such as [`newlines.source`](#newlinessource),
-> could interpret implied default differently but yield to an explicit value.
+The behaviour of `binPack.parentConstructors = source` depends on the value of
+[`newlines.source`](#newlinessource); `keep` maps to `keep` and attempts to preserve the
+space if there's no line break in the source, `fold` maps to `Oneline`, rest to `Never`.
 
 ```scala mdoc:scalafmt
 binPack.parentConstructors = Always
@@ -2855,6 +2855,18 @@ object A {
     a: Int,
     b: Int
   ) extends Bar with Baz
+}
+```
+
+```scala mdoc:scalafmt
+binPack.parentConstructors = keep
+---
+object A {
+  class Foo(a: Int, b: Int) extends Bar(
+    a,
+    b
+  ) with Baz
+  with Qux
 }
 ```
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
@@ -42,6 +42,12 @@ case class BinPack(
     generic.deriveDecoder(this).noTypos
   def literalsRegex: FilterMatcher =
     FilterMatcher(literalsInclude, literalsExclude)
+
+  def keepParentConstructors(implicit style: ScalafmtConfig): Boolean =
+    parentConstructors.eq(BinPack.ParentCtors.keep) ||
+      style.newlines.source.eq(Newlines.keep) &&
+      parentConstructors.eq(BinPack.ParentCtors.source)
+
 }
 object BinPack {
   implicit lazy val surface: generic.Surface[BinPack] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -350,6 +350,7 @@ object ScalafmtConfig {
           )
         }
         addIf(newlines.beforeTypeBounds eq Newlines.keep)
+        addIf(binPack.parentConstructors eq BinPack.ParentCtors.keep)
       }
       if (newlines.source == Newlines.unfold) {
         addIf(align.arrowEnumeratorGenerator)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -993,7 +993,7 @@ class FormatOps(
         Left(SplitTag.OnelineWithChain)
       case BinPack.ParentCtors.Always | BinPack.ParentCtors.Never =>
         Right(false)
-      case BinPack.ParentCtors.MaybeNever =>
+      case _ =>
         Right(style.newlines.source eq Newlines.fold)
     }
     val indent = Indent(Num(indentLen), lastToken, ExpiresOn.After)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1453,6 +1453,7 @@ class Router(formatOps: FormatOps) {
         binPackParentConstructorSplits(
           true,
           Set(rightOwner),
+          enumCase.inits.headOption,
           getLastToken(rightOwner),
           style.indent.extendSite,
           enumCase.inits.length > 1
@@ -1468,6 +1469,7 @@ class Router(formatOps: FormatOps) {
         binPackParentConstructorSplits(
           true,
           template.toSet,
+          template.flatMap(findTemplateGroupOnRight(_.superType)),
           lastToken,
           style.indent.extendSite,
           template.exists(_.inits.length > 1)
@@ -1487,6 +1489,7 @@ class Router(formatOps: FormatOps) {
             binPackParentConstructorSplits(
               isFirstInit(template, leftOwner),
               Set(template),
+              findTemplateGroupOnRight(_.superType)(template),
               templateCurly(template).getOrElse(getLastToken(template)),
               style.indent.main,
               template.inits.length > 1
@@ -1498,6 +1501,7 @@ class Router(formatOps: FormatOps) {
             binPackParentConstructorSplits(
               !t.lhs.is[Type.With],
               withChain(top).toSet,
+              Some(t.rhs),
               top.tokens.last,
               style.indent.main
             )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -802,9 +802,6 @@ object TreeOps {
       owner.is[Init] && init == owner || init.tpe == owner
     }
 
-  def isFirstDerives(t: Template, owner: Tree) =
-    owner.is[Type] && t.derives.headOption.contains(owner)
-
   def getStartOfTemplateBody(template: Template): Option[Token] =
     template.self.tokens.headOption
       .orElse(template.stats.headOption.flatMap(_.tokens.headOption))

--- a/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
+++ b/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
@@ -46,10 +46,8 @@ enum A extends B(
 ) with C
 with D
 >>>
-enum A
-    extends B(
+enum A extends B(
       foo,
       bar
-    )
-      with C
+    ) with C
       with D

--- a/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
+++ b/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
@@ -35,3 +35,21 @@ trait SampleTrait
 
     def foo: Boolean = true
 }
+<<< #2226 enum
+maxColumn = 20
+runner.dialect = scala3
+binPack.parentConstructors = keep
+indent.withSiteRelativeToExtends = 2
+===
+enum A extends B(
+  foo, bar
+) with C
+with D
+>>>
+enum A
+    extends B(
+      foo,
+      bar
+    )
+      with C
+      with D

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -89,10 +89,8 @@ includeCurlyBraceInSelectChains = true
 class A(a: Int, b: String) extends B("""
 foo""") with C
 >>>
-class A(a: Int, b: String)
-    extends B("""
-foo""")
-    with C
+class A(a: Int, b: String) extends B("""
+foo""") with C
 <<< #1640 select chain with multiline arg
 object a {
   foo.B("""

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -82,6 +82,17 @@ class A(a: Int, b: String)
     extends B("""
 foo""")
     with C
+<<< #1640 class with multiline parent ctor, keep
+newlines.source = keep
+includeCurlyBraceInSelectChains = true
+===
+class A(a: Int, b: String) extends B("""
+foo""") with C
+>>>
+class A(a: Int, b: String)
+    extends B("""
+foo""")
+    with C
 <<< #1640 select chain with multiline arg
 object a {
   foo.B("""

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3796,3 +3796,14 @@ type T = A1 & A2 | A3 & A4 | A5 &
   A61 & A62 | A63 & A64 | A65 &
   A66 /* c1 */ | /* c2 */ A67 & A68 |
   A69 & A70[T70]
+<<< #2226
+object Class extends Base
+   with Trait1
+   with Trait2 {
+
+}
+>>>
+object Class
+    extends Base
+    with Trait1
+    with Trait2 {}

--- a/scalafmt-tests/src/test/resources/scala3/Enum.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Enum.stat
@@ -91,6 +91,23 @@ enum A
     with Epsilon {
   case B
 }
+<<< enum with sequence of `with` statements, keep
+maxColumn = 40
+newlines.source = keep
+===
+enum A extends Alpha with Beta with Gamma
+  with Delta with Epsilon {
+  case B
+}
+>>>
+enum A
+    extends Alpha
+    with Beta
+    with Gamma
+    with Delta
+    with Epsilon {
+  case B
+}
 <<< enum case with parent constructors `never`
 binPack.parentConstructors = Never
 maxColumn = 30
@@ -229,6 +246,27 @@ enum Enum2(val a: String, val b: String) {
       with Y
 }
 <<< enum case with constructor
+enum
+Enum2(val i: Int) {
+  case A (val s: String)
+  extends
+  Enum2(1)
+  case B (val t: String)
+  extends
+  Enum2(2)
+  case C (val u: String)
+  extends
+  Enum2(3)
+}
+>>>
+enum Enum2(val i: Int) {
+  case A(val s: String) extends Enum2(1)
+  case B(val t: String) extends Enum2(2)
+  case C(val u: String) extends Enum2(3)
+}
+<<< enum case with constructor, keep
+newlines.source = keep
+===
 enum
 Enum2(val i: Int) {
   case A (val s: String)

--- a/scalafmt-tests/src/test/resources/scala3/Enum.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Enum.stat
@@ -100,12 +100,9 @@ enum A extends Alpha with Beta with Gamma
   case B
 }
 >>>
-enum A
-    extends Alpha
-    with Beta
+enum A extends Alpha with Beta
     with Gamma
-    with Delta
-    with Epsilon {
+    with Delta with Epsilon {
   case B
 }
 <<< enum case with parent constructors `never`
@@ -281,9 +278,12 @@ Enum2(val i: Int) {
 }
 >>>
 enum Enum2(val i: Int) {
-  case A(val s: String) extends Enum2(1)
-  case B(val t: String) extends Enum2(2)
-  case C(val u: String) extends Enum2(3)
+  case A(val s: String)
+      extends Enum2(1)
+  case B(val t: String)
+      extends Enum2(2)
+  case C(val u: String)
+      extends Enum2(3)
 }
 <<< enum case with type parameters
 enum Enum4 [ + T] {

--- a/scalafmt-tests/src/test/resources/scala3/Given.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Given.stat
@@ -34,6 +34,27 @@ given intOrd: Ord[Int]
         else 0
     }
 }
+<<< given with body and multi parents, keep
+maxColumn = 30
+indent.main = 4
+newlines.source = keep
+===
+given intOrd: Ord[Int] with Eq[T]
+  with Sort[T] with {def compare(x: Int, y: Int) = {if (x < y) -1 else if (x > y) +1 else 0 }}
+>>>
+given intOrd: Ord[Int]
+    with Eq[T]
+    with Sort[T]
+    with {
+    def compare(
+        x: Int,
+        y: Int
+    ) = {
+        if (x < y) -1
+        else if (x > y) +1
+        else 0
+    }
+}
 <<< given with body and multi parents single line
 given intOrd: Ord[Int] with Eq[T] with Sort[T] with {}
 >>>
@@ -66,6 +87,24 @@ given [T](using
 maxColumn = 30
 ===
 given [T](using ord: Ord[T]): Alpha with Beta with Gamma with Epsilon with {
+  def a = ???
+}
+>>>
+given [T](using
+    ord: Ord[T]
+): Alpha
+  with Beta
+  with Gamma
+  with Epsilon
+  with {
+  def a = ???
+}
+<<< anonymous given multi parents, keep
+maxColumn = 30
+newlines.source = keep
+===
+given [T](using ord: Ord[T]): Alpha with Beta with Gamma with Epsilon
+  with {
   def a = ???
 }
 >>>

--- a/scalafmt-tests/src/test/resources/scala3/Given.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Given.stat
@@ -44,8 +44,7 @@ given intOrd: Ord[Int] with Eq[T]
 >>>
 given intOrd: Ord[Int]
     with Eq[T]
-    with Sort[T]
-    with {
+    with Sort[T] with {
     def compare(
         x: Int,
         y: Int
@@ -110,9 +109,7 @@ given [T](using ord: Ord[T]): Alpha with Beta with Gamma with Epsilon
 >>>
 given [T](using
     ord: Ord[T]
-): Alpha
-  with Beta
-  with Gamma
+): Alpha with Beta with Gamma
   with Epsilon
   with {
   def a = ???


### PR DESCRIPTION
Refactor `splitWithChain` into `binPackParentConstructorSplits`, automatically determine the intermediate or final expiration for `inits` or `derives` in a template.

That allows modifying a single rule to preserve existing breaks (in `newlines.source=keep`).

Fixes #2226.