### PR TITLE
Router: rule for comment left before comment right

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -49,7 +49,6 @@ object TokenOps {
       ft: FormatToken
   )(implicit style: ScalafmtConfig): Boolean =
     style.optIn.forceNewlineBeforeDocstringSummary &&
-      ft.right.is[Token.Comment] && !ft.left.is[Token.Comment] &&
       isDocstring(ft.meta.right.text) &&
       TreeOps
         .findTreeOrParent(ft.meta.leftOwner) {


### PR DESCRIPTION
This simplifies the case when both left and right are comments. Helps with #2755.