### PR TITLE
Router: do not attach comma after a comment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1380,7 +1380,8 @@ class Router(formatOps: FormatOps) {
         Seq(Split(Space, 0))
 
       // Delim
-      case FormatToken(_, T.Comma(), _) =>
+      case ft @ FormatToken(left, _: T.Comma, _)
+          if !left.is[T.Comment] || newlines == 0 =>
         Seq(
           Split(NoSplit, 0)
         )

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -782,3 +782,29 @@ foo(barBarBarBar, /* c1 */ baz, /* c2 */ qux)
 >>>
 foo(barBarBarBar,
   /* c1 */ baz, /* c2 */ qux)
+<<< comma after mlc
+foo(
+  bar /* c1 */
+  ,
+  baz /* c2 */
+  ,
+)
+>>>
+foo(
+    bar /* c1 */,
+    baz /* c2 */
+)
+<<< comma after mlc, binpack
+binPack.preset = true
+===
+foo(
+  bar /* c1 */
+  ,
+  baz /* c2 */
+  ,
+)
+>>>
+foo(
+    bar /* c1 */,
+    baz /* c2 */
+)

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -791,7 +791,8 @@ foo(
 )
 >>>
 foo(
-    bar /* c1 */,
+    bar /* c1 */
+    ,
     baz /* c2 */
 )
 <<< comma after mlc, binpack
@@ -805,6 +806,7 @@ foo(
 )
 >>>
 foo(
-    bar /* c1 */,
+    bar /* c1 */
+    ,
     baz /* c2 */
 )


### PR DESCRIPTION
Since we can potentially reformat a long single-line comment into a multi-line comment, we can't attach anything that followed the MLC after a break.