### PR TITLE
CliOptions: do not compute `cwd` at compile time

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -22,7 +22,7 @@ object Cli {
       nGContext.getArgs,
       CliOptions.default.copy(
         common = CliOptions.default.common.copy(
-          workingDirectory = workingDirectory,
+          cwd = workingDirectory,
           out = nGContext.out,
           in = nGContext.in,
           err = nGContext.err

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -74,13 +74,16 @@ object NoopOutputStream extends OutputStream { self =>
 }
 
 case class CommonOptions(
-    workingDirectory: AbsoluteFile = AbsoluteFile.userDir,
+    private val cwd: AbsoluteFile = null,
     out: PrintStream = System.out,
     in: InputStream = System.in,
     err: PrintStream = System.err,
     debug: PrintStream = NoopOutputStream.printStream,
     info: PrintStream = NoopOutputStream.printStream
-)
+) {
+  lazy val workingDirectory: AbsoluteFile =
+    Option(cwd).getOrElse(AbsoluteFile.userDir)
+}
 
 case class CliOptions(
     config: Option[Path] = None,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/AbsoluteFile.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/AbsoluteFile.scala
@@ -28,5 +28,4 @@ object AbsoluteFile {
     else None
   }
   def userDir = new AbsoluteFile(new File(System.getProperty("user.dir"))) {}
-  def homeDir = new AbsoluteFile(new File(System.getProperty("user.home"))) {}
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/GitOps.scala
@@ -12,10 +12,6 @@ trait GitOps {
   def rootDir: Option[AbsoluteFile]
 }
 
-object GitOps {
-  def apply(): GitOps = new GitOpsImpl(AbsoluteFile.userDir)
-}
-
 class GitOpsImpl(private[util] val workingDirectory: AbsoluteFile)
     extends GitOps {
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -426,7 +426,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val workingDir = input / "nested"
       val options: CliOptions = {
         val mock = getMockOptions(input, workingDir)
-        mock.copy(common = mock.common.copy(workingDirectory = workingDir))
+        mock.copy(common = mock.common.copy(cwd = workingDir))
       }
       val config = Cli.getConfig(Array("foo.scala"), options).get
       Cli.run(config)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/FileTestOps.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/FileTestOps.scala
@@ -56,7 +56,7 @@ object FileTestOps {
     CliOptions.default.copy(
       gitOpsConstructor = _ => new FakeGitOps(baseDir),
       common = CliOptions.default.common.copy(
-        workingDirectory = workingDir,
+        cwd = workingDir,
         out = out,
         err = out
       )


### PR DESCRIPTION
Possibly handled differently by graalvm, the native compiler. Fixes #2493.