### PR TITLE
Scalafmt: parse configuration directly from file

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -1,5 +1,7 @@
 package org.scalafmt
 
+import java.nio.file.Path
+
 import metaconfig.Configured
 import scala.annotation.tailrec
 import scala.meta.Dialect
@@ -146,6 +148,11 @@ object Scalafmt {
     formatCode(code, style, range).formatted
   }
 
+  // used by ScalafmtReflect.parseConfig
+  def parseHoconConfigFile(configPath: Path): Configured[ScalafmtConfig] =
+    Config.fromHoconFile(configPath.toFile)
+
+  // used by ScalafmtReflect.parseConfig
   def parseHoconConfig(configString: String): Configured[ScalafmtConfig] =
     Config.fromHoconString(configString, None)
 

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
@@ -133,7 +133,11 @@ final case class ScalafmtDynamic(
   ): FormatEval[ScalafmtReflectConfig] = {
     for {
       version <- readVersion(configPath)
-      fmtReflect <- resolveFormatter(configPath, version)
+      fmtReflect <-
+        if (version == ScalafmtVersion.current)
+          Right(ScalafmtReflect.current)
+        else
+          resolveFormatter(configPath, version)
       config <- parseConfig(configPath, fmtReflect)
     } yield config
   }

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -177,3 +177,8 @@ case class ScalafmtReflect(
     module.get(null)
   }
 }
+
+object ScalafmtReflect {
+  val current =
+    ScalafmtReflect(getClass.getClassLoader, ScalafmtVersion.current, false)
+}

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -1,14 +1,13 @@
 package org.scalafmt.dynamic
 
 import com.typesafe.config.ConfigFactory
-import java.net.URLClassLoader
 import java.nio.file.Path
 import org.scalafmt.dynamic.exceptions._
 import org.scalafmt.dynamic.utils.ReflectUtils._
 import scala.util.Try
 
 case class ScalafmtReflect(
-    classLoader: URLClassLoader,
+    classLoader: ClassLoader,
     version: ScalafmtVersion,
     respectVersion: Boolean
 ) {

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
@@ -27,11 +27,14 @@ case class ScalafmtVersion(
 
 object ScalafmtVersion {
 
+  val current = ScalafmtVersion(Int.MaxValue / 100, 0, 0)
+
   private val versionRegex = """(\d)\.(\d)\.(\d)(-RC(\d))?(-SNAPSHOT)?""".r
 
   def parse(version: String): Option[ScalafmtVersion] =
     try {
       version match {
+        case "current" => Some(current)
         case versionRegex(major, minor, patch, null, null, snapshot) =>
           Some(
             ScalafmtVersion(

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -454,10 +454,9 @@ class DynamicSuite extends FunSuite {
         |""".stripMargin
     )
     val thrown = f.assertThrows[ScalafmtDynamicError.ConfigParseError]()
+    assert(thrown.getMessage.startsWith("Invalid config:"))
     assert(
-      thrown.getMessage.startsWith(
-        "Invalid config: <input>:3:0 error: Type mismatch;"
-      )
+      thrown.getMessage.contains(".scalafmt.conf:2:0 error: Type mismatch;")
     )
   }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -446,4 +446,43 @@ class DynamicSuite extends FunSuite {
     assertNotEquals(config, configWithoutRewrites)
     assert(!configWithoutRewrites.hasRewriteRules)
   }
+
+  check("invalid config in current") { f =>
+    f.setConfig(
+      s"""|version=current
+        |align=does-not-exist
+        |""".stripMargin
+    )
+    val thrown = f.assertThrows[ScalafmtDynamicError.ConfigParseError]()
+    assert(
+      thrown.getMessage.startsWith(
+        "Invalid config: <input>:3:0 error: Type mismatch;"
+      )
+    )
+  }
+
+  check("invalid config in 3.0.0-RC6") { f =>
+    f.setConfig(
+      s"""|version=3.0.0-RC6
+        |align=does-not-exist
+        |""".stripMargin
+    )
+    val thrown = f.assertThrows[ScalafmtDynamicError.ConfigParseError]()
+    assert(
+      thrown.getMessage.startsWith(
+        "Invalid config: <input>:3:0 error: Type mismatch;"
+      )
+    )
+  }
+
+  check("invalid config in 2.7.5") { f =>
+    f.setConfig(
+      s"""|version=2.7.5
+        |align=does-not-exist
+        |""".stripMargin
+    )
+    val thrown = f.assertThrows[ScalafmtDynamicError.ConfigParseError]()
+    assert(thrown.getMessage.startsWith("Invalid config: Type mismatch;"))
+  }
+
 }


### PR DESCRIPTION
Previously, we'd parse the configuration file into a `typesafe.config` object, then convert it to a HOCON string and invoke the formatter config parser on it. If there's a parsing error with that string, the formatter wouldn't know where it came from and refer to `<input>` as the source of the configuration.

Instead, pass the path to the config file directly to the new method allowing parsing configuration from a file. Fixes #2631.