### PR TITLE
ScalafmtConfig: allow `fileOverride` shortcuts, set cross-build dialects

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3466,6 +3466,25 @@ project {
 }
 ```
 
+#### `project.layout`
+
+Allows specifying a project structure naming convention which can be used to
+select an appropriate dialect for cross-building if one is explicitly selected
+via [`fileOverride`](#fileoverride). By default, it's disabled (`null`).
+
+Currently, the following options are supported:
+
+- (since v3.2.0) `StandardConvention`: this is the usual naming convention
+  putting scala source code under `src/main/scala` or `src/test/scala`, with
+  alternate cross-build dialects in `src/main/scala-2.13`
+
+If this parameter is set, some supported dialects will be determined automatically;
+if the detected dialect is compatible with the overall one (`runner.dialect`),
+no change will be applied.
+
+Currently, supports scala binary versions 2.10-2.13 as well as 3; also, if the version
+is major scala 2 (i.e., `scala-2`), will select the scala 2.13 dialect.
+
 ### `fileOverride`
 
 > Since v2.5.0.
@@ -3477,10 +3496,10 @@ pattern. For instance,
 ```
 align.preset = none
 fileOverride {
-  "glob:**/*.sbt" {
+  "glob:**.sbt" {
     align.preset = most
   }
-  "glob:**/src/test/scala/**/*.scala" {
+  "glob:**/src/test/scala/**.scala" {
     maxColumn = 120
     binPack.unsafeCallSite = true
   }
@@ -3492,6 +3511,21 @@ uses `align.preset=none` for all files except `.sbt` for which
 suites.
 
 > This parameter does not modify which files are formatted.
+
+File names will be matched against the patterns in the order in which they are
+specified in the configuration file, in case multiple patterns match a given file.
+
+The parameter also allows the following shortcuts:
+
+- (since v3.2.0) setting only the dialect:
+  - `fileOverride { "glob:**/*.sbt" = sbt1 }`
+- (since v3.2.0) setting based on the file extension:
+  - `fileOverride { ".sbt" { runner.dialect = sbt1 } }`
+  - this is simply a shortcut for `glob:**.ext`
+- (since v3.2.0) setting based on the language:
+  - `fileOverride { "lang:scala-2" = scala213 }`
+  - requires [project.layout](#projectlayout) (sets dialect for minor versions)
+  - these patterns will be matched last
 
 ## Spaces
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/NamedDialect.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/NamedDialect.scala
@@ -8,7 +8,8 @@ case class NamedDialect(name: String, dialect: Dialect)
 object NamedDialect {
 
   def apply(pair: sourcecode.Text[Dialect]): NamedDialect = {
-    apply(pair.source.toLowerCase, pair.value)
+    val name = pair.source.substring(pair.source.lastIndexOf('.') + 1)
+    apply(name.toLowerCase, pair.value)
   }
 
   val scala212 = Scala212

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -2,6 +2,11 @@ package org.scalafmt.config
 
 import java.nio.file
 
+import scala.annotation.tailrec
+import scala.meta.Dialect
+import scala.meta.dialects
+
+import org.scalafmt.CompatCollections.JavaConverters._
 import org.scalafmt.sysops.AbsoluteFile
 import org.scalafmt.sysops.OsSpecific._
 
@@ -86,13 +91,62 @@ object ProjectFiles {
   }
 
   sealed abstract class Layout {
-    // TODO
+    def getLang(path: AbsoluteFile): Option[String]
+    def getDialectByLang(lang: String)(implicit
+        dialect: Dialect
+    ): Option[NamedDialect]
   }
 
   object Layout {
 
     case object StandardConvention extends Layout {
-      // TODO
+      private val phaseLabels = Seq("main", "test", "it")
+
+      override def getLang(path: AbsoluteFile): Option[String] = {
+        val dirsIter = path.path.getParent.iterator().asScala
+        val dirs = dirsIter.map(_.toString).toArray
+        getLang(dirs, dirs.length)
+      }
+
+      @tailrec
+      private def getLang(dirs: Array[String], len: Int): Option[String] = {
+        val srcIdx = dirs.lastIndexOf("src", len - 3)
+        if (srcIdx < 0) None
+        else {
+          val langIdx = srcIdx + 2
+          val found = phaseLabels.contains(dirs(srcIdx + 1))
+          if (found) Some(dirs(langIdx)) else getLang(dirs, langIdx)
+        }
+      }
+
+      @inline private def is211(implicit dialect: Dialect) =
+        !dialect.allowCaseClassWithoutParameterList
+      @inline private def is212(implicit dialect: Dialect) =
+        dialect.allowTrailingCommas
+      @inline private def is213(implicit dialect: Dialect) =
+        dialect.allowLiteralTypes
+      @inline private def is3(implicit dialect: Dialect) =
+        dialect.allowSignificantIndentation
+
+      @inline private def nd(text: sourcecode.Text[Dialect]) =
+        Some(NamedDialect(text))
+      private val s210 = nd(dialects.Scala210)
+      private val s211 = nd(dialects.Scala211)
+      private val s212 = nd(NamedDialect.scala212)
+      private val s213 = nd(NamedDialect.scala213)
+      private val s3 = nd(NamedDialect.scala3)
+
+      override def getDialectByLang(lang: String)(implicit
+          dialect: Dialect
+      ): Option[NamedDialect] = lang match {
+        case "scala-2.10" if is211 => s210
+        case "scala-2.11" if is212 || !is211 => s211
+        case "scala-2.12" if is213 || !is212 => s212
+        case "scala-2.13" if is3 || !is213 => s213
+        case "scala-2" if is3 => s213
+        case "scala-3" if !is3 => s3
+        case _ => None
+      }
     }
 
     implicit val reader: ConfCodecEx[Layout] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -10,6 +10,7 @@ import metaconfig.annotation.DeprecatedName
 
 case class ProjectFiles(
     git: Boolean = false,
+    layout: Option[ProjectFiles.Layout] = None,
     includePaths: Seq[String] = ProjectFiles.defaultIncludePaths,
     excludePaths: Seq[String] = Nil,
     @DeprecatedName(
@@ -82,6 +83,23 @@ object ProjectFiles {
       matchesPath(fs.getPath(filename))
     def matchesFile(file: AbsoluteFile): Boolean =
       matchesPath(file.path)
+  }
+
+  sealed abstract class Layout {
+    // TODO
+  }
+
+  object Layout {
+
+    case object StandardConvention extends Layout {
+      // TODO
+    }
+
+    implicit val reader: ConfCodecEx[Layout] =
+      ReaderUtil.oneOf[Layout](
+        StandardConvention
+      )
+
   }
 
 }

--- a/scalafmt-tests/src/test/resources/test/Dialect.source
+++ b/scalafmt-tests/src/test/resources/test/Dialect.source
@@ -87,6 +87,7 @@ def anotherMethod(): Unit = doOtherStuff()
 <<< #2882 scala-3, explicit
 runner.dialect = scala213
 project.layout = StandardConvention
+fileOverride { "lang:scala-3" = scala3 }
 ===
 trait A /* comm */ :
   val cond =
@@ -99,10 +100,16 @@ trait A /* comm */ :
      }
    end if
 >>> foo/src/main/scala-3/bar.scala
-test does not parse
-trait A /* comm */ :
-                 ^
-foo/src/main/scala-3/bar.scala:1: error: [dialect scala213] ; expected but : found
+trait A /* comm */:
+  val cond =
+    if true then
+      stat1
+      stat2
+    else { // c1
+      stat3
+      stat4
+    }
+    end if
 <<< #2882 scala-3, implicit
 runner.dialect = scala213
 project.layout = StandardConvention
@@ -118,13 +125,20 @@ trait A /* comm */ :
      }
    end if
 >>> foo/src/main/scala-3/bar.scala
-test does not parse
-trait A /* comm */ :
-                 ^
-foo/src/main/scala-3/bar.scala:1: error: [dialect scala213] ; expected but : found
+trait A /* comm */:
+  val cond =
+    if true then
+      stat1
+      stat2
+    else { // c1
+      stat3
+      stat4
+    }
+    end if
 <<< #2882 scala-2, explicit
 runner.dialect = scala211
 project.layout = StandardConvention
+fileOverride { "lang:scala-2" = scala213 }
 ===
 object a {
     foo(
@@ -133,13 +147,12 @@ object a {
     )
 }
 >>> foo/src/main/scala-2/bar.scala
-test does not parse
-    foo(
-      bar,
-      baz, // trailing comma
-    )
-  ^
-foo/src/main/scala-2/bar.scala:5: error: [dialect scala211] illegal start of simple expression
+object a {
+  foo(
+    bar,
+    baz // trailing comma
+  )
+}
 <<< #2882 scala-2, implicit with 3
 runner.dialect = scala3
 project.layout = StandardConvention
@@ -148,11 +161,9 @@ object a {
   do { foo } while (bar) // unsupported in scala3
 }
 >>> foo/src/main/scala-2/bar.scala
-test does not parse
 object a {
   do { foo } while (bar) // unsupported in scala3
-^
-foo/src/main/scala-2/bar.scala:2: error: [dialect scala3] do {...} while (...) syntax is no longer supported
+}
 <<< #2882 scala-2, implicit with 213
 runner.dialect = scala213
 project.layout = StandardConvention
@@ -178,13 +189,13 @@ case class a { // unsupported since 2.11
   def foo = 1
 }
 >>> foo/src/main/scala-2.10/bar.scala
-test does not parse
 case class a { // unsupported since 2.11
-           ^
-foo/src/main/scala-2.10/bar.scala:1: error: [dialect scala211] case classes must have a parameter list; try 'case class a()' or 'case object a'
+  def foo = 1
+}
 <<< #2882 scala-2.13, implicit
 runner.dialect = scala211
 project.layout = StandardConvention
+fileOverride { "lang:scala-2.13" = { trailingCommas = always } }
 ===
 object a {
     foo(
@@ -193,25 +204,22 @@ object a {
     )
 }
 >>> foo/src/main/scala-2.13/bar.scala
-test does not parse
-    foo(
-      bar,
-      baz, // trailing comma
-    )
-  ^
-foo/src/main/scala-2.13/bar.scala:5: error: [dialect scala211] illegal start of simple expression
+object a {
+  foo(
+    bar,
+    baz, // trailing comma
+  )
+}
 <<< #2882 .sbt
 runner.dialect = scala211
+fileOverride { ".sbt" = scala213 }
 ===
 foo(
   bar,
   baz, // trailing comma
 )
 >>> foo/bar/baz.sbt
-test does not parse
 foo(
   bar,
-  baz, // trailing comma
+  baz // trailing comma
 )
-^
-foo/bar/baz.sbt:4: error: [dialect scala211] illegal start of simple expression

--- a/scalafmt-tests/src/test/resources/test/Dialect.source
+++ b/scalafmt-tests/src/test/resources/test/Dialect.source
@@ -84,3 +84,134 @@ def anotherMethod(): Unit = doOtherStuff()
 def myMethod(): Unit = doSomeStuff()
 @main
 def anotherMethod(): Unit = doOtherStuff()
+<<< #2882 scala-3, explicit
+runner.dialect = scala213
+project.layout = StandardConvention
+===
+trait A /* comm */ :
+  val cond =
+   if true then
+    stat1
+    stat2
+   else { // c1
+     stat3
+     stat4
+     }
+   end if
+>>> foo/src/main/scala-3/bar.scala
+test does not parse
+trait A /* comm */ :
+                 ^
+foo/src/main/scala-3/bar.scala:1: error: [dialect scala213] ; expected but : found
+<<< #2882 scala-3, implicit
+runner.dialect = scala213
+project.layout = StandardConvention
+===
+trait A /* comm */ :
+  val cond =
+   if true then
+    stat1
+    stat2
+   else { // c1
+     stat3
+     stat4
+     }
+   end if
+>>> foo/src/main/scala-3/bar.scala
+test does not parse
+trait A /* comm */ :
+                 ^
+foo/src/main/scala-3/bar.scala:1: error: [dialect scala213] ; expected but : found
+<<< #2882 scala-2, explicit
+runner.dialect = scala211
+project.layout = StandardConvention
+===
+object a {
+    foo(
+      bar,
+      baz, // trailing comma
+    )
+}
+>>> foo/src/main/scala-2/bar.scala
+test does not parse
+    foo(
+      bar,
+      baz, // trailing comma
+    )
+  ^
+foo/src/main/scala-2/bar.scala:5: error: [dialect scala211] illegal start of simple expression
+<<< #2882 scala-2, implicit with 3
+runner.dialect = scala3
+project.layout = StandardConvention
+===
+object a {
+  do { foo } while (bar) // unsupported in scala3
+}
+>>> foo/src/main/scala-2/bar.scala
+test does not parse
+object a {
+  do { foo } while (bar) // unsupported in scala3
+^
+foo/src/main/scala-2/bar.scala:2: error: [dialect scala3] do {...} while (...) syntax is no longer supported
+<<< #2882 scala-2, implicit with 213
+runner.dialect = scala213
+project.layout = StandardConvention
+===
+object a {
+    foo(
+      bar,
+      baz, // trailing comma
+    )
+}
+>>> foo/src/main/scala-2/bar.scala
+object a {
+  foo(
+    bar,
+    baz // trailing comma
+  )
+}
+<<< #2882 scala-2.10, implicit
+runner.dialect = scala211
+project.layout = StandardConvention
+===
+case class a { // unsupported since 2.11
+  def foo = 1
+}
+>>> foo/src/main/scala-2.10/bar.scala
+test does not parse
+case class a { // unsupported since 2.11
+           ^
+foo/src/main/scala-2.10/bar.scala:1: error: [dialect scala211] case classes must have a parameter list; try 'case class a()' or 'case object a'
+<<< #2882 scala-2.13, implicit
+runner.dialect = scala211
+project.layout = StandardConvention
+===
+object a {
+    foo(
+      bar,
+      baz, // trailing comma
+    )
+}
+>>> foo/src/main/scala-2.13/bar.scala
+test does not parse
+    foo(
+      bar,
+      baz, // trailing comma
+    )
+  ^
+foo/src/main/scala-2.13/bar.scala:5: error: [dialect scala211] illegal start of simple expression
+<<< #2882 .sbt
+runner.dialect = scala211
+===
+foo(
+  bar,
+  baz, // trailing comma
+)
+>>> foo/bar/baz.sbt
+test does not parse
+foo(
+  bar,
+  baz, // trailing comma
+)
+^
+foo/bar/baz.sbt:4: error: [dialect scala211] illegal start of simple expression


### PR DESCRIPTION
Fixes #2882.