### PR TITLE
Display filename alongside line information when debugging

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -13,6 +13,7 @@ import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.util.LoggerOps
 import org.scalafmt.util.TokenOps
 import org.scalafmt.util.TreeOps
+import org.scalameta.FileLine
 
 /** Implements best first search to find optimal formatting.
   */
@@ -83,7 +84,7 @@ private class BestFirstSearch private (
   val memo = mutable.Map.empty[(Int, StateHash), State]
 
   def shortestPathMemo(start: State, stop: Token, depth: Int, maxCost: Int)(
-      implicit line: sourcecode.Line
+      implicit fileLine: FileLine
   ): Option[State] = {
     val key = (start.depth, stateColumnKey(start))
     val cachedState = memo.get(key)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -97,7 +97,7 @@ object Policy {
 
     override def toString = {
       val noDeqPrefix = if (noDequeue) "!" else ""
-      s"[${fileLine}]$endPolicy${noDeqPrefix}d"
+      s"[$fileLine]$endPolicy${noDeqPrefix}d"
     }
 
     override def unexpired(ft: FormatToken): Policy =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -180,8 +180,7 @@ object Policy {
     override def switch(trigger: Token): Policy = conv(_.switch(trigger))
     override def unexpired(ft: FormatToken): Policy = conv(_.unexpired(ft))
     override def noDequeue: Boolean = before.noDequeue
-    override def toString: String =
-      s"REL:[${fileLine}]($before,$after)"
+    override def toString: String = s"REL:[$fileLine]($before,$after)"
 
     private def conv(func: Policy => Policy): Policy = {
       val filtered = func(before)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -200,8 +200,7 @@ object Policy {
       else after.switch(trigger)
     override def unexpired(ft: FormatToken): Policy = conv(_.unexpired(ft))
     override def noDequeue: Boolean = before.noDequeue
-    override def toString: String =
-      s"SW:[${fileLine}]($before,$trigger,$after)"
+    override def toString: String = s"SW:[$fileLine]($before,$trigger,$after)"
 
     private def conv(func: Policy => Policy): Policy = {
       val filtered = func(before)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -6,6 +6,7 @@ import org.scalafmt.internal.ExpiresOn.{After, Before}
 import org.scalafmt.internal.Length.{Num, StateColumn}
 import org.scalafmt.internal.Policy.NoPolicy
 import org.scalafmt.util._
+import org.scalameta.FileLine
 
 import scala.language.implicitConversions
 import scala.meta.Term.ApplyUsing
@@ -649,7 +650,7 @@ class Router(formatOps: FormatOps) {
           if (style.newlines.alwaysBeforeCurlyLambdaParams) null
           else getNoSplit(formatToken, true)
 
-        def multilineSpaceSplit(implicit line: sourcecode.Line): Split = {
+        def multilineSpaceSplit(implicit fileLine: FileLine): Split = {
           val lambdaLeft: Option[Token] =
             matchingOpt(functionExpire(lambda)._1).filter(_.is[T.LeftBrace])
 
@@ -754,7 +755,7 @@ class Router(formatOps: FormatOps) {
 
         def singleLine(
             newlinePenalty: Int
-        )(implicit line: sourcecode.Line): Policy = {
+        )(implicit fileLine: FileLine): Policy = {
           val baseSingleLinePolicy = if (isBracket) {
             if (!multipleArgs)
               PenalizeAllNewlines(
@@ -992,7 +993,7 @@ class Router(formatOps: FormatOps) {
         val indent = getApplyIndent(leftOwner)
         val noSplitIndent =
           if (style.binPack.indentCallSiteOnce) Num(0) else indent
-        def baseNoSplit(implicit line: sourcecode.Line) =
+        def baseNoSplit(implicit fileLine: FileLine) =
           Split(NoSplit, 0).withIndent(noSplitIndent, close, Before)
         val opensLiteralArgumentList =
           styleMap.opensLiteralArgumentList(formatToken)
@@ -1652,7 +1653,7 @@ class Router(formatOps: FormatOps) {
       case FormatToken(open: T.LeftParen, right, _) =>
         val isConfig = couldUseConfigStyle(formatToken)
         val close = matching(open)
-        def spaceSplitWithoutPolicy(implicit line: sourcecode.Line) = {
+        def spaceSplitWithoutPolicy(implicit fileLine: FileLine) = {
           val indent: Length = right match {
             case T.KwIf() => StateColumn
             case T.KwFor() if !style.indentYieldKeyword => StateColumn
@@ -1668,12 +1669,12 @@ class Router(formatOps: FormatOps) {
           val useSpace = style.spaces.inParentheses
           Split(Space(useSpace), 0).withIndent(indent, close, Before)
         }
-        def spaceSplit(implicit line: sourcecode.Line) =
+        def spaceSplit(implicit fileLine: FileLine) =
           spaceSplitWithoutPolicy.withPolicy(PenalizeAllNewlines(close, 1))
         def newlineSplit(
             cost: Int,
             forceDangle: Boolean
-        )(implicit line: sourcecode.Line) = {
+        )(implicit fileLine: FileLine) = {
           val shouldDangle = forceDangle ||
             style.danglingParentheses.callSite
           val policy =
@@ -2145,7 +2146,7 @@ class Router(formatOps: FormatOps) {
   ): Seq[Split] = {
     val expire = getLastToken(body)
     def baseSplit = Split(Space, 0)
-    def newlineSplit(cost: Int)(implicit line: sourcecode.Line) =
+    def newlineSplit(cost: Int)(implicit fileLine: FileLine) =
       CtrlBodySplits.withIndent(Split(Newline, cost), ft, body)
 
     def getClassicSplits =
@@ -2204,9 +2205,9 @@ class Router(formatOps: FormatOps) {
       case _ => 0
     }
 
-    def baseSpaceSplit(implicit line: sourcecode.Line) =
+    def baseSpaceSplit(implicit fileLine: FileLine) =
       Split(Space, 0).notIf(isSingleLineComment(ft.right))
-    def twoBranches(implicit line: sourcecode.Line) =
+    def twoBranches(implicit fileLine: FileLine) =
       baseSpaceSplit
         .withOptimalToken(optimal)
         .withPolicy {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -299,7 +299,10 @@ object State {
     private def compareSplitOrigin(s1: State, s2: State): Int = {
       // We assume the same number of splits, see compareSplitsLength
       // Break ties by the last split's line origin.
-      val r = Integer.compare(s1.split.line.value, s2.split.line.value)
+      val r = Integer.compare(
+        s1.split.fileLine.line.value,
+        s2.split.fileLine.line.value
+      )
       if (r != 0 || s1.prev.depth == 0) r
       else compareSplitOrigin(s1.prev, s2.prev)
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -6,6 +6,7 @@ import org.scalafmt.internal.Decision
 import org.scalafmt.internal.Policy
 import org.scalafmt.internal.Policy.End
 import org.scalafmt.internal.TokenRanges
+import org.scalameta.FileLine
 
 object PolicyOps {
 
@@ -16,7 +17,7 @@ object PolicyOps {
       penalty: Int,
       penalizeLambdas: Boolean = true,
       noSyntaxNL: Boolean = false
-  )(implicit line: sourcecode.Line)
+  )(implicit fileLine: FileLine)
       extends Policy.Clause {
     override val noDequeue: Boolean = false
     override val f: Policy.Pf = {
@@ -33,7 +34,7 @@ object PolicyOps {
         penalty: Int,
         penalizeLambdas: Boolean = true,
         noSyntaxNL: Boolean = false
-    )(implicit line: sourcecode.Line): Policy = {
+    )(implicit fileLine: FileLine): Policy = {
       new PenalizeAllNewlines(
         Policy.End.Before(expire),
         penalty,
@@ -51,7 +52,7 @@ object PolicyOps {
       val endPolicy: End.WithPos,
       okSLC: Boolean = false,
       noSyntaxNL: Boolean = false
-  )(implicit line: sourcecode.Line)
+  )(implicit fileLine: FileLine)
       extends Policy.Clause {
     import TokenOps.isSingleLineComment
     override val noDequeue: Boolean = true
@@ -70,7 +71,7 @@ object PolicyOps {
         exclude: TokenRanges = TokenRanges.empty,
         okSLC: Boolean = false,
         noSyntaxNL: Boolean = false
-    )(implicit line: sourcecode.Line): Policy =
+    )(implicit fileLine: FileLine): Policy =
       policyWithExclude(exclude, End.On, End.After)(
         End.On(expire),
         new SingleLineBlock(_, okSLC = okSLC, noSyntaxNL = noSyntaxNL)
@@ -84,7 +85,7 @@ object PolicyOps {
   )(
       expire: End.WithPos,
       policyFunc: End.WithPos => Policy
-  )(implicit line: sourcecode.Line): Policy = {
+  )(implicit fileLine: FileLine): Policy = {
     val lastPolicy = policyFunc(expire)
     exclude.ranges.foldRight(lastPolicy) { case (range, policy) =>
       new Policy.Relay(

--- a/scalafmt-tests/src/test/scala/org/scalafmt/Debug.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/Debug.scala
@@ -46,7 +46,7 @@ class Debug(val verbose: Boolean) {
     if (enqueuedSplits.nonEmpty) {
       val sb = new StringBuilder()
       enqueuedSplits
-        .groupBy(_.line.value)
+        .groupBy(_.fileLine.line.value)
         .toSeq
         .sortBy(-_._2.size)
         .iterator


### PR DESCRIPTION
It's much easier to find where the Split was created now. It's also possible to navigate there (at least from VSCode, do we want to modify it to work for Intellij?)
```
Debug:63 Split(line=1703 count=1=
        NoSplit:[Router.scala:1703](cost=0, indents=[], PNL:[Router:1703]<28d+1)
Split(line=2249 count=1=
        Newline:[Router.scala:2249](cost=1, indents=[2>x:37], NoPolicy)
Split(line=2245 count=1=
        Space:[Router.scala:2245](cost=0, indents=[], NoPolicy, opt=x:37)

Debug:71 Visited x∙[37:38]: 2
Debug:71 Visited ∙val[0:3]: 1
Debug:71 Visited val∙f[3:5]: 1
Debug:90  3: val             Space:[Router.scala:2076](cost=0, indents=[], NoPolicy) 0 3 [0]
Debug:90  5: f               NoSplit:[Router.scala:1062](cost=0, indents=[], PNL:1058<17d+20) 0 5 [0]
Debug:90  6: :               Space:[Router.scala:2097](cost=0, indents=[], NoPolicy) 0 6 [0]
Debug:90 10: Int             Space:[Router.scala:2084](cost=0, indents=[], NoPolicy) 0 10 [0]
Debug:90 13: =>              Space:[Router.scala:2097](cost=0, indents=[], NoPolicy) 0 13 [0]
Debug:90 17: Int             Space:[Router.scala:2084](cost=0, indents=[], NoPolicy) 0 17 [0]
Debug:90 19: =               Space:[Router.scala:2245](cost=0, indents=[], NoPolicy, opt=x:37) 0 19 [0]
Debug:90 21: (               NoSplit:[Router.scala:1703](cost=0, indents=[], PNL:[Router:1703]<28d+1) 0 21 [0]
Debug:90 22: x               NoSplit:[Router.scala:1237](cost=0, indents=[], NoPolicy) 0 22 [0]
Debug:90 23: :               Space:[Router.scala:2097](cost=0, indents=[], NoPolicy) 0 23 [0]
Debug:90 27: Int             NoSplit:[Router.scala:2060](cost=0, indents=[], NoPolicy) 0 27 [0]
Debug:90 28: )               Space:[Router.scala:2084](cost=0, indents=[], NoPolicy) 0 28 [0]
Debug:90 31: =>              Space:[Router.scala:415](cost=0, indents=[], SLB:[Router:417]@37!d) 0 31 [0]
Debug:90 33: x               Space:[FormatOps.scala:486](cost=0, indents=[], NoPolicy) 0 33 [0]
Debug:90 35: *               Space:[FormatOps.scala:486](cost=0, indents=[], NoPolicy) 0 35 [0]
Debug:90 37: x               Newline:[Router.scala:100](cost=0, indents=[], NoPolicy) 0 37 [0]
Debug:94 Total cost: 0
```

Also, it looks like we could try to remove the implicits in some of the places.