### PR TITLE
Router: disallow breaks in args in binpack=oneline

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2743,15 +2743,17 @@ object a {
 }
 >>>
 object a {
-  val readOut =
-    new ReadOnlyOutputDirectory("main.js" -> raw"""
+  val readOut = new ReadOnlyOutputDirectory(
+    "main.js" -> raw"""
           |console.log("hello");
           |//# sourceMappingURL=main.js.map
           |// some other comment
-          |""".stripMargin, "main.js.map" -> raw"""{
+          |""".stripMargin,
+    "main.js.map" -> raw"""{
           |  "file": "main.js",
           |  "other key": 1
-          |}""".stripMargin)
+          |}""".stripMargin
+  )
 }
 <<< binPack with named parameter values, danglingParentheses
 binPack.preset = true
@@ -4804,8 +4806,7 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
+  def foo(dd: DD[AA[BB], CC] =
         DDD.ddd): Bar[Baz] = {
     // c
     qux
@@ -4824,9 +4825,8 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
-        DDD.ddd): Bar[Baz] = {
+  def foo(dd: DD[AA[BB],
+        CC] = DDD.ddd): Bar[Baz] = {
     // c
     qux
   }
@@ -4846,9 +4846,8 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
-        DDDD.dddd) = {
+  def foo(dd: DD[AA[BB], CC] =
+            DDDD.dddd) = {
     // c
     qux
   }
@@ -4869,9 +4868,8 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
-        DDDD.dddd) = {
+  def foo(dd: DD[AA[BB],
+            CC] = DDDD.dddd) = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2705,6 +2705,54 @@ object a {
       ).foo
   }
 }
+<<< binpack call, oneline, with syntaxNL, single arg
+maxColumn = 60
+binPack.unsafeCallSite = oneline
+optIn.configStyleArguments = false
+===
+object a {
+  val readOut = new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin)
+}
+>>>
+object a {
+  val readOut =
+    new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin)
+}
+<<< binpack call, oneline, with syntaxNL, multiple args
+maxColumn = 60
+binPack.unsafeCallSite = oneline
+optIn.configStyleArguments = false
+===
+object a {
+  val readOut = new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin, "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+}
+>>>
+object a {
+  val readOut =
+    new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin, "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+}
 <<< binPack with named parameter values, danglingParentheses
 binPack.preset = true
 optIn.configStyleArguments = false
@@ -4740,6 +4788,90 @@ object a {
 object a {
   def foo(bb: BB, cc: CC, dd: DD = DDD.ddd): Bar[
     Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDD.ddd): Bar[Baz] = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDD.ddd): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also bracketCallSite
+binPack.bracketCallSite = Oneline
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDD.ddd): Bar[Baz] = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDD.ddd): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also align
+align.openParenDefnSite = true
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDDD.dddd) = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDDD.dddd) = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also bracketCallSite+align
+align.openParenDefnSite = true
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+binPack.bracketCallSite = Oneline
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDDD.dddd) = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDDD.dddd) = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2547,12 +2547,12 @@ object a {
 >>>
 object a {
   test("foo") {
-    a.b(c, d) shouldBe E(
-      Seq(F(1, "v1"), F(2, "v2")),
-      G(Some(Seq(h, i)),
-        Some(Seq(j, k)), a.b, c.d,
-        e.f.g, h.i.j)
-    ).foo
+    a.b(c, d) shouldBe
+      E(Seq(F(1, "v1"), F(2, "v2")),
+        G(Some(Seq(h, i)),
+          Some(Seq(j, k)), a.b, c.d,
+          e.f.g, h.i.j)
+      ).foo
   }
 }
 <<< binpack call, oneline, with syntaxNL, single arg
@@ -2593,15 +2593,17 @@ object a {
 }
 >>>
 object a {
-  val readOut =
-    new ReadOnlyOutputDirectory("main.js" -> raw"""
+  val readOut = new ReadOnlyOutputDirectory(
+    "main.js" -> raw"""
           |console.log("hello");
           |//# sourceMappingURL=main.js.map
           |// some other comment
-          |""".stripMargin, "main.js.map" -> raw"""{
+          |""".stripMargin,
+    "main.js.map" -> raw"""{
           |  "file": "main.js",
           |  "other key": 1
-          |}""".stripMargin)
+          |}""".stripMargin
+  )
 }
 <<< binPack with named parameter values, danglingParentheses
 binPack.preset = true
@@ -4649,9 +4651,8 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
-        DDDD.dddd) = {
+  def foo(dd: DD[AA[BB], CC] =
+            DDDD.dddd) = {
     // c
     qux
   }
@@ -4672,9 +4673,8 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
-        DDDD.dddd) = {
+  def foo(dd: DD[AA[BB], CC] =
+            DDDD.dddd) = {
     // c
     qux
   }
@@ -4755,9 +4755,8 @@ object a {
     s"Cannot parse parameter f as DummyEnum, $wrongValue is not a member of Enum (dummy-value)"
   ))
 
-  when(audienceService.publish(any[Tenant], any[Int]))
-    .thenReturn(Success[NonEmptyList[String], ApiAudience](apiAudience
-      .copy(status = AudienceStatus.Pending.name)))
+  when(audienceService.publish(any[Tenant], any[Int])).thenReturn(Success[NonEmptyList[String],
+    ApiAudience](apiAudience.copy(status = AudienceStatus.Pending.name)))
 }
 <<< unsafeCallSite = Oneline, nested with one arg, several options
 maxColumn = 100

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2555,6 +2555,54 @@ object a {
     ).foo
   }
 }
