### PR TITLE
FormatOps: look up the format token for tree head

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -664,9 +664,6 @@ object Application {
             .router(app => {
               val handler = server.ref(classOf[SampleHandler])
 
-              app.GET("/", req => {
-                app.GET("/new", req => {
-Idempotency violated
               app.GET("/",
                 req => {
                 app.GET("/new",

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -666,12 +666,12 @@ object Application {
 
               app.GET("/",
                 req => {
-                app.GET("/new",
-                  req => {
-                  ServerResponse.ok().bodyValue("dynamically created during GET / index request")
+                  app.GET("/new",
+                    req => {
+                      ServerResponse.ok().bodyValue("dynamically created during GET / index request")
+                    })
+                  handler.hello(req)
                 })
-                handler.hello(req)
-              })
               app.GET("/api", handler.json)
 
             })

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -621,3 +621,67 @@ val a = List(Some(1), None, Some(3), Some(4)).map {
     }
   case _ => "none"
 }
+<<< #2612
+maxColumn = 120
+binPack.preset = true
+rewrite.rules = [RedundantParens]
+===
+object Application {
+  val app = reactiveWebApplication((a) =>
+    a.beans((b) => b.bean(classOf[SampleHandler]).bean(classOf[SampleService]))
+      .enable(
+        webFlux((server) =>
+          server
+            .port(if (server.profiles().contains("test")) 8181 else 8080)
+            .router((app) => {
+              val handler = server.ref(classOf[SampleHandler])
+
+        app.GET("/", (req) => {
+          app.GET("/new", (req) => {
+              ServerResponse.ok().bodyValue("dynamically created during GET / index request")
+          })
+            handler.hello(req)
+        })
+        app.GET("/api", handler.json)
+
+
+            })
+            .codecs(_.string().jackson())
+        )
+      )
+  )
+
+  def main(args: Array[String]): Unit = app.run(args)
+}
+>>>
+object Application {
+  val app = reactiveWebApplication(a =>
+    a.beans(b => b.bean(classOf[SampleHandler]).bean(classOf[SampleService]))
+      .enable(
+        webFlux(server =>
+          server
+            .port(if (server.profiles().contains("test")) 8181 else 8080)
+            .router(app => {
+              val handler = server.ref(classOf[SampleHandler])
+
+              app.GET("/", req => {
+                app.GET("/new", req => {
+Idempotency violated
+              app.GET("/",
+                req => {
+                app.GET("/new",
+                  req => {
+                  ServerResponse.ok().bodyValue("dynamically created during GET / index request")
+                })
+                handler.hello(req)
+              })
+              app.GET("/api", handler.json)
+
+            })
+            .codecs(_.string().jackson())
+        )
+      )
+  )
+
+  def main(args: Array[String]): Unit = app.run(args)
+}


### PR DESCRIPTION
Also, in Router, only unindent single-arg binpack apply. Fixes #2612.