### PR TITLE
FormatWriter: print markdown code blocks relative

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtRunner.scala
@@ -22,12 +22,11 @@ case class ScalafmtRunner(
     ignoreWarnings: Boolean = false,
     fatalWarnings: Boolean = false
 ) {
-  def forSbt: ScalafmtRunner =
-    copy(
-      dialect = dialect
-        .withAllowToplevelTerms(true)
-        .withToplevelSeparator("")
-    )
+  def topLevelDialect: Dialect = dialect
+    .withAllowToplevelTerms(true)
+    .withToplevelSeparator("")
+
+  def forSbt: ScalafmtRunner = copy(dialect = topLevelDialect)
 
   def event(evt: => FormatEvent): Unit =
     if (null != eventCallback) eventCallback(evt)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -744,15 +744,14 @@ class FormatWriter(formatOps: FormatOps) {
           code.foreach { x =>
             if (x.nonEmpty) {
               val matcher = docstringLeadingSpace.matcher(x)
-              val minMargin = margin.length
               if (matcher.lookingAt()) {
                 val offset = matcher.end()
-                val extra = math.max(0, offset - minMargin)
-                val codeIndent = minMargin + extra - extra % 2
+                val extra = math.max(0, offset - leadingMargin)
+                val codeIndent = 1 + leadingMargin + ((extra >> 1) << 1)
                 sb.append(getIndentation(codeIndent))
                 sb.append(CharBuffer.wrap(x, offset, x.length))
               } else
-                sb.append(getIndentation(minMargin)).append(x)
+                sb.append(margin).append(x)
             }
             appendBreak()
           }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -767,6 +767,7 @@ class FormatWriter(formatOps: FormatOps) {
             runner = style.runner.copy(
               debug = false,
               eventCallback = null,
+              dialect = style.runner.topLevelDialect,
               parser = ScalafmtParser.Source
             ),
             // let's not wrap docstrings, to avoid recursion

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1799,15 +1799,15 @@ val a = 1
  * // scala
  * class Formatter(style: ScalaStyle, tree1: Tree)
  * class Formatter(
- *   style: ScalaStyle,
- *   tree12: Tree
+ *     style: ScalaStyle,
+ *     tree12: Tree
  * )
  * class Formatter(
- *   style: ScalaStyle,
- *   tree: Tree,
- *   toks: Array[FormatToken],
- *   statementStarts: Set[Token],
- *   owners: Map[Token, Tree]
+ *     style: ScalaStyle,
+ *     tree: Tree,
+ *     toks: Array[FormatToken],
+ *     statementStarts: Set[Token],
+ *     owners: Map[Token, Tree]
  * )
  * }}}
  */
@@ -1831,15 +1831,15 @@ val a = 1
   * // scala
   * class Formatter(style: ScalaStyle, tree: Tree)
   * class Formatter(
-  *   style: ScalaStyle,
-  *   tree1: Tree
+  *     style: ScalaStyle,
+  *     tree1: Tree
   * )
   * class Formatter(
-  *   style: ScalaStyle,
-  *   tree: Tree,
-  *   toks: Array[FormatToken],
-  *   statementStarts: Set[Token],
-  *   owners: Map[Token, Tree]
+  *     style: ScalaStyle,
+  *     tree: Tree,
+  *     toks: Array[FormatToken],
+  *     statementStarts: Set[Token],
+  *     owners: Map[Token, Tree]
   * )
   * }}}
   */
@@ -1914,15 +1914,15 @@ val a = 1
  * ```scala
  * class Formatter(style: ScalaStyle, tree1: Tree)
  * class Formatter(
- *   style: ScalaStyle,
- *   tree12: Tree
+ *     style: ScalaStyle,
+ *     tree12: Tree
  * )
  * class Formatter(
- *   style: ScalaStyle,
- *   tree: Tree,
- *   toks: Array[FormatToken],
- *   statementStarts: Set[Token],
- *   owners: Map[Token, Tree]
+ *     style: ScalaStyle,
+ *     tree: Tree,
+ *     toks: Array[FormatToken],
+ *     statementStarts: Set[Token],
+ *     owners: Map[Token, Tree]
  * )
  * ```
  * No more nice scala code.
