### PR TITLE
Split: centralize noIndent handling

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -697,8 +697,7 @@ class FormatOps(
         else Some(decideNewlinesOnlyAfterClose(end.left))
       }
       val nlMod = newStmtMod.getOrElse {
-        val hasAttachedComment = ft.noBreak && ft.right.is[T.Comment]
-        getModByNL(if (hasAttachedComment) 0 else 1)
+        Space.orNL(ft.noBreak && ft.right.is[T.Comment])
       }
       val delayedBreak = if (nlMod.isNewline) None else breakAfterComment(ft)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -62,4 +62,7 @@ object Space extends Modification {
 
   def apply(flag: Boolean): Modification = if (flag) this else NoSplit
   def orNL(flag: Boolean): Modification = if (flag) this else Newline
+  def orNL(nl: Int): Modification =
+    if (FormatToken.noBreak(nl)) this
+    else NewlineT(isDouble = FormatToken.hasBlankLine(nl))
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1388,7 +1388,7 @@ class Router(formatOps: FormatOps) {
       case ft @ FormatToken(left: T.Comma, c: T.Comment, _) =>
         if (ft.hasBlankLine) Seq(Split(NewlineT(isDouble = true), 0))
         else if (isSingleLineComment(c) || ft.meta.right.hasNL)
-          Seq(Split(getModByNL(newlines), 0))
+          Seq(Split(Space.orNL(newlines), 0))
         else {
           val trailingComma =
             rightIsCloseDelimToAddTrailingComma(left, nextNonComment(next(ft)))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -4,7 +4,6 @@ import scala.meta.tokens.Token
 
 import org.scalafmt.internal.Policy.NoPolicy
 import org.scalafmt.util.PolicyOps
-import org.scalafmt.util.TokenOps
 import org.scalameta.FileLine
 
 case class OptimalToken(token: Token, killOnFail: Boolean = false) {
@@ -48,14 +47,12 @@ case class Split(
     optimalAt: Option[OptimalToken] = None
 )(implicit val fileLine: FileLine) {
   import PolicyOps._
-  import TokenOps._
 
-  def adapt(formatToken: FormatToken): Split =
-    modExt.mod match {
-      case n: NewlineT if !n.noIndent && rhsIsCommentedOut(formatToken) =>
-        copy(modExt = modExt.copy(mod = NewlineT(n.isDouble, noIndent = true)))
-      case _ => this
-    }
+  def withNoIndent: Split = modExt.mod match {
+    case x @ NewlineT(_, false, _) =>
+      copy(modExt = modExt.copy(mod = x.copy(noIndent = true)))
+    case _ => this
+  }
 
   @inline
   def indentation: String = modExt.indentation

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -9,7 +9,6 @@ import org.scalafmt.config.Newlines
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.FormatToken
 import org.scalafmt.internal.Modification
-import org.scalafmt.internal.NewlineT
 import org.scalafmt.internal.Space
 
 /** Stateless helper functions on [[scala.meta.Token]].
@@ -114,12 +113,8 @@ object TokenOps {
       case _ => false
     }
 
-  def getModByNL(nl: Int): Modification =
-    if (FormatToken.noBreak(nl)) Space
-    else NewlineT(isDouble = FormatToken.hasBlankLine(nl))
-
-  def getMod(ft: FormatToken): Modification =
-    getModByNL(ft.newlinesBetween)
+  @inline
+  def getMod(ft: FormatToken): Modification = Space.orNL(ft.newlinesBetween)
 
   def isAttachedSingleLineComment(ft: FormatToken) =
     isSingleLineComment(ft.right) && ft.noBreak


### PR DESCRIPTION
Do not check this repeatedly in many places as redundant.