### PR TITLE
Respect newlines parameter in extension methods with a single param

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1894,3 +1894,19 @@ given liftPropertyAlias: NiceLiftable[PropertyAlias] with {
   def lift =
      case PropertyAlias(a, b) => '{ PropertyAlias(${ a.expr }, ${ b.expr }) }
 }
+<<< #2725 newline after extension parameter
+extension (a: All) 
+  def getAll: Boolean = a
+>>>
+extension (a: All) def getAll: Boolean = a
+<<< #2725 newline after extension parameter short
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All) def getAll: Boolean = a
+<<< #2725 newline after extension parameter long
+maxColumn = 40
+===
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1846,3 +1846,19 @@ given liftPropertyAlias: NiceLiftable[PropertyAlias] with {
   def lift =
      case PropertyAlias(a, b) => '{ PropertyAlias(${ a.expr }, ${ b.expr }) }
 }
+<<< #2725 newline after extension parameter
+extension (a: All) 
+  def getAll: Boolean = a
+>>>
+extension (a: All) def getAll: Boolean = a
+<<< #2725 newline after extension parameter short
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All) def getAll: Boolean = a
+<<< #2725 newline after extension parameter long
+maxColumn = 40
+===
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1934,3 +1934,20 @@ given liftPropertyAlias: NiceLiftable[PropertyAlias] with {
   def lift =
      case PropertyAlias(a, b) => '{ PropertyAlias(${ a.expr }, ${ b.expr }) }
 }
+<<< #2725 newline after extension parameter
+extension (a: All) 
+  def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a
+<<< #2725 newline after extension parameter short
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All) def getAll: Boolean = a
+<<< #2725 newline after extension parameter long
+maxColumn = 40
+===
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2051,3 +2051,21 @@ given liftPropertyAlias: NiceLiftable[PropertyAlias] with {
          )
        }
 }
+<<< #2725 newline after extension parameter
+extension (a: All) 
+  def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a
+<<< #2725 newline after extension parameter short
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a
+<<< #2725 newline after extension parameter long
+maxColumn = 40
+===
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalafmt/issues/2725