@@ -1946,19 +1946,19 @@ val a = 1
 /** Nice scala code:
   * ```scala
   * class Formatter(
-  *   style: ScalaStyle,
-  *   tree1: Tree
+  *     style: ScalaStyle,
+  *     tree1: Tree
   * )
   * class Formatter(
-  *   style: ScalaStyle,
-  *   tree12: Tree
+  *     style: ScalaStyle,
+  *     tree12: Tree
   * )
   * class Formatter(
-  *   style: ScalaStyle,
-  *   tree: Tree,
-  *   toks: Array[FormatToken],
-  *   statementStarts: Set[Token],
-  *   owners: Map[Token, Tree]
+  *     style: ScalaStyle,
+  *     tree: Tree,
+  *     toks: Array[FormatToken],
+  *     statementStarts: Set[Token],
+  *     owners: Map[Token, Tree]
   * )
   * ```
   * No more nice scala code.
@@ -2180,66 +2180,48 @@ object a {
   /**
    * ```
    * libraryDependencies ++= Seq(
-   * "org.scalacheck" %% "scalacheck" % scalacheckV,
-   * "io.get-coursier" % "interface"  % "0.0.17"
-   * )
-   * ```
-   * ```
-   * libraryDependencies ++= Seq(
-   * "org.scalacheck" %% "scalacheck" % scalacheckV,
-   * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
    *   "io.get-coursier" % "interface"  % "0.0.17"
    * )
    * ```
    * ```
    * libraryDependencies ++= Seq(
-   * "org.scalacheck" %% "scalacheck" % scalacheckV,
-   * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
    *   "io.get-coursier" % "interface"  % "0.0.17"
    * )
    * ```
    * ```
+   *   libraryDependencies ++= Seq(
+   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *     "io.get-coursier" % "interface"  % "0.0.17"
+   *   )
+   * ```
+   * ```
    * libraryDependencies ++= Seq(
-   * "org.scalacheck" %% "scalacheck" % scalacheckV,
-   * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
    *   "io.get-coursier" % "interface"  % "0.0.17"
    * )
    * ```
    * ```scala
    * libraryDependencies ++= Seq(
-   * "org.scalacheck" %% "scalacheck" % scalacheckV,
-   * "io.get-coursier" % "interface"  % "0.0.17"
-   * )
-   * ```
-   * ```scala
-   * libraryDependencies ++= Seq(
-   * "org.scalacheck" %% "scalacheck" % scalacheckV,
-   * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
    *   "io.get-coursier" % "interface"  % "0.0.17"
    * )
    * ```
    * ```scala
    * libraryDependencies ++= Seq(
-   * "org.scalacheck" %% "scalacheck" % scalacheckV,
-   * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
    *   "io.get-coursier" % "interface"  % "0.0.17"
    * )
    * ```
    * ```scala
+   *   libraryDependencies ++= Seq(
+   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *     "io.get-coursier" % "interface"  % "0.0.17"
+   *   )
+   * ```
+   * ```scala
    * libraryDependencies ++= Seq(
-   * "org.scalacheck" %% "scalacheck" % scalacheckV,
-   * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
    *   "io.get-coursier" % "interface"  % "0.0.17"
    * )
@@ -2320,10 +2302,10 @@ object a {
    * )
    * }}}
    * {{{
-   * libraryDependencies ++= Seq(
-   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *   "io.get-coursier" % "interface"  % "0.0.17"
-   * )
+   *   libraryDependencies ++= Seq(
+   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *     "io.get-coursier" % "interface"  % "0.0.17"
+   *   )
    * }}}
    * {{{
    *   libraryDependencies ++= Seq(
@@ -2345,11 +2327,11 @@ object a {
    * )
    * }}}
    * {{{
-   * // scala
-   * libraryDependencies ++= Seq(
-   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *   "io.get-coursier" % "interface"  % "0.0.17"
-   * )
+   *   // scala
+   *   libraryDependencies ++= Seq(
+   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *     "io.get-coursier" % "interface"  % "0.0.17"
+   *   )
    * }}}
    * {{{
    *   // scala
@@ -2431,66 +2413,48 @@ object a {
 
   /** ```
     * libraryDependencies ++= Seq(
-    * "org.scalacheck" %% "scalacheck" % scalacheckV,
-    * "io.get-coursier" % "interface"  % "0.0.17"
-    * )
-    * ```
-    * ```
-    * libraryDependencies ++= Seq(
-    * "org.scalacheck" %% "scalacheck" % scalacheckV,
-    * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
     *   "org.scalacheck" %% "scalacheck" % scalacheckV,
     *   "io.get-coursier" % "interface"  % "0.0.17"
     * )
     * ```
     * ```
     * libraryDependencies ++= Seq(
-    * "org.scalacheck" %% "scalacheck" % scalacheckV,
-    * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
     *   "org.scalacheck" %% "scalacheck" % scalacheckV,
     *   "io.get-coursier" % "interface"  % "0.0.17"
     * )
     * ```
     * ```
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * ```
+    * ```
     * libraryDependencies ++= Seq(
-    * "org.scalacheck" %% "scalacheck" % scalacheckV,
-    * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
     *   "org.scalacheck" %% "scalacheck" % scalacheckV,
     *   "io.get-coursier" % "interface"  % "0.0.17"
     * )
     * ```
     * ```scala
     * libraryDependencies ++= Seq(
-    * "org.scalacheck" %% "scalacheck" % scalacheckV,
-    * "io.get-coursier" % "interface"  % "0.0.17"
-    * )
-    * ```
-    * ```scala
-    * libraryDependencies ++= Seq(
-    * "org.scalacheck" %% "scalacheck" % scalacheckV,
-    * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
     *   "org.scalacheck" %% "scalacheck" % scalacheckV,
     *   "io.get-coursier" % "interface"  % "0.0.17"
     * )
     * ```
     * ```scala
     * libraryDependencies ++= Seq(
-    * "org.scalacheck" %% "scalacheck" % scalacheckV,
-    * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
     *   "org.scalacheck" %% "scalacheck" % scalacheckV,
     *   "io.get-coursier" % "interface"  % "0.0.17"
     * )
     * ```
     * ```scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * ```
+    * ```scala
     * libraryDependencies ++= Seq(
-    * "org.scalacheck" %% "scalacheck" % scalacheckV,
-    * "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
     *   "org.scalacheck" %% "scalacheck" % scalacheckV,
     *   "io.get-coursier" % "interface"  % "0.0.17"
     * )
@@ -2570,10 +2534,10 @@ object a {
     * )
     * }}}
     * {{{
-    * libraryDependencies ++= Seq(
-    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
-    *   "io.get-coursier" % "interface"  % "0.0.17"
-    * )
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
     * }}}
     * {{{
     *   libraryDependencies ++= Seq(
@@ -2595,11 +2559,11 @@ object a {
     * )
     * }}}
     * {{{
-    * // scala
-    * libraryDependencies ++= Seq(
-    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
-    *   "io.get-coursier" % "interface"  % "0.0.17"
-    * )
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
     * }}}
     * {{{
     *   // scala
@@ -2815,12 +2779,6 @@ object a {
 
   /** {{{
    *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-   *  )
-   *  }}}
-   *  {{{
-   *  libraryDependencies ++= Seq(
    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
    *    "io.get-coursier" % "interface"  % "0.0.17"
    *  )
@@ -2832,17 +2790,16 @@ object a {
    *  )
    *  }}}
    *  {{{
-   *  libraryDependencies ++= Seq(
-   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *    "io.get-coursier" % "interface"  % "0.0.17"
-   *  )
+   *    libraryDependencies ++= Seq(
+   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *      "io.get-coursier" % "interface"  % "0.0.17"
+   *    )
    *  }}}
    *  {{{
-   *  // scala
-   *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-   *  )
+   *    libraryDependencies ++= Seq(
+   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *      "io.get-coursier" % "interface"  % "0.0.17"
+   *    )
    *  }}}
    *  {{{
    *  // scala
@@ -2859,11 +2816,18 @@ object a {
    *  )
    *  }}}
    *  {{{
-   *  // scala
-   *  libraryDependencies ++= Seq(
-   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *    "io.get-coursier" % "interface"  % "0.0.17"
-   *  )
+   *    // scala
+   *    libraryDependencies ++= Seq(
+   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *      "io.get-coursier" % "interface"  % "0.0.17"
+   *    )
+   *  }}}
+   *  {{{
+   *    // scala
+   *    libraryDependencies ++= Seq(
+   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *      "io.get-coursier" % "interface"  % "0.0.17"
+   *    )
    *  }}}
    */
   def getAlignColumn(floc: FormatLocation): Int = _

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -2215,10 +2215,10 @@ object a {
    * )
    * ```
    * ```scala
