### PR TITLE
FormatTokensRewrite: migrate RedundantParen/Braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -1,28 +1,20 @@
 package org.scalafmt.rewrite
 
 import scala.annotation.tailrec
-
-import org.scalafmt.config.RedundantBracesSettings
-import org.scalafmt.internal.Side
-import org.scalafmt.internal.SyntacticGroupOps
-import org.scalafmt.internal.TreeSyntacticGroup
 import scala.meta._
-import scala.meta.tokens.Token.LeftBrace
-import scala.meta.tokens.Token.RightBrace
-import scala.meta.tokens.Token.Dot
-import scala.meta.tokens.Token.RightArrow
+import scala.meta.tokens.Token
 
-import org.scalafmt.config.RewriteSettings
+import org.scalafmt.config.{RedundantBracesSettings, ScalafmtConfig}
+import org.scalafmt.internal._
 import org.scalafmt.util.InfixApp
 import org.scalafmt.util.TreeOps._
 
-object RedundantBraces extends RewriteFactory {
+object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
 
-  override def hasChanged(v1: RewriteSettings, v2: RewriteSettings): Boolean =
-    v2.redundantBraces ne v1.redundantBraces
+  override def enabled(implicit style: ScalafmtConfig): Boolean = true
 
-  override def create(implicit ctx: RewriteCtx): RewriteSession =
-    new RedundantBraces
+  override def create(ftoks: FormatTokens): FormatTokensRewrite.Rule =
+    new RedundantBraces(ftoks)
 
   def needParensAroundParams(f: Term.Function): Boolean =
     /* either we have parens or no type; multiple params or
@@ -57,20 +49,111 @@ object RedundantBraces extends RewriteFactory {
 
 /** Removes/adds curly braces where desired.
   */
-class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
+class RedundantBraces(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
 
+  import FormatTokensRewrite._
   import RedundantBraces._
 
-  private val settings: RedundantBracesSettings =
-    ctx.style.rewrite.redundantBraces
+  override def enabled(implicit style: ScalafmtConfig): Boolean =
+    RedundantBraces.enabled
 
-  private val redundantParensFunc =
-    if (!ctx.style.rewrite.rules.contains(RedundantParens)) None
-    else Some((new RedundantParens).rewriteFunc)
+  override def onToken(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Option[Replacement] = Option {
+    ft.right match {
+      case _: Token.LeftBrace => onLeftBrace
+      case _: Token.LeftParen => onLeftParen
+      case _ => null
+    }
+  }
 
-  private def processInterpolation(t: Term.Interpolate): Unit = {
-    import ctx.tokenTraverser._
+  override def onRight(left: Replacement, hasFormatOff: Boolean)(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Option[(Replacement, Replacement)] = Option {
+    ft.right match {
+      case _: Token.RightBrace => onRightBrace(left)
+      case _: Token.RightParen => onRightParen(left)
+      case _ => null
+    }
+  }
 
+  private def onLeftParen(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Replacement = {
+    val rt = ft.right
+    val rtOwner = ft.meta.rightOwner
+    val ok = okToReplaceFunctionInSingleArgApply(rtOwner).exists {
+      case (lp, func) => lp.eq(rt) && func.tokens.last.is[Token.RightBrace]
+    }
+    if (ok) replaceToken("{", Some(rtOwner)) {
+      new Token.LeftBrace(rt.input, rt.dialect, rt.start)
+    }
+    else null
+  }
+
+  private def onRightParen(
+      left: Replacement
+  )(implicit ft: FormatToken): (Replacement, Replacement) =
+    if (left.exists(_.right.is[Token.LeftBrace])) (left, removeToken)
+    else null
+
+  private def onLeftBrace(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Replacement = {
+    def replace = replaceToken("(") {
+      val rt = ft.right
+      new Token.LeftParen(rt.input, rt.dialect, rt.start)
+    } // we will not keep it but will hint to onRight
+    ft.meta.rightOwner match {
+      case t: Term.Function if t.tokens.last.is[Token.RightBrace] =>
+        if (!okToRemoveFunctionInApplyOrInit(t)) null
+        else if (okToReplaceFunctionInSingleArgApply(t)) replace
+        else removeToken
+      case t: Term.Block =>
+        if (okToReplaceBlockInSingleArgApply(t)) replace
+        else if (processBlock(t)) removeToken
+        else null
+      case _: Term.Interpolate =>
+        if (processInterpolation) removeToken else null
+      case meta.Importer(_, List(x))
+          if style.runner.dialect.allowAsForImportRename &&
+            (ConvertToNewScala3Syntax.enabled ||
+              !x.tokens.exists(_.is[Token.RightArrow])) =>
+        removeToken
+      case _ => null
+    }
+  }
+
+  private def onRightBrace(
+      left: Replacement
+  )(implicit ft: FormatToken): (Replacement, Replacement) =
+    left match {
+      case Left(_) => (left, removeToken)
+      case Right(lft @ FormatToken(_, _: Token.LeftParen, _)) =>
+        val rt = ft.right
+        val right = replaceToken("}") { // shifted right
+          new Token.RightBrace(rt.input, rt.dialect, rt.start + 1)
+        }
+        (removeToken(lft), right)
+      case Right(_) => null
+    }
+
+  private def settings(implicit
+      style: ScalafmtConfig
+  ): RedundantBracesSettings =
+    style.rewrite.redundantBraces
+
+  private def redundantParensFunc(implicit
+      style: ScalafmtConfig
+  ): Option[Rule] =
+    if (!style.rewrite.rules.contains(RedundantParens)) None
+    else Some(RedundantParens.create(ftoks))
+
+  private def processInterpolation(implicit ft: FormatToken): Boolean = {
     def isIdentifierAtStart(value: String) =
       value.headOption.exists(x => Character.isLetterOrDigit(x) || x == '_')
 
@@ -84,161 +167,101 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
     def shouldTermBeEscaped(arg: Term.Name): Boolean =
       arg.value.head == '_' || isLiteralIdentifier(arg)
 
-    t.parts.tail.zip(t.args).foreach {
-      case (Lit.String(value), arg: Term.Name)
-          if !isIdentifierAtStart(value) && !shouldTermBeEscaped(arg) =>
-        val open = prevToken(arg.tokens.head)
-        if (open.is[LeftBrace]) {
-          val close = nextToken(arg.tokens.head)
-          if (close.is[RightBrace])
-            ctx.addPatchSet(TokenPatch.Remove(open), TokenPatch.Remove(close))
-        }
-      case _ =>
-    }
+    val ft2 = ftoks(ft, 2) // should point to "name}"
+    ft2.right.is[Token.RightBrace] && (ft2.meta.leftOwner match {
+      case t: Term.Name => !shouldTermBeEscaped(t)
+      case _ => false
+    }) && (ftoks(ft2, 2).right match { // skip splice end, to get interpolation part
+      case Token.Interpolation.Part(value) => !isIdentifierAtStart(value)
+      case _ => false
+    })
   }
 
-  override def rewrite(tree: Tree): Unit =
+  private def okToReplaceBlockInSingleArgApply(
+      b: Term.Block
+  )(implicit style: ScalafmtConfig): Boolean =
+    b.parent.exists {
+      case f: Term.Function =>
+        okToReplaceFunctionInSingleArgApply(f)
+      case _ => false
+    }
+
+  private def okToReplaceFunctionInSingleArgApply(f: Term.Function)(implicit
+      style: ScalafmtConfig
+  ): Boolean =
+    f.parent.flatMap(okToReplaceFunctionInSingleArgApply).exists(_._2 eq f)
+
+  private def getOpeningParen(t: Term.Apply): Option[Token.LeftParen] =
+    ftoks.nextNonComment(ftoks(t.fun.tokens.last)).right match {
+      case lp: Token.LeftParen => Some(lp)
+      case _ => None
+    }
+
+  // single-arg apply of a lambda
+  // a(b => { c; d }) change to a { b => c; d }
+  private def okToReplaceFunctionInSingleArgApply(
+      tree: Tree
+  )(implicit style: ScalafmtConfig): Option[(Token.LeftParen, Term.Function)] =
     tree match {
-      case t: Term.Apply =>
-        processApply(t)
-
-      case t: Init =>
-        processInit(t)
-
-      case b: Term.Block =>
-        processBlock(b, okToRemoveBlock)
-
-      case t: Term.Interpolate if settings.stringInterpolation =>
-        processInterpolation(t)
-
-      case Importer(_, List(importee)) if ctx.dialect.allowAsForImportRename =>
-        processSingleImport(importee)
-
-      case _ =>
+      case ta @ Term.Apply(_, List(func @ Term.Function(_, body)))
+          if (body.is[Term.Block] || func.tokens.last.ne(body.tokens.last)) &&
+            okToRemoveAroundFunctionBody(body, true) =>
+        getOpeningParen(ta).map((_, func))
+      case _ => None
     }
 
-  private def processSingleImport(tree: Importee) = {
-    val tokens = tree.tokens
-    tree match {
-      case _: Importee.Rename | _: Importee.Unimport
-          if !tokens.exists(_.is[RightArrow]) =>
-        ctx.tokenTraverser
-          .findBefore(tokens.head) {
-            case _: LeftBrace => Some(true)
-            case _: Dot => Some(false)
-            case _ => None
-          }
-          .foreach { leftBrace =>
-            val rightBrace = ctx.getMatching(leftBrace)
-            implicit val builder = Seq.newBuilder[TokenPatch]
-            removeBraces(leftBrace, rightBrace)
-            ctx.addPatchSet(builder.result(): _*)
-          }
-      case _ =>
+  // multi-arg apply of single-stat lambdas
+  // a(b => { c }, d => { e }) change to a(b => c, d => e)
+  // a single-stat lambda with braces can be converted to one without braces,
+  // but the reverse conversion isn't always possible
+  private def okToRemoveFunctionInApplyOrInit(
+      t: Term.Function
+  )(implicit style: ScalafmtConfig): Boolean =
+    t.parent match {
+      case Some(_: Init) =>
+        okToRemoveAroundFunctionBody(t.body, false)
+      case Some(p: Term.Apply) =>
+        getOpeningParen(p).isDefined && okToRemoveAroundFunctionBody(
+          t.body,
+          p.args
+        )
+      case _ => false
     }
 
-  }
-
-  private def processInit(tree: Init): Unit =
-    tree.argss.foreach(processMultiArgApply)
-
-  private def processApply(tree: Term.Apply): Unit = {
-    val lastToken = tree.tokens.last
-    if (lastToken.is[Token.RightParen]) {
-      tree.args match {
-        case Nil =>
-        case List(arg) => processSingleArgApply(arg, lastToken)
-        case args => processMultiArgApply(args)
-      }
-    }
-  }
-
-  private def processSingleArgApply(arg: Term, rparen: Token): Unit =
-    arg match {
-      // single-arg apply of a lambda
-      // a(b => { c; d }) change to a { b => c; d }
-      case f: Term.Function
-          if okToRemoveAroundFunctionBody(f.body, true) &&
-            f.tokens.last.is[Token.RightBrace] =>
-        val rbrace = f.tokens.last
-        val lbrace = ctx.getMatching(rbrace)
-        // we really wanted the first token of body but Block usually
-        // points to the next non-whitespace token after opening brace
-        if (lbrace.start <= f.body.tokens.head.start) {
-          val lparen = ctx.getMatching(rparen)
-          implicit val builder = Seq.newBuilder[TokenPatch]
-          builder += TokenPatch.Replace(lparen, lbrace.text)
-          removeBraces(lbrace, rparen)
-          ctx.removeLFToAvoidEmptyLine(rparen)
-          ctx.addPatchSet(builder.result(): _*)
+  private def processBlock(
+      b: Term.Block
+  )(implicit ft: FormatToken, style: ScalafmtConfig): Boolean =
+    (ft.right match {
+      case lb: Token.LeftBrace =>
+        b.tokens.headOption.contains(lb) && b.tokens.last.is[Token.RightBrace]
+      case rb: Token.RightBrace =>
+        b.tokens.lastOption.contains(rb) && b.tokens.head.is[Token.LeftBrace]
+      case _ => false
+    }) && okToRemoveBlock(b) && (b.parent match {
+      case Some(InfixApp(_)) =>
+        /* for infix, we will preserve the block unless the closing brace
+         * follows a non-whitespace character on the same line as we don't
+         * break lines around infix expressions.
+         * we shouldn't join with the previous line (which might also end
+         * in a comment), and if we keep the break before the right brace
+         * we are removing, that will likely invalidate the expression. */
+        def checkOpen = {
+          val nft = ftoks.next(ft)
+          nft.noBreak ||
+          style.newlines.formatInfix && !nft.right.is[Token.Comment]
         }
-      case _ =>
-    }
-
-  private def processMultiArgApply(args: Seq[Term]): Unit =
-    args.foreach {
-      // multi-arg apply of single-stat lambdas
-      // a(b => { c }, d => { e }) change to a(b => c, d => e)
-      // a single-stat lambda with braces can be converted to one without braces,
-      // but the reverse conversion isn't always possible
-      case fun @ Term.Function(_, body)
-          if okToRemoveAroundFunctionBody(body, false) &&
-            fun.tokens.last.is[Token.RightBrace] =>
-        val rbrace = fun.tokens.last
-        val lbrace = ctx.getMatching(rbrace)
-        if (lbrace.start <= body.tokens.head.start) {
-          implicit val builder = Seq.newBuilder[TokenPatch]
-          removeBraces(lbrace, rbrace)
-          ctx.removeLFToAvoidEmptyLine(rbrace)
-          ctx.addPatchSet(builder.result(): _*)
+        def checkClose = {
+          val nft = ftoks(ftoks.matching(ft.right), -1)
+          nft.noBreak ||
+          style.newlines.formatInfix && !nft.left.is[Token.Comment]
         }
-      case b: Term.Block =>
-        processBlock(b, okToRemoveBlockWithinApply)
-      case _ =>
-    }
+        checkOpen && checkClose
+      case _ => true
+    })
 
-  private def processBlock(b: Term.Block, check: Term.Block => Boolean): Unit =
-    b.tokens.headOption.filter(_.is[LeftBrace]).foreach { open =>
-      val close = b.tokens.last
-      if (close.is[RightBrace] && check(b)) {
-        implicit val builder = Seq.newBuilder[TokenPatch]
-        val ok = b.parent match {
-          case Some(InfixApp(_)) =>
-            /* for infix, we will preserve the block unless the closing brace
-             * follows a non-whitespace character on the same line as we don't
-             * break lines around infix expressions.
-             * we shouldn't join with the previous line (which might also end
-             * in a comment), and if we keep the break before the right brace
-             * we are removing, that will likely invalidate the expression. */
-            val canRemove: ((Token, Option[Token.LF])) => Boolean =
-              if (!ctx.style.newlines.formatInfix) { case (_, lfOpt) =>
-                lfOpt.isEmpty
-              }
-              else { case (nonWs, lfOpt) =>
-                if (nonWs.is[Token.Comment]) lfOpt.isEmpty
-                else {
-                  lfOpt.foreach(builder += TokenPatch.Remove(_))
-                  true
-                }
-              }
-            Seq(
-              // ensure can remove opening brace
-              ctx.tokenTraverser.findAfter(open) _,
-              // ensure can remove closing brace
-              ctx.tokenTraverser.findBefore(close) _
-            ).forall(ctx.findNonWhitespaceWith(_).exists(canRemove))
-          case _ =>
-            ctx.removeLFToAvoidEmptyLine(close)
-            true
-        }
-        if (ok) {
-          removeBraces(open, close)
-          ctx.addPatchSet(builder.result(): _*)
-        }
-      }
-    }
-
-  private def okToRemoveBlock(b: Term.Block): Boolean = {
+  private def okToRemoveBlock(
+      b: Term.Block
+  )(implicit style: ScalafmtConfig): Boolean = {
     b.parent.exists {
 
       case p: Case =>
@@ -246,11 +269,11 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
           (p.body eq b) || shouldRemoveSingleStatBlock(b)
         }
 
-      case _: Term.Apply =>
+      case t: Term.Apply =>
         // Example: as.map { _.toString }
         // Leave this alone for now.
         // In future there should be an option to surround such expressions with parens instead of braces
-        false
+        t.args.lengthCompare(1) > 0 && okToRemoveBlockWithinApply(b)
 
       case d: Defn.Def =>
         def disqualifiedByUnit =
@@ -278,11 +301,13 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
         // can't allow: new A with B .foo
         // can allow if: no ".foo", no "with B", or has braces
         !b.parent.exists(_.is[Term.Select]) || t.templ.inits.length <= 1 ||
-          t.templ.stats.nonEmpty || t.tokens.last.is[RightBrace]
+          t.templ.stats.nonEmpty || t.tokens.last.is[Token.RightBrace]
       case _ => true
     }
 
-  private def okToRemoveBlockWithinApply(b: Term.Block): Boolean =
+  private def okToRemoveBlockWithinApply(
+      b: Term.Block
+  )(implicit style: ScalafmtConfig): Boolean =
     getSingleStatIfLineSpanOk(b).exists {
       case f: Term.Function if needParensAroundParams(f) => false
       case Term.Function(_, fb: Term.Block) =>
@@ -294,7 +319,9 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
     }
 
   /** Some blocks look redundant but aren't */
-  private def shouldRemoveSingleStatBlock(b: Term.Block): Boolean =
+  private def shouldRemoveSingleStatBlock(
+      b: Term.Block
+  )(implicit style: ScalafmtConfig): Boolean =
     getSingleStatIfLineSpanOk(b).exists { stat =>
       innerOk(b)(stat) && !b.parent.exists {
         case _: Term.Try | _: Term.TryWithHandler =>
@@ -302,17 +329,15 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
           // inside exists, return true if rewrite is OK
           !stat.tokens.headOption.exists {
             case x: Token.LeftParen =>
-              ctx.getMatchingOpt(x) match {
+              ftoks.matchingOpt(x) match {
                 case Some(y) if y ne stat.tokens.last =>
-                  redundantParensFunc.exists { func =>
-                    findFirstTreeBetween(stat, x, y).exists {
-                      func.isDefinedAt
-                    }
+                  redundantParensFunc.exists { parensRule =>
+                    parensRule.onToken(ftoks(x, -1), style).exists(_.isLeft)
                   }
                 case _ => true
               }
             case x: Token.LeftBrace =>
-              ctx.getMatchingOpt(x) match {
+              ftoks.matchingOpt(x) match {
                 case Some(y) if y ne stat.tokens.last =>
                   findFirstTreeBetween(stat, x, y).exists {
                     case z: Term.Block => okToRemoveBlock(z)
@@ -324,7 +349,7 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
           }
 
         // can't do it for try until 2.13.3
-        case _ if ctx.isPrefixExpr(stat) => false
+        case _ if isPrefixExpr(stat) => false
 
         case parentIf: Term.If if stat.is[Term.If] =>
           // if (a) { if (b) c } else d
@@ -359,24 +384,32 @@ class RedundantBraces(implicit ctx: RewriteCtx) extends RewriteSession {
       }
     }
 
+  @inline
+  private def okToRemoveAroundFunctionBody(b: Term, s: Seq[Tree])(implicit
+      style: ScalafmtConfig
+  ): Boolean =
+    okToRemoveAroundFunctionBody(b, s.lengthCompare(1) == 0)
+
   private def okToRemoveAroundFunctionBody(
       b: Term,
-      okIfMultipleStats: Boolean
-  ): Boolean =
+      okIfMultipleStats: => Boolean
+  )(implicit style: ScalafmtConfig): Boolean =
     settings.methodBodies && (getTermSingleStat(b) match {
       case Some(_: Term.PartialFunction) => false
       case Some(s) => getTermLineSpan(s) <= settings.maxLines
       case _ => okIfMultipleStats
     })
 
-  private def getSingleStatIfLineSpanOk(b: Term.Block): Option[Stat] =
+  private def getSingleStatIfLineSpanOk(b: Term.Block)(implicit
+      style: ScalafmtConfig
+  ): Option[Stat] =
     getBlockSingleStat(b).filter(getTermLineSpan(_) <= settings.maxLines)
 
-  private def removeBraces(lbrace: Token, rbrace: Token)(implicit
-      builder: Rewrite.PatchBuilder
-  ): Unit = {
-    builder += TokenPatch.AddLeft(lbrace, " ", keepTok = false)
-    builder += TokenPatch.AddRight(rbrace, " ", keepTok = false)
-  }
+  // special case for Select which might contain a space instead of dot
+  private def isPrefixExpr(expr: Tree): Boolean =
+    RewriteCtx.isSimpleExprOr(expr) {
+      case t: Term.Select if !RewriteCtx.hasPlaceholder(expr) =>
+        ftoks(t.name.tokens.head, -1).left.is[Token.Dot]
+    }
 
 }

--- a/scalafmt-tests/src/test/resources/scala3/RenameImportExport.stat
+++ b/scalafmt-tests/src/test/resources/scala3/RenameImportExport.stat
@@ -36,7 +36,14 @@ rewrite.rules = [RedundantBraces]
 import java.util.{List   =>  `J-List`}
 >>>
 import java.util.{List => `J-List`}
-<<< no redundant braces in import 
+<<< remove redundant braces old syntax, converting
+rewrite.rules = [RedundantBraces]
+rewrite.scala3.convertToNewSyntax = true
+===
+import java.util.{List   =>  `J-List`}
+>>>
+import java.util.List as `J-List`
+<<< no redundant braces in import
 rewrite.rules = [RedundantBraces]
 ===
 import java.util.List   as  `J-List`


### PR DESCRIPTION
These two rules depend on each other and hence go hand in hand.