### PR TITLE
FormatOps: ignore end marker for ctrl body purpose

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1683,7 +1683,7 @@ class FormatOps(
       @tailrec
       def getBlockStat(t: Tree): Tree = t match {
         case b: Term.Block =>
-          getBlockSingleStat(b) match {
+          getSingleStatExceptEndMarker(b.stats) match {
             case Some(s) if !isEnclosedInMatching(b) => getBlockStat(s)
             case _ => t
           }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -486,7 +486,7 @@ class Router(formatOps: FormatOps) {
           else if (
             condIsDefined ||
             beforeMultiline.eq(Newlines.classic) ||
-            isTreeMultiStatBlock(body)
+            getSingleStatExceptEndMarker(body).isEmpty
           ) withSlbSplit
           else CtrlBodySplits.foldedNonEmptyNonComment(body, nlSplit(ft))
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -644,6 +644,22 @@ object TreeOps {
     case _ => false
   }
 
+  /* An end marker is really more like a closing brace for formatting purposes
+   * (but not when rewriting) so we should ignore it when considering whether a
+   * block contains only a single statement. NB: in FormatWriter, when choosing
+   * to insert or remove end markers, we avoid such borderline cases.
+   */
+  def getSingleStatExceptEndMarker(s: Seq[Stat]): Option[Stat] =
+    s.headOption.filter { _ =>
+      val len2 = s.lengthCompare(2)
+      len2 < 0 || len2 == 0 && s(1).is[Term.EndMarker]
+    }
+
+  def getSingleStatExceptEndMarker(t: Tree): Option[Tree] = t match {
+    case Term.Block(s) => getSingleStatExceptEndMarker(s)
+    case _ => Some(t)
+  }
+
   def getTreeSingleStat(t: Tree): Option[Tree] =
     t match {
       case b: Term.Block => getBlockSingleStat(b)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -897,6 +897,7 @@ object a:
         if x < y then -1 else if x > y then +1 else 0
 <<< rewrite with match
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
+rewrite.scala3.insertEndMarkerMinLines = 2 # will not apply, we use single-stat blocks
 ===
 enum IndentWidth {
    def foo = { this match {
@@ -913,6 +914,22 @@ enum IndentWidth {
           }
     }
   }
+   def foo = { this match {
+      case a =>
+         that match {
+            case b => bb
+            case c => cc
+         }
+         end match
+      case b =>
+         that match {
+            case c => cc
+            case _ => dd
+          }
+    }
+    end match
+  }
+  end foo
 }
 >>>
 enum IndentWidth:
@@ -926,6 +943,19 @@ enum IndentWidth:
         that match
            case c => cc
            case _ => dd
+   def foo =
+      this match
+         case a =>
+           that match
+              case b => bb
+              case c => cc
+           end match
+         case b =>
+           that match
+              case c => cc
+              case _ => dd
+      end match
+   end foo
 <<< rewrite with catch
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -843,6 +843,7 @@ object a:
         if x < y then -1 else if x > y then +1 else 0
 <<< rewrite with match
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
+rewrite.scala3.insertEndMarkerMinLines = 2 # will not apply, we use single-stat blocks
 ===
 enum IndentWidth {
    def foo = { this match {
@@ -859,6 +860,22 @@ enum IndentWidth {
           }
     }
   }
+   def foo = { this match {
+      case a =>
+         that match {
+            case b => bb
+            case c => cc
+         }
+         end match
+      case b =>
+         that match {
+            case c => cc
+            case _ => dd
+          }
+    }
+    end match
+  }
+  end foo
 }
 >>>
 enum IndentWidth:
@@ -871,6 +888,18 @@ enum IndentWidth:
       case b => that match
            case c => cc
            case _ => dd
+   def foo =
+      this match
+         case a =>
+           that match
+              case b => bb
+              case c => cc
+           end match
+         case b => that match
+              case c => cc
+              case _ => dd
+      end match
+   end foo
 <<< rewrite with catch
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -325,8 +325,7 @@ object a:
 >>>
 object a:
    def foo = this match
-      case A =>
-        that match
+      case A => that match
            case b => bb
            case c => cc
         end match
@@ -382,8 +381,7 @@ object a:
    def foo =
      try foo
      catch
-        case A =>
-          that match
+        case A => that match
              case b => bb
              case c => cc
           end match
@@ -880,8 +878,7 @@ enum IndentWidth {
 >>>
 enum IndentWidth:
    def foo = this match
-      case a =>
-        that match
+      case a => that match
            case b => bb
            case c => cc
         end match
@@ -890,8 +887,7 @@ enum IndentWidth:
            case _ => dd
    def foo =
       this match
-         case a =>
-           that match
+         case a => that match
               case b => bb
               case c => cc
            end match
@@ -929,8 +925,7 @@ enum IndentWidth:
    def foo =
      try foo
      catch
-        case a =>
-          that match
+        case a => that match
              case b => bb
              case c => cc
           end match
@@ -972,8 +967,7 @@ enum IndentWidth {
   def foo = {
     try foo
     catch {
-      case a =>
-        that match {
+      case a => that match {
                // format: off
                   case b => bb
                // format: on
@@ -1019,8 +1013,7 @@ enum IndentWidth:
    def foo =
      try foo
      catch
-        case a =>
-          that match
+        case a => that match
              // scalafmt: { indent { significant = 1 } }
              case b => bb
              case c => cc

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -899,6 +899,7 @@ object a:
         if x < y then -1 else if x > y then +1 else 0
 <<< rewrite with match
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
+rewrite.scala3.insertEndMarkerMinLines = 2 # will not apply, we use single-stat blocks
 ===
 enum IndentWidth {
    def foo = { this match {
@@ -915,6 +916,22 @@ enum IndentWidth {
           }
     }
   }
+   def foo = { this match {
+      case a =>
+         that match {
+            case b => bb
+            case c => cc
+         }
+         end match
+      case b =>
+         that match {
+            case c => cc
+            case _ => dd
+          }
+    }
+    end match
+  }
+  end foo
 }
 >>>
 enum IndentWidth:
@@ -928,6 +945,19 @@ enum IndentWidth:
         that match
            case c => cc
            case _ => dd
+   def foo =
+      this match
+         case a =>
+           that match
+              case b => bb
+              case c => cc
+           end match
+         case b =>
+           that match
+              case c => cc
+              case _ => dd
+      end match
+   end foo
 <<< rewrite with catch
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -956,6 +956,7 @@ object a:
            0
 <<< rewrite with match
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
+rewrite.scala3.insertEndMarkerMinLines = 2 # will not apply, we use single-stat blocks
 ===
 enum IndentWidth {
    def foo = { this match {
@@ -972,6 +973,22 @@ enum IndentWidth {
           }
     }
   }
+   def foo = { this match {
+      case a =>
+         that match {
+            case b => bb
+            case c => cc
+         }
+         end match
+      case b =>
+         that match {
+            case c => cc
+            case _ => dd
+          }
+    }
+    end match
+  }
+  end foo
 }
 >>>
 enum IndentWidth:
@@ -990,6 +1007,23 @@ enum IndentWidth:
                cc
              case _ =>
                dd
+   def foo =
+      this match
+         case a =>
+           that match
+              case b =>
+                bb
+              case c =>
+                cc
+           end match
+         case b =>
+           that match
+              case c =>
+                cc
+              case _ =>
+                dd
+      end match
+   end foo
 <<< rewrite with catch
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
 ===


### PR DESCRIPTION
This makes formatting with or without an end marker consistent. Follow-on to #3021.