### PR TITLE
FormatTokens: implement isEnclosedInParens

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -838,9 +838,7 @@ class FormatOps(
   }
 
   private def getLastEnclosedToken(tree: Tree): T = {
-    val tokens = tree.tokens
-    val slice = if (isEnclosedInMatching(tree)) tokens.dropRight(1) else tokens
-    findLastNonTrivialToken(slice)
+    tokens.getLastExceptParen(tree.tokens).left
   }
 
   @tailrec

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2057,14 +2057,16 @@ class FormatOps(
         danglingKeyword: Boolean = true,
         indentOpt: Option[Int] = None
     )(implicit fileLine: FileLine, style: ScalafmtConfig): Seq[Split] = {
-      val end = tokens.getLast(tree)
+      val treeTokens = tree.tokens
+      val end = tokens.getLast(treeTokens)
       val slbExpire = nextNonCommentSameLine(end).left
       val closeOpt =
         if (isTuple(tree)) None
         else {
           val maybeClose = prevNonComment(end)
-          if (!tokens.isCloseMatchingHead(maybeClose.left)(tree)) None
-          else Some(prevNonCommentBefore(maybeClose).left)
+          tokens
+            .getClosingIfInParens(maybeClose)(tokens.getHead(treeTokens))
+            .map(prevNonComment(_).left)
         }
       def nlPolicy(implicit fileLine: FileLine) =
         if (danglingKeyword)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -112,6 +112,11 @@ class FormatTokens(leftTok2tok: Map[TokenOps.TokenHash, Int])(
   def getClosingIfInParens(tokens: Tokens): Option[FormatToken] =
     getHeadOpt(tokens).flatMap(getClosingIfInParens(getLastNonTrivial(tokens)))
 
+  def getLastExceptParen(tokens: Tokens): FormatToken = {
+    val last = getLastNonTrivial(tokens)
+    getClosingIfInParens(last)(getHead(tokens)).getOrElse(last)
+  }
+
   @tailrec
   final def findTokenWith[A](
       ft: FormatToken,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -96,18 +96,21 @@ class FormatTokens(leftTok2tok: Map[TokenOps.TokenHash, Int])(
   def isEnclosedInMatching(tree: Tree): Boolean =
     isEnclosedInMatching(tree.tokens)
 
-  def isCloseMatchingHead(close: Token)(tree: => Tree): Boolean =
-    matchingOpt(close).exists(_ eq getHead(tree).left)
-
   @inline private def areMatchingParens(close: Token)(open: => Token): Boolean =
     close.is[Token.RightParen] && areMatching(close)(open)
 
   def isEnclosedInParens(tokens: Tokens): Boolean =
-    getLastNonTrivialOpt(tokens).exists { last =>
-      areMatchingParens(last.left)(getHead(tokens).left)
-    }
+    getClosingIfInParens(tokens).isDefined
   def isEnclosedInParens(tree: Tree): Boolean =
     isEnclosedInParens(tree.tokens)
+
+  def getClosingIfInParens(
+      last: FormatToken
+  )(head: FormatToken): Option[FormatToken] =
+    if (areMatchingParens(last.left)(head.left)) Some(prev(last))
+    else None
+  def getClosingIfInParens(tokens: Tokens): Option[FormatToken] =
+    getHeadOpt(tokens).flatMap(getClosingIfInParens(getLastNonTrivial(tokens)))
 
   @tailrec
   final def findTokenWith[A](

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -356,7 +356,7 @@ class FormatWriter(formatOps: FormatOps) {
   private def checkInsertBraces(locations: Array[FormatLocation]): Unit = {
     def checkInfix(tree: Tree): Boolean = tree match {
       case ai @ Term.ApplyInfix(lhs, op, _, rhs) =>
-        tokens.isEnclosedInMatching(ai) ||
+        tokens.isEnclosedInParens(ai) ||
         tokens.prevNonCommentSameLine(tokens.tokenJustBefore(op)).noBreak &&
         checkInfix(lhs) && (rhs.lengthCompare(1) != 0 || checkInfix(rhs.head))
       case _ => true

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1672,9 +1672,7 @@ class Router(formatOps: FormatOps) {
           case x: Term.Match => SelectLike(x, getKwMatchAfterDot(t))
         }
         val prevSelect = findPrevSelect(thisSelect, enclosed)
-        val expireDropRight = if (isEnclosedInMatching(expireTree)) 1 else 0
-        val expireTreeSlice = expireTree.tokens.dropRight(expireDropRight)
-        val expire = findLastNonTrivialToken(expireTreeSlice)
+        val expire = tokens.getLastExceptParen(expireTree.tokens).left
         val indentLen = style.indent.main
 
         def breakOnNextDot: Policy =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -135,8 +135,7 @@ class RedundantParens(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
     }
 
   private def breaksBeforeOpAndNotEnclosed(ia: InfixApp): Boolean = {
-    val allToks = ia.all.tokens
-    !ftoks.areMatching(allToks.head)(allToks.last) && breaksBeforeOp(ia)
+    !ftoks.isEnclosedInParens(ia.all) && breaksBeforeOp(ia)
   }
 
   private def breaksBeforeOp(ia: InfixApp): Boolean = {


### PR DESCRIPTION
This method will apply only to parens, not just any matching delimiters, and will in the future also include those just outside the tree.