### PR TITLE
CliOptions: store paths as File, resolve on demand

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -4,7 +4,6 @@ import java.io.File
 import java.util.Date
 
 import org.scalafmt.Versions
-import org.scalafmt.util.AbsoluteFile
 import scopt.OptionParser
 
 object CliArgParser {
@@ -41,15 +40,6 @@ object CliArgParser {
 
       private def readConfig(contents: String, c: CliOptions): CliOptions = {
         c.copy(configStr = Some(contents))
-      }
-
-      private def readConfigFromFile(
-          file: String,
-          c: CliOptions
-      ): CliOptions = {
-        val configFile =
-          AbsoluteFile.fromFile(new File(file), c.common.workingDirectory)
-        c.copy(config = Some(configFile.jfile.toPath))
       }
 
       head("scalafmt", Versions.nightly)
@@ -99,8 +89,8 @@ object CliArgParser {
         .text(
           "use project filters even when specific files to format are provided"
         )
-      opt[String]('c', "config")
-        .action(readConfigFromFile)
+      opt[File]('c', "config")
+        .action((file, c) => c.copy(config = Some(file)))
         .text("a file path to .scalafmt.conf.")
       opt[String]("config-str")
         .action(readConfig)

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliOptionsTest.scala
@@ -56,7 +56,7 @@ class CliOptionsTest extends FunSuite {
 
   test(".configPath returns path to specified configuration path") {
     val tempPath = Files.createTempFile(".scalafmt", ".conf")
-    val opt = baseCliOptions.copy(config = Some(tempPath))
+    val opt = baseCliOptions.copy(config = Some(tempPath.toFile))
     assert(tempPath == opt.configPath)
   }
 
@@ -92,7 +92,7 @@ class CliOptionsTest extends FunSuite {
       |""".stripMargin
     Files.write(configPath, config.getBytes)
 
-    val opt = baseCliOptions.copy(config = Some(configPath))
+    val opt = baseCliOptions.copy(config = Some(configPath.toFile))
     assert(opt.scalafmtConfig.get.onTestFailure == expected)
   }
 
@@ -101,7 +101,7 @@ class CliOptionsTest extends FunSuite {
   ) {
     val configDir = Files.createTempDirectory("temp-dir")
     val configPath = Paths.get(configDir.toString + "/.scalafmt.conf")
-    val opt = baseCliOptions.copy(config = Some(configPath))
+    val opt = baseCliOptions.copy(config = Some(configPath.toFile))
     assert(opt.scalafmtConfig.isInstanceOf[Configured.NotOk])
     val confError = opt.scalafmtConfig.asInstanceOf[Configured.NotOk].error
     assert(confError.cause.exists(_.isInstanceOf[NoSuchFileException]))

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -318,7 +318,7 @@ trait CliTestBehavior { this: AbstractCliTest =>
         |version="$version"
                """.stripMargin
       Files.write(scalafmtConfig, config.getBytes)
-      val options = baseCliOptions.copy(config = Some(scalafmtConfig))
+      val options = baseCliOptions.copy(config = Some(scalafmtConfig.toFile))
       intercept[NoMatchingFiles.type] {
         Cli.run(options)
       }


### PR DESCRIPTION
This might also help with obscure file resolution issues around our native builds. Fixes #2616.