### PR TITLE
FormatOps: find stmt starts after redundant parens

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -90,7 +90,7 @@ class FormatOps(
 
   private[internal] val soft = new SoftKeywordClasses(dialect)
   private[internal] val statementStarts =
-    getStatementStarts(topSourceTree, tokens(_).left, soft)
+    getStatementStarts(topSourceTree, tokens.after(_).left, soft)
   // Maps token to number of non-whitespace bytes before the token's position.
   private final val nonWhitespaceOffset: Map[Token, Int] = {
     val resultB = Map.newBuilder[Token, Int]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -103,7 +103,8 @@ object TreeOps {
     val ret = Map.newBuilder[TokenHash, Tree]
     ret.sizeHint(tree.tokens.length)
 
-    def addTok(token: Token, tree: Tree) = ret += hash(token) -> tree
+    def addTok(token: Token, tree: Tree) =
+      ret += hash(replacedWith(token)) -> tree
     def addTree(t: Tree, tree: Tree) =
       t.tokens.find(!_.is[Trivia]).foreach(addTok(_, tree))
     def addAll(trees: Seq[Tree]) = trees.foreach(x => addTree(x, x))

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -743,3 +743,29 @@ object Application {
 
   def main(args: Array[String]): Unit = app.run(args)
 }
+<<< #2712 literal
+class Toto() {
+  private def myScalaFmtTest(): String = {
+    val test = new Toto
+    ("test")
+  }
+}
+>>>
+test does not parse
+class Toto() {
+  private def myScalaFmtTest(): String = {
+    val test = new Toto "test"
+                      ^
+<<< #2712 name
+class Toto() {
+  private def myScalaFmtTest(): String = {
+    val test = new Toto
+    (a)
+  }
+}
+>>>
+class Toto() {
+  private def myScalaFmtTest(): String = {
+    val test = new Toto a
+  }
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -751,11 +751,12 @@ class Toto() {
   }
 }
 >>>
-test does not parse
 class Toto() {
   private def myScalaFmtTest(): String = {
-    val test = new Toto "test"
-                      ^
+    val test = new Toto
+    "test"
+  }
+}
 <<< #2712 name
 class Toto() {
   private def myScalaFmtTest(): String = {
@@ -766,6 +767,7 @@ class Toto() {
 >>>
 class Toto() {
   private def myScalaFmtTest(): String = {
-    val test = new Toto a
+    val test = new Toto
+    a
   }
 }


### PR DESCRIPTION
Fixes #2712.