### PR TITLE
[Scala 3] Allow `then` and `if` at the end of indentation under danglingParentheses = false

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1616,8 +1616,7 @@ if // comm
 >>>
 if // comm
    val cond1 = true
-   (a1 && a2) == cond1
-then
+   (a1 && a2) == cond1 then
    val exitCode = 1
    exitCode
 <<< if indentation danglingParentheses false oneline
@@ -1631,5 +1630,34 @@ if
     
 >>>
 if (a1 && a2) == cond1 then
+   val exitCode = 1
+   exitCode
+<<< while indentation danglingParentheses false
+danglingParentheses.ctrlSite = false
+===
+while // comm
+    val cond1 = true
+    (a1 && a2) == cond1
+  do
+    val exitCode = 1
+    exitCode
+    
+>>>
+while // comm
+   val cond1 = true
+   (a1 && a2) == cond1 do
+   val exitCode = 1
+   exitCode
+<<< if indentation danglingParentheses false oneline
+danglingParentheses.ctrlSite = false
+===
+while
+    (a1 && a2) == cond1
+  do
+    val exitCode = 1
+    exitCode
+    
+>>>
+while (a1 && a2) == cond1 do
    val exitCode = 1
    exitCode

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1580,8 +1580,7 @@ if // comm
 >>>
 if // comm
    val cond1 = true
-   (a1 && a2) == cond1
-then
+   (a1 && a2) == cond1 then
    val exitCode = 1
    exitCode
 <<< if indentation danglingParentheses false oneline
@@ -1595,5 +1594,34 @@ if
     
 >>>
 if (a1 && a2) == cond1 then
+   val exitCode = 1
+   exitCode
+<<< while indentation danglingParentheses false
+danglingParentheses.ctrlSite = false
+===
+while // comm
+    val cond1 = true
+    (a1 && a2) == cond1
+  do
+    val exitCode = 1
+    exitCode
+    
+>>>
+while // comm
+   val cond1 = true
+   (a1 && a2) == cond1 do
+   val exitCode = 1
+   exitCode
+<<< if indentation danglingParentheses false oneline
+danglingParentheses.ctrlSite = false
+===
+while
+    (a1 && a2) == cond1
+  do
+    val exitCode = 1
+    exitCode
+    
+>>>
+while (a1 && a2) == cond1 do
    val exitCode = 1
    exitCode

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1655,8 +1655,7 @@ if // comm
 >>>
 if // comm
    val cond1 = true
-   (a1 && a2) == cond1
-then
+   (a1 && a2) == cond1 then
    val exitCode = 1
    exitCode
 <<< if indentation danglingParentheses false oneline
@@ -1670,5 +1669,34 @@ if
     
 >>>
 if (a1 && a2) == cond1 then
+   val exitCode = 1
+   exitCode
+<<< while indentation danglingParentheses false
+danglingParentheses.ctrlSite = false
+===
+while // comm
+    val cond1 = true
+    (a1 && a2) == cond1
+  do
+    val exitCode = 1
+    exitCode
+    
+>>>
+while // comm
+   val cond1 = true
+   (a1 && a2) == cond1 do
+   val exitCode = 1
+   exitCode
+<<< if indentation danglingParentheses false oneline
+danglingParentheses.ctrlSite = false
+===
+while
+    (a1 && a2) == cond1
+  do
+    val exitCode = 1
+    exitCode
+    
+>>>
+while (a1 && a2) == cond1 do
    val exitCode = 1
    exitCode

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1774,8 +1774,7 @@ if // comm
 >>>
 if // comm
    val cond1 = true
-   (a1 && a2) == cond1
-then
+   (a1 && a2) == cond1 then
    val exitCode = 1
    exitCode
 <<< if indentation danglingParentheses false oneline
@@ -1789,5 +1788,34 @@ if
     
 >>>
 if (a1 && a2) == cond1 then
+   val exitCode = 1
+   exitCode
+<<< while indentation danglingParentheses false
+danglingParentheses.ctrlSite = false
+===
+while // comm
+    val cond1 = true
+    (a1 && a2) == cond1
+  do
+    val exitCode = 1
+    exitCode
+    
+>>>
+while // comm
+   val cond1 = true
+   (a1 && a2) == cond1 do
+   val exitCode = 1
+   exitCode
+<<< if indentation danglingParentheses false oneline
+danglingParentheses.ctrlSite = false
+===
+while
+    (a1 && a2) == cond1
+  do
+    val exitCode = 1
+    exitCode
+    
+>>>
+while (a1 && a2) == cond1 do
    val exitCode = 1
    exitCode


### PR DESCRIPTION
This is a follow up from https://github.com/scalameta/scalafmt/pull/2594#pullrequestreview-685371567