### PR TITLE
Add `cross` (from SBT) to the exclude infix list

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
@@ -21,6 +21,7 @@ object Pattern {
   val neverInfix = Pattern(
     Seq("[\\w\\d_]+"),
     Seq(
+      "cross",
       "until",
       "to",
       "by",


### PR DESCRIPTION
Example:

```sbt
addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
```