### PR TITLE
Router: binpack defn single-line to avoid overflow

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -4382,9 +4382,9 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      bb: BB, cc: CC, dd: DD = DDD.ddd
-  ): Bar[Baz] = {
+  def foo(bb: BB, cc: CC, dd: DD = DDD.ddd): Bar[
+    Baz
+  ] = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -4807,9 +4807,9 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      bb: BB, cc: CC, dd: DD = DDD.ddd
-  ): Bar[Baz] = {
+  def foo(bb: BB, cc: CC, dd: DD = DDD.ddd): Bar[
+    Baz
+  ] = {
     // c
     qux
   }


### PR DESCRIPTION
The current rule could occasionally lead to overflow since it didn't use a `killall` (remove path on failure) optimal token, and then would arrive at a point where other viable alternatives would have been set aside.