### PR TITLE
Router: don't force single-line for single-arg

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1254,7 +1254,8 @@ class FormatWriter(formatOps: FormatOps) {
           }
       }
 
-      trav(topSourceTree)
+      if (locations.length == tokens.length)
+        trav(topSourceTree)
       extraBlankMap.toMap
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -614,8 +614,9 @@ class Router(formatOps: FormatOps) {
               val nlPolicy = nft.right match {
                 case t: T.LeftParen => decideNewlinesOnlyBeforeClose(t)
                 case t: T.Colon
-                    if (style.newlines.sometimesBeforeColonInMethodReturnType
-                      || nft.left.is[T.Comment]) && defn =>
+                    if defn && (nft.left.is[T.Comment] ||
+                      style.newlines.sometimesBeforeColonInMethodReturnType
+                      && defDefReturnType(rightOwner).isDefined) =>
                   decideNewlinesOnlyBeforeClose(t)
                 case _ => NoPolicy
               }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -623,7 +623,10 @@ class Router(formatOps: FormatOps) {
                 Split(NoSplit, 0).withSingleLine(slbEnd),
                 Split(Newline, 1)
                   .withIndent(indent)
-                  .withSingleLineOpt(if (multipleArgs) None else Some(close))
+                  .withPolicy(
+                    penalizeNewlineByNesting(open, close),
+                    multipleArgs
+                  )
                   .andPolicy(nlPolicy)
               )
             case Newlines.keep =>

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -4102,3 +4102,33 @@ object a {
         "foo12"
       )
 }
+<<< #2561 enum, single arg, wide
+maxColumn = 80
+runner.parser = source
+runner.dialect = scala3
+newlines {
+  beforeOpenParenDefnSite = true
+  beforeOpenParenCallSite = true
+}
+===
+package dev.muve.vdom
+
+enum Namespace(val uri: String | Null):
+   case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
+   case xlink extends Namespace("http://www.w3.org/1999/xlink")
+   case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")
+   case svg extends Namespace("http://www.w3.org/2000/svg")
+   case muve extends Namespace("http://dev.muve/2021/muve")
+
+   case none extends Namespace(null)
+>>>
+package dev.muve.vdom
+
+enum Namespace(val uri: String | Null):
+  case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
+  case xlink extends Namespace("http://www.w3.org/1999/xlink")
+  case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")
+  case svg extends Namespace("http://www.w3.org/2000/svg")
+  case muve extends Namespace("http://dev.muve/2021/muve")
+
+  case none extends Namespace(null)

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -3919,3 +3919,33 @@ object a {
       "foo12"
     )
 }
+<<< #2561 enum, single arg, wide
+maxColumn = 80
+runner.parser = source
+runner.dialect = scala3
+newlines {
+  beforeOpenParenDefnSite = true
+  beforeOpenParenCallSite = true
+}
+===
+package dev.muve.vdom
+
+enum Namespace(val uri: String | Null):
+   case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
+   case xlink extends Namespace("http://www.w3.org/1999/xlink")
+   case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")
+   case svg extends Namespace("http://www.w3.org/2000/svg")
+   case muve extends Namespace("http://dev.muve/2021/muve")
+
+   case none extends Namespace(null)
+>>>
+package dev.muve.vdom
+
+enum Namespace(val uri: String | Null):
+  case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
+  case xlink extends Namespace("http://www.w3.org/1999/xlink")
+  case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")
+  case svg extends Namespace("http://www.w3.org/2000/svg")
+  case muve extends Namespace("http://dev.muve/2021/muve")
+
+  case none extends Namespace(null)

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -4118,3 +4118,33 @@ object a {
         "foo12"
       )
 }
+<<< #2561 enum, single arg, wide
+maxColumn = 80
+runner.parser = source
+runner.dialect = scala3
+newlines {
+  beforeOpenParenDefnSite = true
+  beforeOpenParenCallSite = true
+}
+===
+package dev.muve.vdom
+
+enum Namespace(val uri: String | Null):
+   case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
+   case xlink extends Namespace("http://www.w3.org/1999/xlink")
+   case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")
+   case svg extends Namespace("http://www.w3.org/2000/svg")
+   case muve extends Namespace("http://dev.muve/2021/muve")
+
+   case none extends Namespace(null)
+>>>
+package dev.muve.vdom
+
+enum Namespace(val uri: String | Null):
+  case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
+  case xlink extends Namespace("http://www.w3.org/1999/xlink")
+  case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")
+  case svg extends Namespace("http://www.w3.org/2000/svg")
+  case muve extends Namespace("http://dev.muve/2021/muve")
+
+  case none extends Namespace(null)

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -4310,8 +4310,7 @@ enum Namespace
   (
       val uri: String |
         Null
-  )
-:
+  ):
   case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
   case xlink extends Namespace("http://www.w3.org/1999/xlink")
   case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -4304,4 +4304,6 @@ enum Namespace(val uri: String | Null):
 
    case none extends Namespace(null)
 >>>
-org.scalafmt.util.FormatException: java.lang.ArrayIndexOutOfBoundsException: 59
+BestFirstSearch:317 Failed to format
+UNABLE TO FORMAT,
+tok=|∙Null[55:60]

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -4284,3 +4284,24 @@ object a {
       "foo12"
     )
 }
+<<< #2561 enum, single arg, wide
+maxColumn = 80
+runner.parser = source
+runner.dialect = scala3
+newlines {
+  beforeOpenParenDefnSite = true
+  beforeOpenParenCallSite = true
+}
+===
+package dev.muve.vdom
+
+enum Namespace(val uri: String | Null):
+   case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
+   case xlink extends Namespace("http://www.w3.org/1999/xlink")
+   case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")
+   case svg extends Namespace("http://www.w3.org/2000/svg")
+   case muve extends Namespace("http://dev.muve/2021/muve")
+
+   case none extends Namespace(null)
+>>>
+org.scalafmt.util.FormatException: java.lang.ArrayIndexOutOfBoundsException: 59

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -4304,6 +4304,18 @@ enum Namespace(val uri: String | Null):
 
    case none extends Namespace(null)
 >>>
-BestFirstSearch:317 Failed to format
-UNABLE TO FORMAT,
-tok=|∙Null[55:60]
+package dev.muve.vdom
+
+enum Namespace
+  (
+      val uri: String |
+        Null
+  )
+:
+  case xhtml extends Namespace("http://www.w3.org/1999/xhtml")
+  case xlink extends Namespace("http://www.w3.org/1999/xlink")
+  case xmlns extends Namespace("http://www.w3.org/2000/xmlns/")
+  case svg extends Namespace("http://www.w3.org/2000/svg")
+  case muve extends Namespace("http://dev.muve/2021/muve")
+
+  case none extends Namespace(null)


### PR DESCRIPTION
Penalize instead. Some arguments cannot be formatted on a single line, such as when `unfold` is used.

Fixes #2561.