### PR TITLE
Fix indentation when using braceless block with single Defn

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2087,7 +2087,7 @@ class FormatOps(
         val leftOwner = ft.meta.leftOwner
         findTreeWithParentSimple(nft.meta.rightOwner)(_ eq leftOwner) match {
           case Some(t: Term.Block)
-              if t.stats.lengthCompare(1) > 0 && isBlockStart(t, nft) =>
+              if !hasSingleTermStat(t) && isBlockStart(t, nft) =>
             Some(getSplitsMaybeBlock(ft, nft, t, true))
           case _ => None
         }
@@ -2367,7 +2367,8 @@ class FormatOps(
         allowMain: Boolean
     )(implicit line: sourcecode.Line, style: ScalafmtConfig): Seq[Split] = {
       val multiStat = isTreeMultiStatBlock(tree)
-      val forceNL = multiStat || shouldBreakInOptionalBraces(nft)
+      val forceNL =
+        !hasSingleTermStatIfBlock(tree) || shouldBreakInOptionalBraces(nft)
       getSplits(ft, tree, forceNL, allowMain && !multiStat)
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -634,18 +634,26 @@ object TreeOps {
     case _ => false
   }
 
-  def getTermSingleStat(t: Term): Option[Tree] =
+  def getTreeSingleStat(t: Tree): Option[Tree] =
     t match {
       case b: Term.Block => getBlockSingleStat(b)
       case _ => Some(t)
     }
 
-  def getTermLineSpan(b: Tree): Int =
+  def getTreeLineSpan(b: Tree): Int =
     if (b.tokens.isEmpty) 0
     else {
       val pos = b.pos
       pos.endLine - pos.startLine
     }
+
+  def hasSingleTermStat(t: Term.Block): Boolean =
+    getBlockSingleStat(t).exists(_.is[Term])
+
+  def hasSingleTermStatIfBlock(t: Tree): Boolean = t match {
+    case b: Term.Block => hasSingleTermStat(b)
+    case _ => true
+  }
 
   /** In cases like:
     * {{{

--- a/scalafmt-tests/src/test/resources/scala3/Issues.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Issues.stat
@@ -49,3 +49,11 @@ val f: String => PartialFunction[String, Int] = s =>
     5
   case "Goodbye" =>
     0
+<<< single val in block
+object Util:
+  def assertPropPassed(prop: Prop): Unit =
+    val _ = ""
+>>>
+object Util:
+  def assertPropPassed(prop: Prop): Unit =
+    val _ = ""


### PR DESCRIPTION
Previously, it was not possible to have a single val in a block and not have braces, which is why it didn't work for Scala 3.

Now, we make sure that indentation is added always if we have a single statement, which is a Defn.