### PR TITLE
ScalafmtConfig: set default infix exclude for sbt

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
@@ -11,6 +11,11 @@ case class Pattern(
     FilterMatcher.mkRegexp(includeFilters),
     FilterMatcher.mkRegexp(excludeFilters, true)
   )
+
+  private[config] def forSbt: Option[Pattern] =
+    // if the user customized these, we don't touch
+    if (excludeFilters ne Pattern.neverInfix.excludeFilters) None
+    else Some(copy(excludeFilters = Pattern.sbtExclude))
 }
 
 object Pattern {
@@ -49,4 +54,8 @@ object Pattern {
       "theSameElementsAs"
     )
   )
+
+  private val sbtExclude = Seq(
+    "cross"
+  ) ++ neverInfix.excludeFilters
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
@@ -26,6 +26,8 @@ case class RewriteSettings(
     Some((missing ++ changed).map(_.toString).sorted).filter(_.nonEmpty)
   }
 
+  private[config] def forSbt: RewriteSettings =
+    neverInfix.forSbt.fold(this)(x => copy(neverInfix = x))
 }
 
 object RewriteSettings {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -164,7 +164,8 @@ case class ScalafmtConfig(
     NamedDialect.getName(dialect).getOrElse("unknown dialect")
   )
 
-  def forSbt: ScalafmtConfig = copy(runner = runner.forSbt)
+  def forSbt: ScalafmtConfig =
+    copy(runner = runner.forSbt, rewrite = rewrite.forSbt)
 
   private lazy val expandedFileOverride = Try {
     val langPrefix = "lang:"

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
@@ -179,4 +179,4 @@ object a {
 <<< exclude "cross" for sbt
 foo("bar" % "baz" % "qux" cross CrossVersion.full)
 >>> a.sbt
-foo(("bar" % "baz" % "qux").cross(CrossVersion.full))
+foo("bar" % "baz" % "qux" cross CrossVersion.full)

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
@@ -176,3 +176,7 @@ object a {
 object a {
   ((a(b("c")).over(d)) / (e + 1)).as(f)
 }
+<<< exclude "cross" for sbt
+foo("bar" % "baz" % "qux" cross CrossVersion.full)
+>>> a.sbt
+foo(("bar" % "baz" % "qux").cross(CrossVersion.full))


### PR DESCRIPTION
Supersedes #2962.