### PR TITLE
BestFirstSearch: improve active overflow detection

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -197,7 +197,8 @@ private class BestFirstSearch private (
                   if (null == nextNextState) null
                   else traverseSameLine(nextNextState, depth)
                 if (null != furtherState) {
-                  if (furtherState.column > style.maxColumn)
+                  val delta = furtherState.totalCost - nextNextState.totalCost
+                  if (delta > Constants.ExceedColumnPenalty)
                     Q.enqueue(nextNextState)
                   else {
                     optimalNotFound = false

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -258,6 +258,7 @@ final case class State(
     }
   }
 
+  def totalCost: Int = cost + math.max(0, delayedPenalty)
 }
 
 object State {

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -185,8 +185,7 @@ object a {
 >>>
 object a {
   intercept[TestException] {
-    val ct =
-      Thread.currentThread() // Ensure that the thunk is executed in the tests thread
+    val ct = Thread.currentThread() // Ensure that the thunk is executed in the tests thread
     val ct =
       Thread.currentThread() // Ensure that the thunk is executed in the tests thread
   }

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -965,3 +965,61 @@ object a {
     Some(dummyBrand), 1f, 1f, item_id, tenant, inid, catalog, channel,
     order_date.split("-")(0).toInt, order_date.split("-")(1).toInt, "v1", order_date)
 }
+<<< trailing-wrapped comments with fold, binpack(lots) and dangling
+maxColumn = 100
+indent.callSite = 2
+align.preset = none
+newlines.source = fold
+includeCurlyBraceInSelectChains = true
+comments.wrap = trailing
+danglingParentheses.preset = true
+binPack {
+  unsafeCallSite = oneline
+  literalArgumentLists = true
+  literalsExclude = []
+  literalsIncludeSimpleExpr = true
+}
+===
+object a {
+  private val impressionUniqueMetricsData = Seq(
+    // out of range
+    ImpUnique("2018-01-02", 102, Some("444"), Some(1), Some(2), Some(1), None, None, 2018, 1, ver), /*
+     * aggimp3 */
+  )
+}
+>>>
+Idempotency violated
+object a {
+  private val impressionUniqueMetricsData = Seq(
+    // out of range
+    ImpUnique(
+      "2018-01-02", 102, Some("444"), Some(1), Some(2), Some(1), None, None, 2018, 1, ver
+    ) /* aggimp3 */
+  )
+}
+<<< trailing-wrapped comments with fold, binpack=oneline
+maxColumn = 29
+indent.callSite = 2
+align.preset = none
+newlines.source = fold
+includeCurlyBraceInSelectChains = true
+comments.wrap = trailing
+binPack.unsafeCallSite = oneline
+===
+object a {
+  private val foo = Seq(
+    // out of range
+    Bar("2018-01-02", 1, ver), /*
+     * baz */
+  )
+}
+>>>
+Idempotency violated
+object a {
+  private val foo =
+    Seq(
+      // out of range
+      Bar("2018-01-02", 1,
+        ver) /* baz */
+    )
+}

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -622,7 +622,8 @@ object a {
   val foo =
     Seq( // First 2 will not be taken into account since this app for 'Do Not Sell'
       CcpaRequestIds("luid", "1", None, date, version, RequestType.Delete),
-      CcpaRequestIds("hemlmd5", "MD5-1", None, date, version, RequestType.Delete), /* Next 2 will
+      CcpaRequestIds("hemlmd5", "MD5-1", None, date, version,
+                     RequestType.Delete), /* Next 2 will
        * not be taken into account since 'filterDoNotSellBy' is not set */
       CcpaRequestIds("luid", "2", date, None, version, RequestType.DoNotSell),
       CcpaRequestIds("hemlmd5", "MD5-2", date, None, version, RequestType.DoNotSell)
@@ -651,7 +652,8 @@ object a {
   val foo =
     Seq( // First 2 will not be taken into account since this app for 'Do Not Sell'
       CcpaRequestIds("luid", "1", None, date, version, RequestType.Delete),
-      CcpaRequestIds("hemlmd5", "MD5-1", None, date, version, RequestType.Delete), /* Next 2 will
+      CcpaRequestIds("hemlmd5", "MD5-1", None, date, version,
+                     RequestType.Delete), /* Next 2 will
        * not be taken into account since 'filterDoNotSellBy' is not set */
       CcpaRequestIds("luid", "2", date, None, version, RequestType.DoNotSell),
       CcpaRequestIds("hemlmd5", "MD5-2", date, None, version, RequestType.DoNotSell)
@@ -988,13 +990,11 @@ object a {
   )
 }
 >>>
-Idempotency violated
 object a {
   private val impressionUniqueMetricsData = Seq(
     // out of range
-    ImpUnique(
-      "2018-01-02", 102, Some("444"), Some(1), Some(2), Some(1), None, None, 2018, 1, ver
-    ) /* aggimp3 */
+    ImpUnique("2018-01-02", 102, Some("444"), Some(1), Some(2), Some(1), None, None, 2018, 1,
+      ver) /* aggimp3 */
   )
 }
 <<< trailing-wrapped comments with fold, binpack=oneline
@@ -1014,12 +1014,10 @@ object a {
   )
 }
 >>>
-Idempotency violated
 object a {
-  private val foo =
-    Seq(
-      // out of range
-      Bar("2018-01-02", 1,
-        ver) /* baz */
-    )
+  private val foo = Seq(
+    // out of range
+    Bar("2018-01-02", 1,
+      ver) /* baz */
+  )
 }


### PR DESCRIPTION
Since we can support cases of inactive overflow (comments which would later be wrapped, or cases when minor overflow is allowed), we should not look at the column to detect this.