### PR TITLE
ProjectFiles: rename include to includePaths

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2418,8 +2418,8 @@ If this boolean flag is set, only format files tracked by git.
 > Since v3.0.0.
 
 ```scala mdoc:defaults
-project.include
-project.exclude
+project.includePaths
+project.excludePaths
 ```
 
 Allows specifying
@@ -2432,11 +2432,11 @@ For instance,
 
 ```conf
 project {
-  include = [
+  includePaths = [
     "glob:**.scala",
     "regex:.*\\.sc"
   ]
-  exclude = [
+  excludePaths = [
     "glob:**/src/test/scala/**.scala"
   ]
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -10,17 +10,17 @@ import metaconfig.annotation.DeprecatedName
 
 case class ProjectFiles(
     git: Boolean = false,
-    include: Seq[String] = Seq("glob:**.scala", "glob:**.sbt", "glob:**.sc"),
-    exclude: Seq[String] = Nil,
+    includePaths: Seq[String] = ProjectFiles.defaultIncludePaths,
+    excludePaths: Seq[String] = Nil,
     @DeprecatedName(
       "includeFilters",
-      "use `include` with `regex:` prefix",
+      "use `includePaths` with `regex:` prefix",
       "v3.0.0"
     )
     includeFilters: Seq[String] = Nil,
     @DeprecatedName(
       "excludeFilters",
-      "use `exclude` with `regex:` prefix",
+      "use `excludePaths` with `regex:` prefix",
       "v3.0.0"
     )
     excludeFilters: Seq[String] = Nil
@@ -39,6 +39,9 @@ object ProjectFiles {
 
   private implicit val fs: file.FileSystem = file.FileSystems.getDefault
 
+  val defaultIncludePaths =
+    Seq("glob:**.scala", "glob:**.sbt", "glob:**.sc")
+
   private sealed abstract class PathMatcher {
     def matches(path: file.Path): Boolean
   }
@@ -46,8 +49,8 @@ object ProjectFiles {
   object FileMatcher {
     def apply(pf: ProjectFiles, regexExclude: Seq[String] = Nil): FileMatcher =
       new FileMatcher(
-        nio(pf.include) ++ regex(pf.includeFilters),
-        nio(pf.exclude) ++ regex(pf.excludeFilters ++ regexExclude)
+        nio(pf.includePaths) ++ regex(pf.includeFilters),
+        nio(pf.excludePaths) ++ regex(pf.excludeFilters ++ regexExclude)
       )
     private def create(seq: Seq[String], f: String => PathMatcher) =
       seq.map(_.asFilename).distinct.map(f)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -47,11 +47,20 @@ object ProjectFiles {
   }
 
   object FileMatcher {
-    def apply(pf: ProjectFiles, regexExclude: Seq[String] = Nil): FileMatcher =
+    def apply(
+        pf: ProjectFiles,
+        regexExclude: Seq[String] = Nil
+    ): FileMatcher = {
+      // check if includePaths were specified explicitly
+      val useIncludePaths =
+        pf.includePaths.ne(defaultIncludePaths) || pf.includeFilters.isEmpty
+      val includePaths = if (useIncludePaths) pf.includePaths else Seq.empty
       new FileMatcher(
-        nio(pf.includePaths) ++ regex(pf.includeFilters),
+        nio(includePaths) ++ regex(pf.includeFilters),
         nio(pf.excludePaths) ++ regex(pf.excludeFilters ++ regexExclude)
       )
+    }
+
     private def create(seq: Seq[String], f: String => PathMatcher) =
       seq.map(_.asFilename).distinct.map(f)
     private def nio(seq: Seq[String]) = create(seq, new Nio(_))

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -14,7 +14,7 @@ import munit.FunSuite
 import org.scalafmt.Error.NoMatchingFiles
 import org.scalafmt.Versions
 import org.scalafmt.cli.FileTestOps._
-import org.scalafmt.config.{Config, ScalafmtConfig}
+import org.scalafmt.config.{Config, ProjectFiles, ScalafmtConfig}
 import org.scalafmt.util.{AbsoluteFile, FileOps}
 import org.scalafmt.util.OsSpecific._
 
@@ -939,6 +939,88 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
         |
         |/target/foo.scala
         |object A   { }
+        |""".stripMargin
+    noArgTest(
+      input,
+      expected,
+      Seq(Array.empty[String], Array("--mode", "diff"))
+    )
+  }
+
+  test(s"scalafmt: includeFilters overrides default includePaths") {
+    val input = string2dir(
+      s"""|/bar.scala
+        |object    FormatMe {
+        |  val x = 1
+        |}
+        |
+        |/target/foo.scala
+        |object A   { }
+        |
+        |/.scalafmt.conf
+        |maxColumn = 2
+        |project { includeFilters = ["bar"] }
+        |""".stripMargin
+    )
+
+    val expected =
+      s"""|/.scalafmt.conf
+        |maxColumn = 2
+        |project { includeFilters = ["bar"] }
+        |
+        |/bar.scala
+        |object FormatMe {
+        |  val x =
+        |    1
+        |}
+        |
+        |/target/foo.scala
+        |object A   { }
+        |""".stripMargin
+    noArgTest(
+      input,
+      expected,
+      Seq(Array.empty[String], Array("--mode", "diff"))
+    )
+  }
+
+  test(s"scalafmt: includeFilters with explicit includePaths") {
+    val defaultIncludePathsJson =
+      ProjectFiles.defaultIncludePaths.mkString("[\"", "\", \"", "\"]")
+    val input = string2dir(
+      s"""|/bar.scala
+        |object    FormatMe {
+        |  val x = 1
+        |}
+        |
+        |/target/foo.scala
+        |object A   { }
+        |
+        |/.scalafmt.conf
+        |maxColumn = 2
+        |project {
+        |  includePaths = $defaultIncludePathsJson
+        |  includeFilters = ["bar"]
+        |}
+        |""".stripMargin
+    )
+
+    val expected =
+      s"""|/.scalafmt.conf
+        |maxColumn = 2
+        |project {
+        |  includePaths = $defaultIncludePathsJson
+        |  includeFilters = ["bar"]
+        |}
+        |
+        |/bar.scala
+        |object FormatMe {
+        |  val x =
+        |    1
+        |}
+        |
+        |/target/foo.scala
+        |object A {}
         |""".stripMargin
     noArgTest(
       input,

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -873,4 +873,78 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
     assertEquals(None: Option[CliOptions], obtained)
   }
 
+  test(s"scalafmt use includePaths") {
+    val input = string2dir(
+      s"""|/bar.scala
+        |object    FormatMe {
+        |  val x = 1
+        |}
+        |
+        |/target/foo.scala
+        |object A   { }
+        |
+        |/.scalafmt.conf
+        |maxColumn = 2
+        |project { includePaths = ["glob:**/bar.scala"] }
+        |""".stripMargin
+    )
+
+    val expected =
+      s"""|/.scalafmt.conf
+        |maxColumn = 2
+        |project { includePaths = ["glob:**/bar.scala"] }
+        |
+        |/bar.scala
+        |object FormatMe {
+        |  val x =
+        |    1
+        |}
+        |
+        |/target/foo.scala
+        |object A   { }
+        |""".stripMargin
+    noArgTest(
+      input,
+      expected,
+      Seq(Array.empty[String], Array("--mode", "diff"))
+    )
+  }
+
+  test(s"scalafmt use excludePaths") {
+    val input = string2dir(
+      s"""|/foo.scala
+        |object    FormatMe {
+        |  val x = 1
+        |}
+        |
+        |/target/foo.scala
+        |object A   { }
+        |
+        |/.scalafmt.conf
+        |maxColumn = 2
+        |project { excludePaths = ["glob:**target**"] }
+        |""".stripMargin
+    )
+
+    val expected =
+      s"""|/.scalafmt.conf
+        |maxColumn = 2
+        |project { excludePaths = ["glob:**target**"] }
+        |
+        |/foo.scala
+        |object FormatMe {
+        |  val x =
+        |    1
+        |}
+        |
+        |/target/foo.scala
+        |object A   { }
+        |""".stripMargin
+    noArgTest(
+      input,
+      expected,
+      Seq(Array.empty[String], Array("--mode", "diff"))
+    )
+  }
+
 }


### PR DESCRIPTION
Unfortuntely, `include` is a hocon reserved keyword, used to include another application config. Let's rename.