### PR TITLE
RedundantParens: fix bugs introduced in v3.5.3

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -77,9 +77,13 @@ class RedundantParens(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
         }
 
       case t =>
+        def isContains(seq: Seq[Tree]): Boolean = seq.contains(t)
         t.parent.forall {
-          case TreeOps.SplitCallIntoParts(_, args) =>
-            !args.fold(_.contains(t), _.exists(_.contains(t)))
+          case TreeOps.SplitCallIntoParts(_, args)
+              if args
+                .fold(Some(_).filter(isContains), _.find(isContains))
+                .exists(TreeOps.isSeqSingle) =>
+            false
           case TreeOps.SplitAssignIntoParts((body, _)) =>
             body.eq(t) && (t match {
               case InfixApp(ia) => !breaksBeforeOp(ia)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -61,7 +61,8 @@ class RedundantParens(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
       style: ScalafmtConfig
   ): Boolean =
     tree match {
-      case _: Term.Tuple | _: Type.Tuple | _: Lit.Unit => numParens >= 3
+      case _: Term.Tuple | _: Type.Tuple | _: Pat.Tuple | _: Lit.Unit =>
+        numParens >= 3
 
       case _ if numParens >= 2 => true
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -928,10 +928,11 @@ object TreeOps {
     @tailrec
     def iter(trees: List[Tree]): Option[Tree] = trees match {
       case head :: rest =>
-        val headStart = head.pos.start
+        val headPos = head.pos
+        val headStart = headPos.start
         if (headStart < beforeParens) iter(rest)
         else {
-          val ok = headStart < afterParens &&
+          val ok = headStart < afterParens && headStart < headPos.end &&
             rest.headOption.forall(_.pos.start >= afterParens)
           if (ok) Some(head) else None
         }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -918,8 +918,8 @@ object a {
 }
 >>>
 object a {
-  new foo
-  case class foo[bar](implicit baz: qux)
+  new foo()
+  case class foo[bar]()(implicit baz: qux)
 }
 <<< casting
 object a {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -885,7 +885,7 @@ object a {
 }
 >>>
 object a {
-  new F ~> F { foo }
+  new (F ~> F) { foo }
 }
 <<< infix with new
 object a {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -863,3 +863,69 @@ object a {
     foo
   }
 }
+<<< tuple pattern
+object a {
+  foo match {
+    case bar((baz, qux)) =>
+    case bar(((baz, qux))) =>
+    case bar((((baz, qux)))) =>
+  }
+}
+>>>
+object a {
+  foo match {
+    case bar(baz, qux) =>
+    case bar(baz, qux) =>
+    case bar(baz, qux) =>
+  }
+}
+<<< infix as new anonymous
+object a {
+  new (F ~> F) { foo }
+}
+>>>
+object a {
+  new F ~> F { foo }
+}
+<<< infix with new
+object a {
+  foo * (new bar)
+  foo * (new bar(baz).qux)
+  (new foo) * bar
+  (new foo(bar).baz) * qux
+}
+>>>
+object a {
+  foo * new bar
+  foo * new bar(baz).qux
+  new foo * bar
+  new foo(bar).baz * qux
+}
+<<< infix with anonymous function
+object a {
+  foo map (_.foo[A])
+  foo map (new foo(_).bar)
+}
+>>>
+object a {
+  foo map _.foo[A]
+  foo map new foo(_).bar
+}
+<<< empty parens
+object a {
+  new foo()
+  case class foo[bar]()(implicit baz: qux)
+}
+>>>
+object a {
+  new foo
+  case class foo[bar](implicit baz: qux)
+}
+<<< casting
+object a {
+  new foo((bar: baz))
+}
+>>>
+object a {
+  new foo(bar: baz)
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -874,9 +874,9 @@ object a {
 >>>
 object a {
   foo match {
-    case bar(baz, qux) =>
-    case bar(baz, qux) =>
-    case bar(baz, qux) =>
+    case bar((baz, qux)) =>
+    case bar((baz, qux)) =>
+    case bar((baz, qux)) =>
   }
 }
 <<< infix as new anonymous


### PR DESCRIPTION
Follow on to #3207. Fixes #3215.