### PR TITLE
State: correctly compute line widths in strings and interpolations with strip margin

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -355,6 +355,14 @@ object State {
           } else identity
           val pipe = getStripMarginChar(ft.meta.rightOwner)
           getColumnsWithStripMargin(pipe, syntax, firstNL, margin, firstLength)
+        case _: Token.Interpolation.Part =>
+          val margin: Int => Int = if (style.assumeStandardLibraryStripMargin) {
+            // 1 for '|'
+            val adjusted = 1 + indent
+            _ => adjusted
+          } else identity
+          val pipe = getStripMarginCharForInterpolate(ft.meta.rightOwner)
+          getColumnsWithStripMargin(pipe, syntax, firstNL, margin, firstLength)
         case _ =>
           val lastNewline = syntax.length - syntax.lastIndexOf('\n') - 1
           (firstLength, lastNewline)

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -482,13 +482,14 @@ class Test {
     }
 }
 >>>
-Idempotency violated
 class Test {
   val test = foo.bar.baz
-    .map(thisvariablenameisreallylong => fr"""UPDATE mytable
-                                             |SET
-                                             | column = $thisvariablenameisreallylong
-                                             |WHERE column2 = ${foo.bar}""".stripMargin.update.run).getOrElse {
+    .map(thisvariablenameisreallylong =>
+      fr"""UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin.update.run
+    ).getOrElse {
       ().pure[ConnectionIO]
     }
 }
@@ -508,13 +509,14 @@ class Test {
     }
 }
 >>>
-Idempotency violated
 class Test {
   val test = foo.bar.baz
-    .map(thisvariablenameisreallylong => fr"""UPDATE mytable
-                                             =SET
-                                             = column = $thisvariablenameisreallylong
-                                             =WHERE column2 = ${foo.bar}""".stripMargin('=').update.run).getOrElse {
+    .map(thisvariablenameisreallylong =>
+      fr"""UPDATE mytable
+          =SET
+          = column = $thisvariablenameisreallylong
+          =WHERE column2 = ${foo.bar}""".stripMargin('=').update.run
+    ).getOrElse {
       ().pure[ConnectionIO]
     }
 }

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -331,12 +331,10 @@ class Test {
 >>>
 class Test {
   val test = foo.bar.baz
-    .map(thisvariablenameisreallylong =>
-      """UPDATE mytable
+    .map(thisvariablenameisreallylong => """UPDATE mytable
           |SET
           | column = $thisvariablenameisreallylong
-          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run
-    ).getOrElse {
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run).getOrElse {
       ().pure[ConnectionIO]
     }
 }
@@ -406,13 +404,14 @@ class Test {
     }
 }
 >>>
-Idempotency violated
 class Test {
   val test = foo.bar.baz
-    .map(thisvariablenameisreallylong => """UPDATE mytable
-                                           =SET
-                                           = column = $thisvariablenameisreallylong
-                                           =WHERE column2 = ${foo.bar}""".stripMargin('=').update.run).getOrElse {
+    .map(thisvariablenameisreallylong =>
+      """UPDATE mytable
+        =SET
+        = column = $thisvariablenameisreallylong
+        =WHERE column2 = ${foo.bar}""".stripMargin('=').update.run
+    ).getOrElse {
       ().pure[ConnectionIO]
     }
 }

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -314,3 +314,208 @@ final class MyClass {
   println(s"""${1}
     """.stripMargin)
 }
+<<< #3090 string without margin
+maxColumn = 100
+optIn.breaksInsideChains = true
+===
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => """UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+>>>
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong =>
+      """UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+<<< #3090 string without margin, no align
+maxColumn = 100
+align.stripMargin = false
+optIn.breaksInsideChains = true
+===
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => """UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+>>>
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => """UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+<<< #3090 string with margin '|'
+maxColumn = 100
+optIn.breaksInsideChains = true
+===
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => """UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin.update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+>>>
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong =>
+      """UPDATE mytable
+        |SET
+        | column = $thisvariablenameisreallylong
+        |WHERE column2 = ${foo.bar}""".stripMargin.update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+<<< #3090 string with margin '='
+maxColumn = 100
+optIn.breaksInsideChains = true
+===
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => """UPDATE mytable
+          =SET
+          = column = $thisvariablenameisreallylong
+          =WHERE column2 = ${foo.bar}""".stripMargin('=').update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+>>>
+Idempotency violated
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => """UPDATE mytable
+                                           =SET
+                                           = column = $thisvariablenameisreallylong
+                                           =WHERE column2 = ${foo.bar}""".stripMargin('=').update.run).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+<<< #3090 interpolation without margin
+maxColumn = 100
+optIn.breaksInsideChains = true
+===
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong =>
+      fr"""UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+>>>
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => fr"""UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+<<< #3090 interpolation without margin, no align
+maxColumn = 100
+align.stripMargin = false
+optIn.breaksInsideChains = true
+===
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong =>
+      fr"""UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+>>>
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => fr"""UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin1.update.run).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+<<< #3090 interpolation with margin '|'
+maxColumn = 100
+optIn.breaksInsideChains = true
+===
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong =>
+      fr"""UPDATE mytable
+          |SET
+          | column = $thisvariablenameisreallylong
+          |WHERE column2 = ${foo.bar}""".stripMargin.update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+>>>
+Idempotency violated
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => fr"""UPDATE mytable
+                                             |SET
+                                             | column = $thisvariablenameisreallylong
+                                             |WHERE column2 = ${foo.bar}""".stripMargin.update.run).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+<<< #3090 interpolation with margin '='
+maxColumn = 100
+optIn.breaksInsideChains = true
+===
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong =>
+      fr"""UPDATE mytable
+          =SET
+          = column = $thisvariablenameisreallylong
+          =WHERE column2 = ${foo.bar}""".stripMargin('=').update.run
+    ).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}
+>>>
+Idempotency violated
+class Test {
+  val test = foo.bar.baz
+    .map(thisvariablenameisreallylong => fr"""UPDATE mytable
+                                             =SET
+                                             = column = $thisvariablenameisreallylong
+                                             =WHERE column2 = ${foo.bar}""".stripMargin('=').update.run).getOrElse {
+      ().pure[ConnectionIO]
+    }
+}


### PR DESCRIPTION
Fixes #3090.
- For strings, didn't use the parameter to `.stripMargin` call to detect the right strip margin character.
- For interpolations, didn't handle strip margin at all
