### PR TITLE
Add dialect to allow formatting with -Xsource:3 option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,10 @@ enum class Weekday {
 
 Please also see [rewrite rules](#scala3-rewrites) for Scala 3.
 
+Additionally, when using `-Xsource:3` option for Scala 2 you can change the
+dialect to `Scala213Source3`, which will allow to format the new syntax ported
+from Scala 3.
+
 ## Presets
 
 Some sections provide preset values to set multiple parameters at once. These

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
@@ -89,6 +89,7 @@ object ScalafmtRunner {
         Scala211,
         scala212,
         scala213,
+        Scala213Source3,
         Sbt0137,
         Sbt1,
         Dotty,


### PR DESCRIPTION
Since Scala 2.13.6 and 2.12.14 it is possible to use `-Xsource:3`, which adds support for some of the new scala 3 syntax. ~~None of those changes should influence Scalafmt, so I think it would be good to set it as the default.~~