### PR TITLE
Explain limitations of newlines.afterCurlyLambdaParams

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1725,6 +1725,8 @@ something.map { x =>
 something.map { x => f(x) }
 ```
 
+`afterCurlyLambdaParams.keep` cannot be used with `newlines.source = fold`.
+
 ```scala mdoc:scalafmt
 newlines.afterCurlyLambdaParams = keep
 ---

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -288,10 +288,11 @@ object ScalafmtConfig {
     val allErrors = new mutable.ArrayBuffer[String]
     locally {
       implicit val errors = new mutable.ArrayBuffer[String]
+      addIf(
+        newlines.afterCurlyLambdaParams == AfterCurlyLambdaParams.preserve &&
+          newlines.source == Newlines.fold
+      )
       if (newlines.sourceIgnored) {
-        addIf(
-          newlines.afterCurlyLambdaParams == AfterCurlyLambdaParams.preserve
-        )
         addIf(optIn.configStyleArguments && align.openParenCallSite && newlines.beforeOpenParenCallSite.isEmpty)
         addIf(optIn.configStyleArguments && align.openParenDefnSite && newlines.beforeOpenParenDefnSite.isEmpty)
         newlines.beforeMultiline.foreach { x =>

--- a/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
+++ b/scalafmt-tests/src/test/resources/newlines/afterCurlyLambdaPreserve.stat
@@ -53,3 +53,26 @@ def f = {
     g(x)
   }
 }
+
+<<< #2822 keep with unfold
+newlines.source=unfold
+===
+object O{
+something.map { x =>
+
+  f(x)
+}
+
+something.map { x => f(x) }
+}
+>>>
+object O {
+  something.map { x =>
+
+    f(x)
+  }
+
+  something.map { x =>
+    f(x)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalafmt/issues/2822