+<<< binpack call, oneline, with syntaxNL, single arg
+maxColumn = 60
+binPack.unsafeCallSite = oneline
+optIn.configStyleArguments = false
+===
+object a {
+  val readOut = new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin)
+}
+>>>
+object a {
+  val readOut =
+    new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin)
+}
+<<< binpack call, oneline, with syntaxNL, multiple args
+maxColumn = 60
+binPack.unsafeCallSite = oneline
+optIn.configStyleArguments = false
+===
+object a {
+  val readOut = new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin, "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+}
+>>>
+object a {
+  val readOut =
+    new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin, "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+}
 <<< binPack with named parameter values, danglingParentheses
 binPack.preset = true
 optIn.configStyleArguments = false
@@ -4543,6 +4591,90 @@ object a {
   def foo(bb: BB, cc: CC, dd: DD = DDD.ddd): Bar[
     Baz
   ] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDD.ddd): Bar[Baz] = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] = DDD.ddd
+  ): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also bracketCallSite
+binPack.bracketCallSite = Oneline
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDD.ddd): Bar[Baz] = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] = DDD.ddd
+  ): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also align
+align.openParenDefnSite = true
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDDD.dddd) = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDDD.dddd) = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also bracketCallSite+align
+align.openParenDefnSite = true
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+binPack.bracketCallSite = Oneline
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDDD.dddd) = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDDD.dddd) = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2748,15 +2748,17 @@ object a {
 }
 >>>
 object a {
-  val readOut =
-    new ReadOnlyOutputDirectory("main.js" -> raw"""
+  val readOut = new ReadOnlyOutputDirectory(
+    "main.js" -> raw"""
           |console.log("hello");
           |//# sourceMappingURL=main.js.map
           |// some other comment
-          |""".stripMargin, "main.js.map" -> raw"""{
+          |""".stripMargin,
+    "main.js.map" -> raw"""{
           |  "file": "main.js",
           |  "other key": 1
-          |}""".stripMargin)
+          |}""".stripMargin
+  )
 }
 <<< binPack with named parameter values, danglingParentheses
 binPack.preset = true
@@ -4831,8 +4833,7 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
+  def foo(dd: DD[AA[BB], CC] =
         DDD.ddd): Bar[Baz] = {
     // c
     qux
@@ -4851,8 +4852,7 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
+  def foo(dd: DD[AA[BB], CC] =
         DDD.ddd): Bar[Baz] = {
     // c
     qux
@@ -4873,9 +4873,8 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
-        DDDD.dddd) = {
+  def foo(dd: DD[AA[BB], CC] =
+            DDDD.dddd) = {
     // c
     qux
   }
@@ -4896,9 +4895,8 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      dd: DD[AA[BB], CC] =
-        DDDD.dddd) = {
+  def foo(dd: DD[AA[BB], CC] =
+            DDDD.dddd) = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2710,6 +2710,54 @@ object a {
       ).foo
   }
 }
+<<< binpack call, oneline, with syntaxNL, single arg
+maxColumn = 60
+binPack.unsafeCallSite = oneline
+optIn.configStyleArguments = false
+===
+object a {
+  val readOut = new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin)
+}
+>>>
+object a {
+  val readOut =
+    new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin)
+}
+<<< binpack call, oneline, with syntaxNL, multiple args
+maxColumn = 60
+binPack.unsafeCallSite = oneline
+optIn.configStyleArguments = false
+===
+object a {
+  val readOut = new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin, "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+}
+>>>
+object a {
+  val readOut =
+    new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin, "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+}
 <<< binPack with named parameter values, danglingParentheses
 binPack.preset = true
 optIn.configStyleArguments = false
@@ -4767,6 +4815,90 @@ object a {
 object a {
   def foo(bb: BB, cc: CC,
       dd: DD = DDD.ddd): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDD.ddd): Bar[Baz] = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDD.ddd): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also bracketCallSite
+binPack.bracketCallSite = Oneline
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDD.ddd): Bar[Baz] = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDD.ddd): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also align
+align.openParenDefnSite = true
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDDD.dddd) = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDDD.dddd) = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also bracketCallSite+align
+align.openParenDefnSite = true
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+binPack.bracketCallSite = Oneline
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDDD.dddd) = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDDD.dddd) = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2869,6 +2869,54 @@ object a {
       ).foo
   }
 }
