### PR TITLE
FormatOps: unfold yield correctly and consistently

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1745,14 +1745,8 @@ class FormatOps(
       def slbSplit(end: T)(implicit fileLine: FileLine) =
         Split(Space, 0).withSingleLine(end, noSyntaxNL = true)
       body match {
-        case _: Term.ForYield =>
-          // unfold policy on yield forces a break
-          // revert it if we are attempting a single line
-          val noBreakOnYield = Policy.before(expire) {
-            case Decision(ft, s) if s.isEmpty && ft.right.is[T.KwYield] =>
-              Seq(Split(Space, 0))
-          }
-          slbSplit(expire).andPolicy(noBreakOnYield)
+        // we force newlines in for/yield
+        case _: Term.ForYield => Split.ignored
         // we force newlines in try/catch/finally
         case _: Term.Try | _: Term.TryWithHandler => Split.ignored
         // don't tuck curried apply

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -657,7 +657,9 @@ maxColumn = 80
 val attributes =
   for (i ← 1 to count) yield i
 >>>
-val attributes = for (i ← 1 to count) yield i
+val attributes =
+  for (i ← 1 to count)
+    yield i
 <<< 2.14 val with short for/do
 maxColumn = 80
 ===

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -655,10 +655,18 @@ def attributes =
 maxColumn = 80
 ===
 val attributes =
- for (i ← 1 to count)
- yield i
+  for (i ← 1 to count) yield i
 >>>
 val attributes = for (i ← 1 to count) yield i
+<<< 2.14 val with short for/do
+maxColumn = 80
+===
+val attributes =
+  for (i ← 1 to count) i * i
+>>>
+val attributes =
+  for (i ← 1 to count)
+    i * i
 <<< 2.15 val with literal apply
 object a {
    val a = b(0x1F, // ID1


### PR DESCRIPTION
We were handling it differently in some cases, and inconsistent with `while` and other `for`.