### PR TITLE
FormatWriter: valid syntax for end marker labels

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1671,35 +1671,35 @@ object FormatWriter {
   private def getEndMarkerLabel(tree: Tree): String = tree match {
     // templates
     case _: Term.NewAnonymous => "new"
-    case t: Defn.Class => t.name.value
-    case t: Defn.Object => t.name.value
-    case t: Defn.Trait => t.name.value
-    case t: Defn.Enum => t.name.value
+    case t: Defn.Class => t.name.toString
+    case t: Defn.Object => t.name.toString
+    case t: Defn.Trait => t.name.toString
+    case t: Defn.Enum => t.name.toString
     case t: Defn.Given =>
-      val label = t.name.value
+      val label = t.name.toString
       if (label.isEmpty) "given" else label
-    case t: Pkg.Object => t.name.value
+    case t: Pkg.Object => t.name.toString
     // definitions
-    case t: Defn.Def => t.name.value
+    case t: Defn.Def => t.name.toString
     case t: Defn.GivenAlias =>
-      val label = t.name.value
+      val label = t.name.toString
       if (label.isEmpty) "given" else label
-    case t: Defn.Type => t.name.value
+    case t: Defn.Type => t.name.toString
     case t: Defn.Val =>
       t.pats match {
-        case List(Pat.Var(n)) => n.value
+        case List(Pat.Var(n)) => n.toString
         case _ => "val"
       }
     case t: Defn.Var =>
       t.pats match {
-        case List(Pat.Var(n)) => n.value
+        case List(Pat.Var(n)) => n.toString
         case _ => "var"
       }
     // other
     case t: Pkg =>
       t.ref match {
-        case x: Term.Name => x.value
-        case x: Term.Select => x.name.value
+        case x: Term.Name => x.toString
+        case x: Term.Select => x.name.toString
         case _ => null
       }
     case _: meta.Ctor.Secondary => "this"

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1975,8 +1975,6 @@ rewrite.scala3.insertEndMarkerMinLines = 1
 object `Accept-Ranges`:
   val r = ""
 >>>
-test does not parse
 object `Accept-Ranges`:
    val r = ""
-end Accept-Ranges
-^
+end `Accept-Ranges`

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1968,3 +1968,15 @@ extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
   def getAll: Boolean = a
+<<< #2740
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 1
+===
+object `Accept-Ranges`:
+  val r = ""
+>>>
+test does not parse
+object `Accept-Ranges`:
+   val r = ""
+end Accept-Ranges
+^

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1924,8 +1924,6 @@ rewrite.scala3.insertEndMarkerMinLines = 1
 object `Accept-Ranges`:
   val r = ""
 >>>
-test does not parse
 object `Accept-Ranges`:
    val r = ""
-end Accept-Ranges
-^
+end `Accept-Ranges`

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1917,3 +1917,15 @@ extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
   def getAll: Boolean = a
+<<< #2740
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 1
+===
+object `Accept-Ranges`:
+  val r = ""
+>>>
+test does not parse
+object `Accept-Ranges`:
+   val r = ""
+end Accept-Ranges
+^

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2009,3 +2009,15 @@ extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
   def getAll: Boolean = a
+<<< #2740
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 1
+===
+object `Accept-Ranges`:
+  val r = ""
+>>>
+test does not parse
+object `Accept-Ranges`:
+   val r = ""
+end Accept-Ranges
+^

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2016,8 +2016,6 @@ rewrite.scala3.insertEndMarkerMinLines = 1
 object `Accept-Ranges`:
   val r = ""
 >>>
-test does not parse
 object `Accept-Ranges`:
    val r = ""
-end Accept-Ranges
-^
+end `Accept-Ranges`

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2127,3 +2127,15 @@ extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
   def getAll: Boolean = a
+<<< #2740
+runner.parser = source
+rewrite.scala3.insertEndMarkerMinLines = 1
+===
+object `Accept-Ranges`:
+  val r = ""
+>>>
+test does not parse
+object `Accept-Ranges`:
+   val r = ""
+end Accept-Ranges
+^

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2134,8 +2134,6 @@ rewrite.scala3.insertEndMarkerMinLines = 1
 object `Accept-Ranges`:
   val r = ""
 >>>
-test does not parse
 object `Accept-Ranges`:
    val r = ""
-end Accept-Ranges
-^
+end `Accept-Ranges`


### PR DESCRIPTION
Fixes #2740.