### PR TITLE
TreeOps: fix statement start for rewritten lambda

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -180,8 +180,8 @@ object TreeOps {
           }
         // special handling for rewritten apply(x => { b }) to a { x => b }
         case Term.Apply(_, List(f: Term.Function))
-            if f.tokens.lastOption // see if closing brace was moved
-              .exists(x => x.is[Token.RightBrace] && replacedWith(x).ne(x)) =>
+            if subtree.tokens.lastOption // see if closing paren was moved
+              .exists(x => x.is[Token.RightParen] && replacedWith(x).ne(x)) =>
           addAll(Seq(f))
         case t => // Nothing
           addAll(extractStatementsIfAny(t))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -142,8 +142,8 @@ object TreeOps {
       )
     }
 
-    def loop(x: Tree): Unit = {
-      x match {
+    def loop(subtree: Tree): Unit = {
+      subtree match {
         case t: Defn.Class => addDefn[KwClass](t.mods, t)
         case t: Defn.Def => addDefn[KwDef](t.mods, t)
         case t: Defn.Given => addDefn[KwGiven](t.mods, t)
@@ -186,7 +186,7 @@ object TreeOps {
         case t => // Nothing
           addAll(extractStatementsIfAny(t))
       }
-      x.children.foreach(loop)
+      subtree.children.foreach(loop)
     }
     loop(tree)
     ret.result()

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1978,3 +1978,21 @@ object `Accept-Ranges`:
 object `Accept-Ranges`:
    val r = ""
 end `Accept-Ranges`
+<<< #2781
+rewrite.scala3.removeOptionalBraces = yes
+===
+object x:
+  val y = List(1).map(v => {
+    println(v)
+    v + 1
+  })
+>>>
+Idempotency violated
+ object x:
+-   val y = List(1).map(v =>
++   val y = List(1).map(
++   v =>
+       println(v)
+-      v + 1
+-   )
++      v + 1)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1987,12 +1987,8 @@ object x:
     v + 1
   })
 >>>
-Idempotency violated
- object x:
--   val y = List(1).map(v =>
-+   val y = List(1).map(
-+   v =>
-       println(v)
--      v + 1
--   )
-+      v + 1)
+object x:
+   val y = List(1).map(v =>
+      println(v)
+      v + 1
+   )

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1936,12 +1936,8 @@ object x:
     v + 1
   })
 >>>
-Idempotency violated
- object x:
--   val y = List(1).map(v =>
-+   val y = List(1).map(
-+   v =>
-       println(v)
--      v + 1
--   )
-+      v + 1)
+object x:
+   val y = List(1).map(v =>
+      println(v)
+      v + 1
+   )

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1927,3 +1927,21 @@ object `Accept-Ranges`:
 object `Accept-Ranges`:
    val r = ""
 end `Accept-Ranges`
+<<< #2781
+rewrite.scala3.removeOptionalBraces = yes
+===
+object x:
+  val y = List(1).map(v => {
+    println(v)
+    v + 1
+  })
+>>>
+Idempotency violated
+ object x:
+-   val y = List(1).map(v =>
++   val y = List(1).map(
++   v =>
+       println(v)
+-      v + 1
+-   )
++      v + 1)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2019,3 +2019,21 @@ object `Accept-Ranges`:
 object `Accept-Ranges`:
    val r = ""
 end `Accept-Ranges`
+<<< #2781
+rewrite.scala3.removeOptionalBraces = yes
+===
+object x:
+  val y = List(1).map(v => {
+    println(v)
+    v + 1
+  })
+>>>
+Idempotency violated
+ object x:
+-   val y = List(1).map(v =>
++   val y = List(1).map(
++   v =>
+       println(v)
+-      v + 1
+-   )
++      v + 1)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2028,12 +2028,8 @@ object x:
     v + 1
   })
 >>>
-Idempotency violated
- object x:
--   val y = List(1).map(v =>
-+   val y = List(1).map(
-+   v =>
-       println(v)
--      v + 1
--   )
-+      v + 1)
+object x:
+   val y = List(1).map(v =>
+      println(v)
+      v + 1
+   )

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2137,3 +2137,21 @@ object `Accept-Ranges`:
 object `Accept-Ranges`:
    val r = ""
 end `Accept-Ranges`
+<<< #2781
+rewrite.scala3.removeOptionalBraces = yes
+===
+object x:
+  val y = List(1).map(v => {
+    println(v)
+    v + 1
+  })
+>>>
+Idempotency violated
+ object x:
+-   val y = List(1).map(v =>
++   val y = List(1).map(
++   v =>
+       println(v)
+-      v + 1
+-   )
++      v + 1)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2146,12 +2146,8 @@ object x:
     v + 1
   })
 >>>
-Idempotency violated
- object x:
--   val y = List(1).map(v =>
-+   val y = List(1).map(
-+   v =>
-       println(v)
--      v + 1
--   )
-+      v + 1)
+object x:
+   val y = List(1).map(v =>
+      println(v)
+      v + 1
+   )


### PR DESCRIPTION
Addresses non-idempotent formatting in #2781.