### PR TITLE
Scalameta: upgrade to v4.5.9

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.10.0"
-  val scalametaV  = "4.5.8"
+  val scalametaV  = "4.5.9"
   val scalacheckV = "1.15.4"
   val coursier    = "1.0.3"
   val munitV      = "0.7.29"

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -2,7 +2,7 @@ package org.scalafmt.rewrite
 
 import scala.annotation.tailrec
 import scala.meta._
-import scala.meta.internal.trees.PlaceholderChecks
+import scala.meta.internal.trees.PlaceholderChecks.hasPlaceholder
 
 import org.scalafmt.config.FilterMatcher
 import org.scalafmt.config.RewriteSettings
@@ -103,12 +103,10 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
     val op = ai.op.value
     InfixApp.isLeftAssoc(op) && matcher.matches(op) && (ai.args match {
       case arg :: Nil if !isWrapped(arg) =>
-        !ctx.style.rewrite.allowInfixPlaceholderArg &&
-        PlaceholderChecks.isPlaceholder(arg) ||
-        !PlaceholderChecks.hasPlaceholder(arg)
+        !hasPlaceholder(arg, ctx.style.rewrite.allowInfixPlaceholderArg)
       case _ => true
     }) && (ai.lhs match {
-      case lhs: Term.ApplyInfix if PlaceholderChecks.hasPlaceholder(lhs) =>
+      case lhs: Term.ApplyInfix if hasPlaceholder(lhs, true) =>
         isWrapped(lhs) || checkMatchingInfix(lhs)
       case _ => true
     })

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1291,3 +1291,11 @@ object a:
 (a + b)
 >>>
 a + b
+<<< #3241
+object a {
+  (Box.apply(_: Int, _: String)).tupled
+}
+>>>
+object a {
+  Box.apply(_: Int, _: String).tupled
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1297,5 +1297,5 @@ object a {
 }
 >>>
 object a {
-  Box.apply(_: Int, _: String).tupled
+  (Box.apply(_: Int, _: String)).tupled
 }


### PR DESCRIPTION
Fixes parsing of additional anonymous functions. Fixes #3241.

