### PR TITLE
DynamicSuite: use previous stable instead

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -311,6 +311,8 @@ lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
     "scalameta" -> scalametaV,
     "nightly" -> version.value,
     "stable" -> stableVersion.value,
+    "previousStable" ->
+      previousStableVersion.value.getOrElse(stableVersion.value),
     "scala" -> scalaVersion.value,
     "scala212" -> scala212,
     "coursier" -> coursier,

--- a/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -194,7 +194,7 @@ class DynamicSuite extends FunSuite {
     }
   }
 
-  def latest = BuildInfo.stable
+  def latest = BuildInfo.previousStable
 
   def checkVersion(version: String, dialect: String): Unit = {
     check(s"v$version") { f =>


### PR DESCRIPTION
Around version release time, the tag points to the new version but it hadn't yet been published and hence not availalble, hence we can't use the stable version.