### PR TITLE
Update link to Mill's new website

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -388,9 +388,9 @@ plugin:
 
 ## Mill
 
-Mill have scalafmt support built-in:
+Mill has scalafmt support built-in:
 
-- [scalafmt module](http://www.lihaoyi.com/mill/page/configuring-mill.html#reformatting-your-code)
+- [scalafmt module](https://com-lihaoyi.github.io/mill/page/configuring-mill.html#reformatting-your-code)
 
 ## Standalone library
 


### PR DESCRIPTION
This links to that new site for Mill which has moved to a new Github organization and as announced in the blog post [here](https://www.lihaoyi.com/post/IntroducingthecomlihaoyiGithubOrganization.html).