### PR TITLE
FormatOps: opt braces for significant indent only

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1094,11 +1094,11 @@ class a(vi: Int, vs: String):
 >>>
 class a(vi: Int, vs: String):
    def this() =
-
      this(0, "")
 
    end this
-   def this(vi: Int) = this(vi, "")
+   def this(vi: Int) =
+     this(vi, "")
    end this
 <<< rewrite with end markers: this; with equals, not only init
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1048,9 +1048,7 @@ class a(vi: Int, vs: String):
   end this
 >>>
 class a(vi: Int, vs: String):
-   def this() =
-
-     this(0, "")
+   def this() = this(0, "")
 
    end this
    def this(vi: Int) = this(vi, "")

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1102,7 +1102,6 @@ class a(vi: Int, vs: String):
 >>>
 class a(vi: Int, vs: String):
    def this() =
-
      this(0, "")
 
    end this

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -1177,13 +1177,10 @@ class a(vi: Int, vs: String):
   end this
 >>>
 class a(vi: Int, vs: String):
-   def this() =
-
-     this(0, "")
+   def this() = this(0, "")
 
    end this
-   def this(vi: Int) =
-     this(vi, "")
+   def this(vi: Int) = this(vi, "")
    end this
 <<< rewrite with end markers: this; with equals, not only init
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo


### PR DESCRIPTION
Let's fall back on regular split rules for cases when we are not using significant indentation, to reduce discrepancy with scala2 codebase and to avoid having to duplicate complex rules.