### PR TITLE
ProjectFiles: add `PathMatcher` patterns

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2377,19 +2377,37 @@ val identity = Array(1, 0, 0,
 
 Configure which source files should be formatted in this project.
 
+#### `project.git`
+
+If this boolean flag is set, only format files tracked by git.
+
+#### `project.include/exclude`
+
+> Since v3.0.0.
+
+```scala mdoc:defaults
+project.include
+project.exclude
+```
+
+Allows specifying
+[PathMatcher](https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileSystem.html#getPathMatcher-java.lang.String-)
+selection patterns to identify further which files are to be formatted (explicit `glob:` or
+`regex:` prefixes are required; keep in mind that `PathMatcher` patterns must match the entire
+path).
+
+For instance,
+
 ```conf
-# Only format files tracked by git.
-project.git = true
-# manually exclude files to format.
-project.excludeFilters = [
-   regex1
-   regex2
-]
-# manually include files to format.
-project.includeFilters = [
-  regex1
-  regex2
-]
+project {
+  include = [
+    "glob:**.scala",
+    "regex:.*\\.sc"
+  ]
+  exclude = [
+    "glob:**/src/test/scala/**.scala"
+  ]
+}
 ```
 
 ### `fileOverride`

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -7,9 +7,8 @@ import util.control.Breaks
 import metaconfig.Configured
 import org.scalafmt.Error.{MisformattedFile, NoMatchingFiles}
 import org.scalafmt.{Formatted, Scalafmt, Versions}
-import org.scalafmt.config.{FilterMatcher, ScalafmtConfig}
+import org.scalafmt.config.{ProjectFiles, ScalafmtConfig}
 import org.scalafmt.CompatCollections.ParConverters._
-import org.scalafmt.util.OsSpecific
 
 import scala.meta.internal.tokenizers.PlatformTokenizerCache
 import scala.meta.parsers.ParseException
@@ -26,11 +25,9 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
         ExitCode.UnexpectedError
       case Configured.Ok(scalafmtConf) =>
         options.common.debug.println(s"parsed config (v${Versions.version})")
-        val filterMatcher: FilterMatcher = FilterMatcher(
-          scalafmtConf.project.includeFilters
-            .map(OsSpecific.fixSeparatorsInPathPattern),
-          (scalafmtConf.project.excludeFilters ++ options.customExcludes)
-            .map(OsSpecific.fixSeparatorsInPathPattern)
+        val filterMatcher = ProjectFiles.FileMatcher(
+          scalafmtConf.project,
+          options.customExcludes
         )
 
         val inputMethods = getInputMethods(options, filterMatcher.matchesFile)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -5,7 +5,6 @@ import org.scalafmt.util.OsSpecific
 
 case class ProjectFiles(
     git: Boolean = false,
-    files: Seq[String] = Nil,
     includeFilters: Seq[String] = Seq(".*\\.scala$", ".*\\.sbt$", ".*\\.sc$"),
     excludeFilters: Seq[String] = Nil
 ) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -7,9 +7,11 @@ import scala.collection.mutable
 import scala.io.Codec
 import scala.meta.Dialect
 import scala.util.Try
+
 import metaconfig._
 import metaconfig.Configured._
 import org.scalafmt.util.LoggerOps
+import org.scalafmt.util.OsSpecific._
 import org.scalafmt.util.ValidationOps
 
 /** Configuration options for scalafmt.
@@ -200,7 +202,7 @@ case class ScalafmtConfig(
     val fs = file.FileSystems.getDefault
     fileOverride.values.map { case (pattern, conf) =>
       val style = decoder.read(conf).get
-      fs.getPathMatcher(pattern) -> style
+      fs.getPathMatcher(pattern.asFilename) -> style
     }
   }
   def getConfigFor(filename: String): ScalafmtConfig = {


### PR DESCRIPTION
Also, deprecate old regex-only patterns as the new option allows both. Fixes #1648.