-   *   libraryDependencies ++= Seq(
-   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *     "io.get-coursier" % "interface"  % "0.0.17"
-   *   )
+   * libraryDependencies ++= Seq(
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
    * ```
    * ```scala
    * libraryDependencies ++= Seq(
@@ -2327,25 +2327,25 @@ object a {
    * )
    * }}}
    * {{{
-   *   // scala
-   *   libraryDependencies ++= Seq(
-   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *     "io.get-coursier" % "interface"  % "0.0.17"
-   *   )
+   * // scala
+   * libraryDependencies ++= Seq(
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
    * }}}
    * {{{
-   *   // scala
-   *   libraryDependencies ++= Seq(
-   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *     "io.get-coursier" % "interface"  % "0.0.17"
-   *   )
+   * // scala
+   * libraryDependencies ++= Seq(
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
    * }}}
    * {{{
-   *   // scala
-   *   libraryDependencies ++= Seq(
-   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *     "io.get-coursier" % "interface"  % "0.0.17"
-   *   )
+   * // scala
+   * libraryDependencies ++= Seq(
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
    * }}}
    */
   def getAlignColumn(floc: FormatLocation): Int = _
@@ -2448,10 +2448,10 @@ object a {
     * )
     * ```
     * ```scala
-    *   libraryDependencies ++= Seq(
-    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
-    *     "io.get-coursier" % "interface"  % "0.0.17"
-    *   )
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
     * ```
     * ```scala
     * libraryDependencies ++= Seq(
@@ -2559,25 +2559,25 @@ object a {
     * )
     * }}}
     * {{{
-    *   // scala
-    *   libraryDependencies ++= Seq(
-    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
-    *     "io.get-coursier" % "interface"  % "0.0.17"
-    *   )
+    * // scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
     * }}}
     * {{{
-    *   // scala
-    *   libraryDependencies ++= Seq(
-    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
-    *     "io.get-coursier" % "interface"  % "0.0.17"
-    *   )
+    * // scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
     * }}}
     * {{{
-    *   // scala
-    *   libraryDependencies ++= Seq(
-    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
-    *     "io.get-coursier" % "interface"  % "0.0.17"
-    *   )
+    * // scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
     * }}}
     */
   def getAlignColumn(floc: FormatLocation): Int = _
@@ -2680,10 +2680,10 @@ object a {
    *  )
    *  ```
    *  ```scala
-   *    libraryDependencies ++= Seq(
-   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *      "io.get-coursier" % "interface"  % "0.0.17"
-   *    )
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
    *  ```
    *  ```scala
    *  libraryDependencies ++= Seq(
@@ -2798,18 +2798,18 @@ object a {
    *  )
    *  }}}
    *  {{{
-   *    // scala
-   *    libraryDependencies ++= Seq(
-   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *      "io.get-coursier" % "interface"  % "0.0.17"
-   *    )
+   *  // scala
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
    *  }}}
    *  {{{
-   *    // scala
-   *    libraryDependencies ++= Seq(
-   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *      "io.get-coursier" % "interface"  % "0.0.17"
-   *    )
+   *  // scala
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
    *  }}}
    */
   def getAlignColumn(floc: FormatLocation): Int = _

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -1863,15 +1863,15 @@ val a = 1
  *  // scala
  *  class Formatter(style: ScalaStyle, tree: Tree)
  *  class Formatter(
- *    style: ScalaStyle,
- *    tree1: Tree
+ *      style: ScalaStyle,
+ *      tree1: Tree
  *  )
  *  class Formatter(
- *    style: ScalaStyle,
- *    tree: Tree,
- *    toks: Array[FormatToken],
- *    statementStarts: Set[Token],
- *    owners: Map[Token, Tree]
+ *      style: ScalaStyle,
+ *      tree: Tree,
+ *      toks: Array[FormatToken],
+ *      statementStarts: Set[Token],
+ *      owners: Map[Token, Tree]
  *  )
  *  }}}
  */
