### PR TITLE
FormatOps: optional braces in `= partial function`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2110,6 +2110,8 @@ class FormatOps(
         ft.meta.leftOwner match {
           case t: Ctor.Secondary =>
             getSplitsForStats(ft, nft, t.init, t.stats, true)
+          case SplitAssignIntoParts((x: Term.PartialFunction, _)) =>
+            getSplitsForStats(ft, nft, x.cases, false)
           case _ => BlockImpl.tryGetSplits(ft, nft)
         }
 
@@ -2117,6 +2119,8 @@ class FormatOps(
           style: ScalafmtConfig
       ): Option[T] = ft.meta.leftOwner match {
         case t: Ctor.Secondary => if (t.stats.nonEmpty) treeLast(t) else None
+        case SplitAssignIntoParts((x: Term.PartialFunction, _)) =>
+          treeLast(x)
         case _ => BlockImpl.tryGetRightBrace(ft, nft)
       }
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -525,6 +525,10 @@ object TreeOps {
     case t: Defn.Val => (t.rhs, None)
     case t: Defn.Var => (t.rhs.getOrElse(t), None) // var x: Int = _, no policy
   }
+  object SplitAssignIntoParts {
+    def unapply(tree: Tree): Option[AssignParts] =
+      splitAssignIntoParts.lift(tree)
+  }
   val SplitAssignIntoPartsLeft =
     new FormatToken.ExtractFromMeta(x => splitAssignIntoParts.lift(x.leftOwner))
 

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -761,10 +761,6 @@ val f: String => String =
   case "horses" => "are neat"
   case _ => "cows are sweet"
 >>>
-<input>:2: error: illegal start of simple expression
-case "horses" => "are neat"
-^
-case _        => "cows are sweet"
 val f: String => String =
-case "horses" => "are neat"
-case _        => "cows are sweet"
+   case "horses" => "are neat"
+   case _        => "cows are sweet"

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -756,3 +756,15 @@ object Foo:
             .exists(SomeObjectLongName.isTrue) =>
         None
    )
+<<< #2425 partial function
+val f: String => String =
+  case "horses" => "are neat"
+  case _ => "cows are sweet"
+>>>
+<input>:2: error: illegal start of simple expression
+case "horses" => "are neat"
+^
+case _        => "cows are sweet"
+val f: String => String =
+case "horses" => "are neat"
+case _        => "cows are sweet"

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -736,3 +736,15 @@ object Foo:
             if a.someField.otherField.function()
               .exists(SomeObjectLongName.isTrue) => None
    )
+<<< #2425 partial function
+val f: String => String =
+  case "horses" => "are neat"
+  case _ => "cows are sweet"
+>>>
+<input>:2: error: illegal start of simple expression
+case "horses" => "are neat"
+^
+case _        => "cows are sweet"
+val f: String => String =
+case "horses" => "are neat"
+case _        => "cows are sweet"

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -741,10 +741,6 @@ val f: String => String =
   case "horses" => "are neat"
   case _ => "cows are sweet"
 >>>
-<input>:2: error: illegal start of simple expression
-case "horses" => "are neat"
-^
-case _        => "cows are sweet"
 val f: String => String =
-case "horses" => "are neat"
-case _        => "cows are sweet"
+   case "horses" => "are neat"
+   case _        => "cows are sweet"

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -782,3 +782,15 @@ object Foo:
           ) =>
         None
    )
+<<< #2425 partial function
+val f: String => String =
+  case "horses" => "are neat"
+  case _ => "cows are sweet"
+>>>
+<input>:2: error: illegal start of simple expression
+case "horses" => "are neat"
+^
+case _        => "cows are sweet"
+val f: String => String =
+case "horses" => "are neat"
+case _        => "cows are sweet"

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -787,10 +787,6 @@ val f: String => String =
   case "horses" => "are neat"
   case _ => "cows are sweet"
 >>>
-<input>:2: error: illegal start of simple expression
-case "horses" => "are neat"
-^
-case _        => "cows are sweet"
 val f: String => String =
-case "horses" => "are neat"
-case _        => "cows are sweet"
+   case "horses" => "are neat"
+   case _        => "cows are sweet"

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -831,13 +831,8 @@ val f: String => String =
   case "horses" => "are neat"
   case _ => "cows are sweet"
 >>>
-<input>:2: error: illegal start of simple expression
-case "horses" =>
-^
-  "are neat"
-case _ =>
 val f: String => String =
-case "horses" =>
-  "are neat"
-case _ =>
-  "cows are sweet"
+   case "horses" =>
+     "are neat"
+   case _ =>
+     "cows are sweet"

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -826,3 +826,18 @@ object Foo:
               .exists(SomeObjectLongName.isTrue) =>
           None
    )
+<<< #2425 partial function
+val f: String => String =
+  case "horses" => "are neat"
+  case _ => "cows are sweet"
+>>>
+<input>:2: error: illegal start of simple expression
+case "horses" =>
+^
+  "are neat"
+case _ =>
+val f: String => String =
+case "horses" =>
+  "are neat"
+case _ =>
+  "cows are sweet"


### PR DESCRIPTION
Fixes #2425.