### PR TITLE
CliOptions: use config defaults from source class (and other refactors)

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -1,7 +1,6 @@
 package org.scalafmt.cli
 
 import com.martiansoftware.nailgun.NGContext
-import java.io.{InputStream, PrintStream}
 import java.nio.file.{Files, Paths}
 
 import org.scalafmt.Versions
@@ -33,24 +32,6 @@ object Cli {
     nGContext.exit(exit.code)
   }
 
-  def main(
-      args: Array[String],
-      in: InputStream,
-      out: PrintStream,
-      err: PrintStream,
-      workingDirectory: String
-  ): Unit = {
-    val options = CliOptions.default.copy(
-      common = CommonOptions(
-        in = in,
-        out = out,
-        err = err,
-        workingDirectory = AbsoluteFile.fromPath(workingDirectory).get
-      )
-    )
-    mainWithOptions(args, options)
-  }
-
   private def throwIfError(exit: ExitCode): Unit = {
     if (exit != ExitCode.Ok) {
       throw new RuntimeException(exit.toString) with NoStackTrace
@@ -58,7 +39,7 @@ object Cli {
   }
 
   def main(args: Array[String]): Unit = {
-    val exit = mainWithOptions(args, CliOptions())
+    val exit = mainWithOptions(args, CliOptions.default)
     sys.exit(exit.code)
   }
 

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -59,7 +59,7 @@ object Cli {
     val expandedArguments = expandArguments(args)
     CliArgParser.scoptParser
       .parse(expandedArguments, init)
-      .map(CliOptions.auto(expandedArguments, init))
+      .map(CliOptions.auto)
   }
 
   private def expandArguments(args: Array[String]): Array[String] = {

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -98,32 +98,26 @@ object Cli {
     // - `scalafmt-dynamic` if the specified `version` setting doesn't match build version.
     // - `scalafmt-core` if the specified `version` setting match with build version
     //   (or if the `version` is not specified).
-    options.version match {
-      case None =>
-        Right(ScalafmtCoreRunner)
-      case Some(v) =>
-        if (v == Versions.version) {
-          Right(ScalafmtCoreRunner)
-        } else if (isNativeImage) {
-          Left(
-            s"""error: invalid Scalafmt version.
-              |
-              |This Scalafmt installation has version '${Versions.version}' and the version configured in '${options.configPath}' is '${v}'.
-              |To fix this problem, add the following line to .scalafmt.conf:
-              |```
-              |version = '${Versions.version}'
-              |```
-              |
-              |NOTE: this error happens only when running a native Scalafmt binary.
-              |Scalafmt automatically installs and invokes the correct version of Scalafmt when running on the JVM.
-              |""".stripMargin
-          )
-        } else {
-          Right(ScalafmtDynamicRunner)
-        }
+    options.getVersionIfDifferent match {
+      case Some(v) if isNativeImage =>
+        Left(
+          s"""error: invalid Scalafmt version.
+            |
+            |This Scalafmt installation has version '${Versions.version}' and the version configured in '${options.configPath}' is '${v}'.
+            |To fix this problem, add the following line to .scalafmt.conf:
+            |```
+            |version = '${Versions.version}'
+            |```
+            |
+            |NOTE: this error happens only when running a native Scalafmt binary.
+            |Scalafmt automatically installs and invokes the correct version of Scalafmt when running on the JVM.
+            |""".stripMargin
+        )
+      case None => Right(ScalafmtCoreRunner)
+      case _ => Right(ScalafmtDynamicRunner)
     }
-
   }
+
   private[cli] def runWithRunner(
       options: CliOptions,
       runner: ScalafmtRunner

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -98,9 +98,6 @@ object CliArgParser {
         .action((_, c) => writeMode(c, WriteMode.Stdout))
         .text("write formatted files to stdout")
 
-      opt[Boolean]("git")
-        .action((opt, c) => c.copy(git = Some(opt)))
-        .text("if true, ignore files in .gitignore (default false)")
       opt[Seq[String]]("exclude")
         .unbounded()
         .action((excludes, c) => c.copy(customExcludes = excludes))

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -7,7 +7,7 @@ import java.nio.file.{Files, Path}
 import com.typesafe.config.{ConfigException, ConfigFactory}
 import metaconfig.Configured
 import org.scalafmt.Versions
-import org.scalafmt.config.{Config, ScalafmtConfig}
+import org.scalafmt.config.{Config, ScalafmtConfig, ScalafmtRunner}
 import org.scalafmt.util.{AbsoluteFile, GitOps, GitOpsImpl, OsSpecific}
 
 import scala.io.Codec
@@ -128,13 +128,6 @@ case class CliOptions(
 ) {
   lazy val writeMode: WriteMode = writeModeOpt.getOrElse(WriteMode.Override)
 
-  // These default values are copied from here.
-  // https://github.com/scalameta/scalafmt/blob/f2154330afa0bc4a0a556598adeb116eafecb8e3/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala#L127-L162
-  private[this] val DefaultGit = false
-  private[this] val DefaultFatalWarnings = false
-  private[this] val DefaultIgnoreWarnings = false
-  private[this] val DefaultEncoding = Codec.UTF8
-
   /** Create a temporary file that contains configuration string specified by `--config-str`.
     * This temporary file will be passed to `scalafmt-dynamic`.
     * See https://github.com/scalameta/scalafmt/pull/1367#issuecomment-464744077
@@ -208,18 +201,23 @@ case class CliOptions(
       case _ => filters.mkString("(", "|", ")").r
     }
 
-  private[cli] def isGit: Boolean = readGit(configPath).getOrElse(DefaultGit)
+  private[cli] def isGit: Boolean =
+    readGit(configPath).getOrElse(ScalafmtConfig.default.project.git)
 
   private[cli] def fatalWarnings: Boolean =
-    readFatalWarnings(configPath).getOrElse(DefaultFatalWarnings)
+    readFatalWarnings(configPath).getOrElse(
+      ScalafmtRunner.default.fatalWarnings
+    )
 
   private[cli] def ignoreWarnings: Boolean =
-    readIgnoreWarnings(configPath).getOrElse(DefaultIgnoreWarnings)
+    readIgnoreWarnings(configPath).getOrElse(
+      ScalafmtRunner.default.ignoreWarnings
+    )
 
   private[cli] def onTestFailure: Option[String] = readOnTestFailure(configPath)
 
   private[cli] def encoding: Codec =
-    readEncoding(configPath).getOrElse(DefaultEncoding)
+    readEncoding(configPath).getOrElse(ScalafmtConfig.default.encoding)
 
   /** Returns None if .scalafmt.conf is not found or
     * version setting is missing.

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -112,7 +112,6 @@ case class CliOptions(
     customFiles: Seq[AbsoluteFile] = Nil,
     customExcludes: Seq[String] = Nil,
     respectProjectFilters: Boolean = false,
-    git: Option[Boolean] = None,
     nonInteractive: Boolean = false,
     mode: Option[FileFetchMode] = None,
     assumeFilename: String = "stdin.scala", // used when read from stdin

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -6,8 +6,8 @@ import java.nio.file.{Files, Path}
 
 import com.typesafe.config.{ConfigException, ConfigFactory}
 import metaconfig.Configured
-import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.config.Config
+import org.scalafmt.Versions
+import org.scalafmt.config.{Config, ScalafmtConfig}
 import org.scalafmt.util.{AbsoluteFile, GitOps, GitOpsImpl, OsSpecific}
 
 import scala.io.Codec
@@ -224,8 +224,8 @@ case class CliOptions(
   /** Returns None if .scalafmt.conf is not found or
     * version setting is missing.
     */
-  private[cli] def version: Option[String] =
-    readVersion(configPath)
+  private[cli] def getVersionIfDifferent: Option[String] =
+    readVersion(configPath).filter(_ != Versions.version)
 
   private def readGit(config: Path): Option[Boolean] = {
     try {

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -170,8 +170,8 @@ case class CliOptions(
     }).getOrElse(Configured.Ok(ScalafmtConfig.default))
   }
 
-  val fileFetchMode: FileFetchMode =
-    mode.orElse(Some(GitFiles).filter(_ => isGit)).getOrElse(RecursiveSearch)
+  lazy val fileFetchMode: FileFetchMode =
+    mode.getOrElse(if (isGit) GitFiles else RecursiveSearch)
 
   val files: Seq[AbsoluteFile] =
     if (customFiles.isEmpty)
@@ -180,11 +180,6 @@ case class CliOptions(
       customFiles
 
   val gitOps: GitOps = gitOpsConstructor(common.workingDirectory)
-  /*
-  def withProject(projectFiles: ProjectFiles): CliOptions = {
-    this.copy(config = config.copy(project = projectFiles))
-  }
-   */
 
   def withFiles(files: Seq[AbsoluteFile]): CliOptions = {
     this.copy(customFiles = files)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
@@ -11,6 +11,14 @@ import org.scalafmt.config.PlatformConfig._
 // can be seen here https://scalameta.org/scalafmt/#Standalonelibrary
 object Config {
 
+  def hoconStringToConf(input: String, path: Option[String]): Configured[Conf] =
+    fromInput(Input.String(input), path)
+
+  def hoconFileToConf(input: File, path: Option[String]): Configured[Conf] =
+    Configured
+      .fromExceptionThrowing(Input.File(input))
+      .andThen(fromInput(_, path))
+
   def fromInput(input: Input, path: Option[String]): Configured[Conf] = {
     val configured = implicitly[MetaconfigParser].fromInput(input)
     path match {
@@ -33,7 +41,7 @@ object Config {
       path: Option[String],
       default: ScalafmtConfig
   ): Configured[ScalafmtConfig] =
-    fromConf(fromInput(Input.String(string), path), default = default)
+    fromConf(hoconStringToConf(string, path), default = default)
 
   /** Read ScalafmtConfig from String contents from an optional HOCON path. */
   def fromHoconFile(
@@ -41,7 +49,7 @@ object Config {
       path: Option[String] = None,
       default: ScalafmtConfig = ScalafmtConfig.default
   ): Configured[ScalafmtConfig] =
-    fromConf(fromInput(Input.File(file), path), default = default)
+    fromConf(hoconFileToConf(file, path), default = default)
 
   def fromConf(
       conf: Configured[Conf],


### PR DESCRIPTION
This is to avoid duplicating information -- and to avoid deleting a setting accidentally since it's "not used" anywhere. See https://github.com/scalameta/scalafmt/issues/1644#issuecomment-578411802.