@@ -1982,19 +1982,19 @@ val a = 1
 /** Nice scala code:
  *  ```scala
  *  class Formatter(
- *    style: ScalaStyle,
- *    tree1: Tree
+ *      style: ScalaStyle,
+ *      tree1: Tree
  *  )
  *  class Formatter(
- *    style: ScalaStyle,
- *    tree12: Tree
+ *      style: ScalaStyle,
+ *      tree12: Tree
  *  )
  *  class Formatter(
- *    style: ScalaStyle,
- *    tree: Tree,
- *    toks: Array[FormatToken],
- *    statementStarts: Set[Token],
- *    owners: Map[Token, Tree]
+ *      style: ScalaStyle,
+ *      tree: Tree,
+ *      toks: Array[FormatToken],
+ *      statementStarts: Set[Token],
+ *      owners: Map[Token, Tree]
  *  )
  *  ```
  *  No more nice scala code.
@@ -2645,66 +2645,48 @@ object a {
 
   /** ```
    *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-   *  )
-   *  ```
-   *  ```
-   *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
    *    "io.get-coursier" % "interface"  % "0.0.17"
    *  )
    *  ```
    *  ```
    *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
    *    "io.get-coursier" % "interface"  % "0.0.17"
    *  )
    *  ```
    *  ```
+   *    libraryDependencies ++= Seq(
+   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *      "io.get-coursier" % "interface"  % "0.0.17"
+   *    )
+   *  ```
+   *  ```
    *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
    *    "io.get-coursier" % "interface"  % "0.0.17"
    *  )
    *  ```
    *  ```scala
    *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-   *  )
-   *  ```
-   *  ```scala
-   *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
    *    "io.get-coursier" % "interface"  % "0.0.17"
    *  )
    *  ```
    *  ```scala
    *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
    *    "io.get-coursier" % "interface"  % "0.0.17"
    *  )
    *  ```
    *  ```scala
+   *    libraryDependencies ++= Seq(
+   *      "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *      "io.get-coursier" % "interface"  % "0.0.17"
+   *    )
+   *  ```
+   *  ```scala
    *  libraryDependencies ++= Seq(
-   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
-   *  "io.get-coursier" % "interface"  % "0.0.17"
-Idempotency violated
    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
    *    "io.get-coursier" % "interface"  % "0.0.17"
    *  )

--- a/scalafmt-tests/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/src/test/resources/test/JavaDoc.stat
@@ -2116,3 +2116,755 @@ object a {
    * ```
    */
 }
