### PR TITLE
FormatOps: add optional braces after `package a:`

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1471,3 +1471,17 @@ object a:
    class a:
       val a =
         a
+<<< package colonEol
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 4
+===
+package a.b.c:
+  object a:
+    println("ah")
+    println("ha")
+>>>
+test does not parse
+package a.b.c:
+object a:
+   println("ah")
+   println("ha")

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1480,8 +1480,8 @@ package a.b.c:
     println("ah")
     println("ha")
 >>>
-test does not parse
 package a.b.c:
-object a:
-   println("ah")
-   println("ha")
+   object a:
+      println("ah")
+      println("ha")
+end c

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1435,3 +1435,17 @@ object a:
 object a:
    class a:
       val a = a
+<<< package colonEol
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 4
+===
+package a.b.c:
+  object a:
+    println("ah")
+    println("ha")
+>>>
+test does not parse
+package a.b.c:
+object a:
+   println("ah")
+   println("ha")

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1444,8 +1444,8 @@ package a.b.c:
     println("ah")
     println("ha")
 >>>
-test does not parse
 package a.b.c:
-object a:
-   println("ah")
-   println("ha")
+   object a:
+      println("ah")
+      println("ha")
+end c

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1520,8 +1520,8 @@ package a.b.c:
     println("ah")
     println("ha")
 >>>
-test does not parse
 package a.b.c:
-object a:
-   println("ah")
-   println("ha")
+   object a:
+      println("ah")
+      println("ha")
+end c

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1511,3 +1511,17 @@ object a:
    class a:
       val a =
         a
+<<< package colonEol
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 4
+===
+package a.b.c:
+  object a:
+    println("ah")
+    println("ha")
+>>>
+test does not parse
+package a.b.c:
+object a:
+   println("ah")
+   println("ha")

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1630,3 +1630,17 @@ object a:
 object a:
    class a:
       val a = a
+<<< package colonEol
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 4
+===
+package a.b.c:
+  object a:
+    println("ah")
+    println("ha")
+>>>
+test does not parse
+package a.b.c:
+object a:
+   println("ah")
+   println("ha")

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1639,8 +1639,8 @@ package a.b.c:
     println("ah")
     println("ha")
 >>>
-test does not parse
 package a.b.c:
-object a:
-   println("ah")
-   println("ha")
+   object a:
+      println("ah")
+      println("ha")
+end c


### PR DESCRIPTION
Apparently, the `colonEol` indentation marker is slated to be supported in a variety of additional situations, not just with templates. For now, add package support. Other cases are not yet recognized by the `scalameta` parser.

https://dotty.epfl.ch/docs/reference/other-new-features/indentation.html#variant-indentation-marker-
