### PR TITLE
BestFirstSearch: use full search in nested blocks

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -154,7 +154,9 @@ private class BestFirstSearch private (
             else Q.clear()
         }
 
-        val blockClose = shouldRecurseOnBlock(splitToken, stop)
+        val blockClose =
+          if (start.eq(curr) && 0 != maxCost) None
+          else shouldRecurseOnBlock(splitToken, stop)
         if (blockClose.nonEmpty)
           blockClose.foreach { end =>
             shortestPathMemo(curr, end, depth + 1, maxCost)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -150,8 +150,7 @@ private class BestFirstSearch private (
             dequeueSpots.contains(tokenHash) &&
             (depth > 0 || !isInsideNoOptZone(splitToken))
           )
-            if (depth == 0) addGeneration
-            else Q.clear()
+            addGeneration
         }
 
         val blockClose =


### PR DESCRIPTION
Reduces the number of states and thus "Search state exploded" failures. Fixes #2633.