+<<< indents within markdown code block, Asterisk
+align.preset = more
+docstrings.wrap = yes
+docstrings.style = Asterisk
+===
+object a {
+  /**
+    * ```
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * ```
+    * ```
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * ```
+    *  ```
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  ```
+    * ```scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```scala
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * ```
+    * ```scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * ```
+    *  ```scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  ```
+    */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+>>>
+object a {
+
+  /**
+   * ```
+   * libraryDependencies ++= Seq(
+   * "org.scalacheck" %% "scalacheck" % scalacheckV,
+   * "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * ```
+   * ```
+   * libraryDependencies ++= Seq(
+   * "org.scalacheck" %% "scalacheck" % scalacheckV,
+   * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * ```
+   * ```
+   * libraryDependencies ++= Seq(
+   * "org.scalacheck" %% "scalacheck" % scalacheckV,
+   * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * ```
+   * ```
+   * libraryDependencies ++= Seq(
+   * "org.scalacheck" %% "scalacheck" % scalacheckV,
+   * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * ```
+   * ```scala
+   * libraryDependencies ++= Seq(
+   * "org.scalacheck" %% "scalacheck" % scalacheckV,
+   * "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * ```
+   * ```scala
+   * libraryDependencies ++= Seq(
+   * "org.scalacheck" %% "scalacheck" % scalacheckV,
+   * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * ```
+   * ```scala
+   * libraryDependencies ++= Seq(
+   * "org.scalacheck" %% "scalacheck" % scalacheckV,
+   * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * ```
+   * ```scala
+   * libraryDependencies ++= Seq(
+   * "org.scalacheck" %% "scalacheck" % scalacheckV,
+   * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * ```
+   */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+<<< indents within code block, Asterisk
+align.preset = more
+docstrings.wrap = yes
+docstrings.style = Asterisk
+===
+object a {
+  /**
+    * {{{
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * }}}
+    * {{{
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    *  {{{
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  }}}
+    * {{{
+    * // scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    *  // scala
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * }}}
+    * {{{
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    *  {{{
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  }}}
+    */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+>>>
+object a {
+
+  /**
+   * {{{
+   * libraryDependencies ++= Seq(
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * }}}
+   * {{{
+   * libraryDependencies ++= Seq(
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * }}}
+   * {{{
+   *   libraryDependencies ++= Seq(
+   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *     "io.get-coursier" % "interface"  % "0.0.17"
+   *   )
+   * }}}
+   * {{{
+   *   libraryDependencies ++= Seq(
+   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *     "io.get-coursier" % "interface"  % "0.0.17"
+   *   )
+   * }}}
+   * {{{
+   * // scala
+   * libraryDependencies ++= Seq(
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * }}}
+   * {{{
+   * // scala
+   * libraryDependencies ++= Seq(
+   *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *   "io.get-coursier" % "interface"  % "0.0.17"
+   * )
+   * }}}
+   * {{{
+   *   // scala
+   *   libraryDependencies ++= Seq(
+   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *     "io.get-coursier" % "interface"  % "0.0.17"
+   *   )
+   * }}}
+   * {{{
+   *   // scala
+   *   libraryDependencies ++= Seq(
+   *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *     "io.get-coursier" % "interface"  % "0.0.17"
+   *   )
+   * }}}
+   */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+<<< indents within markdown code block, SpaceAsterisk
+align.preset = more
+docstrings.wrap = yes
+docstrings.style = SpaceAsterisk
+===
+object a {
+  /**
+    * ```
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * ```
+    * ```
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * ```
+    *  ```
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  ```
+    * ```scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```scala
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * ```
+    * ```scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * ```
+    *  ```scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  ```
+    */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+>>>
+object a {
+
+  /** ```
+    * libraryDependencies ++= Seq(
+    * "org.scalacheck" %% "scalacheck" % scalacheckV,
+    * "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```
+    * libraryDependencies ++= Seq(
+    * "org.scalacheck" %% "scalacheck" % scalacheckV,
+    * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```
+    * libraryDependencies ++= Seq(
+    * "org.scalacheck" %% "scalacheck" % scalacheckV,
+    * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```
+    * libraryDependencies ++= Seq(
+    * "org.scalacheck" %% "scalacheck" % scalacheckV,
+    * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```scala
+    * libraryDependencies ++= Seq(
+    * "org.scalacheck" %% "scalacheck" % scalacheckV,
+    * "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```scala
+    * libraryDependencies ++= Seq(
+    * "org.scalacheck" %% "scalacheck" % scalacheckV,
+    * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```scala
+    * libraryDependencies ++= Seq(
+    * "org.scalacheck" %% "scalacheck" % scalacheckV,
+    * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```scala
+    * libraryDependencies ++= Seq(
+    * "org.scalacheck" %% "scalacheck" % scalacheckV,
+    * "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+<<< indents within code block, SpaceAsterisk
+align.preset = more
+docstrings.wrap = yes
+docstrings.style = SpaceAsterisk
+===
+object a {
+  /**
+    * {{{
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * }}}
+    * {{{
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    *  {{{
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  }}}
+    * {{{
+    * // scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    *  // scala
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * }}}
+    * {{{
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    *  {{{
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  }}}
+    */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+>>>
+object a {
+
+  /** {{{
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    * {{{
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    * {{{
+    * // scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    * // scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    * {{{
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+<<< indents within markdown code block, AsteriskSpace
+align.preset = more
+docstrings.wrap = yes
+docstrings.style = AsteriskSpace
+===
+object a {
+  /**
+    * ```
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * ```
+    * ```
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * ```
+    *  ```
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  ```
+    * ```scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * ```
+    * ```scala
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * ```
+    * ```scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * ```
+    *  ```scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  ```
+    */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+>>>
+object a {
+
+  /** ```
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  ```
+   *  ```
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  ```
+   *  ```
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  ```
+   *  ```
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  ```
+   *  ```scala
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  ```
+   *  ```scala
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  ```
+   *  ```scala
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  ```
+   *  ```scala
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+Idempotency violated
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  ```
+   */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+<<< indents within code block, AsteriskSpace
+align.preset = more
+docstrings.wrap = yes
+docstrings.style = AsteriskSpace
+===
+object a {
+  /**
+    * {{{
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * }}}
+    * {{{
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    *  {{{
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  }}}
+    * {{{
+    * // scala
+    * libraryDependencies ++= Seq(
+    *   "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *   "io.get-coursier" % "interface"  % "0.0.17"
+    * )
+    * }}}
+    * {{{
+    *  // scala
+    *  libraryDependencies ++= Seq(
+    *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *    "io.get-coursier" % "interface"  % "0.0.17"
+    *  )
+    * }}}
+    * {{{
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    * }}}
+    *  {{{
+    *   // scala
+    *   libraryDependencies ++= Seq(
+    *     "org.scalacheck" %% "scalacheck" % scalacheckV,
+    *     "io.get-coursier" % "interface"  % "0.0.17"
+    *   )
+    *  }}}
+    */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}
+>>>
+object a {
+
+  /** {{{
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  }}}
+   *  {{{
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  }}}
+   *  {{{
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  }}}
+   *  {{{
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  }}}
+   *  {{{
+   *  // scala
+   *  libraryDependencies ++= Seq(
+   *  "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *  "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  }}}
+   *  {{{
+   *  // scala
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  }}}
+   *  {{{
+   *  // scala
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  }}}
+   *  {{{
+   *  // scala
+   *  libraryDependencies ++= Seq(
+   *    "org.scalacheck" %% "scalacheck" % scalacheckV,
+   *    "io.get-coursier" % "interface"  % "0.0.17"
+   *  )
+   *  }}}
+   */
+  def getAlignColumn(floc: FormatLocation): Int = _
+}


### PR DESCRIPTION
- The regular code blocks contain full leading whitespace while markdown block are relative to the opening fence thus handle them differently.
- Fix an off-by-1 margin calculation applicable to all code blocks.
- Allow top-level terms in scaladoc.