### PR TITLE
TreeOps: fix bug in `getLastCall`

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -4167,8 +4167,7 @@ line
     y1 := centre + offset * c,
     x2 := centre + (length - offset) * s,
     y2 := centre - (length - offset) * c,
-    (SvgA.filter := "url(#handShadow)").when
-      (hasShadow),
+    (SvgA.filter := "url(#handShadow)").when(hasShadow),
     strokeWidth := width,
     stroke := colour
   )

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -4147,3 +4147,28 @@ enum Namespace(val uri: String | Null):
   case muve extends Namespace("http://dev.muve/2021/muve")
 
   case none extends Namespace(null)
+<<< #2561 nested apply as parameter
+maxColumn = 80
+runner.dialect = scala3
+newlines.beforeOpenParenCallSite = unfold
+===
+line
+  (x1 := centre - offset * s,
+   y1 := centre + offset * c,
+   x2 := centre + (length - offset) * s,
+   y2 := centre - (length - offset) * c,
+   (SvgA.filter := "url(#handShadow)").when(hasShadow),
+   strokeWidth := width,
+   stroke := colour)
+>>>
+line
+  (
+    x1 := centre - offset * s,
+    y1 := centre + offset * c,
+    x2 := centre + (length - offset) * s,
+    y2 := centre - (length - offset) * c,
+    (SvgA.filter := "url(#handShadow)").when
+      (hasShadow),
+    strokeWidth := width,
+    stroke := colour
+  )

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -3964,3 +3964,29 @@ enum Namespace(val uri: String | Null):
   case muve extends Namespace("http://dev.muve/2021/muve")
 
   case none extends Namespace(null)
+<<< #2561 nested apply as parameter
+maxColumn = 80
+runner.dialect = scala3
+newlines.beforeOpenParenCallSite = unfold
+===
+line
+  (x1 := centre - offset * s,
+   y1 := centre + offset * c,
+   x2 := centre + (length - offset) * s,
+   y2 := centre - (length - offset) * c,
+   (SvgA.filter := "url(#handShadow)").when(hasShadow),
+   strokeWidth := width,
+   stroke := colour)
+>>>
+line
+  (
+    x1 := centre - offset * s,
+    y1 := centre + offset * c,
+    x2 := centre + (length - offset) * s,
+    y2 := centre - (length - offset) * c,
+    (SvgA.filter := "url(#handShadow)")
+      .when
+        (hasShadow),
+    strokeWidth := width,
+    stroke := colour
+  )

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -3984,9 +3984,7 @@ line
     y1 := centre + offset * c,
     x2 := centre + (length - offset) * s,
     y2 := centre - (length - offset) * c,
-    (SvgA.filter := "url(#handShadow)")
-      .when
-        (hasShadow),
+    (SvgA.filter := "url(#handShadow)").when(hasShadow),
     strokeWidth := width,
     stroke := colour
   )

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -4181,8 +4181,7 @@ line
     y1 := centre + offset * c,
     x2 := centre + (length - offset) * s,
     y2 := centre - (length - offset) * c,
-    (SvgA.filter := "url(#handShadow)").when
-      (hasShadow),
+    (SvgA.filter := "url(#handShadow)").when(hasShadow),
     strokeWidth := width,
     stroke := colour
   )

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -4161,3 +4161,28 @@ enum Namespace(val uri: String | Null):
   case muve extends Namespace("http://dev.muve/2021/muve")
 
   case none extends Namespace(null)
+<<< #2561 nested apply as parameter
+maxColumn = 80
+runner.dialect = scala3
+newlines.beforeOpenParenCallSite = unfold
+===
+line
+  (x1 := centre - offset * s,
+   y1 := centre + offset * c,
+   x2 := centre + (length - offset) * s,
+   y2 := centre - (length - offset) * c,
+   (SvgA.filter := "url(#handShadow)").when(hasShadow),
+   strokeWidth := width,
+   stroke := colour)
+>>>
+line
+  (
+    x1 := centre - offset * s,
+    y1 := centre + offset * c,
+    x2 := centre + (length - offset) * s,
+    y2 := centre - (length - offset) * c,
+    (SvgA.filter := "url(#handShadow)").when
+      (hasShadow),
+    strokeWidth := width,
+    stroke := colour
+  )

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -4368,3 +4368,28 @@ enum Namespace
         ("http://dev.muve/2021/muve")
 
   case none extends Namespace(null)
+<<< #2561 nested apply as parameter
+maxColumn = 80
+runner.dialect = scala3
+newlines.beforeOpenParenCallSite = unfold
+===
+line
+  (x1 := centre - offset * s,
+   y1 := centre + offset * c,
+   x2 := centre + (length - offset) * s,
+   y2 := centre - (length - offset) * c,
+   (SvgA.filter := "url(#handShadow)").when(hasShadow),
+   strokeWidth := width,
+   stroke := colour)
+>>>
+line
+  (
+    x1 := centre - offset * s,
+    y1 := centre + offset * c,
+    x2 := centre + (length - offset) * s,
+    y2 := centre - (length - offset) * c,
+    (SvgA.filter := "url(#handShadow)").when
+      (hasShadow),
+    strokeWidth := width,
+    stroke := colour
+  )

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -4388,8 +4388,7 @@ line
     y1 := centre + offset * c,
     x2 := centre + (length - offset) * s,
     y2 := centre - (length - offset) * c,
-    (SvgA.filter := "url(#handShadow)").when
-      (hasShadow),
+    (SvgA.filter := "url(#handShadow)").when(hasShadow),
     strokeWidth := width,
     stroke := colour
   )


### PR DESCRIPTION
Previously, we inadvertently cover cases when one Apply is a parameter to another, rather than representing the next parameter group. Fixes #2561.
