### PR TITLE
Router: indent, handle comma in repeated enum cases

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1484,25 +1484,20 @@ class Router(formatOps: FormatOps) {
             )
           }
         }
-        splitsOpt.getOrElse {
-          if (!style.newlines.formatInfix && leftOwner.is[Term.ApplyInfix])
-            Seq(
-              // Do whatever the user did if infix.
-              Split(Space.orNL(newlines == 0), 0)
-            )
-          else {
-            val indent = leftOwner match {
-              case _: Defn.Val | _: Defn.Var =>
-                style.indent.getDefnSite(leftOwner)
-              case _ =>
-                0
-            }
+        def altSplits = leftOwner match {
+          case _: Term.ApplyInfix if !style.newlines.formatInfix =>
+            // Do whatever the user did if infix.
+            Seq(Split(Space.orNL(newlines == 0), 0))
+          case _: Defn.Val | _: Defn.Var =>
+            val indent = style.indent.getDefnSite(leftOwner)
             Seq(
               Split(Space, 0),
               Split(Newline, 1).withIndent(indent, right, After)
             )
-          }
+          case _ =>
+            Seq(Split(Space, 0), Split(Newline, 1))
         }
+        splitsOpt.getOrElse(altSplits)
       case FormatToken(_, T.Semicolon(), _) =>
         Seq(
           Split(NoSplit, 0)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1494,6 +1494,11 @@ class Router(formatOps: FormatOps) {
               Split(Space, 0),
               Split(Newline, 1).withIndent(indent, right, After)
             )
+          case _: Defn.RepeatedEnumCase if {
+                if (!style.newlines.sourceIgnored) newlines != 0
+                else style.newlines.source eq Newlines.unfold
+              } =>
+            Seq(Split(Newline, 0))
           case _ =>
             Seq(Split(Space, 0), Split(Newline, 1))
         }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2085,6 +2085,12 @@ class Router(formatOps: FormatOps) {
         insideInfixSplit(app, formatToken)
 
       // Case
+      case FormatToken(_: T.KwCase, _, _)
+          if leftOwner.is[Defn.RepeatedEnumCase] =>
+        val indent =
+          Indent(style.indent.main, leftOwner.tokens.last, ExpiresOn.After)
+        Seq(Split(Space, 0).withIndent(indent))
+
       case FormatToken(_: T.KwCase, _, _) if leftOwner.is[CaseTree] =>
         val owner = leftOwner.asInstanceOf[CaseTree]
         val body = owner.body

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3328,11 +3328,11 @@ enum SerializedField extends jl.Enum[SerializedField] {
 >>>
 enum SerializedField extends jl.Enum[SerializedField] {
   case UNKNOWN, // represents a field code we didn't recognize
-  END_MARKER, // end of a list of fields
-  ROOT_VALUE, // Fields at the root
-  ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
-  VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
-  ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
-  ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
-  ORIGIN_NULL_RESOURCE
+    END_MARKER, // end of a list of fields
+    ROOT_VALUE, // Fields at the root
+    ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
+    VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+    ORIGIN_NULL_RESOURCE
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3312,3 +3312,27 @@ allMatching(versionString, partialFunctions)
 allMatching(versionString,
             partialFunctions
            )(partialFunctions)
+<<< #3056
+enum SerializedField extends jl.Enum[SerializedField] {
+  case UNKNOWN,         // represents a field code we didn't recognize
+    END_MARKER,         // end of a list of fields
+    ROOT_VALUE,         // Fields at the root
+    ROOT_WAS_CONFIG,
+    VALUE_DATA,         // Fields that make up a value
+    VALUE_ORIGIN,    
+    ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER,
+    ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE, ORIGIN_NULL_RESOURCE
+}
+>>>
+enum SerializedField extends jl.Enum[SerializedField] {
+  case UNKNOWN, // represents a field code we didn't recognize
+  END_MARKER, // end of a list of fields
+  ROOT_VALUE, // Fields at the root
+  ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
+  VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
+  ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+  ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+  ORIGIN_NULL_RESOURCE
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3330,9 +3330,12 @@ enum SerializedField extends jl.Enum[SerializedField] {
   case UNKNOWN, // represents a field code we didn't recognize
     END_MARKER, // end of a list of fields
     ROOT_VALUE, // Fields at the root
-    ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
-    VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
-    ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ROOT_WAS_CONFIG,
+    VALUE_DATA, // Fields that make up a value
+    VALUE_ORIGIN,
+    ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER,
+    ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
     ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
     ORIGIN_NULL_RESOURCE
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3171,11 +3171,11 @@ enum SerializedField extends jl.Enum[SerializedField] {
 >>>
 enum SerializedField extends jl.Enum[SerializedField] {
   case UNKNOWN, // represents a field code we didn't recognize
-  END_MARKER, // end of a list of fields
-  ROOT_VALUE, // Fields at the root
-  ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
-  VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
-  ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
-  ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
-  ORIGIN_NULL_RESOURCE
+    END_MARKER, // end of a list of fields
+    ROOT_VALUE, // Fields at the root
+    ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
+    VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+    ORIGIN_NULL_RESOURCE
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3155,3 +3155,27 @@ allMatching(versionString, partialFunctions)
 allMatching(versionString,
             partialFunctions
            )(partialFunctions)
+<<< #3056
+enum SerializedField extends jl.Enum[SerializedField] {
+  case UNKNOWN,         // represents a field code we didn't recognize
+    END_MARKER,         // end of a list of fields
+    ROOT_VALUE,         // Fields at the root
+    ROOT_WAS_CONFIG,
+    VALUE_DATA,         // Fields that make up a value
+    VALUE_ORIGIN,
+    ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER,
+    ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE, ORIGIN_NULL_RESOURCE
+}
+>>>
+enum SerializedField extends jl.Enum[SerializedField] {
+  case UNKNOWN, // represents a field code we didn't recognize
+  END_MARKER, // end of a list of fields
+  ROOT_VALUE, // Fields at the root
+  ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
+  VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
+  ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+  ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+  ORIGIN_NULL_RESOURCE
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3317,11 +3317,11 @@ enum SerializedField extends jl.Enum[SerializedField] {
 >>>
 enum SerializedField extends jl.Enum[SerializedField] {
   case UNKNOWN, // represents a field code we didn't recognize
-  END_MARKER, // end of a list of fields
-  ROOT_VALUE, // Fields at the root
-  ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
-  VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
-  ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
-  ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
-  ORIGIN_NULL_RESOURCE
+    END_MARKER, // end of a list of fields
+    ROOT_VALUE, // Fields at the root
+    ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
+    VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+    ORIGIN_NULL_RESOURCE
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3319,9 +3319,12 @@ enum SerializedField extends jl.Enum[SerializedField] {
   case UNKNOWN, // represents a field code we didn't recognize
     END_MARKER, // end of a list of fields
     ROOT_VALUE, // Fields at the root
-    ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
-    VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
-    ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ROOT_WAS_CONFIG,
+    VALUE_DATA, // Fields that make up a value
+    VALUE_ORIGIN,
+    ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER,
+    ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
     ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
     ORIGIN_NULL_RESOURCE
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3301,3 +3301,27 @@ allMatching(versionString,
             partialFunctions
            )
            (partialFunctions)
+<<< #3056
+enum SerializedField extends jl.Enum[SerializedField] {
+  case UNKNOWN,         // represents a field code we didn't recognize
+    END_MARKER,         // end of a list of fields
+    ROOT_VALUE,         // Fields at the root
+    ROOT_WAS_CONFIG,
+    VALUE_DATA,         // Fields that make up a value
+    VALUE_ORIGIN,
+    ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER,
+    ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE, ORIGIN_NULL_RESOURCE
+}
+>>>
+enum SerializedField extends jl.Enum[SerializedField] {
+  case UNKNOWN, // represents a field code we didn't recognize
+  END_MARKER, // end of a list of fields
+  ROOT_VALUE, // Fields at the root
+  ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
+  VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
+  ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+  ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+  ORIGIN_NULL_RESOURCE
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3421,9 +3421,17 @@ enum SerializedField extends jl.Enum[SerializedField] {
   case UNKNOWN, // represents a field code we didn't recognize
     END_MARKER, // end of a list of fields
     ROOT_VALUE, // Fields at the root
-    ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
-    VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
-    ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
-    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+    ROOT_WAS_CONFIG,
+    VALUE_DATA, // Fields that make up a value
+    VALUE_ORIGIN,
+    ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER,
+    ORIGIN_END_LINE_NUMBER,
+    ORIGIN_TYPE,
+    ORIGIN_URL,
+    ORIGIN_COMMENTS,
+    ORIGIN_NULL_URL,
+    ORIGIN_NULL_COMMENTS,
+    ORIGIN_RESOURCE,
     ORIGIN_NULL_RESOURCE
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3419,11 +3419,11 @@ enum SerializedField extends jl.Enum[SerializedField] {
 >>>
 enum SerializedField extends jl.Enum[SerializedField] {
   case UNKNOWN, // represents a field code we didn't recognize
-  END_MARKER, // end of a list of fields
-  ROOT_VALUE, // Fields at the root
-  ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
-  VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
-  ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
-  ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
-  ORIGIN_NULL_RESOURCE
+    END_MARKER, // end of a list of fields
+    ROOT_VALUE, // Fields at the root
+    ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
+    VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+    ORIGIN_NULL_RESOURCE
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3403,3 +3403,27 @@ allMatching
     partialFunctions
    )
    (partialFunctions)
+<<< #3056
+enum SerializedField extends jl.Enum[SerializedField] {
+  case UNKNOWN,         // represents a field code we didn't recognize
+    END_MARKER,         // end of a list of fields
+    ROOT_VALUE,         // Fields at the root
+    ROOT_WAS_CONFIG,
+    VALUE_DATA,         // Fields that make up a value
+    VALUE_ORIGIN,
+    ORIGIN_DESCRIPTION, // Fields that make up an origin
+    ORIGIN_LINE_NUMBER,
+    ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+    ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE, ORIGIN_NULL_RESOURCE
+}
+>>>
+enum SerializedField extends jl.Enum[SerializedField] {
+  case UNKNOWN, // represents a field code we didn't recognize
+  END_MARKER, // end of a list of fields
+  ROOT_VALUE, // Fields at the root
+  ROOT_WAS_CONFIG, VALUE_DATA, // Fields that make up a value
+  VALUE_ORIGIN, ORIGIN_DESCRIPTION, // Fields that make up an origin
+  ORIGIN_LINE_NUMBER, ORIGIN_END_LINE_NUMBER, ORIGIN_TYPE, ORIGIN_URL,
+  ORIGIN_COMMENTS, ORIGIN_NULL_URL, ORIGIN_NULL_COMMENTS, ORIGIN_RESOURCE,
+  ORIGIN_NULL_RESOURCE
+}


### PR DESCRIPTION
Fixes #3056.