### PR TITLE
Router: fix inconsistent indentation for `: tpe`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1152,8 +1152,12 @@ class Router(formatOps: FormatOps) {
         val sameLineSplit = Space(endsWithSymbolIdent(left))
         val bopSplits = style.newlines.getBeforeOpenParenDefnSite.map { x =>
           val ob = OptionalBraces.get(next(nextNonComment(expireFt))).nonEmpty
+          def extraIfBody = style.indent.extraBeforeOpenParenDefnSite
           val indent =
-            if (ob) style.indent.getSignificant else style.indent.main
+            if (ob) style.indent.getSignificant + extraIfBody
+            else
+              style.indent.main +
+                (if (defDefBody(rightOwner).isEmpty) 0 else extraIfBody)
           Seq(
             Split(sameLineSplit, 0)
               .onlyIf(newlines == 0 || x.ne(Newlines.keep))

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -3832,12 +3832,16 @@ class fooClass(foo1: String)
      (foo5: String) {
   def fooFunc(foo1: String)
        (foo2: String)
-    : String = ???
+       : String = ???
   def fooFunc(foo1: String)
        (foo2: String)(foo3: String)
        (foo4: String)(foo5: String)
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
   def notAnInterestingFunction
        (foo1: String)
        (
@@ -3858,8 +3862,12 @@ class fooClass(foo1: String)
            foo11: Int,
            foo12: Int
        ) // this line also doesn't fit
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
 }
 <<< #2561 scala 2: defn, align
 align.preset = none
@@ -4056,7 +4064,7 @@ class fooClass(foo1: String)
     : String
   def fooFunc(foo1: String)
        (foo2: String)
-    : String = ???
+       : String = ???
   def fooFunc(foo1: String)
     (foo2: String)(foo3: String)
     (foo4: String)(foo5: String)
@@ -4064,12 +4072,12 @@ class fooClass(foo1: String)
   def fooFunc(foo1: String)
         (foo2: String)(foo3: String)
         (foo4: String)(foo5: String)
-     : (
-         String,
-         String,
-         String,
-         String
-     ) =
+        : (
+            String,
+            String,
+            String,
+            String
+        ) =
      bar
      baz
   def notAnInterestingFunction
@@ -4091,8 +4099,12 @@ class fooClass(foo1: String)
            foo11: Int,
            foo12: Int
        ) // this line also doesn't fit
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
 }
 <<< #2561 scala 3: call, no align
 maxColumn = 25

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -4013,7 +4013,18 @@ class fooClass
   def fooFunc
     (foo1: String)
     (foo2: String)
+    : String
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
     : String = ???
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
+    (foo3: String)
+    (foo4: String)
+    (foo5: String)
+    : (String, String, String, String)
   def fooFunc
     (foo1: String)
     (foo2: String)
@@ -4041,8 +4052,15 @@ class fooClass(foo1: String)
      ) // this line doesn't fit
      (foo5: String) {
   def fooFunc(foo1: String)
+    (foo2: String)
+    : String
+  def fooFunc(foo1: String)
        (foo2: String)
     : String = ???
+  def fooFunc(foo1: String)
+    (foo2: String)(foo3: String)
+    (foo4: String)(foo5: String)
+    : (String, String, String, String)
   def fooFunc(foo1: String)
         (foo2: String)(foo3: String)
         (foo4: String)(foo5: String)

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -3834,7 +3834,18 @@ class fooClass
   def fooFunc
     (foo1: String)
     (foo2: String)
+    : String
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
     : String = ???
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
+    (foo3: String)
+    (foo4: String)
+    (foo5: String)
+    : (String, String, String, String)
   def fooFunc
     (foo1: String)
     (foo2: String)
@@ -3862,8 +3873,15 @@ class fooClass(foo1: String)
      ) // this line doesn't fit
      (foo5: String) {
   def fooFunc(foo1: String)
+    (foo2: String)
+    : String
+  def fooFunc(foo1: String)
        (foo2: String)
     : String = ???
+  def fooFunc(foo1: String)
+    (foo2: String)(foo3: String)
+    (foo4: String)(foo5: String)
+    : (String, String, String, String)
   def fooFunc(foo1: String)
         (foo2: String)(foo3: String)
         (foo4: String)(foo5: String)

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -3653,12 +3653,16 @@ class fooClass(foo1: String)
      (foo5: String) {
   def fooFunc(foo1: String)
        (foo2: String)
-    : String = ???
+       : String = ???
   def fooFunc(foo1: String)
        (foo2: String)(foo3: String)
        (foo4: String)(foo5: String)
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
   def notAnInterestingFunction
        (foo1: String)
        (
@@ -3679,8 +3683,12 @@ class fooClass(foo1: String)
            foo11: Int,
            foo12: Int
        ) // this line also doesn't fit
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
 }
 <<< #2561 scala 2: defn, align
 align.preset = none
@@ -3877,7 +3885,7 @@ class fooClass(foo1: String)
     : String
   def fooFunc(foo1: String)
        (foo2: String)
-    : String = ???
+       : String = ???
   def fooFunc(foo1: String)
     (foo2: String)(foo3: String)
     (foo4: String)(foo5: String)
@@ -3885,12 +3893,12 @@ class fooClass(foo1: String)
   def fooFunc(foo1: String)
         (foo2: String)(foo3: String)
         (foo4: String)(foo5: String)
-     : (
-         String,
-         String,
-         String,
-         String
-     ) =
+        : (
+            String,
+            String,
+            String,
+            String
+        ) =
      bar
      baz
   def notAnInterestingFunction
@@ -3912,8 +3920,12 @@ class fooClass(foo1: String)
            foo11: Int,
            foo12: Int
        ) // this line also doesn't fit
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
 }
 <<< #2561 scala 3: call, no align
 maxColumn = 25

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -3852,8 +3852,12 @@ class fooClass
        (foo3: String)
        (foo4: String)
        (foo5: String)
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
   def notAnInterestingFunction
        (foo1: String)
        (
@@ -3874,8 +3878,12 @@ class fooClass
            foo11: Int,
            foo12: Int
        ) // this line also doesn't fit
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
 }
 <<< #2561 scala 2: defn, align
 align.preset = none
