### PR TITLE
RedundantParens: handle infix arg if not enclosed

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -99,6 +99,11 @@ class RedundantParens(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
     val ok = ft.meta.rightOwner match {
       case Term.Apply(_, List(t @ (_: Term.Block | _: Term.PartialFunction))) =>
         t.tokens.headOption.exists(_.is[Token.LeftBrace])
+      case Term.ApplyInfix(_, op, _, List(arg)) =>
+        arg match {
+          case _: Term.Tuple | _: Lit.Unit => false
+          case _ => op.pos.end <= ft.right.start
+        }
       case _: Term.Match => style.dialect.allowMatchAsOperator
       case _ => false
     }


### PR DESCRIPTION
In case open paren in a infix expression is not part of the arg but precedes it (as will be done in scalameta 4.5.5), handle it, too.