### PR TITLE
Scalameta: upgrade to v4.5.7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.10.0"
-  val scalametaV  = "4.5.5"
+  val scalametaV  = "4.5.7"
   val scalacheckV = "1.15.4"
   val coursier    = "1.0.3"
   val munitV      = "0.7.29"

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -920,8 +920,8 @@ object a {
 }
 >>>
 object a {
-  foo map _.foo[A]
-  foo map new foo(_).bar
+  foo map (_.foo[A])
+  foo map (new foo(_).bar)
 }
 <<< empty parens
 object a {


### PR DESCRIPTION
Includes fixes to the parser in detecting anonymous functions (v4.5.7)
and exclusion of parens from the positions of enclosed trees (v4.5.6).