@@ -4086,12 +4094,12 @@ class fooClass
         (foo3: String)
         (foo4: String)
         (foo5: String)
-     : (
-         String,
-         String,
-         String,
-         String
-     ) =
+        : (
+            String,
+            String,
+            String,
+            String
+        ) =
      bar
      baz
   def notAnInterestingFunction
@@ -4113,8 +4121,12 @@ class fooClass
            foo11: Int,
            foo12: Int
        ) // this line also doesn't fit
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
 }
 <<< #2561 scala 3: call, no align
 maxColumn = 25

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -4032,7 +4032,16 @@ class fooClass
     (foo2: String, foo3: String, foo4: Map[String, Map[String, Map[String, String]]]) // this line doesn't fit
     (foo5: String) {
   def fooFunc(foo1: String)(foo2: String):
+    String
+  def fooFunc(foo1: String)(foo2: String):
     String = ???
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
+    (foo3: String)
+    (foo4: String)
+    (foo5: String):
+    (String, String, String, String)
   def fooFunc
     (foo1: String)
     (foo2: String)
@@ -4061,7 +4070,16 @@ class fooClass
      ) // this line doesn't fit
      (foo5: String) {
   def fooFunc(foo1: String)
+    (foo2: String): String
+  def fooFunc(foo1: String)
        (foo2: String): String = ???
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
+    (foo3: String)
+    (foo4: String)
+    (foo5: String)
+    : (String, String, String, String)
   def fooFunc
         (foo1: String)
         (foo2: String)

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -3975,15 +3975,19 @@ class fooClass
   def fooFunc
        (foo1: String)
        (foo2: String)
-    : String = ???
+       : String = ???
   def fooFunc
        (foo1: String)
        (foo2: String)
        (foo3: String)
        (foo4: String)
        (foo5: String)
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
   def notAnInterestingFunction
        (foo1: String)
        (
@@ -4004,8 +4008,12 @@ class fooClass
            foo11: Int,
            foo12: Int
        ) // this line also doesn't fit
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
 }
 <<< #2561 scala 2: defn, align
 align.preset = none
@@ -4261,8 +4269,12 @@ class fooClass
            foo11: Int,
            foo12: Int
        ) // this line also doesn't fit
-    : (String, String, String, String) =
-    ???
+       : (
+           String,
+           String,
+           String,
+           String
+       ) = ???
 }
 <<< #2561 scala 3: call, no align
 maxColumn = 25

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -4173,7 +4173,18 @@ class fooClass
   def fooFunc
     (foo1: String)
     (foo2: String)
+    : String
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
     : String = ???
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
+    (foo3: String)
+    (foo4: String)
+    (foo5: String)
+    : (String, String, String, String)
   def fooFunc
     (foo1: String)
     (foo2: String)
@@ -4202,8 +4213,22 @@ class fooClass
      ) // this line doesn't fit
      (foo5: String) {
   def fooFunc
+    (foo1: String)
+    (foo2: String): String
+  def fooFunc
        (foo1: String)
        (foo2: String): String = ???
+  def fooFunc
+    (foo1: String)
+    (foo2: String)
+    (foo3: String)
+    (foo4: String)
+    (foo5: String): (
+      String,
+      String,
+      String,
+      String
+  )
   def fooFunc
         (foo1: String)
         (foo2: String)


### PR DESCRIPTION
Fixes #2561.