### PR TITLE
ConvertToNewScala3Syntax: guard on dialect flags

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1328,11 +1328,11 @@ object a {
 }
 >>>
 object a {
-  import A.{min => minimum, `*` => multiply}
-  import Predef.{augmentString => _, _}
-  import scala.{annotation => ann}
+  import A.{min as minimum, `*` as multiply}
+  import Predef.{augmentString as _, *}
+  import scala.{annotation as ann}
   import java as j
-  import Predef.{augmentString => _}
+  import Predef.{augmentString as _}
 }
 <<< rewrite to new syntax, wildcard
 rewrite.scala3.convertToNewSyntax = true
@@ -1353,7 +1353,7 @@ object a {
 }
 >>>
 object a {
-  def foo(a: Foo[_]): Unit = ???
+  def foo(a: Foo[?]): Unit = ???
 }
 <<< rewrite to new syntax, vararg splices, call
 rewrite.scala3.convertToNewSyntax = true
@@ -1373,7 +1373,7 @@ def foo: Unit =
   foo(a: _*)
 >>>
 def foo: Unit =
-  foo(a: _*)
+  foo(a*)
 <<< rewrite to new syntax, vararg splices, pat bind
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1398,7 +1398,7 @@ object a {
 >>>
 object a {
   lst match {
-    case List(0, 1, xs @ _*) => foo
+    case List(0, 1, xs*) => foo
   }
 }
 <<< if break before then if multiline cond

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1314,6 +1314,26 @@ object a:
    import scala.{annotation as ann}
    import java as j
    import Predef.{augmentString as _}
+<<< rewrite to new syntax, imports, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+ import A.{min => minimum, `*` => multiply}
+ import Predef.{augmentString => _, _}
+ import scala.{annotation => ann}
+ import java as j
+ import Predef.{augmentString => _}
+}
+>>>
+object a {
+  import A.{min => minimum, `*` => multiply}
+  import Predef.{augmentString => _, _}
+  import scala.{annotation => ann}
+  import java as j
+  import Predef.{augmentString => _}
+}
 <<< rewrite to new syntax, wildcard
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1323,6 +1343,18 @@ object a:
 >>>
 object a:
    def foo(a: Foo[?]): Unit = ???
+<<< rewrite to new syntax, wildcard, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+  def foo(a: Foo[_]): Unit = ???
+}
+>>>
+object a {
+  def foo(a: Foo[_]): Unit = ???
+}
 <<< rewrite to new syntax, vararg splices, call
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1332,6 +1364,16 @@ def foo: Unit =
 >>>
 def foo: Unit =
   foo(a*)
+<<< rewrite to new syntax, vararg splices, call, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+def foo: Unit =
+  foo(a: _*)
+>>>
+def foo: Unit =
+  foo(a: _*)
 <<< rewrite to new syntax, vararg splices, pat bind
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1343,6 +1385,22 @@ object a:
 object a:
    lst match
       case List(0, 1, xs*) => foo
+<<< rewrite to new syntax, vararg splices, pat bind, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+  lst match {
+    case List(0, 1, xs @ _*) => foo
+  }
+}
+>>>
+object a {
+  lst match {
+    case List(0, 1, xs @ _*) => foo
+  }
+}
 <<< if break before then if multiline cond
 maxColumn = 12
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1284,11 +1284,11 @@ object a {
 }
 >>>
 object a {
-  import A.{min => minimum, `*` => multiply}
-  import Predef.{augmentString => _, _}
-  import scala.{annotation => ann}
+  import A.{min as minimum, `*` as multiply}
+  import Predef.{augmentString as _, *}
+  import scala.{annotation as ann}
   import java as j
-  import Predef.{augmentString => _}
+  import Predef.{augmentString as _}
 }
 <<< rewrite to new syntax, wildcard
 rewrite.scala3.convertToNewSyntax = true
@@ -1309,7 +1309,7 @@ object a {
 }
 >>>
 object a {
-  def foo(a: Foo[_]): Unit = ???
+  def foo(a: Foo[?]): Unit = ???
 }
 <<< rewrite to new syntax, vararg splices, call
 rewrite.scala3.convertToNewSyntax = true
@@ -1327,7 +1327,7 @@ runner.dialect = scala213source3
 def foo: Unit =
   foo(a: _*)
 >>>
