### PR TITLE
FormatOps: fix bug with vertical multiline

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1243,7 +1243,8 @@ class FormatOps(
       // - There's an implicit keyword and newlineBeforeImplicitKW is enabled
       // - newlineAfterOpenParen is enabled
       // - Mixed-params case with constructor modifier `] private (`
-      case Decision(t @ FormatToken(open2 @ T.LeftParen(), right, _), _) =>
+      case Decision(t @ FormatToken(open2 @ T.LeftParen(), right, _), _)
+          if ownerCheck(t.meta.leftOwner) =>
         val close2 = matching(open2)
 
         // We don't want to create newlines for default values.

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -31,9 +31,13 @@ object Test {
 object Test {
 
   def create(
-    somethingInfo: foo.T = Something("my-something", Some("test-something"), "something",
-      Some(Format("something", "something")), Some(something.Something("something",
-          "something", "something", "something")))
+    somethingInfo: foo.T = Something(
+      "my-something",
+      Some("test-something"),
+      "something",
+      Some(Format("something", "something")),
+      Some(something.Something("something", "something", "something", "something"))
+    )
   ): Unit = {
     w(foo)
   }


### PR DESCRIPTION
The rule mistakenly matched the wrong `(` and led to a binpack-like formatting of default parameters containing an Apply.