### PR TITLE
Router: minor optimization for apply

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -839,14 +839,14 @@ class Router(formatOps: FormatOps) {
         def singleLine(
             newlinePenalty: Int
         )(implicit fileLine: FileLine): Policy = {
-          val baseSingleLinePolicy = if (isBracket) {
-            if (!multipleArgs)
-              PenalizeAllNewlines(
-                close,
-                newlinePenalty,
-                penalizeLambdas = false
-              )
-            else SingleLineBlock(close, noSyntaxNL = true)
+          if (multipleArgs && (isBracket || excludeBlocks.ranges.isEmpty)) {
+            SingleLineBlock(close, noSyntaxNL = true)
+          } else if (isBracket) {
+            PenalizeAllNewlines(
+              close,
+              newlinePenalty,
+              penalizeLambdas = false
+            )
           } else {
             val penalty =
               if (!multipleArgs) newlinePenalty
@@ -861,8 +861,6 @@ class Router(formatOps: FormatOps) {
               )
             )
           }
-
-          baseSingleLinePolicy
         }
 
         val tupleSite = isTuple(leftOwner)

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1621,6 +1621,7 @@ maxColumn = 60
      val q"def this(..$params) = $rhs2" = q"def this(x: Int) = this(0)"
    """)
 >>>
-fails("'this' expected but unquotee found", """
+fails("'this' expected but unquotee found",
+      """
      val q"def this(..$params) = $rhs2" = q"def this(x: Int) = this(0)"
    """)

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1614,3 +1614,13 @@ object a {
     (((-3 to 3) ++ List(17, 127, Int.MaxValue, Int.MinValue + 1)).distinct
       .sortBy(n => (math.abs(n), n))) :+ Int.MinValue
 }
+<<< multi-arg apply with multiline constants
+maxColumn = 60
+===
+  fails("'this' expected but unquotee found", """
+     val q"def this(..$params) = $rhs2" = q"def this(x: Int) = this(0)"
+   """)
+>>>
+fails("'this' expected but unquotee found", """
+     val q"def this(..$params) = $rhs2" = q"def this(x: Int) = this(0)"
+   """)


### PR DESCRIPTION
SingleLineBlock leads to fewer paths to explore so use it instead of PenalizeNewlines when in reality the latter should lead to equivalent formatting.

In this case, a 10000 penalty on any newlines without any exclude ranges with an available lower-cost alternative will in most cases be the same as using single-line format.

Exceptions include cases with multiline constants as arguments, and some rare cases of previously suboptimal formatting, due to complexity of preceding code.