### PR TITLE
RedundantParens: detect enclosed trees properly

### DIFF
--- a/scalafmt-tests/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/default/Lambda.stat
@@ -226,7 +226,7 @@ def test(dataFrame: DataFrame) = {
   }
 >>>
 def test(dataFrame: DataFrame) = {
-  val zeroAccumulator = Array.fill(1)(((0.0, 0)))
+  val zeroAccumulator = Array.fill(1)((0.0, 0))
 
   dataFrame.rdd
     .aggregate(zeroAccumulator)(

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
@@ -388,7 +388,7 @@ object a {
 }
 >>>
 object a {
-  ((a(b("c")).over(d)) / (e + 1)).as(f)
+  (a(b("c")).over(d) / (e + 1)).as(f)
 }
 <<< exclude "cross" for sbt
 foo("bar" % "baz" % "qux" cross CrossVersion.full)

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -442,26 +442,6 @@ object a {
         }) =>
   }
 }
-<<< #2194 6 match with parens and scala3
-runner.dialect = scala3
-===
-object a {
-  val b = c match {
-    case true if (d match (({
-      case true  => true
-      case false => false
-    }))) =>
-  }
-}
->>>
-object a {
-  val b = c match {
-    case true if d match {
-          case true  => true
-          case false => false
-        } =>
-  }
-}
 <<< #2194 6 match with parens and no braces
 runner.dialect = scala3
 ===
@@ -830,4 +810,44 @@ object a {
   b c /* c1 */
     [A] /* c2 */
     (/* c3 */ d, e)
+}
+<<< if with/without then
+runner.dialect = scala3
+===
+object a {
+  if (a > 0) then {
+    foo
+  }
+  if (a > 0) {
+    foo
+  }
+}
+>>>
+object a {
+  if a > 0 then {
+    foo
+  }
+  if (a > 0) {
+    foo
+  }
+}
+<<< while with/without do
+runner.dialect = scala3
+===
+object a {
+  while (a > 0) do {
+    foo
+  }
+  while (a > 0) {
+    foo
+  }
+}
+>>>
+object a {
+  while a > 0 do {
+    foo
+  }
+  while (a > 0) {
+    foo
+  }
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -255,8 +255,8 @@ object a {
 }
 >>>
 object a {
-  private val foo = ((bar == baz
-    || bar == baz)
+  private val foo = (bar == baz
+    || bar == baz
     || bar == baz)
 }
 <<< #1953
@@ -783,13 +783,13 @@ object a {
   b c /* c1 */
     (/* c2 */ (/* c3 */ ))
   b c /* c1 */
-    (/* c2 */ (/* c3 */ (/* c4 */ )))
+    (/* c2 */ (/* c3 */ /* c4 */ ))
   b c /* c1 */
     (/* c2 */ d, e)
   b c /* c1 */
     (/* c2 */ ( /* c3 */ d, e))
   b c /* c1 */
-    (/* c2 */ ( /* c3 */ ( /* c4 */ d, e)))
+    (/* c2 */ ( /* c3 */ /* c4 */ d, e))
   b c /* c1 */
     (/* c2 */ c + d /* c3 */ ).foo
 }


### PR DESCRIPTION
This now allows us to use a single approach which is no longer overly sensitive to whether the scalameta parser includes the parentheses as part of the enclosed or enclosing tree. Required for #3200.