### PR TITLE
FormatOps: rename `tree` field to `topSourceTree`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -288,7 +288,7 @@ private class BestFirstSearch private (
 
   def getBestPath: SearchResult = {
     val state = {
-      def run = shortestPath(State.start, tree.tokens.last)
+      def run = shortestPath(State.start, topSourceTree.tokens.last)
       val state = run
       if (null != state || keepSlowStates) state
       else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1061,7 +1061,7 @@ class FormatWriter(formatOps: FormatOps) {
         }
     }
 
-    trav(tree)
+    trav(topSourceTree)
     (headBuffer.result(), lastBuffer.result())
   }
 


### PR DESCRIPTION
Multiple methods use `tree` as a parameter name, and this leads to bugs when the parameter is renamed by usage is preserved. Let's rename the class field to something quite unambiguous.