### PR TITLE
Scalameta: upgrade to v4.5.8

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.10.0"
-  val scalametaV  = "4.5.7"
+  val scalametaV  = "4.5.8"
   val scalacheckV = "1.15.4"
   val coursier    = "1.0.3"
   val munitV      = "0.7.29"


### PR DESCRIPTION
Fixes a bug with Term.Select positions on the right of an infix.