### PR TITLE
FormatOps: check for left brace in multistat block

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2513,12 +2513,17 @@ class FormatOps(
       }
     }
 
-    private def isThenPWithOptionalBraces(tree: Term.If): Boolean =
-      tokenBefore(tree.thenp).left match {
+    private def isThenPWithOptionalBraces(tree: Term.If): Boolean = {
+      val thenp = tree.thenp
+      val before = tokens.tokenJustBefore(thenp)
+      prevNonComment(before).left match {
         case _: T.KwThen => true
         case _: T.LeftBrace => false
-        case _ => isTreeMultiStatBlock(tree.thenp)
+        case _ =>
+          isTreeMultiStatBlock(thenp) && (!before.right.is[T.LeftBrace] ||
+            matchingOpt(before.right).exists(rb => rb.end < thenp.pos.end))
       }
+    }
 
     @tailrec
     private def isElsePWithOptionalBraces(tree: Term.If): Boolean =

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -5913,3 +5913,48 @@ class Foo {
     if (true) "aaaaa"
     else "bbbbb"
 }
+<<< #3276
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+>>>
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+<<< #3276 2
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {c; a + b}.foo
+    else
+      false
+}
+>>>
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1) { c; a + b }.foo
+    else
+      false
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -5632,3 +5632,44 @@ class Foo {
   val foo =
     if (true) "aaaaa" else "bbbbb"
 }
+<<< #3276
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+>>>
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) { true }
+    else false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else false
+}
+<<< #3276 2
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {c; a + b}.foo
+    else
+      false
+}
+>>>
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1) { c; a + b }.foo
+    else false
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -5919,3 +5919,48 @@ class Foo {
     if (true) "aaaaa"
     else "bbbbb"
 }
+<<< #3276
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+>>>
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+<<< #3276 2
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {c; a + b}.foo
+    else
+      false
+}
+>>>
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1) { c; a + b }.foo
+    else
+      false
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -6053,3 +6053,51 @@ class Foo {
     if (true) "aaaaa"
     else "bbbbb"
 }
+<<< #3276
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+>>>
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+<<< #3276 2
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {c; a + b}.foo
+    else
+      false
+}
+>>>
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1) {
+      c;
+      a + b
+    }.foo
+    else
+      false
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3443,3 +3443,63 @@ object a:
       val x = 4
       4 == 3
    do 5
+<<< #3276
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+>>>
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else false
+}
+<<< #3276 2
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {c; a + b}.foo
+    else
+      false
+}
+>>>
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1) { c; a + b }.foo
+    else
+      false
+}
+<<< #3276 3
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {a + b}.foo
+      c
+    else
+      false
+}
+>>>
+test does not parse
+    if (1 == 1)
+    { a + b }.foo
+    c
+    else false
+  ^

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3497,9 +3497,10 @@ class Foo() {
       false
 }
 >>>
-test does not parse
+class Foo() {
+  def notOK: Boolean =
     if (1 == 1)
-    { a + b }.foo
-    c
+       { a + b }.foo
+       c
     else false
-  ^
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3470,7 +3470,8 @@ class Foo() {
     if (1 == 1) {
       println("Some code")
       true
-    } else false
+    } else
+      false
 }
 <<< #3276 2
 class Foo() {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3330,9 +3330,10 @@ class Foo() {
       false
 }
 >>>
-test does not parse
+class Foo() {
+  def notOK: Boolean =
     if (1 == 1)
-    { a + b }.foo
-    c
+       { a + b }.foo
+       c
     else false
-  ^
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3281,3 +3281,58 @@ object a:
       val x = 4
       4 == 3
    do 5
+<<< #3276
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+>>>
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) { true }
+    else false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else false
+}
+<<< #3276 2
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {c; a + b}.foo
+    else
+      false
+}
+>>>
+class Foo() {
+  def notOK: Boolean = if (1 == 1) { c; a + b }.foo else false
+}
+<<< #3276 3
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {a + b}.foo
+      c
+    else
+      false
+}
+>>>
+test does not parse
+    if (1 == 1)
+    { a + b }.foo
+    c
+    else false
+  ^

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3452,7 +3452,7 @@ class Foo() {
       println("Some code")
       true
     } else
-       false
+      false
 }
 <<< #3276 2
 class Foo() {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3479,9 +3479,11 @@ class Foo() {
       false
 }
 >>>
-test does not parse
+class Foo() {
+  def notOK: Boolean =
     if (1 == 1)
-    { a + b }.foo
-    c
+       { a + b }.foo
+       c
     else
-  ^
+       false
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3424,3 +3424,64 @@ object a:
       val x = 4
       4 == 3
    do 5
+<<< #3276
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+>>>
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+       false
+}
+<<< #3276 2
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {c; a + b}.foo
+    else
+      false
+}
+>>>
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1) { c; a + b }.foo
+    else
+      false
+}
+<<< #3276 3
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {a + b}.foo
+      c
+    else
+      false
+}
+>>>
+test does not parse
+    if (1 == 1)
+    { a + b }.foo
+    c
+    else
+  ^

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3595,9 +3595,13 @@ class Foo() {
       false
 }
 >>>
-test does not parse
-      a + b
-    }.foo
-    c
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+       {
+         a + b
+       }.foo
+       c
     else
-  ^
+       false
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3565,7 +3565,7 @@ class Foo() {
       println("Some code")
       true
     } else
-       false
+      false
 }
 <<< #3276 2
 class Foo() {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3537,3 +3537,67 @@ object a:
       4 == 3
    do
       5
+<<< #3276
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+      false
+}
+>>>
+class Foo() {
+  def ok: Boolean =
+    if (1 == 1) {
+      true
+    } else
+      false
+
+  def notOK: Boolean =
+    if (1 == 1) {
+      println("Some code")
+      true
+    } else
+       false
+}
+<<< #3276 2
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {c; a + b}.foo
+    else
+      false
+}
+>>>
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1) {
+      c;
+      a + b
+    }.foo
+    else
+      false
+}
+<<< #3276 3
+class Foo() {
+  def notOK: Boolean =
+    if (1 == 1)
+      {a + b}.foo
+      c
+    else
+      false
+}
+>>>
+test does not parse
+      a + b
+    }.foo
+    c
+    else
+  ^


### PR DESCRIPTION
Depending on how scalameta parses the code, the left brace could be just before the multistat block (previously covered) or at the head of it. Fixes #3276.