-def foo: Unit = foo(a: _*)
+def foo: Unit = foo(a*)
 <<< rewrite to new syntax, vararg splices, pat bind
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1351,7 +1351,7 @@ object a {
 }
 >>>
 object a {
-  lst match { case List(0, 1, xs @ _*) => foo }
+  lst match { case List(0, 1, xs*) => foo }
 }
 <<< if break before then if multiline cond
 maxColumn = 12

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1270,6 +1270,26 @@ object a:
    import scala.{annotation as ann}
    import java as j
    import Predef.{augmentString as _}
+<<< rewrite to new syntax, imports, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+ import A.{min => minimum, `*` => multiply}
+ import Predef.{augmentString => _, _}
+ import scala.{annotation => ann}
+ import java as j
+ import Predef.{augmentString => _}
+}
+>>>
+object a {
+  import A.{min => minimum, `*` => multiply}
+  import Predef.{augmentString => _, _}
+  import scala.{annotation => ann}
+  import java as j
+  import Predef.{augmentString => _}
+}
 <<< rewrite to new syntax, wildcard
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1279,6 +1299,18 @@ object a:
 >>>
 object a:
    def foo(a: Foo[?]): Unit = ???
+<<< rewrite to new syntax, wildcard, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+  def foo(a: Foo[_]): Unit = ???
+}
+>>>
+object a {
+  def foo(a: Foo[_]): Unit = ???
+}
 <<< rewrite to new syntax, vararg splices, call
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1287,6 +1319,15 @@ def foo: Unit =
   foo(a: _*)
 >>>
 def foo: Unit = foo(a*)
+<<< rewrite to new syntax, vararg splices, call, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+def foo: Unit =
+  foo(a: _*)
+>>>
+def foo: Unit = foo(a: _*)
 <<< rewrite to new syntax, vararg splices, pat bind
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1298,6 +1339,20 @@ object a:
 object a:
    lst match
       case List(0, 1, xs*) => foo
+<<< rewrite to new syntax, vararg splices, pat bind, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+  lst match {
+    case List(0, 1, xs @ _*) => foo
+  }
+}
+>>>
+object a {
+  lst match { case List(0, 1, xs @ _*) => foo }
+}
 <<< if break before then if multiline cond
 maxColumn = 12
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1350,11 +1350,11 @@ object a {
 }
 >>>
 object a {
-  import A.{min => minimum, `*` => multiply}
-  import Predef.{augmentString => _, _}
-  import scala.{annotation => ann}
+  import A.{min as minimum, `*` as multiply}
+  import Predef.{augmentString as _, *}
+  import scala.{annotation as ann}
   import java as j
-  import Predef.{augmentString => _}
+  import Predef.{augmentString as _}
 }
 <<< rewrite to new syntax, wildcard
 rewrite.scala3.convertToNewSyntax = true
@@ -1375,7 +1375,7 @@ object a {
 }
 >>>
 object a {
-  def foo(a: Foo[_]): Unit = ???
+  def foo(a: Foo[?]): Unit = ???
 }
 <<< rewrite to new syntax, vararg splices, call
 rewrite.scala3.convertToNewSyntax = true
@@ -1395,7 +1395,7 @@ def foo: Unit =
   foo(a: _*)
 >>>
 def foo: Unit =
-  foo(a: _*)
+  foo(a*)
 <<< rewrite to new syntax, vararg splices, pat bind
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1420,7 +1420,7 @@ object a {
 >>>
 object a {
   lst match {
-    case List(0, 1, xs @ _*) => foo
+    case List(0, 1, xs*) => foo
   }
 }
 <<< if break before then if multiline cond

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1336,6 +1336,26 @@ object a:
    import scala.{annotation as ann}
    import java as j
    import Predef.{augmentString as _}
+<<< rewrite to new syntax, imports, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+ import A.{min => minimum, `*` => multiply}
+ import Predef.{augmentString => _, _}
+ import scala.{annotation => ann}
+ import java as j
+ import Predef.{augmentString => _}
+}
+>>>
+object a {
+  import A.{min => minimum, `*` => multiply}
+  import Predef.{augmentString => _, _}
+  import scala.{annotation => ann}
+  import java as j
+  import Predef.{augmentString => _}
+}
 <<< rewrite to new syntax, wildcard
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1345,6 +1365,18 @@ object a:
 >>>
 object a:
    def foo(a: Foo[?]): Unit = ???
