### PR TITLE
Correcting dockerize job to run when a release is created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - run: git fetch --tags -f
       - run:
-          # for GitOps tests	
+          # for GitOps tests
           git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"
       - run: TEST="2.12" sbt ci-test
         shell: bash
@@ -98,17 +98,23 @@ jobs:
   dockerize:
     needs: [native-image,test]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'release' && github.event.action == 'created'
+    if: startsWith(github.ref, 'refs/tags/v') && github.event_name != 'release'
     steps:
-      - uses: actions/checkout@v2
-      - run: git fetch --unshallow
-      - uses: actions/download-artifact@v2.0.10
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Downloading scalafmt-linux-musl for Docker Build
+        uses: actions/download-artifact@v2.0.10
         with:
           name: scalafmt-linux-musl
           path: tmp/scalafmt-linux-musl
-      - uses: docker/build-push-action@v2.7.0
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: scalameta/scalafmt
-          tag_with_ref: true
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: scalameta/scalafmt:$(echo $GITHUB_REF | cut -d / -f 3)


### PR DESCRIPTION
I believe this step has been broken for a while. The latest tagged docker container on hub is `v2.7.5`

Looking at the actions log from latest release commit https://github.com/scalameta/scalafmt/runs/3777211161

It shows that the artifact was uploaded in the CI:release run, but the `dockerize` job was not executed.

The `dockerize` job was executed in the CI:Push run, but the artifact isn't uploaded in that run, so the `dockerize` step fails

I think this change will correct this behavior, so that when future `v` tag'd releases are created, it will upload the artifact, and then dockerize will run.