### PR TITLE
Add documentation for Markdown formatting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3958,6 +3958,44 @@ importSelectors = singleLine
 import a.b.{c, d, e, f, g}
 ```
 
+## Markdown Formatting
+
+> Since v3.0.0.
+
+Will format all `scala mdoc` fences inside Markdown files.
+
+```conf
+# Format default filetypes + Markdown files
+project.includePaths."+" = ["glob:**.md"]
+
+# *Only* format Markdown files
+project.includePaths = [ "glob:**.md" ]
+```
+
+Before:
+
+````markdown
+Markdown prose beginning.
+
+```scala mdoc
+val x  =       3
+```
+
+Markdown prose end.
+````
+
+After:
+
+````markdown
+Markdown prose beginning.
+
+```scala mdoc
+val x = 3
+```
+
+Markdown prose end.
+````
+
 ## Edition
 
 > Removed in 2.7.0


### PR DESCRIPTION
I tried for a while to use the `mdoc:scalafmt` approach to document this, but it was a snake eating its tail, so I resorted to this basic version for the sake of getting _something_ out there for users.