### PR TITLE
Newlines: fix copy-pasted value in DeprecateName

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -172,7 +172,7 @@ case class Newlines(
     )
     topLevelStatementsMinBreaks: Int = 1,
     @annotation.DeprecatedName(
-      "topLevelStatementsMinBreaks",
+      "topLevelStatements",
       "Use newlines.topLevelStatementBlankLines instead",
       "3.0.0"
     )


### PR DESCRIPTION
Metaconfig effectively renders this parameter unusable as it redirects to another one. See scalameta/metaconfig#135.