### PR TITLE
Router: treat multi-line comment before NL as SLC

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -719,6 +719,10 @@ the token).
 > [ScalaFiddle Playgroud](https://scalameta.org/docs/trees/scalafiddle.html) or
 > [AST Explorer](https://scalameta.org/docs/trees/astexplorer.html).
 
+> The special code `//` is used for single-line comments. Also, since v3.3.1, this
+> includes multi-line comments `/* ... */` which do not themselves contain newlines
+> but are followed by one (i.e., can trivially be changed to a `//` comment).
+
 ```scala mdoc:scalafmt
 align.tokens = [{
   code = "=>"
@@ -1971,6 +1975,7 @@ class Engine[TD, EI, PD, Q, P, A](
 
 This flag tries to avoid a newline if the line would overflow only because of
 trailing single-line comment (one which starts with `//`).
+Also, since v3.3.1, this includes a trailing `/* ... */` without embedded breaks.
 
 ```scala mdoc:scalafmt
 maxColumn = 40

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -5,19 +5,12 @@ package org.scalafmt.internal
   * Used by [[Policy]] to enforce non-local formatting.
   */
 case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
-  import org.scalafmt.util.TokenOps._
 
   @inline def noNewlines: Seq[Split] =
     Decision.noNewlineSplits(splits)
 
   @inline def onlyNewlinesWithFallback(default: => Split): Seq[Split] =
     Decision.onlyNewlinesWithFallback(splits, default)
-
-  def forceNewline: Seq[Split] =
-    if (isAttachedSingleLineComment(formatToken))
-      splits
-    else
-      onlyNewlinesWithoutFallback
 
   def onlyNewlinesWithoutFallback: Seq[Split] =
     onlyNewlineSplits

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -43,6 +43,8 @@ case class FormatToken(left: Token, right: Token, meta: FormatToken.Meta) {
   @inline def hasBlankLine: Boolean = FormatToken.hasBlankLine(newlinesBetween)
 
   @inline def leftHasNewline = meta.left.hasNL
+  @inline def rightHasNewline = meta.right.hasNL
+  @inline def hasBreakOrEOF: Boolean = hasBreak || right.is[Token.EOF]
 
   /** A format token is uniquely identified by its left token.
     */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -162,6 +162,22 @@ class FormatTokens(leftTok2tok: Map[TokenOps.TokenHash, Int])(
   @inline
   def tokenBefore(trees: Seq[Tree]): FormatToken = tokenBefore(trees.head)
 
+  @inline
+  def isBreakAfterRight(ft: FormatToken): Boolean =
+    next(ft).hasBreakOrEOF
+
+  @inline
+  def isRightCommentThenBreak(ft: FormatToken): Boolean =
+    ft.right.is[Token.Comment] && isBreakAfterRight(ft)
+
+  @inline
+  def isRightLikeSingleLineComment(ft: FormatToken): Boolean =
+    isRightCommentThenBreak(ft) && !ft.rightHasNewline
+
+  @inline
+  def isAttachedCommentThenBreak(ft: FormatToken): Boolean =
+    ft.noBreak && isRightCommentThenBreak(ft)
+
 }
 
 object FormatTokens {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -590,7 +590,7 @@ class FormatWriter(formatOps: FormatOps) {
 
       def formatComment(implicit sb: StringBuilder): Unit = {
         val text = tok.meta.left.text
-        if (isSingleLineComment(text))
+        if (text.startsWith("//"))
           new FormatSlc(text).format
         else if (text == "/**/")
           sb.append(text)
@@ -1113,7 +1113,7 @@ class FormatWriter(formatOps: FormatOps) {
                 else if (alignContainer ne container) {
                   val pos1 = alignContainer.pos
                   val pos2 = container.pos
-                  if (isSingleLineComment(ft.right)) {
+                  if (tokens.isRightLikeSingleLineComment(ft)) {
                     if (pos1.end >= tokens.prevNonCommentSameLine(ft).left.end)
                       appendCandidate()
                   } else if (pos2.start <= pos1.start && pos2.end >= pos1.end) {
@@ -1261,7 +1261,7 @@ class FormatWriter(formatOps: FormatOps) {
 
     def getAlignContainer(implicit fl: FormatLocation): Option[Tree] = {
       val ft = fl.formatToken
-      val slc = isSingleLineComment(ft.right)
+      val slc = tokens.isRightLikeSingleLineComment(ft)
       val code = if (slc) "//" else ft.meta.right.text
 
       fl.style.alignMap.get(code).flatMap { matchers =>
@@ -1559,8 +1559,8 @@ class FormatWriter(formatOps: FormatOps) {
     // skip checking if row1 and row2 matches if both of them continues to a single line of comment
     // in order to vertical align adjacent single lines of comment.
     // see: https://github.com/scalameta/scalafmt/issues/1242
-    val slc1 = isSingleLineComment(row1.floc.formatToken.right)
-    val slc2 = isSingleLineComment(row2.floc.formatToken.right)
+    val slc1 = tokens.isRightLikeSingleLineComment(row1.floc.formatToken)
+    val slc2 = tokens.isRightLikeSingleLineComment(row2.floc.formatToken)
     if (slc1 || slc2) slc1 && slc2
     else
       (row1.alignContainer eq row2.alignContainer) &&

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -8,7 +8,6 @@ import scala.meta.tokens.Token
 
 import org.scalafmt.config.Comments
 import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.util.TokenOps
 import org.scalafmt.util.TreeOps._
 
 /** A partial formatting solution up to splits.length number of tokens.
@@ -191,7 +190,7 @@ final case class State(
         else prev.getOverflowPenalty(split, defaultOverflowPenalty + 1)
       } else if (
         style.newlines.avoidForSimpleOverflowSLC &&
-        TokenOps.isSingleLineComment(ft.right)
+        tokens.isRightCommentThenBreak(ft)
       ) {
         result(0, prevActive)
       } else if (

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
@@ -382,7 +382,7 @@ object Imports extends RewriteFactory {
       ctx.tokenTraverser.findAtOrBefore(ctx.getIndex(tok) - 1) {
         case _: Token.LF =>
           if (hadLf) Some(true) else { hadLf = true; None }
-        case t: Token.Comment if TokenOps.isSingleLineComment(t) =>
+        case t: Token.Comment if TokenOps.isSingleLineIfComment(t) =>
           slc.prepend(t); hadLf = false; None
         case Whitespace() => None
         case _ => if (!hadLf && !slc.isEmpty) slc.remove(0); Some(false)
@@ -393,7 +393,7 @@ object Imports extends RewriteFactory {
     protected final def getCommentAfter(tok: Token): Option[Token] =
       ctx.tokenTraverser.findAtOrAfter(ctx.getIndex(tok) + 1) {
         case _: Token.LF => Some(false)
-        case t: Token.Comment if TokenOps.isSingleLineComment(t) =>
+        case t: Token.Comment if TokenOps.isSingleLineIfComment(t) =>
           Some(true)
         case Whitespace() | _: Token.Comma => None
         case _ => Some(false)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
@@ -6,7 +6,6 @@ import scala.meta.tokens.Token
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.FormatToken
 import org.scalafmt.internal.FormatTokens
-import org.scalafmt.util.TokenOps
 
 import metaconfig._
 
@@ -74,7 +73,7 @@ private class PreferCurlyFors(ftoks: FormatTokens)
       case _: Token.Semicolon
           if !style.rewrite.preferCurlyFors.removeTrailingSemicolonsOnly || {
             val next = ftoks.next(ft)
-            next.hasBreak || TokenOps.isSingleLineComment(next.right)
+            next.hasBreak || ftoks.isRightCommentThenBreak(next)
           } =>
         ft.meta.rightOwner match {
           case _: Term.For | _: Term.ForYield => removeToken

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -60,12 +60,12 @@ object PolicyOps {
       noSyntaxNL: Boolean = false
   )(implicit fileLine: FileLine)
       extends Policy.Clause {
-    import TokenOps.isSingleLineComment
+    import TokenOps.isLeftCommentThenBreak
     override val noDequeue: Boolean = true
     override def toString: String = "SLB:" + super.toString
     override val f: Policy.Pf = {
       case Decision(ft, s)
-          if !(ft.right.is[T.EOF] || okSLC && isSingleLineComment(ft.left)) =>
+          if !(ft.right.is[T.EOF] || okSLC && isLeftCommentThenBreak(ft)) =>
         if (noSyntaxNL && ft.leftHasNewline) Seq.empty else s.filterNot(_.isNL)
     }
   }

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -102,7 +102,8 @@ def f = {
 def f = {
   something.call((x, y) =>
     // comment
-    /* comment */ {
+    /* comment */
+    {
       g(x)
       g(y)
     })
@@ -139,7 +140,8 @@ def f = {
 >>>
 def f = {
   something.call((x, y) => // comment
-    /* comment */ {
+    /* comment */
+    {
       g(x)
       g(y)
     })
@@ -176,7 +178,8 @@ def f = {
 >>>
 def f = {
   something.call((x, y) => /* comment1 */
-    /* comment2 */ {
+    /* comment2 */
+    {
       g(x)
       g(y)
     })
@@ -209,7 +212,8 @@ def f = {
 def f = {
   something.call(
     (aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
-      /* comment2 */ {
+      /* comment2 */
+      {
         g(x)
         g(y)
       })
@@ -227,9 +231,12 @@ def f = {
 >>>
 def f = {
   something.call(
-    (aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
-      /* comment1 */
-      /* comment2 */ {
+    (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ) => /* comment1 */
+      /* comment2 */
+      {
         g(x)
         g(y)
       })

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingF.stat
@@ -66,7 +66,27 @@ def f = {
       g(y)
     })
 }
-<<< 1.4: multi-arg multi-stmt lambda call with multiple split comments
+<<< 1.4: multi-arg multi-stmt lambda call with multiple attached/detached comments
+def f = {
+  something.call (
+     (x, y) =>
+     // comment
+     /* comment */ {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call((x, y) =>
+    // comment
+    /* comment */ {
+      g(x)
+      g(y)
+    })
+}
+<<< 1.4: multi-arg multi-stmt lambda call with multiple detached comments
 def f = {
   something.call (
      (x, y) =>
@@ -91,6 +111,24 @@ def f = {
 def f = {
   something.call (
      (x, y) =>     // comment
+     /* comment */ {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call((x, y) => // comment
+    /* comment */ {
+      g(x)
+      g(y)
+    })
+}
+<<< 1.5: multi-arg multi-stmt lambda call with multiple attached/detached comments
+def f = {
+  something.call (
+     (x, y) =>     // comment
      /* comment */
      {
        g(x)
@@ -106,7 +144,25 @@ def f = {
       g(y)
     })
 }
-<<< 1.6: multi-arg multi-stmt lambda call with multiple inline comments
+<<< 1.6: multi-arg multi-stmt lambda call with multiple detached comments
+def f = {
+  something.call (
+     (x, y) =>     /* comment1 */
+     /* comment2 */ {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call((x, y) => /* comment1 */
+    /* comment2 */ {
+      g(x)
+      g(y)
+    })
+}
+<<< 1.6: multi-arg multi-stmt lambda call with multiple attached/detached inline comments
 def f = {
   something.call (
      (x, y) =>     /* comment1 */
@@ -139,7 +195,26 @@ def f = {
     /* comment3 */
     g(x))
 }
-<<< 1.7: multi-arg multi-stmt lambda call with long params
+<<< 1.7: multi-arg multi-stmt lambda call with long params, detached comment
+def f = {
+  something.call ((aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+     /* comment2 */
+     {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    (aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+      /* comment2 */ {
+        g(x)
+        g(y)
+      })
+}
+<<< 1.7: multi-arg multi-stmt lambda call with long params, attached/detached comments
 def f = {
   something.call ((aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>     /* comment1 */
      /* comment2 */

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -104,7 +104,8 @@ def f = {
 def f = {
   something.call((x, y) =>
     // comment
-    /* comment */ {
+    /* comment */
+    {
       g(x)
       g(y)
     }
@@ -143,7 +144,8 @@ def f = {
 >>>
 def f = {
   something.call((x, y) => // comment
-    /* comment */ {
+    /* comment */
+    {
       g(x)
       g(y)
     }
@@ -163,7 +165,8 @@ def f = {
 >>>
 def f = {
   something.call((x, y) => /* comment1 */
-    /* comment2 */ {
+    /* comment2 */
+    {
       g(x)
       g(y)
     }
@@ -183,7 +186,8 @@ def f = {
 >>>
 def f = {
   something.call((x, y) => /* comment1 */
-    /* comment2 */ {
+    /* comment2 */
+    {
       g(x)
       g(y)
     }
@@ -218,7 +222,8 @@ def f = {
 def f = {
   something.call(
     (aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
-      /* comment2 */ {
+      /* comment2 */
+      {
         g(x)
         g(y)
       }
@@ -237,9 +242,12 @@ def f = {
 >>>
 def f = {
   something.call(
-    (aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
-      /* comment1 */
-      /* comment2 */ {
+    (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
+        bbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    ) => /* comment1 */
+      /* comment2 */
+      {
         g(x)
         g(y)
       }

--- a/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
+++ b/scalafmt-tests/src/test/resources/newlines/beforeConfigSingleArgParenLambdaParamsF_danglingT.stat
@@ -67,7 +67,28 @@ def f = {
     }
   )
 }
-<<< 1.4: multi-arg multi-stmt lambda call with multiple split comments
+<<< 1.4: multi-arg multi-stmt lambda call with attached/detached comments
+def f = {
+  something.call (
+     (x, y) =>
+     // comment
+     /* comment */ {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call((x, y) =>
+    // comment
+    /* comment */ {
+      g(x)
+      g(y)
+    }
+  )
+}
+<<< 1.4: multi-arg multi-stmt lambda call with multiple detached comments
 def f = {
   something.call (
      (x, y) =>
@@ -89,7 +110,26 @@ def f = {
     }
   )
 }
-<<< 1.5: multi-arg multi-stmt lambda call with multiple attached comments
+<<< 1.5: multi-arg multi-stmt lambda call with attached comments
+def f = {
+  something.call (
+     (x, y) =>     // comment
+     /* comment */ {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call((x, y) => // comment
+    /* comment */ {
+      g(x)
+      g(y)
+    }
+  )
+}
+<<< 1.5: multi-arg multi-stmt lambda call with attached/detached comments
 def f = {
   something.call (
      (x, y) =>     // comment
@@ -109,7 +149,27 @@ def f = {
     }
   )
 }
-<<< 1.6: multi-arg multi-stmt lambda call with multiple inline comments
+<<< 1.6: multi-arg multi-stmt lambda call with detached inline comment
+def f = {
+  something.call (
+     (x, y) =>     /* comment1 */
+     /* comment2 */
+     {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call((x, y) => /* comment1 */
+    /* comment2 */ {
+      g(x)
+      g(y)
+    }
+  )
+}
+<<< 1.6: multi-arg multi-stmt lambda call with attached/detached inline comments
 def f = {
   something.call (
      (x, y) =>     /* comment1 */
@@ -145,6 +205,26 @@ def f = {
   )
 }
 <<< 1.7: multi-arg multi-stmt lambda call with long params
+def f = {
+  something.call ((aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+     /* comment2 */
+     {
+       g(x)
+       g(y)
+     }
+  )
+}
+>>>
+def f = {
+  something.call(
+    (aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>
+      /* comment2 */ {
+        g(x)
+        g(y)
+      }
+  )
+}
+<<< 1.7: multi-arg multi-stmt lambda call with long params, attached mlc
 def f = {
   something.call ((aaaaaaaaaaaaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbbbbbbbbbbbb) =>     /* comment1 */
      /* comment2 */

--- a/scalafmt-tests/src/test/resources/unit/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/unit/DefDef.stat
@@ -137,8 +137,7 @@ implicit def xorBifunctor
     : Bitraverse[Xor] =
   new Bitraverse[Xor] {
     def bitraverse[G[_], A, B, C, D](
-        /*c1*/ fab: Xor[A, B])(
-        /*c2*/
+        /*c1*/ fab: Xor[A, B])( /*c2*/
         f: A => G[C],
         g: B => G[D])(implicit
         G: Applicative[G])


### PR DESCRIPTION
Since we now can rewrite single-line comments as multi-line, the latter need to be treated the same, or idempotence will arise.

