### PR TITLE
Fixing ScalaDoc heading output.

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -683,7 +683,7 @@ class FormatWriter(formatOps: FormatOps) {
                   sb.append(margin).append(t.fence)
                   appendBreak()
                 case t: Scaladoc.Heading =>
-                  val delimiter = t.level * '='
+                  val delimiter = "=" * t.level
                   sb.append(delimiter).append(t.title).append(delimiter)
                   appendBreak()
                 case t: Scaladoc.Tag =>

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1952,3 +1952,30 @@ val a = 1
  *   bar baz qux
  */
 val a = 1
+<<< #2619 do not modify wikidoc heading delimiters
+docstrings.style = SpaceAsterisk
+docstrings.wrap = yes
+maxColumn = 20
+===
+/** =Heading1=
+  *
+  * I exceed the configured column count in a docstring.
+  *
+  * ==Heading2 - Long headings will not get wrapped==
+  *
+  * ===Heading3 also not getting wrapped===
+  */
+val a = 1
+>>>
+/** =Heading1=
+  *
+  * I exceed the
+  * configured
+  * column count in
+  * a docstring.
+  *
+  * ==Heading2 - Long headings will not get wrapped==
+  *
+  * ===Heading3 also not getting wrapped===
+  */
+val a = 1

--- a/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
@@ -12,9 +12,11 @@ class CommentTest extends FunSuite {
     )
 
   private val wrapStyle: ScalafmtConfig =
-    ScalafmtConfig.default.copy(docstrings =
-      ScalafmtConfig.default.docstrings
-        .copy(wrap = Docstrings.Wrap.yes)
+    ScalafmtConfig.default.copy(
+      maxColumn = 20,
+      docstrings = ScalafmtConfig.default.docstrings.copy(
+        wrap = Docstrings.Wrap.yes
+      )
     )
 
   test("remove trailing space in comments") {
@@ -135,13 +137,28 @@ class CommentTest extends FunSuite {
     val original = """
       |/** =Heading1=
       |  *
-      |  * ==Heading2==
+      |  * I exceed the configured column count in a docstring.
       |  *
-      |  * ===Heading3===
+      |  * ==Heading2 - Long headings will not get wrapped==
+      |  *
+      |  * ===Heading3 also not getting wrapped===
       |  */
       |""".stripMargin
 
-    val expected = original
+    val expected = """
+      |/** =Heading1=
+      |  *
+      |  * I exceed the
+      |  * configured
+      |  * column count in
+      |  * a docstring.
+      |  *
+      |  * ==Heading2 - Long headings will not get wrapped==
+      |  *
+      |  * ===Heading3 also not getting wrapped===
+      |  */
+      |""".stripMargin
+
     val obtained = Scalafmt.format(original, wrapStyle).get
     assertNoDiff(obtained, expected)
   }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
@@ -11,6 +11,12 @@ class CommentTest extends FunSuite {
         .copy(style = Docstrings.Asterisk, wrap = Docstrings.Wrap.no)
     )
 
+  private val wrapStyle: ScalafmtConfig =
+    ScalafmtConfig.default.copy(docstrings =
+      ScalafmtConfig.default.docstrings
+        .copy(wrap = Docstrings.Wrap.yes)
+    )
+
   test("remove trailing space in comments") {
     val trailingSpace = "   "
     val original = s"""object a {
@@ -122,6 +128,21 @@ class CommentTest extends FunSuite {
       |}
       |""".stripMargin
     val obtained = Scalafmt.format(original, javadocStyle).get
+    assertNoDiff(obtained, expected)
+  }
+
+  test("preserve wikidoc headings when docstring wrap is enabled") {
+    val original = """
+      |/** =Heading1=
+      |  *
+      |  * ==Heading2==
+      |  *
+      |  * ===Heading3===
+      |  */
+      |""".stripMargin
+
+    val expected = original
+    val obtained = Scalafmt.format(original, wrapStyle).get
     assertNoDiff(obtained, expected)
   }
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/CommentTest.scala
@@ -11,14 +11,6 @@ class CommentTest extends FunSuite {
         .copy(style = Docstrings.Asterisk, wrap = Docstrings.Wrap.no)
     )
 
-  private val wrapStyle: ScalafmtConfig =
-    ScalafmtConfig.default.copy(
-      maxColumn = 20,
-      docstrings = ScalafmtConfig.default.docstrings.copy(
-        wrap = Docstrings.Wrap.yes
-      )
-    )
-
   test("remove trailing space in comments") {
     val trailingSpace = "   "
     val original = s"""object a {
@@ -130,36 +122,6 @@ class CommentTest extends FunSuite {
       |}
       |""".stripMargin
     val obtained = Scalafmt.format(original, javadocStyle).get
-    assertNoDiff(obtained, expected)
-  }
-
-  test("preserve wikidoc headings when docstring wrap is enabled") {
-    val original = """
-      |/** =Heading1=
-      |  *
-      |  * I exceed the configured column count in a docstring.
-      |  *
-      |  * ==Heading2 - Long headings will not get wrapped==
-      |  *
-      |  * ===Heading3 also not getting wrapped===
-      |  */
-      |""".stripMargin
-
-    val expected = """
-      |/** =Heading1=
-      |  *
-      |  * I exceed the
-      |  * configured
-      |  * column count in
-      |  * a docstring.
-      |  *
-      |  * ==Heading2 - Long headings will not get wrapped==
-      |  *
-      |  * ===Heading3 also not getting wrapped===
-      |  */
-      |""".stripMargin
-
-    val obtained = Scalafmt.format(original, wrapStyle).get
     assertNoDiff(obtained, expected)
   }
 }


### PR DESCRIPTION
Prior to this fix, ScalaDoc headings were rewritten to numeric values if `docstrings.wrap` was set to `yes`. The specific version I was using locally was `3.0.0-RC5`. Examples of what I was seeing:

- `==Foo==` became `122Foo122`
- `===Foo===` became `183Foo183`

The delimiter calculation was multiplying a char by a number, which resulted in a numeric value.

Haven't contributed here before - sorry if I've missed anything! I added a test which showed the old behavior and verified the fix, ran all of the tests afterwards, ran scalafmt on my changeset.