### PR TITLE
RedundantParens: only scala3 match-as-operator

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -161,16 +161,17 @@ class RedundantParens(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
               case _: Term.PartialFunction => true
               case _ => style.rewrite.redundantParens.infixSide.isDefined
             }
-          case p =>
+          case _ =>
             t match {
               case _: Lit | _: Name | _: Term.Interpolate => true
               case _: Term.PartialFunction | _: Term.Apply => true
               case t: Term.Select =>
                 ftoks.tokenBefore(t.name).left.is[Token.Dot]
-              case t: Term.Match if style.dialect.allowMatchAsOperator =>
-                !p.is[Term.ApplyInfix] ||
-                ftoks.tokenAfter(t.expr).right.is[Token.Dot] &&
-                ftoks.tokenBefore(t.cases).left.is[Token.LeftBrace]
+              case t: Term.Match
+                  if style.dialect.allowMatchAsOperator &&
+                    ftoks.tokenAfter(t.expr).right.is[Token.Dot] &&
+                    ftoks.tokenBefore(t.cases).left.is[Token.LeftBrace] =>
+                true
               case _ => false
             }
         }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1283,6 +1283,7 @@ object a:
     case bar => baz
   ).qux
 >>>
-test does not parse
 object a:
-      ^
+  (foo match
+    case bar => baz
+  ).qux

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1275,3 +1275,14 @@ object a {
 object a {
   val compose: (B => C) => (A => B) => (A => C) = _.compose
 }
+<<< #3238 match with opt braces in select
+runner.dialect = scala3
+===
+object a:
+  (foo match
+    case bar => baz
+  ).qux
+>>>
+test does not parse
+object a:
+      ^


### PR DESCRIPTION
Fixes #3238.