### PR TITLE
RedundantBraces: keep in macro quotes/splices

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -298,6 +298,8 @@ class RedundantBraces(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
 
       case Term.Block(List(`b`)) => true
 
+      case _: Term.QuotedMacroExpr | _: Term.SplicedMacroExpr => false
+
       case _ =>
         settings.generalExpressions && shouldRemoveSingleStatBlock(b)
     }

--- a/scalafmt-tests/src/test/resources/scala3/Macro.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Macro.stat
@@ -7,6 +7,12 @@ ${ locationImpl() }
 '{   new Location() }
 >>>
 '{ new Location() }
+<<< remove redundant braces in quote braces
+rewrite.rules = [RedundantBraces]
+===
+'{   { new Location() } }
+>>>
+'{ new Location() }
 <<< quote expr
 ${
 val x   = 'expr
@@ -27,11 +33,23 @@ ${ assertImpl('expr) }
 throw new   AssertionError(s"failed assertion: ${${ showExpr(expr) }}")
 >>>
 throw new AssertionError(s"failed assertion: ${${ showExpr(expr) }}")
-<<< functions
+<<< functions in splices
 '{   (x: T) => ${ f('x) } }
 >>>
 '{ (x: T) => ${ f('x) } }
-<<< unctions spliced
+<<< functions with RedundantBraces
+rewrite.rules = [RedundantBraces]
+===
+'{   (x: T) => ${ f('x) } }
+>>>
+'{ (x: T) => ${ f('x) } }
+<<< remove redundant braces in functions in splices
+rewrite.rules = [RedundantBraces]
+===
+'{   (x: T) => ${ { f('x) } } }
+>>>
+'{ (x: T) => ${ f('x) } }
+<<< functions spliced
   (x: Expr[T]) => '{ $f($x) }
 >>>
 (x: Expr[T]) => '{ $f($x) }
@@ -115,3 +133,15 @@ body match {
       } if aVeryLongCondition(parameter) => subArgs.flatMap(flatSumArgs)
   case body => body
 }
+<<< redundant braces in splices and quotes
+rewrite.rules = [RedundantBraces]
+===
+def to[T, R](f: Expr[T] => Expr[R])(using
+    t: Type[T]
+)(using Type[R], Quotes): Expr[T => R] =
+  '{ { (x: t.Underlying) => ${ { f('x) } } } }
+>>>
+def to[T, R](f: Expr[T] => Expr[R])(using
+    t: Type[T]
+)(using Type[R], Quotes): Expr[T => R] =
+  '{ (x: t.Underlying) => ${ f('x) } }


### PR DESCRIPTION
Fixes #2554. Minor refactor from #2555.