### PR TITLE
FormatTokens: check outside parens for enclosed

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
@@ -55,7 +55,7 @@ object Error {
       extends Error("Formatter output does not parse:\n" + msg)
 
   case class UnexpectedTree[Expected <: Tree: ClassTag](obtained: Tree)
-      extends Error(s"""Expected: ${classTag[Expected].runtimeClass.getClass}
+      extends Error(s"""Expected: ${classTag[Expected].runtimeClass.getName}
         |Obtained: ${log(obtained)}""".stripMargin)
 
   case class CantFormatFile(msg: String)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -108,7 +108,12 @@ class FormatTokens(leftTok2tok: Map[TokenOps.TokenHash, Int])(
       last: FormatToken
   )(head: FormatToken): Option[FormatToken] =
     if (areMatchingParens(last.left)(head.left)) Some(prev(last))
-    else None
+    else {
+      val afterLast = nextNonComment(last)
+      if (areMatchingParens(afterLast.right)(prevNonCommentBefore(head).left))
+        Some(afterLast)
+      else None
+    }
   def getClosingIfInParens(tokens: Tokens): Option[FormatToken] =
     getHeadOpt(tokens).flatMap(getClosingIfInParens(getLastNonTrivial(tokens)))
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -450,7 +450,12 @@ object TreeOps {
     }
 
   def isCallSiteLeft(ft: FormatToken)(implicit style: ScalafmtConfig): Boolean =
-    isCallSite(ft.meta.leftOwner)
+    ft.meta.leftOwner match {
+      case Term.ApplyInfix(_, op, _, List(arg))
+          if op.pos.end <= ft.left.start => // parens used to belong to rhs
+        isCallSite(arg)
+      case t => isCallSite(t)
+    }
 
   def isTuple(tree: Tree): Boolean =
     tree match {


### PR DESCRIPTION
In scalameta v4.5.6, some enclosed trees do not actually contain the enclosing parentheses, hence check for these cases.