### PR TITLE
FormatTokensRewrite: migrate RewriteTrailingCommas

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -191,7 +191,8 @@ object FormatTokensRewrite {
 
   private val factories = Seq(
     RemoveScala3OptionalBraces,
-    ConvertToNewScala3Syntax
+    ConvertToNewScala3Syntax,
+    RewriteTrailingCommas
   )
 
   private[rewrite] trait Rule {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -11,7 +11,6 @@ import scala.meta.transversers.SimpleTraverser
 
 import org.scalafmt.config.ReaderUtil
 import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.config.TrailingCommas
 import org.scalafmt.util.{TokenOps, TokenTraverser, TreeOps, Trivia, Whitespace}
 
 case class RewriteCtx(
@@ -152,14 +151,7 @@ object Rewrite {
   }
 
   def apply(input: VirtualFile, style: ScalafmtConfig): VirtualFile = {
-    val trailingCommaRewrite =
-      if (
-        !style.runner.dialect.allowTrailingCommas ||
-        style.trailingCommas == TrailingCommas.preserve
-      ) Seq.empty
-      else Seq(RewriteTrailingCommas)
-
-    val rewrites = style.rewrite.rules ++ trailingCommaRewrite
+    val rewrites = style.rewrite.rules
     if (rewrites.isEmpty) {
       input
     } else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
@@ -1,76 +1,76 @@
 package org.scalafmt.rewrite
 
 import scala.meta._
-import scala.meta.classifiers.Classifier
 import scala.meta.tokens.Token
 
+import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.config.TrailingCommas
+import org.scalafmt.internal.FormatToken
+import org.scalafmt.internal.FormatTokens
 import org.scalafmt.util.TreeOps
-import org.scalafmt.util.Whitespace
 
-object RewriteTrailingCommas extends Rewrite {
-  override def create(implicit ctx: RewriteCtx): RewriteSession =
-    new RewriteTrailingCommas
+object RewriteTrailingCommas extends FormatTokensRewrite.RuleFactory {
+
+  override def enabled(implicit style: ScalafmtConfig): Boolean =
+    style.runner.dialect.allowTrailingCommas &&
+      style.trailingCommas != TrailingCommas.preserve
+
+  override def create(ftoks: FormatTokens): FormatTokensRewrite.Rule =
+    new RewriteTrailingCommas(ftoks)
+
 }
 
-class RewriteTrailingCommas(implicit ctx: RewriteCtx) extends RewriteSession {
+private class RewriteTrailingCommas(ftoks: FormatTokens)
+    extends FormatTokensRewrite.Rule {
 
   /* even if this rule is called for 'always', we'll still remove any trailing
    * commas here, to avoid any idempotence problems caused by an extra comma,
    * with a different AST, in a subsequent runs; in FormatWriter, we'll add
    * them back if there is a newline before the closing bracket/paren/brace */
-  override def rewrite(tree: Tree): Unit =
-    tree match {
-      case t: Importer =>
-        t.tokens.lastOption match {
-          case Some(close: Token.RightBrace) => before(close)
-          case _ =>
-        }
 
-      case TreeOps.SplitDefnIntoParts(_, _, tparams, paramss) =>
-        afterTParams(tparams)
-        afterEachArgs(paramss)
+  import FormatTokensRewrite._
 
-      case TreeOps.SplitCallIntoParts(_, either) =>
-        either match {
-          case Left(args) => afterArgs(args)
-          case Right(argss) => afterEachArgs(argss)
-        }
+  override def enabled(implicit style: ScalafmtConfig): Boolean =
+    RewriteTrailingCommas.enabled
 
-      case _ =>
+  override def onToken(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Option[Replacement] = {
+    val ok = ft.right.is[Token.Comma] && {
+      val rightOwner = ft.meta.rightOwner
+      val nft = ftoks.nextNonComment(ftoks.next(ft))
+
+      // comma and paren/bracket/brace need to have the same owner
+      (rightOwner eq nft.meta.rightOwner) && (nft.right match {
+        case _: Token.RightBracket =>
+          rightOwner match {
+            case TreeOps.SplitDefnIntoParts(_) => true
+            case _ => false
+          }
+
+        case _: Token.RightParen =>
+          rightOwner match {
+            case TreeOps.SplitDefnIntoParts(_) => true
+            case TreeOps.SplitCallIntoParts(_) => true
+            case _ => false
+          }
+
+        case _: Token.RightBrace =>
+          rightOwner match {
+            case _: Importer => true
+            case _ => false
+          }
+
+        case _ => false
+      })
     }
-
-  private def patch(token: Token): Unit =
-    ctx.addPatchSet(TokenPatch.Remove(token))
-
-  private def before(close: Token): Unit =
-    ctx.tokenTraverser.findBefore(close) {
-      case c: Token.Comma => patch(c); Some(false)
-      case Whitespace() | _: Token.Comment => None
-      case _ => Some(false)
-    }
-
-  private def forwardBeforeType[A](
-      start: Token
-  )(implicit cls: Classifier[Token, A]): Unit = {
-    var comma: Token.Comma = null
-    ctx.tokenTraverser.findAfter(start) {
-      case Whitespace() | _: Token.Comment => None
-      case c: Token.Comma => comma = c; None
-      case t => if (comma != null && cls(t)) patch(comma); Some(false)
-    }
+    if (ok) Some(removeToken) else None
   }
 
-  private def afterTParams(tparams: Seq[Type.Param]): Unit =
-    tparams.lastOption.foreach {
-      _.tokens.lastOption.foreach(forwardBeforeType[Token.RightBracket])
-    }
-
-  private def afterArgs(args: Seq[Tree]): Unit =
-    args.lastOption.foreach {
-      _.tokens.lastOption.foreach(forwardBeforeType[Token.RightParen])
-    }
-
-  private def afterEachArgs(argss: Seq[Seq[Tree]]): Unit =
-    argss.foreach(afterArgs)
+  override def onRight(lt: Replacement, hasFormatOff: Boolean)(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Option[(Replacement, Replacement)] = None
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -55,12 +55,6 @@ class StyleMap(
             case Configured.Ok(style) =>
               if (init.rewrite.rulesChanged(style.rewrite))
                 warn("May not override rewrite settings")
-              else if (
-                init.trailingCommas != style.trailingCommas ||
-                init.runner.dialect.allowTrailingCommas !=
-                  style.runner.dialect.allowTrailingCommas
-              )
-                warn("May not override rewrite settings (trailingCommas)")
               changeStyle(style)
             case Configured.NotOk(e) =>
               // TODO(olafur) report error via callback


### PR DESCRIPTION
Also, since the new implementation uses StyleMap, remove the check in StyleMap prohibiting overrides of this setting. Fixes #1861.