### PR TITLE
Don't throw no files error if project filters are on 

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -41,7 +41,7 @@ trait ScalafmtRunner {
     } else {
       val projectFiles: Seq[AbsoluteFile] =
         getFilesFromCliOptions(options, filter)
-      if (projectFiles.isEmpty && options.mode.isEmpty)
+      if (projectFiles.isEmpty && options.mode.isEmpty && !options.respectProjectFilters)
         throw Error.NoMatchingFiles
       options.common.debug
         .print(s"Files to be formatted:\n${projectFiles.mkString("\n")}\n")

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -41,7 +41,9 @@ trait ScalafmtRunner {
     } else {
       val projectFiles: Seq[AbsoluteFile] =
         getFilesFromCliOptions(options, filter)
-      if (projectFiles.isEmpty && options.mode.isEmpty && !options.respectProjectFilters)
+      if (
+        projectFiles.isEmpty && options.mode.isEmpty && !options.respectProjectFilters
+      )
         throw Error.NoMatchingFiles
       options.common.debug
         .print(s"Files to be formatted:\n${projectFiles.mkString("\n")}\n")

--- a/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -352,6 +352,28 @@ trait CliTestBehavior { this: AbstractCliTest =>
       run(stdin)
     }
 
+    test(
+      s"scalafmt (no matching files) is okay with --respect-project-filters: $label"
+    ) {
+      runArgs(
+        Array(
+          "--respect-project-filters",
+          "--config-str",
+          s"""{version="$version",style=IntelliJ}"""
+        )
+      )
+      val stdin = getConfig(
+        Array(
+          "--stdin",
+          "--config-str",
+          s"""{version="$version",style=IntelliJ}"""
+        )
+      ).copy(
+        common = CommonOptions(in = new ByteArrayInputStream("".getBytes))
+      )
+      run(stdin)
+    }
+
     test(s"scalafmt (no arg) read config from git repo: $label") {
       val input = string2dir(
         s"""|/foo.scala


### PR DESCRIPTION
Respecting project filters might result in an empty file set to check