### PR TITLE
ScalafmtReporter: use ScalafmtException to wrap

### DIFF
--- a/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtException.java
+++ b/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtException.java
@@ -1,0 +1,9 @@
+package org.scalafmt.interfaces;
+
+public class ScalafmtException extends RuntimeException {
+
+    public ScalafmtException(String message, Throwable cause) {
+        super(message, cause, true, false);
+    }
+
+}

--- a/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtReporter.java
+++ b/scalafmt-interfaces/src/main/java/org/scalafmt/interfaces/ScalafmtReporter.java
@@ -35,7 +35,7 @@ public interface ScalafmtReporter {
      *          when the error appeared as a position.
      */
     default void error(Path file, String message, Throwable e) {
-        error(file, new RuntimeException(message, e));
+        error(file, new ScalafmtException(message, e));
     }
 
     /**


### PR DESCRIPTION
For cases when the tool is invoked inside an IDE, this provides a better context for the error than a vanilla runtime exception.