### PR TITLE
ScalafmtConfig: no dangling parens for scala.js

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -284,6 +284,7 @@ object ScalafmtConfig {
       unsafeCallSite = BinPack.Unsafe.Always,
       parentConstructors = BinPack.ParentCtors.Always
     ),
+    danglingParentheses = DanglingParentheses(false, false),
     indent = Indents(callSite = 4, defnSite = 4),
     importSelectors = ImportSelectors.binPack,
     newlines = default.newlines.copy(


### PR DESCRIPTION
That style uses either config style (which preserves or forces dangling regardless of the setting) or binpacking without dangling. Currently, binpacking ignores the dangling setting but is about to use it.