+<<< binpack call, oneline, with syntaxNL, single arg
+maxColumn = 60
+binPack.unsafeCallSite = oneline
+optIn.configStyleArguments = false
+===
+object a {
+  val readOut = new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin)
+}
+>>>
+object a {
+  val readOut =
+    new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin)
+}
+<<< binpack call, oneline, with syntaxNL, multiple args
+maxColumn = 60
+binPack.unsafeCallSite = oneline
+optIn.configStyleArguments = false
+===
+object a {
+  val readOut = new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin, "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+}
+>>>
+object a {
+  val readOut =
+    new ReadOnlyOutputDirectory("main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin, "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+}
 <<< binPack with named parameter values, danglingParentheses
 binPack.preset = true
 optIn.configStyleArguments = false
@@ -4993,6 +5041,90 @@ object a {
   def foo(bb: BB, cc: CC, dd: DD = DDD.ddd): Bar[
     Baz
   ] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDD.ddd): Bar[Baz] = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] = DDD.ddd
+  ): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also bracketCallSite
+binPack.bracketCallSite = Oneline
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDD.ddd): Bar[Baz] = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] = DDD.ddd
+  ): Bar[Baz] = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also align
+align.openParenDefnSite = true
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDDD.dddd) = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDDD.dddd) = {
+    // c
+    qux
+  }
+}
+<<< unsafeDefnSite = Oneline, one arg, also bracketCallSite+align
+align.openParenDefnSite = true
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+binPack.bracketCallSite = Oneline
+binPack.unsafeDefnSite = Oneline
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+object a {
+  def foo(dd: DD[AA[BB], CC] = DDDD.dddd) = {
+      // c
+      qux
+    }
+}
+>>>
+object a {
+  def foo(
+      dd: DD[AA[BB], CC] =
+        DDDD.dddd) = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -2884,11 +2884,13 @@ object a {
 >>>
 object a {
   val readOut =
-    new ReadOnlyOutputDirectory("main.js" -> raw"""
+    new ReadOnlyOutputDirectory(
+      "main.js" -> raw"""
           |console.log("hello");
           |//# sourceMappingURL=main.js.map
           |// some other comment
-          |""".stripMargin)
+          |""".stripMargin
+    )
 }
 <<< binpack call, oneline, with syntaxNL, multiple args
 maxColumn = 60
@@ -2908,14 +2910,17 @@ object a {
 >>>
 object a {
   val readOut =
-    new ReadOnlyOutputDirectory("main.js" -> raw"""
+    new ReadOnlyOutputDirectory(
+      "main.js" -> raw"""
           |console.log("hello");
           |//# sourceMappingURL=main.js.map
           |// some other comment
-          |""".stripMargin, "main.js.map" -> raw"""{
+          |""".stripMargin,
+      "main.js.map" -> raw"""{
           |  "file": "main.js",
           |  "other key": 1
-          |}""".stripMargin)
+          |}""".stripMargin
+    )
 }
 <<< binPack with named parameter values, danglingParentheses
 binPack.preset = true

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -241,7 +241,8 @@ object a {
 }
 >>>
 object a {
-  foo(new SimpleMethodName(new SimpleMethodName(validateSimpleEncodedName(name,
+  foo(
+      new SimpleMethodName(new SimpleMethodName(validateSimpleEncodedName(name,
           0, len, openAngleBracketOK = false))),
       new SimpleMethodName(new SimpleMethodName(validateSimpleEncodedName(name,
           0, len, openAngleBracketOK = false))))
@@ -490,10 +491,12 @@ optDef.getOrElse {
 optDef.getOrElse {
   abort(foo &&
     bar)
-  abort(foo &&
+  abort(
+      foo &&
       bar,
       baz)
-  abort(foo &&
+  abort(
+      foo &&
       bar,
       foo &&
       bar,
@@ -521,10 +524,12 @@ foo.bar {
 foo.bar {
   abort(foo &&
     bar)
-  abort(foo &&
+  abort(
+      foo &&
       bar,
       baz)
-  abort(foo &&
+  abort(
+      foo &&
       bar,
       foo &&
       bar,
@@ -739,7 +744,8 @@ optDef.getOrElse {
 optDef.getOrElse {
   abort(fooFoo &&
     barBar)
-  abort(fooFoo &&
+  abort(
+      fooFoo &&
       barBar,
       bazBaz)
 }
@@ -759,7 +765,8 @@ optDef.getOrElse {
 optDef.getOrElse {
   abort(fooFoo &&
     barBar)
-  abort(fooFoo &&
+  abort(
+      fooFoo &&
       barBar,
       bazBaz)
 }
@@ -788,13 +795,15 @@ object a {
 object a {
   Seq(foo +
     bar)
-  Seq(foo +
+  Seq(
+    foo +
       bar,
     foo +
       bar)
   Seq(foo &&
     bar)
-  Seq(foo &&
+  Seq(
+    foo &&
     bar,
     foo &&
     bar)
@@ -824,13 +833,15 @@ object a {
 object a {
   Seq(foo +
     bar)
-  Seq(foo +
+  Seq(
+    foo +
       bar,
     foo +
       bar)
   Seq(foo &&
     bar)
-  Seq(foo &&
+  Seq(
+    foo &&
     bar,
     foo &&
     bar)
@@ -859,13 +870,15 @@ object a {
 object a {
   Seq(foo +
     bar)
-  Seq(foo +
+  Seq(
+    foo +
       bar,
     foo +
       bar)
   Seq(foo &&
     bar)
-  Seq(foo &&
+  Seq(
+    foo &&
     bar,
     foo &&
     bar)


### PR DESCRIPTION
Fix bug in binpack=oneline implementation:
    - handling of the first arg is different from subsequent ones (which
      uses a single-line block no-split policy)
    - the single-line block policy must also exclude multiline strings.