### PR TITLE
Add := as a default AlignToken

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
@@ -78,6 +78,7 @@ object AlignToken {
     AlignToken("←", "Enumerator.Generator"),
     AlignToken("->", applyInfix),
     AlignToken("→", applyInfix),
+    AlignToken(":=", applyInfix),
     AlignToken("=", "(Enumerator.Val|Defn.(Va(l|r)|GivenAlias|Def|Type))")
   )
 

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -97,6 +97,36 @@ def status = column[Int]("status")
   def name    = column[String]("name")
   def status  = column[Int]("status")
 }
+<<< sbt := operator
+{
+  scalaVersion := "2.13.6"
+  version := "0.1.0-SNAPSHOT"
+}
+>>>
+{
+  scalaVersion := "2.13.6"
+  version      := "0.1.0-SNAPSHOT"
+}
+<<< sbt := operator with in ThisBuild
+{
+  scalaVersion in ThisBuild := "2.13.6"
+  version in ThisBuild := "0.1.0-SNAPSHOT"
+}
+>>>
+{
+  scalaVersion in ThisBuild := "2.13.6"
+  version in ThisBuild      := "0.1.0-SNAPSHOT"
+}
+<<< sbt := operator with /
+{
+  ThisBuild / scalaVersion := "2.13.6"
+  ThisBuild / version := "0.1.0-SNAPSHOT"
+}
+>>>
+{
+  ThisBuild / scalaVersion := "2.13.6"
+  ThisBuild / version      := "0.1.0-SNAPSHOT"
+}
 <<< colors #138
 // tuples
 val colors = Map (


### PR DESCRIPTION
This PR adds `:=` to the default list of aligned tokens. The reason why `:=` is being added is because its used frequently in sbt files and if you are writing something like

```scala
ThisBuild / scalaVersion := "2.13.6"
ThisBuild / version := "0.1.0-SNAPSHOT"
```

And you are doing vertical alignment of tokens it makes sense to align `:=` just like you would with `=` i.e. so you would end up with

```scala
ThisBuild / scalaVersion := "2.13.6"
ThisBuild / version      := "0.1.0-SNAPSHOT"
```

I can verify this works locally with the following `.scalafmt.conf` configuration

```
align.tokens.add = [
  {code = ":=", owner = "Term.ApplyInfix"}
]
```

This PR should do the equivalent as a default.