### PR TITLE
BestFirstSearch: increase `format:off` penalty

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -246,7 +246,7 @@ private class BestFirstSearch private (
         val isNL = ft.hasBreak
         val mod = Provided(ft)
         active.map { x =>
-          val penalty = if (x.isNL == isNL) 0 else Constants.ExceedColumnPenalty
+          val penalty = if (x.isNL == isNL) 0 else Constants.ShouldBeNewline
           x.withMod(mod).withPenalty(penalty)
         }
       } else active

--- a/scalafmt-tests/src/test/resources/unit/FormatOff.stat
+++ b/scalafmt-tests/src/test/resources/unit/FormatOff.stat
@@ -121,4 +121,40 @@ object App {
   // format: on
 }
 >>>
-FormatTests:53 [e]: org.scalafmt.Error$SearchStateExploded: Search state exploded on ')∙,[2105:2106]', line 26
+object App {
+  // format: off
+  def ignoreThisFn(param: ParamType) =
+      new BigClassLotsOfArgs(
+        param.callWithType[Container[ArgType]]("argName1", Some(None)),
+        param.callWithType[Container[ArgType]]("argName2", Some(None)),
+        param.callWithType[Container[ArgType]]("argName3", Some(None)),
+        param.callWithType[Container[ArgType]]("argName4", Some(None)),
+        param.callWithType[Container[ArgType]]("argName5", Some(None)),
+        param.callWithType[Container[ArgType]]("argName6", Some(None)),
+        param.callWithType[Container[ArgType]]("argName7", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName8", Some(None)),
+        param.callWithType[Container[ArgType]]("argName9", Some(None)),
+        param.callWithType[Container[ArgType]]("argName10", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName11", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName12", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName13", Some(None)),
+        param.callWithType[Container[ArgType]]("argName14", Some(None)),
+        param.callWithType[Container[ArgType]]("argName15", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName16", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName17", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName18", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName19", Some(None)),
+        param.callWithType[Container[ObjectContainingTypes.ShortTypeName]]("argName20", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.ShortTypeName]]("argName21", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.ShortTypeName]]("argName22", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.ShortTypeName]]("argName23", Some(None)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName]]("argName24", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName1]]("argName25", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName2]]("argName26", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName3]]("argName27", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName4]]("argName28", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName5]]("slightlyLongerArgName1", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName6]]("slightlyLongerArgName2", Some(Container.empty))
+      )
+  // format: on
+}

--- a/scalafmt-tests/src/test/resources/unit/FormatOff.stat
+++ b/scalafmt-tests/src/test/resources/unit/FormatOff.stat
@@ -80,3 +80,45 @@ val x    =  "ads"
 // format: off
 val x    =  "ads"
 // format: on
+<<< #2596
+maxColumn = 120
+===
+object App {
+  // format: off
+  def ignoreThisFn(param: ParamType) =
+      new BigClassLotsOfArgs(
+        param.callWithType[Container[ArgType]]("argName1", Some(None)),
+        param.callWithType[Container[ArgType]]("argName2", Some(None)),
+        param.callWithType[Container[ArgType]]("argName3", Some(None)),
+        param.callWithType[Container[ArgType]]("argName4", Some(None)),
+        param.callWithType[Container[ArgType]]("argName5", Some(None)),
+        param.callWithType[Container[ArgType]]("argName6", Some(None)),
+        param.callWithType[Container[ArgType]]("argName7", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName8", Some(None)),
+        param.callWithType[Container[ArgType]]("argName9", Some(None)),
+        param.callWithType[Container[ArgType]]("argName10", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName11", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName12", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName13", Some(None)),
+        param.callWithType[Container[ArgType]]("argName14", Some(None)),
+        param.callWithType[Container[ArgType]]("argName15", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName16", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName17", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName18", Some(Container.empty)),
+        param.callWithType[Container[ArgType]]("argName19", Some(None)),
+        param.callWithType[Container[ObjectContainingTypes.ShortTypeName]]("argName20", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.ShortTypeName]]("argName21", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.ShortTypeName]]("argName22", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.ShortTypeName]]("argName23", Some(None)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName]]("argName24", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName1]]("argName25", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName2]]("argName26", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName3]]("argName27", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName4]]("argName28", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName5]]("slightlyLongerArgName1", Some(Container.empty)),
+        param.callWithType[Container[ObjectContainingTypes.AReasonablyLongTypeName6]]("slightlyLongerArgName2", Some(Container.empty))
+      )
+  // format: on
+}
+>>>
+FormatTests:53 [e]: org.scalafmt.Error$SearchStateExploded: Search state exploded on ')∙,[2105:2106]', line 26


### PR DESCRIPTION
When `format:off` lines exceed `maxColumn`, some splits will be penalized for exceeding `maxColumn` and others will be penalized for violating the `format:off` marker.

Make sure that `format:off` violations have higher penalty. Fixes #2596.