### PR TITLE
ScalafmtDynamic: download even current build

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
@@ -133,10 +133,8 @@ final case class ScalafmtDynamic(
   ): FormatEval[ScalafmtReflectConfig] = {
     for {
       version <- readVersion(configPath)
-      current = ScalafmtReflect.current
-      fmtReflect <-
-        if (version == current.version) Right(current)
-        else resolveFormatter(configPath, version)
+      // can't use current build directly, -dynamic doesn't include -core
+      fmtReflect <- resolveFormatter(configPath, version)
       config <- fmtReflect.parseConfig(configPath).toEither.left.map {
         case ex: ScalafmtDynamicError => ex
         case ex => new UnknownConfigError(configPath, ex)

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -166,12 +166,3 @@ case class ScalafmtReflect(
     module.get(null)
   }
 }
-
-object ScalafmtReflect {
-
-  lazy val current = ScalafmtReflect(
-    getClass.getClassLoader,
-    ScalafmtVersion.parse(BuildInfo.stable).get
-  )
-
-}

--- a/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -439,19 +439,6 @@ class DynamicSuite extends FunSuite {
     assert(!configWithoutRewrites.hasRewriteRules)
   }
 
-  check("invalid config in current") { f =>
-    f.setConfig(
-      s"""|version=${BuildInfo.stable}
-        |align=does-not-exist
-        |""".stripMargin
-    )
-    val thrown = f.assertThrows[ScalafmtDynamicError.ConfigParseError]()
-    assert(thrown.getMessage.startsWith("Invalid config:"))
-    assert(
-      thrown.getMessage.contains(".scalafmt.conf:2:0 error: Type mismatch;")
-    )
-  }
-
   check("invalid config in 3.0.0-RC6") { f =>
     f.setConfig(
       s"""|version=3.0.0-RC6


### PR DESCRIPTION
Because the -dynamic module doesn't include the necessary -core.

This is follow-up to #2839; prior to that change, current had been used for CliTest with "core" option but that was fixed in #2873 to detect the current build and use the core runner.