### PR TITLE
FormatOps: implement indentOperator.exemptScope

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -509,22 +509,55 @@ def fooDef
 Normally, the first eligible break _inside_ a chain of infix operators is
 indented by 2.
 
-This group of parameters allows overriding which infix operators are eligible
-and controls when indentation is _omitted_.
+This group of parameters allows overriding which infix operators, and in which
+context, are eligible to be exempted from this, with indentation _omitted_.
 
-#### `indentOperator.topLevelOnly`
+If you wish to disable this functionality, set `indentOperator.excludeRegex = '^$'`.
 
-If true, only top-level infix operators are eligible to be exempted from the
-default indentation rule.
+#### `indentOperator.exemptScope`
 
-```scala mdoc:defaults
-indentOperator.topLevelOnly
-```
+Added in 3.4.0, this parameter determines when an infix operator can be exempted from applying
+continuation indentation.
+
+It accepts the following values, to determine the context in which infix operators are eligible
+to be exempted from the default indentation rule:
+
+- `oldTopLevel` (default): "top-level" infix operators
+  - the definition of top-level historically refers to infix expressions whose direct parent is
+    a block (typically as the last statement in that block), `if/while` (as condition or body),
+    or case clause (as pattern or body)
+  - this value replaced deprecated `indentOperator.topLevelOnly=true`
+  - this approach is also somewhat inconsistent with what it was intended to accomplish, and
+    kept only for backwards compatibility; please consider using one of the alternatives
+- `aloneEnclosed`: infix operators which are enclosed in braces or parens as the only statement
+  in a block or body of a braces-enclosed lambda function; an `if/while` condition; the only
+  argument of a method call; or similar;
+  - it also includes a few scenarios where parens can be omitted, such case clause patterns,
+    conditions in new scala3 `if-then` and `while-do` syntax, etc.
+  - however, block braces are not optional
+- `aloneArgOrBody`: infix operators as an `if/while` condition; an argument of a method call; the
+  only statement in a block; entire body of an assignment, case clause, control statement, etc;
+  - it is intended to help implement a requirement of the
+    [scala-js coding style](https://github.com/scala-js/scala-js/blob/main/CODINGSTYLE.md#long-expressions-with-binary-operators).
+- `all`: all infix operators
+  - this value replaced deprecated `indentOperator.topLevelOnly=false`
 
 ```scala mdoc:scalafmt
-indentOperator.topLevelOnly = true
+indentOperator.exemptScope = oldTopLevel
 ---
 function(
+  a &&
+    b,
+  a &&
+    b
+)
+function(a &&
+    b)(a &&
+    b)
+function(
+  a &&
+    b
+)(
   a &&
     b
 )
@@ -535,9 +568,71 @@ function {
 ```
 
 ```scala mdoc:scalafmt
-indentOperator.topLevelOnly = false
+indentOperator.exemptScope = all
 ---
 function(
+  a &&
+    b,
+  a &&
+    b
+)
+function(a &&
+    b)(a &&
+    b)
+function(
+  a &&
+    b
+)(
+  a &&
+    b
+)
+function {
+  a &&
+    b
+}
+```
+
+```scala mdoc:scalafmt
+indentOperator.exemptScope = aloneEnclosed
+---
+function(
+  a &&
+    b,
+  a &&
+    b
+)
+function(a &&
+    b)(a &&
+    b)
+function(
+  a &&
+    b
+)(
+  a &&
+    b
+)
+function {
+  a &&
+    b
+}
+```
+
+```scala mdoc:scalafmt
+indentOperator.exemptScope = aloneArgOrBody
+---
+function(
+  a &&
+    b,
+  a &&
+    b
+)
+function(a &&
+    b)(a &&
+    b)
+function(
+  a &&
+    b
+)(
   a &&
     b
 )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -25,9 +25,9 @@ import metaconfig._
   *   a +=
   *     b
   *   }}}
-  * @param topLevelOnly
-  *   If true, allows no indentation on infix operators in top-level functions
-  *   only. For example,
+  * @param exemptScope
+  *   If topLevel, allows no indentation on infix operators in top-level
+  *   functions only. For example,
   *   {{{
   *   // top-level, flag doesn't apply
   *   a &&
@@ -48,6 +48,12 @@ import metaconfig._
   *   [[https://github.com/scala-js/scala-js/blob/master/CODINGSTYLE.md#long-expressions-with-binary-operators]]
   */
 case class IndentOperator(
+    private val exemptScope: Option[IndentOperator.Exempt] = None,
+    @annotation.DeprecatedName(
+      "topLevelOnly",
+      "Use indentOperator.exemptScope instead (true->topLevelOnly, false->all)",
+      "3.4.0"
+    )
     topLevelOnly: Boolean = true,
     @annotation.ExtraName("include")
     includeRegex: String = ".*",
@@ -78,4 +84,14 @@ object IndentOperator {
     case Conf.Str("default") => IndentOperator.default
   }
 
+  sealed abstract class Exempt
+  object Exempt {
+    case object all extends Exempt
+    case object oldTopLevel extends Exempt
+    case object aloneEnclosed extends Exempt
+    case object aloneArgOrBody extends Exempt
+
+    implicit val reader: ConfCodecEx[Exempt] = ReaderUtil
+      .oneOf[Exempt](all, oldTopLevel, aloneEnclosed, aloneArgOrBody)
+  }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -54,7 +54,7 @@ case class IndentOperator(
       "Use indentOperator.exemptScope instead (true->topLevelOnly, false->all)",
       "3.4.0"
     )
-    topLevelOnly: Boolean = true,
+    private val topLevelOnly: Boolean = true,
     @annotation.ExtraName("include")
     includeRegex: String = ".*",
     @annotation.ExtraName("exclude")
@@ -65,6 +65,12 @@ case class IndentOperator(
 
   def noindent(op: String): Boolean =
     excludeRegexp.matcher(op).find() || !includeRegexp.matcher(op).find()
+
+  lazy val getExemptScope: IndentOperator.Exempt =
+    exemptScope.getOrElse(
+      if (topLevelOnly) IndentOperator.Exempt.oldTopLevel
+      else IndentOperator.Exempt.all
+    )
 }
 
 object IndentOperator {

--- a/scalafmt-tests/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/src/test/resources/test/IndentOperator.stat
@@ -2956,7 +2956,7 @@ object a {
     b
   } else
     a &&
-    b
+      b
   if (
     a &&
     b
@@ -2965,12 +2965,12 @@ object a {
     b
   } else
     a &&
-    b
+      b
   if a &&
     b
   then
     a &&
-    b
+      b
   else {
     a &&
     b
@@ -2980,7 +2980,7 @@ object a {
     b
   then
     a &&
-    b
+      b
   else {
     a &&
     b
@@ -3193,24 +3193,24 @@ object a {
     b
   )
     a &&
-    b
+      b
   while (
     a &&
     b
   )
     a &&
-    b
+      b
   while a &&
     b
   do
     a &&
-    b
+      b
   while
     a &&
     b
   do
     a &&
-    b
+      b
 }
 <<< aloneArgOrBody, while
 runner.dialect = scala3
@@ -3375,7 +3375,7 @@ object a {
 object a {
   foo(
     a &&
-      b
+    b
   )
   foo {
     a &&
@@ -3389,10 +3389,10 @@ object a {
   )
   foo(
     a &&
-      b
+    b
   )(
     a &&
-      b
+    b
   )
 }
 <<< aloneArgOrBody, apply
@@ -3426,7 +3426,7 @@ object a {
 object a {
   foo(
     a &&
-      b
+    b
   )
   foo {
     a &&
@@ -3434,16 +3434,16 @@ object a {
   }
   foo(
     a &&
-      b,
+    b,
     a &&
-      b
+    b
   )
   foo(
     a &&
-      b
+    b
   )(
     a &&
-      b
+    b
   )
 }
 <<< oldTopLevel, apply
@@ -3524,21 +3524,21 @@ a match {
 a match {
   case foo =>
     a &&
-    b
+      b
   case foo =>
     val baz = qux
     a &&
-    b
+      b
   case bar => {
     val baz = qux
     a &&
-    b
+      b
   }
   case bar if
         a &&
           b =>
     a &&
-    b
+      b
 }
 <<< aloneArgOrBody, case
 newlines.source = keep
@@ -3571,11 +3571,11 @@ a match {
   case foo =>
     val baz = qux
     a &&
-    b
+      b
   case bar => {
     val baz = qux
     a &&
-    b
+      b
   }
   case bar if
         a &&
@@ -3654,7 +3654,7 @@ object a {
   foo { x =>
     val bar = qux
     a &&
-    b
+      b
   }
   foo(x =>
     a &&
@@ -3689,11 +3689,11 @@ object a {
   foo { x =>
     val bar = qux
     a &&
-    b
+      b
   }
   foo(x =>
     a &&
-      b
+    b
   )
 }
 <<< oldTopLevel, lambda

--- a/scalafmt-tests/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/src/test/resources/test/IndentOperator.stat
@@ -2906,3 +2906,828 @@ object a {
     b
   }
 }
+<<< aloneEnclosed, if
+runner.dialect = scala3
+newlines.source = keep
+indentOperator.exemptScope = aloneEnclosed
+===
+object a {
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if (a &&
+    b) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if a &&
+    b then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+  if
+    a &&
+    b then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+}
+>>>
+object a {
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if a &&
+    b
+  then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+  if
+    a &&
+    b
+  then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+}
+<<< aloneArgOrBody, if
+runner.dialect = scala3
+newlines.source = keep
+indentOperator.exemptScope = aloneArgOrBody
+===
+object a {
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if (a &&
+    b) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if a &&
+    b then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+  if
+    a &&
+    b then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+}
+>>>
+object a {
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if a &&
+    b
+  then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+  if
+    a &&
+    b
+  then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+}
+<<< oldTopLevel, if
+runner.dialect = scala3
+newlines.source = keep
+indentOperator.exemptScope = oldTopLevel
+===
+object a {
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if (a &&
+    b) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if a &&
+    b then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+  if
+    a &&
+    b then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+}
+>>>
+object a {
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  } else
+    a &&
+    b
+  if a &&
+    b
+  then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+  if
+    a &&
+    b
+  then
+    a &&
+    b
+  else {
+    a &&
+    b
+  }
+}
+<<< aloneEnclosed, while
+runner.dialect = scala3
+newlines.source = keep
+indentOperator.exemptScope = aloneEnclosed
+===
+object a {
+  while (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  }
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while (a &&
+    b)
+    a &&
+    b
+  while a &&
+    b do
+    a &&
+    b
+  while
+    a &&
+    b do
+    a &&
+    b
+}
+>>>
+object a {
+  while (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  }
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while a &&
+    b
+  do
+    a &&
+    b
+  while
+    a &&
+    b
+  do
+    a &&
+    b
+}
+<<< aloneArgOrBody, while
+runner.dialect = scala3
+newlines.source = keep
+indentOperator.exemptScope = aloneArgOrBody
+===
+object a {
+  while (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  }
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while (a &&
+    b)
+    a &&
+    b
+  while a &&
+    b do
+    a &&
+    b
+  while
+    a &&
+    b do
+    a &&
+    b
+}
+>>>
+object a {
+  while (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  }
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while a &&
+    b
+  do
+    a &&
+    b
+  while
+    a &&
+    b
+  do
+    a &&
+    b
+}
+<<< oldTopLevel, while
+runner.dialect = scala3
+newlines.source = keep
+indentOperator.exemptScope = oldTopLevel
+===
+object a {
+  while (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  }
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while (a &&
+    b)
+    a &&
+    b
+  while a &&
+    b do
+    a &&
+    b
+  while
+    a &&
+    b do
+    a &&
+    b
+}
+>>>
+object a {
+  while (
+    a &&
+    b
+  ) {
+    a &&
+    b
+  }
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while (
+    a &&
+    b
+  )
+    a &&
+    b
+  while a &&
+    b
+  do
+    a &&
+    b
+  while
+    a &&
+    b
+  do
+    a &&
+    b
+}
+<<< aloneEnclosed, apply
+newlines.source = keep
+indentOperator.exemptScope = aloneEnclosed
+===
+object a {
+  foo(
+    a &&
+    b
+  )
+  foo {
+    a &&
+    b
+  }
+  foo(
+      a &&
+      b,
+      a &&
+      b
+  )
+  foo(
+      a &&
+      b
+  )(
+      a &&
+      b
+  )
+}
+>>>
+object a {
+  foo(
+    a &&
+      b
+  )
+  foo {
+    a &&
+    b
+  }
+  foo(
+    a &&
+      b,
+    a &&
+      b
+  )
+  foo(
+    a &&
+      b
+  )(
+    a &&
+      b
+  )
+}
+<<< aloneArgOrBody, apply
+newlines.source = keep
+indentOperator.exemptScope = aloneArgOrBody
+===
+object a {
+  foo(
+    a &&
+    b
+  )
+  foo {
+    a &&
+    b
+  }
+  foo(
+      a &&
+      b,
+      a &&
+      b
+  )
+  foo(
+      a &&
+      b
+  )(
+      a &&
+      b
+  )
+}
+>>>
+object a {
+  foo(
+    a &&
+      b
+  )
+  foo {
+    a &&
+    b
+  }
+  foo(
+    a &&
+      b,
+    a &&
+      b
+  )
+  foo(
+    a &&
+      b
+  )(
+    a &&
+      b
+  )
+}
+<<< oldTopLevel, apply
+newlines.source = keep
+indentOperator.exemptScope = oldTopLevel
+===
+object a {
+  foo(
+    a &&
+    b
+  )
+  foo {
+    a &&
+    b
+  }
+  foo(
+      a &&
+      b,
+      a &&
+      b
+  )
+  foo(
+      a &&
+      b
+  )(
+      a &&
+      b
+  )
+}
+>>>
+object a {
+  foo(
+    a &&
+      b
+  )
+  foo {
+    a &&
+    b
+  }
+  foo(
+    a &&
+      b,
+    a &&
+      b
+  )
+  foo(
+    a &&
+      b
+  )(
+    a &&
+      b
+  )
+}
+<<< aloneEnclosed, case
+newlines.source = keep
+indentOperator.exemptScope = aloneEnclosed
+===
+a match {
+  case foo =>
+    a &&
+      b
+  case foo =>
+    val baz = qux
+    a &&
+      b
+  case bar => {
+    val baz = qux
+    a &&
+      b
+  }
+  case bar if
+    a &&
+    b =>
+    a &&
+      b
+}
+>>>
+a match {
+  case foo =>
+    a &&
+    b
+  case foo =>
+    val baz = qux
+    a &&
+    b
+  case bar => {
+    val baz = qux
+    a &&
+    b
+  }
+  case bar if
+        a &&
+          b =>
+    a &&
+    b
+}
+<<< aloneArgOrBody, case
+newlines.source = keep
+indentOperator.exemptScope = aloneArgOrBody
+===
+a match {
+  case foo =>
+    a &&
+      b
+  case foo =>
+    val baz = qux
+    a &&
+      b
+  case bar => {
+    val baz = qux
+    a &&
+      b
+  }
+  case bar if
+    a &&
+    b =>
+    a &&
+      b
+}
+>>>
+a match {
+  case foo =>
+    a &&
+    b
+  case foo =>
+    val baz = qux
+    a &&
+    b
+  case bar => {
+    val baz = qux
+    a &&
+    b
+  }
+  case bar if
+        a &&
+          b =>
+    a &&
+    b
+}
+<<< oldTopLevel, case
+newlines.source = keep
+indentOperator.exemptScope = oldTopLevel
+===
+a match {
+  case foo =>
+    a &&
+      b
+  case foo =>
+    val baz = qux
+    a &&
+      b
+  case bar => {
+    val baz = qux
+    a &&
+      b
+  }
+  case bar if
+    a &&
+    b =>
+    a &&
+      b
+}
+>>>
+a match {
+  case foo =>
+    a &&
+    b
+  case foo =>
+    val baz = qux
+    a &&
+    b
+  case bar => {
+    val baz = qux
+    a &&
+    b
+  }
+  case bar if
+        a &&
+          b =>
+    a &&
+    b
+}
+<<< aloneEnclosed, lambda
+newlines.source = keep
+indentOperator.exemptScope = aloneEnclosed
+===
+object a {
+  foo { x =>
+    a &&
+      b
+  }
+  foo { x =>
+    val bar = qux
+    a &&
+      b
+  }
+  foo ( x =>
+    a &&
+      b
+  )
+}
+>>>
+object a {
+  foo { x =>
+    a &&
+    b
+  }
+  foo { x =>
+    val bar = qux
+    a &&
+    b
+  }
+  foo(x =>
+    a &&
+      b
+  )
+}
+<<< aloneArgOrBody, lambda
+newlines.source = keep
+indentOperator.exemptScope = aloneArgOrBody
+===
+object a {
+  foo { x =>
+    a &&
+      b
+  }
+  foo { x =>
+    val bar = qux
+    a &&
+      b
+  }
+  foo ( x =>
+    a &&
+      b
+  )
+}
+>>>
+object a {
+  foo { x =>
+    a &&
+    b
+  }
+  foo { x =>
+    val bar = qux
+    a &&
+    b
+  }
+  foo(x =>
+    a &&
+      b
+  )
+}
+<<< oldTopLevel, lambda
+newlines.source = keep
+indentOperator.exemptScope = oldTopLevel
+===
+object a {
+  foo { x =>
+    a &&
+      b
+  }
+  foo { x =>
+    val bar = qux
+    a &&
+      b
+  }
+  foo ( x =>
+    a &&
+      b
+  )
+}
+>>>
+object a {
+  foo { x =>
+    a &&
+    b
+  }
+  foo { x =>
+    val bar = qux
+    a &&
+    b
+  }
+  foo(x =>
+    a &&
+      b
+  )
+}


### PR DESCRIPTION
current `topLevelOnly` was likely intended to implement https://github.com/scala-js/scala-js/blob/main/CODINGSTYLE.md#long-expressions-with-binary-operators but the result is not as described.

the new `enclosedAlone` option attempts to do that instead, but needs confirmation from scalajs developers.