### PR TITLE
RemoveEmptyDocstrings: implement as a rewrite rule

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3146,7 +3146,7 @@ docstrings.style = AsteriskSpace
 
 ### `docstrings.removeEmpty`
 
-If set, will cause empty standalone docstrings to be removed.
+If set, will cause empty docstrings to be removed.
 
 > Since v3.0.4.
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -129,8 +129,6 @@ class FormatWriter(formatOps: FormatOps) {
       if (initStyle.rewrite.scala3.insertEndMarkerMinLines > 0)
         checkInsertEndMarkers(result)
     }
-    if (initStyle.docstrings.removeEmpty)
-      checkRemoveEmptyDocstrings(result)
     if (
       initStyle.rewrite.rules.contains(RedundantBraces) &&
       !initStyle.rewrite.redundantBraces.parensForOneLineApply.contains(false)
@@ -321,27 +319,6 @@ class FormatWriter(formatOps: FormatOps) {
         }
       }
     }
-
-  private def checkRemoveEmptyDocstrings(
-      locations: Array[FormatLocation]
-  ): Unit = {
-    var removedLines = 0
-    locations.foreach { x =>
-      val ft = x.formatToken
-      val idx = ft.meta.idx
-      val floc = if (removedLines > 0 && x.leftLineId >= 0) {
-        val floc = x.copy(leftLineId = x.leftLineId + removedLines)
-        locations(idx) = floc
-        floc
-      } else x
-      val ok = ft.left.is[T.Comment] && floc.isStandalone &&
-        emptyDocstring.matcher(ft.meta.left.text).matches()
-      if (ok) {
-        locations(idx) = floc.copy(leftLineId = -1)
-        removedLines += 1
-      }
-    }
-  }
 
   class FormatLocations(val locations: Array[FormatLocation]) {
 
@@ -1746,5 +1723,8 @@ object FormatWriter {
       beg: FormatToken,
       end: FormatToken
   ): Int = getLineDiff(toks(beg.meta.idx), toks(end.meta.idx))
+
+  def isEmptyDocstring(text: String): Boolean =
+    emptyDocstring.matcher(text).matches()
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -190,6 +190,7 @@ object FormatTokensRewrite {
   private val factories = Seq(
     RemoveScala3OptionalBraces,
     ConvertToNewScala3Syntax,
+    RemoveEmptyDocstrings,
     RewriteTrailingCommas
   )
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -148,7 +148,8 @@ class FormatTokensRewrite(
         // below, only non-paired tokens
 
         case _: T.Comment => // formatOff gets set only by comment
-          if (formatOffStack.nonEmpty && ft.meta.formatOff)
+          if (!ft.meta.formatOff) applyRules
+          else if (formatOffStack.nonEmpty)
             formatOffStack.update(0, true)
 
         case _ if ft.meta.formatOff =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveEmptyDocstrings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveEmptyDocstrings.scala
@@ -1,0 +1,36 @@
+package org.scalafmt.rewrite
+
+import scala.meta._
+import scala.meta.tokens.Token
+
+import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.internal.FormatToken
+import org.scalafmt.internal.FormatTokens
+import org.scalafmt.internal.FormatWriter
+
+object RemoveEmptyDocstrings
+    extends FormatTokensRewrite.Rule
+    with FormatTokensRewrite.RuleFactory {
+
+  import FormatTokensRewrite._
+
+  override def enabled(implicit style: ScalafmtConfig): Boolean =
+    style.docstrings.removeEmpty
+
+  override def create(ftoks: FormatTokens): FormatTokensRewrite.Rule = this
+
+  override def onToken(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Option[Replacement] = {
+    val skip = ft.right.is[Token.Comment] &&
+      FormatWriter.isEmptyDocstring(ft.meta.right.text)
+    if (skip) Some(removeToken) else None
+  }
+
+  override def onRight(lt: Replacement, hasFormatOff: Boolean)(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Option[(Replacement, Replacement)] = None
+
+}


### PR DESCRIPTION
Fixes #2039. Follow-up to #2733.