### PR TITLE
Workflows: be sure to fetch tags with --unshallow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
       - uses: olafurpg/setup-scala@v13
         with:
           java-version: ${{ matrix.java }}
-      - run: git fetch --tags -f
+      # https://github.com/dwijnand/sbt-dynver#setup
+      - run: git fetch --tags --unshallow -f
       - run:
           # for GitOps tests
           git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v13
       - uses: olafurpg/setup-gpg@v3
+      # https://github.com/dwijnand/sbt-dynver#setup
       - run: git fetch --tags --unshallow -f
       - name: Publish ${{ github.ref }}
         run: sbt ci-release docs/docusaurusPublishGhpages


### PR DESCRIPTION
This is required, as explained in: https://github.com/dwijnand/sbt-dynver#setup

Without it, our tests running in CI end up with "0.0.0" as the version.