### PR TITLE
CliOptions: parse config into a Conf object

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -197,6 +197,12 @@ object CliArgParser {
         |$usageExamples
         |Please file bugs to https://github.com/scalameta/scalafmt/issues
       """.stripMargin)
+
+      checkConfig { c =>
+        if (c.config.isDefined && c.configStr.isDefined)
+          failure("may not specify both --config and --config-str")
+        else success
+      }
     }
   def buildInfo =
     s"""build commit: ${Versions.commit}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -857,4 +857,20 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
     assert(config.maxColumn == 40)
     assert(obtained.files.head.jfile.getName() == "foobar.scala")
   }
+
+  test("can't specify both --config and --config-str") {
+    val errStream = new ByteArrayOutputStream()
+    val obtained = Console.withErr(errStream) {
+      Cli.getConfig(
+        Array("--config", "foo", "--config-str", "bar"),
+        CliOptions.default
+      )
+    }
+    assertEquals(
+      errStream.toString.trim,
+      "Error: may not specify both --config and --config-str"
+    )
+    assertEquals(None: Option[CliOptions], obtained)
+  }
+
 }


### PR DESCRIPTION
Also, add an explicit check to CliArgParser, to disallow having both `--config` and `--config-str` specified, since only one of them is actually processed.