### PR TITLE
TreeOps: move findEnclosedXxx from RedundantParens

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -18,30 +18,6 @@ object RedundantParens extends Rewrite with FormatTokensRewrite.RuleFactory {
   override def create(ftoks: FormatTokens): FormatTokensRewrite.Rule =
     new RedundantParens(ftoks)
 
-  private def findEnclosedBetweenParens(
-      lt: FormatToken,
-      rt: FormatToken,
-      tree: Tree
-  ): Option[Tree] = {
-    val beforeParens = lt.left.start
-    val afterParens = rt.right.start
-    @tailrec
-    def iter(trees: List[Tree]): Option[Tree] = trees match {
-      case head :: rest =>
-        val headStart = head.pos.start
-        if (headStart <= beforeParens) iter(rest)
-        else {
-          val ok = headStart < afterParens &&
-            rest.headOption.forall(_.pos.start >= afterParens)
-          if (ok) Some(head) else None
-        }
-      case _ => None
-    }
-    val pos = tree.pos
-    val found = beforeParens < pos.start && pos.end <= afterParens
-    if (found) Some(tree) else iter(tree.children)
-  }
-
   private def infixNeedsParens(outer: InfixApp, inner: Tree): Boolean = {
     val sgOuter = TreeSyntacticGroup(outer.all)
     val sgInner = TreeSyntacticGroup(inner)
@@ -163,7 +139,8 @@ class RedundantParens(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
             ) =>
           iter(ftoks.prev(prev), ftoks.next(next), cnt + 1)
         case (prev, next) =>
-          findEnclosedBetweenParens(prev, next, ft.meta.rightOwner)
+          TreeOps
+            .findEnclosedBetweenParens(prev, next, ft.meta.rightOwner)
             .map((cnt, _))
       }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -138,9 +138,9 @@ class RedundantParens(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
               next @ FormatToken(_, _: Token.RightParen, _)
             ) =>
           iter(ftoks.prev(prev), ftoks.next(next), cnt + 1)
-        case (prev, next) =>
+        case _ =>
           TreeOps
-            .findEnclosedBetweenParens(prev, next, ft.meta.rightOwner)
+            .findEnclosedBetweenParens(lt.right, rt.left, ft.meta.rightOwner)
             .map((cnt, _))
       }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -916,4 +916,28 @@ object TreeOps {
     }
   }
 
+  def findEnclosedBetweenParens(
+      lt: FormatToken,
+      rt: FormatToken,
+      tree: Tree
+  ): Option[Tree] = {
+    val beforeParens = lt.left.start
+    val afterParens = rt.right.start
+    @tailrec
+    def iter(trees: List[Tree]): Option[Tree] = trees match {
+      case head :: rest =>
+        val headStart = head.pos.start
+        if (headStart <= beforeParens) iter(rest)
+        else {
+          val ok = headStart < afterParens &&
+            rest.headOption.forall(_.pos.start >= afterParens)
+          if (ok) Some(head) else None
+        }
+      case _ => None
+    }
+    val pos = tree.pos
+    val found = beforeParens < pos.start && pos.end <= afterParens
+    if (found) Some(tree) else iter(tree.children)
+  }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -917,17 +917,17 @@ object TreeOps {
   }
 
   def findEnclosedBetweenParens(
-      lt: FormatToken,
-      rt: FormatToken,
+      lt: Token,
+      rt: Token,
       tree: Tree
   ): Option[Tree] = {
-    val beforeParens = lt.left.start
-    val afterParens = rt.right.start
+    val beforeParens = lt.start
+    val afterParens = rt.end
     @tailrec
     def iter(trees: List[Tree]): Option[Tree] = trees match {
       case head :: rest =>
         val headStart = head.pos.start
-        if (headStart <= beforeParens) iter(rest)
+        if (headStart < beforeParens) iter(rest)
         else {
           val ok = headStart < afterParens &&
             rest.headOption.forall(_.pos.start >= afterParens)
@@ -936,7 +936,7 @@ object TreeOps {
       case _ => None
     }
     val pos = tree.pos
-    val found = beforeParens < pos.start && pos.end <= afterParens
+    val found = beforeParens <= pos.start && pos.end <= afterParens
     if (found) Some(tree) else iter(tree.children)
   }
 


### PR DESCRIPTION
Will be needed when we upgrade scalameta to v4.5.6.