### PR TITLE
Installation: update package sizes as of 2022

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -242,7 +242,7 @@ scalafmt --version # should be @STABLE_VERSION@
 
 #### standalone
 
-Alternatively, you can create a complete standalone executable with:
+Alternatively, you can create a complete standalone executable (40+ MB in 2022) with:
 
 ```sh
 coursier bootstrap org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \
@@ -254,7 +254,7 @@ coursier bootstrap org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \
 
 #### slim
 
-Finally, you can choose to obtain a slim 15 KiB bootstrap script instead with:
+Finally, you can choose to obtain a slim bootstrap script (100+ KB in 2022) instead with:
 
 ```sh
 coursier bootstrap org.scalameta:scalafmt-cli_2.13:@STABLE_VERSION@ \


### PR DESCRIPTION
The slim version of scalafmt has not been 15 KiB for a long time; the size of 2.7.5 in October 2020 was 27Kb while 3.3.3 is 123Kb.