### PR TITLE
FormatWriter: fully determine blank line indices

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -137,13 +137,16 @@ class FormatTokens(leftTok2tok: Map[TokenOps.TokenHash, Int])(
 
   @inline
   def tokenAfter(tree: Tree): FormatToken = nextNonComment(getLast(tree))
-
   @inline
   def tokenAfter(trees: Seq[Tree]): FormatToken = tokenAfter(trees.last)
 
   @inline
-  def tokenBefore(token: Token): FormatToken = prevNonComment(apply(token, -1))
+  def justBefore(token: Token): FormatToken = apply(token, -1)
+  @inline
+  def tokenJustBefore(tree: Tree): FormatToken = justBefore(tree.tokens.head)
 
+  @inline
+  def tokenBefore(token: Token): FormatToken = prevNonComment(justBefore(token))
   @inline
   def tokenBefore(tree: Tree): FormatToken = tokenBefore(tree.tokens.head)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -601,15 +601,6 @@ object TreeOps {
   def isProcedureSyntax(defn: Defn.Def): Boolean =
     defn.decltpe.exists(_.tokens.isEmpty)
 
-  // matches tree nodes that can be considered "top-level statement": package/object/trait/def/val
-  object MaybeTopLevelStat {
-    def unapply(tree: Tree): Option[Tree] =
-      tree match {
-        case _: Pkg | _: Defn | _: Decl => Some(tree)
-        case _ => None
-      }
-  }
-
   def isXmlBrace(owner: Tree): Boolean =
     owner match {
       case _: Term.Xml | _: Pat.Xml => true

--- a/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.source
+++ b/scalafmt-tests/src/test/resources/newlines/alwaysBeforeTopLevelStatements.source
@@ -201,3 +201,204 @@ object a {
   }
 
 }
+<<< #2511 with packages, trailing comments etc.
+newlines.topLevelStatements = [before, after]
+===
+package a
+package a1
+import a.b
+import a.b
+
+// c1
+import a.b
+import a.b
+package b {
+ trait a {}
+ // c1
+ class a {
+  type a = a
+ }
+ // c2
+
+ // c1
+ object a {
+  type a = a
+ }
+ // c1
+ package c {
+  import a.b
+  import a.b
+  package d {
+   trait a {}
+   class a {
+    type a = a
+   }
+   object a {}
+   import a.b
+   import a.b
+   // c1
+   class a {
+    type a = a
+   }
+   // c2
+  }
+  trait a {}
+ }
+ // c2
+}
+>>>
+package a
+package a1
+
+import a.b
+import a.b
+
+// c1
+import a.b
+import a.b
+
+package b {
+  trait a {}
+
+  // c1
+  class a {
+    type a = a
+  }
+
+  // c2
+
+  // c1
+  object a {
+    type a = a
+  }
+
+  // c1
+  package c {
+    import a.b
+    import a.b
+
+    package d {
+      trait a {}
+
+      class a {
+        type a = a
+      }
+
+      object a {}
+      import a.b
+      import a.b
+
+      // c1
+      class a {
+        type a = a
+      }
+
+      // c2
+    }
+
+    trait a {}
+  }
+
+  // c2
+}
+<<< #2511 use topLevelStatementBlankLines instead
+newlines.topLevelStatements = [before, after]
+newlines.templateBodyIfMinStatements = [before,after]
+===
+package a
+package a1
+import a.b
+import a.b
+
+// c1
+import a.b
+import a.b
+package b {
+ trait a {}
+ // c1
+ class a {
+  type a = a
+ }
+ // c2
+
+ // c1
+ object a {
+  type a = a
+ }
+ // c1
+ package c {
+  import a.b
+  import a.b
+  package d {
+   trait a {}
+   class a {
+    type a = a
+   }
+   object a {}
+   import a.b
+   import a.b
+   // c1
+   class a {
+    type a = a
+   }
+   // c2
+  }
+  trait a {}
+ }
+ // c2
+}
+>>>
+package a
+package a1
+
+import a.b
+import a.b
+
+// c1
+import a.b
+import a.b
+
+package b {
+  trait a {}
+
+  // c1
+  class a {
+    type a = a
+  }
+
+  // c2
+
+  // c1
+  object a {
+    type a = a
+  }
+
+  // c1
+  package c {
+    import a.b
+    import a.b
+
+    package d {
+      trait a {}
+
+      class a {
+        type a = a
+      }
+
+      object a {}
+      import a.b
+      import a.b
+
+      // c1
+      class a {
+        type a = a
+      }
+
+      // c2
+    }
+
+    trait a {}
+  }
+
+  // c2
+}


### PR DESCRIPTION
Earlier, we would store a potential location and then later check if it should be supplied with an extra blank. Instead, do that at once.

Towards #2511.