+<<< rewrite to new syntax, wildcard, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+  def foo(a: Foo[_]): Unit = ???
+}
+>>>
+object a {
+  def foo(a: Foo[_]): Unit = ???
+}
 <<< rewrite to new syntax, vararg splices, call
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1354,6 +1386,16 @@ def foo: Unit =
 >>>
 def foo: Unit =
   foo(a*)
+<<< rewrite to new syntax, vararg splices, call, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+def foo: Unit =
+  foo(a: _*)
+>>>
+def foo: Unit =
+  foo(a: _*)
 <<< rewrite to new syntax, vararg splices, pat bind
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1365,6 +1407,22 @@ object a:
 object a:
    lst match
       case List(0, 1, xs*) => foo
+<<< rewrite to new syntax, vararg splices, pat bind, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+  lst match {
+    case List(0, 1, xs @ _*) => foo
+  }
+}
+>>>
+object a {
+  lst match {
+    case List(0, 1, xs @ _*) => foo
+  }
+}
 <<< if break before then if multiline cond
 maxColumn = 12
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1472,11 +1472,11 @@ object a {
 }
 >>>
 object a {
-  import A.{min => minimum, `*` => multiply}
-  import Predef.{augmentString => _, _}
-  import scala.{annotation => ann}
+  import A.{min as minimum, `*` as multiply}
+  import Predef.{augmentString as _, *}
+  import scala.{annotation as ann}
   import java as j
-  import Predef.{augmentString => _}
+  import Predef.{augmentString as _}
 }
 <<< rewrite to new syntax, wildcard
 rewrite.scala3.convertToNewSyntax = true
@@ -1497,7 +1497,7 @@ object a {
 }
 >>>
 object a {
-  def foo(a: Foo[_]): Unit = ???
+  def foo(a: Foo[?]): Unit = ???
 }
 <<< rewrite to new syntax, vararg splices, call
 rewrite.scala3.convertToNewSyntax = true
@@ -1515,7 +1515,7 @@ runner.dialect = scala213source3
 def foo: Unit =
   foo(a: _*)
 >>>
-def foo: Unit = foo(a: _*)
+def foo: Unit = foo(a*)
 <<< rewrite to new syntax, vararg splices, pat bind
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1541,7 +1541,7 @@ object a {
 >>>
 object a {
   lst match {
-    case List(0, 1, xs @ _*) =>
+    case List(0, 1, xs*) =>
       foo
   }
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1458,6 +1458,26 @@ object a:
    import scala.{annotation as ann}
    import java as j
    import Predef.{augmentString as _}
+<<< rewrite to new syntax, imports, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+ import A.{min => minimum, `*` => multiply}
+ import Predef.{augmentString => _, _}
+ import scala.{annotation => ann}
+ import java as j
+ import Predef.{augmentString => _}
+}
+>>>
+object a {
+  import A.{min => minimum, `*` => multiply}
+  import Predef.{augmentString => _, _}
+  import scala.{annotation => ann}
+  import java as j
+  import Predef.{augmentString => _}
+}
 <<< rewrite to new syntax, wildcard
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1467,6 +1487,18 @@ object a:
 >>>
 object a:
    def foo(a: Foo[?]): Unit = ???
+<<< rewrite to new syntax, wildcard, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+  def foo(a: Foo[_]): Unit = ???
+}
+>>>
+object a {
+  def foo(a: Foo[_]): Unit = ???
+}
 <<< rewrite to new syntax, vararg splices, call
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1475,6 +1507,15 @@ def foo: Unit =
   foo(a: _*)
 >>>
 def foo: Unit = foo(a*)
+<<< rewrite to new syntax, vararg splices, call, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+def foo: Unit =
+  foo(a: _*)
+>>>
+def foo: Unit = foo(a: _*)
 <<< rewrite to new syntax, vararg splices, pat bind
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = yes
@@ -1487,6 +1528,23 @@ object a:
    lst match
       case List(0, 1, xs*) =>
         foo
+<<< rewrite to new syntax, vararg splices, pat bind, scala2-source3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+runner.dialect = scala213source3
+===
+object a {
+  lst match {
+    case List(0, 1, xs @ _*) => foo
+  }
+}
+>>>
+object a {
+  lst match {
+    case List(0, 1, xs @ _*) =>
+      foo
+  }
+}
 <<< if break before then if multiline cond
 maxColumn = 12
 ===


### PR DESCRIPTION
Remove the overall guard on significant indentation. Fixes #2730.