### PR TITLE
IndentOperator: rename `include` to `includeRegex`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -539,23 +539,28 @@ function {
 }
 ```
 
-#### `indentOperator.exclude`
+#### `indentOperator.excludeRegex`
 
 Defines a regular expression for excluded infix operators. If an eligible
 operator matches, it will not be indented.
 
+In v3.1.0, this parameter was renamed from `indentOperator.exclude`.
+
 ```scala mdoc:defaults
-indentOperator.exclude
+indentOperator.excludeRegex
 ```
 
-#### `indentOperator.include`
+#### `indentOperator.includeRegex`
 
 Defines a regular expression for included infix operators. If an eligible
 operator matches and is not excluded explicitly by
-[indentOperator.exclude](#indentoperatorexclude), it be will indented.
+[indentOperator.excludeRegex](#indentoperatorexcluderegex), it be will indented.
+
+In v3.1.0, due to conflict with built-in HOCON keyword, this parameter was
+renamed from `indentOperator.include`.
 
 ```scala mdoc:defaults
-indentOperator.include
+indentOperator.includeRegex
 ```
 
 #### `indentOperator.preset`

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -49,11 +49,13 @@ import metaconfig._
   */
 case class IndentOperator(
     topLevelOnly: Boolean = true,
-    include: String = ".*",
-    exclude: String = "^(&&|\\|\\|)$"
+    @annotation.ExtraName("include")
+    includeRegex: String = ".*",
+    @annotation.ExtraName("exclude")
+    excludeRegex: String = "^(&&|\\|\\|)$"
 ) {
-  private val includeRegexp = include.r.pattern
-  private val excludeRegexp = exclude.r.pattern
+  private val includeRegexp = includeRegex.r.pattern
+  private val excludeRegexp = excludeRegex.r.pattern
 
   def noindent(op: String): Boolean =
     excludeRegexp.matcher(op).find() || !includeRegexp.matcher(op).find()
@@ -61,7 +63,7 @@ case class IndentOperator(
 
 object IndentOperator {
   private val default = IndentOperator()
-  private val akka = IndentOperator(include = "^.*=$", exclude = "^$")
+  private val akka = IndentOperator(includeRegex = "^.*=$", excludeRegex = "^$")
 
   implicit lazy val surface: generic.Surface[IndentOperator] =
     generic.deriveSurface


### PR DESCRIPTION
Otherwise, it conflicts with HOCON reserved keyword. Fixes #2840.