### PR TITLE
Cli `--test` - return non zero exit code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ docs/xx.md
 .metals/
 metals.sbt
 .bloop/
+.vscode
 
 node_modules/
 .java-version

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -154,7 +154,7 @@ object Cli {
     if (
       options.writeMode == WriteMode.Test &&
       !options.fatalWarnings &&
-      !exit.is(ExitCode.TestError)
+      exit.is(ExitCode.ParseError)
     ) {
       // Ignore parse errors etc.
       ExitCode.Ok

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -199,6 +199,19 @@ trait CliTestBehavior { this: AbstractCliTest =>
       val str = FileOps.readFile(tmpFile.toString)
       assertNoDiff(str, unformatted)
     }
+    test(s"scalafmt --test fails with non zero exit code $label") {
+      val tmpFile = Files.createTempFile("prefix", ".scala")
+      Files.write(tmpFile, unformatted.getBytes)
+      val args = Array(
+        tmpFile.toFile.getPath,
+        "--test",
+        "--config-str",
+        s"""{version="$version",style=IntelliJ, docstring = Asterisk}"""
+      )
+      val formatInPlace = getConfig(args)
+      val exit = Cli.run(formatInPlace)
+      assert(exit.is(ExitCode.UnexpectedError))
+    }
 
     test(s"scalafmt foo.randomsuffix is formatted: $label") {
       val tmpFile = Files.createTempFile("prefix", "randomsuffix")


### PR DESCRIPTION
Previously, in case if there an error in configuration the error was suppressed and the exit code was `0`.
That's affected scalafmt [upgrade in scalameta/scalameta](https://github.com/scalameta/scalameta/runs/3392476513#step:4:37) where we didn't notice that our config is wrong.