### PR TITLE
Updating dockerize CI step to properly use docker/metadata-action instead of generating tags with shell cmnds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: scalameta/scalafmt
+          tags: type=semver,pattern={{raw}}
       - name: Downloading scalafmt-linux-musl for Docker Build
         uses: actions/download-artifact@v2.0.10
         with:
@@ -117,4 +123,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: scalameta/scalafmt:$(echo $GITHUB_REF | cut -d / -f 3)
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
@kitbellew saw another dockerize failure when pushing v3.0.7 tag
Error message:  (from [this CI run](https://github.com/scalameta/scalafmt/runs/3953976222?check_suite_focus=true))
```
Error: buildx failed with: error: invalid tag "scalameta/scalafmt:$(echo $GITHUB_REF | cut -d / -f 3)": invalid reference format
```
Comment: https://github.com/scalameta/scalafmt/pull/2800#issuecomment-947834111


This PR replaces the shell command that was failing the Dockerize step with a new action Docker recommends called `docker/metadata-action`.    That [action's docs explain](https://github.com/docker/metadata-action#semver) the `semver` usage I used in this PR 