### PR TITLE
 ScalafmtConfig: getConfigFor returns Try, uses AbsoluteFile

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -163,11 +163,13 @@ case class ScalafmtConfig(
       fs.getPathMatcher(pattern.asFilename) -> style
     }
   }
-  def getConfigFor(filename: String): ScalafmtConfig = {
+  def getConfigFor(filename: String): Try[ScalafmtConfig] = {
     val absfile = AbsoluteFile(FileOps.getFile(filename))
-    expandedFileOverride.get
-      .collectFirst { case (pm, style) if pm.matches(absfile.path) => style }
-      .getOrElse(this)
+    expandedFileOverride.map { x =>
+      x
+        .collectFirst { case (pm, style) if pm.matches(absfile.path) => style }
+        .getOrElse(this)
+    }
   }
 
   private[scalafmt] lazy val encloseSelectChains =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -8,6 +8,8 @@ import scala.meta.Dialect
 import scala.util.Try
 
 import metaconfig._
+import org.scalafmt.sysops.AbsoluteFile
+import org.scalafmt.sysops.FileOps
 import org.scalafmt.sysops.OsSpecific._
 import org.scalafmt.util.LoggerOps
 import org.scalafmt.util.ValidationOps
@@ -162,9 +164,9 @@ case class ScalafmtConfig(
     }
   }
   def getConfigFor(filename: String): ScalafmtConfig = {
-    val path = file.FileSystems.getDefault.getPath(filename)
+    val absfile = AbsoluteFile(FileOps.getFile(filename))
     expandedFileOverride.get
-      .collectFirst { case (pm, style) if pm.matches(path) => style }
+      .collectFirst { case (pm, style) if pm.matches(absfile.path) => style }
       .getOrElse(this)
   }
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/ScalafmtConfigTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/ScalafmtConfigTest.scala
@@ -38,8 +38,8 @@ class ScalafmtConfigTest extends FunSuite {
       """.stripMargin
       )
       .get
-    val nlCfg1 = config.getConfigFor("/x/src/main/scala/foo.scala").newlines
-    val nlCfg2 = config.getConfigFor("/x/src/test/scala/bar.scala").newlines
+    val nlCfg1 = config.getConfigFor("/x/src/main/scala/foo.scala").get.newlines
+    val nlCfg2 = config.getConfigFor("/x/src/test/scala/bar.scala").get.newlines
     assert(nlCfg1.source == Newlines.fold)
     assert(nlCfg2.source == Newlines.unfold)
     assert(nlCfg1.topLevelStatements == Seq(Newlines.before, Newlines.after))


### PR DESCRIPTION
1. Since the caller uses a wrapped similar to Try, makes no sense to throw here.
2. To allow proper path name matching, we need to have the full path.