### PR TITLE
FormatOps: optional braces after old-style loops

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2121,17 +2121,19 @@ class FormatOps(
               def rightBrace = blockLast(thenp)
             })
           case t @ Term.For(_, b) if !nft.right.is[T.KwDo] =>
-            // unsupported except for right brace
             Some(new OptionalBracesRegion {
-              def owner = None
-              def splits = None
+              def owner = Some(t)
+              def splits =
+                if (!isTreeMultiStatBlock(b)) None
+                else Some(getSplits(ft, b, true))
               def rightBrace = blockLast(b)
             })
           case t @ Term.While(_, b) if !nft.right.is[T.KwDo] =>
-            // unsupported except for right brace
             Some(new OptionalBracesRegion {
-              def owner = None
-              def splits = None
+              def owner = Some(t)
+              def splits =
+                if (!isTreeMultiStatBlock(b)) None
+                else Some(getSplits(ft, b, true))
               def rightBrace = blockLast(b)
             })
           case _ => None

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -2225,8 +2225,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    for (scene <- scenes.all)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    for (scene <- scenes.all)
      scene.updateLogicalState(tpf)
    for (scene <- scenes.all)
@@ -2254,8 +2254,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    while (true)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    while (true)
      scene.updateLogicalState(tpf)
    while (true)
@@ -2285,9 +2285,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    for (scene <- scenes.all)
-     scene.updateLogicalState(tpf)
-   end for
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    end for
    for (scene <- scenes.all)
      scene.updateLogicalState(tpf)
@@ -2321,15 +2320,19 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    while (true)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
+   end while
    while (true)
      scene.updateLogicalState(tpf)
+   end while
    while (true)
      while (true)
        scene.updateLogicalState(tpf)
+   end while
    while (true)
      scene.updateLogicalState(
        tpf,
        scene.updateLogicalState(tpf)
      )
+   end while

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -2152,8 +2152,9 @@ def update(tpf: Float): Unit =
     scene.updateLogicalState(tpf)
 >>>
 def update(tpf: Float): Unit =
-   for (scene <- scenes.all) scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+   for (scene <- scenes.all)
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    for (scene <- scenes.all) scene.updateLogicalState(tpf)
 <<< 2790 while loops indentation
 def update(tpf: Float): Unit =
@@ -2164,8 +2165,9 @@ def update(tpf: Float): Unit =
     scene.updateLogicalState(tpf)
 >>>
 def update(tpf: Float): Unit =
-   while (true) scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+   while (true)
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    while (true) scene.updateLogicalState(tpf)
 <<< 2790 for loops indentation end marker
 rewrite.scala3.insertEndMarkerMinLines = 1
@@ -2185,9 +2187,9 @@ def update(tpf: Float): Unit =
   )
 >>>
 def update(tpf: Float): Unit =
-   for (scene <- scenes.all) scene.updateLogicalState(tpf)
-   end for
-   scene.updateGeometricState()
+   for (scene <- scenes.all)
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    end for
    for (scene <- scenes.all) scene.updateLogicalState(tpf)
    end for
@@ -2215,8 +2217,13 @@ def update(tpf: Float): Unit =
   )
 >>>
 def update(tpf: Float): Unit =
+   while (true)
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
+   end while
    while (true) scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
-   while (true) scene.updateLogicalState(tpf)
+   end while
    while (true) while (true) scene.updateLogicalState(tpf)
+   end while
    while (true) scene.updateLogicalState(tpf, scene.updateLogicalState(tpf))
+   end while

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2258,8 +2258,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    for (scene <- scenes.all)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    for (scene <- scenes.all)
      scene.updateLogicalState(tpf)
 <<< 2790 while loops indentation
@@ -2272,8 +2272,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    while (true)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    while (true)
      scene.updateLogicalState(tpf)
 <<< 2790 for loops indentation end marker
@@ -2295,9 +2295,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    for (scene <- scenes.all)
-     scene.updateLogicalState(tpf)
-   end for
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    end for
    for (scene <- scenes.all)
      scene.updateLogicalState(tpf)
@@ -2330,14 +2329,18 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    while (true)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
+   end while
    while (true)
      scene.updateLogicalState(tpf)
+   end while
    while (true)
      while (true)
        scene.updateLogicalState(tpf)
+   end while
    while (true) scene.updateLogicalState(
      tpf,
      scene.updateLogicalState(tpf)
    )
+   end while

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2362,8 +2362,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    for (scene <- scenes.all)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    for (scene <- scenes.all)
      scene.updateLogicalState(tpf)
 <<< 2790 while loops indentation
@@ -2376,8 +2376,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    while (true)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    while (true)
      scene.updateLogicalState(tpf)
 <<< 2790 for loops indentation end marker
@@ -2400,9 +2400,8 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    for (scene <- scenes.all)
-     scene.updateLogicalState(tpf)
-   end for
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
    end for
    for (scene <- scenes.all)
      scene.updateLogicalState(tpf)
@@ -2436,12 +2435,16 @@ def update(tpf: Float): Unit =
 >>>
 def update(tpf: Float): Unit =
    while (true)
-     scene.updateLogicalState(tpf)
-   scene.updateGeometricState()
+      scene.updateLogicalState(tpf)
+      scene.updateGeometricState()
+   end while
    while (true)
      scene.updateLogicalState(tpf)
+   end while
    while (true)
      while (true)
        scene.updateLogicalState(tpf)
+   end while
    while (true)
      scene.updateLogicalState(tpf, scene.updateLogicalState(tpf))
+   end while


### PR DESCRIPTION
Fixes #2790. Based on #2791 (additional tests and minor match change).