### PR TITLE
FormatOps: consider infix case body as top level

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -580,7 +580,7 @@ class FormatOps(
         child.parent.collect {
           case _: Term.Block | _: Term.If | _: Term.While | _: Source => true
           case fun: Term.FunctionTerm if isBlockFunction(fun) => true
-          case t: Case => t.pat eq child
+          case t: Case => t.pat.eq(child) || t.body.eq(child)
         }
       }
       def isInfixTopLevelMatch(op: String, noindent: Boolean): Boolean = {

--- a/scalafmt-tests/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/src/test/resources/default/Advanced.stat
@@ -152,8 +152,8 @@ val testFilter: String => Boolean = {
 options.testFilter match {
   case UnknownTests => // inline comment
     !blacklistedTestFileNames.contains(absPath) &&
-      !whitelistedTestFileNames.contains(absPath) &&
-      !buglistedTestFileNames.contains(absPath)
+    !whitelistedTestFileNames.contains(absPath) &&
+    !buglistedTestFileNames.contains(absPath)
 }
 <<< callStatement genjscode
           callStatement = js.If(genIsInstanceOf(callTrg, rtClass.tpe), {


### PR DESCRIPTION
If the case body contains more than one statement, with infix being the last one, then infix is considered to be part of a top-level Block.

Hence, we need to treat the standalone infix the same, for consistency.