### PR TITLE
FormatWriter: improve end marker handling

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -246,7 +246,11 @@ class FormatWriter(formatOps: FormatOps) {
     locations.foreach { floc =>
       getOptionalBracesOwner(floc, 2).foreach { owner =>
         val endFt = tokens.getLast(owner)
-        if (!tokens.nextNonComment(endFt).meta.rightOwner.is[Term.EndMarker]) {
+        val ok = tokens.nextNonComment(endFt).meta.rightOwner match {
+          case em: Term.EndMarker => em.parent != owner.parent
+          case _ => true
+        }
+        if (ok) {
           val end = endFt.meta.idx
           val eLoc = locations(end)
           val bLoc = locations(tokens.tokenJustBefore(owner).meta.idx)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -246,7 +246,7 @@ class FormatWriter(formatOps: FormatOps) {
     locations.foreach { floc =>
       getOptionalBracesOwner(floc, 2).foreach { owner =>
         val endFt = tokens.getLast(owner)
-        if (!endFt.meta.rightOwner.is[Term.EndMarker]) {
+        if (!tokens.nextNonComment(endFt).meta.rightOwner.is[Term.EndMarker]) {
           val end = endFt.meta.idx
           val eLoc = locations(end)
           val bLoc = locations(tokens.tokenJustBefore(owner).meta.idx)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1495,8 +1495,6 @@ object a:
    class b:
       val c =
         d
-   end b
-end a
 // c
 end a
 <<< 1 end marker at end of file
@@ -1528,7 +1526,6 @@ object a:
    class b:
       val c =
         d
-end a
 // c
 end a
 <<< no end markers at end of file

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1495,6 +1495,7 @@ object a:
    class b:
       val c =
         d
+   end b
 // c
 end a
 <<< 1 end marker at end of file

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1480,6 +1480,25 @@ object a:
         a
    end a
 end a
+<<< 2 end markers at end of file, comment
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 3
+===
+object a:
+  class b:
+    val c =
+      d
+  // c
+end a
+>>>
+object a:
+   class b:
+      val c =
+        d
+   end b
+end a
+// c
+end a
 <<< 1 end marker at end of file
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 4
@@ -1493,6 +1512,24 @@ object a:
    class b:
       val c =
         d
+end a
+<<< 1 end marker at end of file, comment
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 4
+===
+object a:
+  class b:
+    val c =
+      d
+  // c
+end a
+>>>
+object a:
+   class b:
+      val c =
+        d
+end a
+// c
 end a
 <<< no end markers at end of file
 runner.parser = source

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1485,14 +1485,14 @@ runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 4
 ===
 object a:
-  class a:
-    val a =
-      a
+  class b:
+    val c =
+      d
 >>>
 object a:
-   class a:
-      val a =
-        a
+   class b:
+      val c =
+        d
 end a
 <<< no end markers at end of file
 runner.parser = source

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1460,6 +1460,7 @@ end a
 object a:
    class b:
       val c = d
+   end b
 // c
 end a
 <<< 1 end marker at end of file

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1446,6 +1446,24 @@ object a:
       val a = a
    end a
 end a
+<<< 2 end markers at end of file, comment
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 2
+===
+object a:
+  class b:
+    val c =
+      d
+  // c
+end a
+>>>
+object a:
+   class b:
+      val c = d
+   end b
+end a
+// c
+end a
 <<< 1 end marker at end of file
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 3
@@ -1458,6 +1476,23 @@ object a:
 object a:
    class b:
       val c = d
+end a
+<<< 1 end marker at end of file, comment
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 3
+===
+object a:
+  class b:
+    val c =
+      d
+  // c
+end a
+>>>
+object a:
+   class b:
+      val c = d
+end a
+// c
 end a
 <<< no end markers at end of file
 runner.parser = source

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1460,8 +1460,6 @@ end a
 object a:
    class b:
       val c = d
-   end b
-end a
 // c
 end a
 <<< 1 end marker at end of file
@@ -1491,7 +1489,6 @@ end a
 object a:
    class b:
       val c = d
-end a
 // c
 end a
 <<< no end markers at end of file

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1446,18 +1446,18 @@ object a:
       val a = a
    end a
 end a
-<<< 1 end markers at end of file
+<<< 1 end marker at end of file
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 3
 ===
 object a:
-  class a:
-    val a =
-      a
+  class b:
+    val c =
+      d
 >>>
 object a:
-   class a:
-      val a = a
+   class b:
+      val c = d
 end a
 <<< no end markers at end of file
 runner.parser = source

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1535,6 +1535,7 @@ object a:
    class b:
       val c =
         d
+   end b
 // c
 end a
 <<< 1 end marker at end of file

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1520,6 +1520,25 @@ object a:
         a
    end a
 end a
+<<< 2 end markers at end of file, comment
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 3
+===
+object a:
+  class b:
+    val c =
+      d
+  // c
+end a
+>>>
+object a:
+   class b:
+      val c =
+        d
+   end b
+end a
+// c
+end a
 <<< 1 end marker at end of file
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 4
@@ -1533,6 +1552,24 @@ object a:
    class b:
       val c =
         d
+end a
+<<< 1 end marker at end of file, comment
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 4
+===
+object a:
+  class b:
+    val c =
+      d
+  // c
+end a
+>>>
+object a:
+   class b:
+      val c =
+        d
+end a
+// c
 end a
 <<< no end markers at end of file
 runner.parser = source

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1535,8 +1535,6 @@ object a:
    class b:
       val c =
         d
-   end b
-end a
 // c
 end a
 <<< 1 end marker at end of file
@@ -1568,7 +1566,6 @@ object a:
    class b:
       val c =
         d
-end a
 // c
 end a
 <<< no end markers at end of file

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1525,14 +1525,14 @@ runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 4
 ===
 object a:
-  class a:
-    val a =
-      a
+  class b:
+    val c =
+      d
 >>>
 object a:
-   class a:
-      val a =
-        a
+   class b:
+      val c =
+        d
 end a
 <<< no end markers at end of file
 runner.parser = source

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1655,6 +1655,7 @@ end a
 object a:
    class b:
       val c = d
+   end b
 // c
 end a
 <<< 1 end marker at end of file

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1641,6 +1641,24 @@ object a:
       val a = a
    end a
 end a
+<<< 2 end markers at end of file, comment
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 2
+===
+object a:
+  class b:
+    val c =
+      d
+  // c
+end a
+>>>
+object a:
+   class b:
+      val c = d
+   end b
+end a
+// c
+end a
 <<< 1 end marker at end of file
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 3
@@ -1653,6 +1671,23 @@ object a:
 object a:
    class b:
       val c = d
+end a
+<<< 1 end marker at end of file, comment
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 3
+===
+object a:
+  class b:
+    val c =
+      d
+  // c
+end a
+>>>
+object a:
+   class b:
+      val c = d
+end a
+// c
 end a
 <<< no end markers at end of file
 runner.parser = source

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1655,8 +1655,6 @@ end a
 object a:
    class b:
       val c = d
-   end b
-end a
 // c
 end a
 <<< 1 end marker at end of file
@@ -1686,7 +1684,6 @@ end a
 object a:
    class b:
       val c = d
-end a
 // c
 end a
 <<< no end markers at end of file

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1646,13 +1646,13 @@ runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 3
 ===
 object a:
-  class a:
-    val a =
-      a
+  class b:
+    val c =
+      d
 >>>
 object a:
-   class a:
-      val a = a
+   class b:
+      val c = d
 end a
 <<< no end markers at end of file
 runner.parser = source


### PR DESCRIPTION
Match the right end marker and allow comments before it.