### PR TITLE
FormatOps: force config style on token, not tree

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -186,13 +186,19 @@ object TokenOps {
       argss: Seq[Seq[A]],
       matchingOpt: Token => Option[Token]
   ): Option[Seq[A]] =
-    matchingOpt(token).flatMap { other =>
-      // find the arg group starting with given format token
-      val beg = math.min(token.start, other.start)
-      argss
-        .find(_.headOption.exists(_.tokens.head.start >= beg))
-        .filter(_.head.tokens.head.start <= math.max(token.end, other.end))
-    }
+    matchingOpt(token).flatMap(findArgsBetween(token, _, argss))
+
+  def findArgsBetween[A <: Tree](
+      token: Token,
+      other: Token,
+      argss: Seq[Seq[A]]
+  ): Option[Seq[A]] = {
+    // find the arg group starting with given format token
+    val beg = math.min(token.start, other.start)
+    argss
+      .find(_.headOption.exists(_.tokens.head.start >= beg))
+      .filter(_.head.tokens.head.start <= math.max(token.end, other.end))
+  }
 
   def getXmlLastLineIndent(tok: Xml.Part): Option[Int] = {
     val part = tok.value

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -510,15 +510,6 @@ object TreeOps {
       splitCallIntoParts.lift(tree)
   }
 
-  object CallArgsForConfigStyle {
-    def unapply(tree: Tree): Option[Seq[Tree]] = Some(tree match {
-      case t: Term.Apply => t.args
-      case t: Init => t.argss.flatten
-      case t: Term.ApplyUsing => t.args
-      case _ => Seq.empty
-    }).filter(_.nonEmpty)
-  }
-
   type DefnParts = (Seq[Mod], Name, Seq[Type.Param], Seq[Seq[Term.Param]])
   val splitDefnIntoParts: PartialFunction[Tree, DefnParts] = {
     // types

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1920,9 +1920,7 @@ class a {
     customDnsResolver = customDnsResolver,
     retries = 0,
     maxIdleDuration = Duration.Inf
-  )(
-    F
-  )
+  )(F)
 }
 <<< #3309 apply
 preset = default

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1896,3 +1896,57 @@ object a {
     )
   }
 }
+<<< #3309 init
+preset = default
+align.preset = none
+danglingParentheses.preset = true
+maxColumn = 100
+runner.optimizer.forceConfigStyleMinArgCount = 5
+===
+class a {
+  private[BlazeClientBuilder] def this(foo: Int) = this(
+    asynchronousChannelGroup = asynchronousChannelGroup,
+    channelOptions = channelOptions,
+    customDnsResolver = customDnsResolver,
+    retries = 0,
+    maxIdleDuration = Duration.Inf
+  )(F)
+}
+>>>
+class a {
+  private[BlazeClientBuilder] def this(foo: Int) = this(
+    asynchronousChannelGroup = asynchronousChannelGroup,
+    channelOptions = channelOptions,
+    customDnsResolver = customDnsResolver,
+    retries = 0,
+    maxIdleDuration = Duration.Inf
+  )(
+    F
+  )
+}
+<<< #3309 apply
+preset = default
+align.preset = none
+danglingParentheses.preset = true
+maxColumn = 100
+runner.optimizer.forceConfigStyleMinArgCount = 5
+===
+class a {
+  private[BlazeClientBuilder] def thiz(foo: Int) = thiz(
+    asynchronousChannelGroup = asynchronousChannelGroup,
+    channelOptions = channelOptions,
+    customDnsResolver = customDnsResolver,
+    retries = 0,
+    maxIdleDuration = Duration.Inf
+  )(F)
+}
+>>>
+class a {
+  private[BlazeClientBuilder] def thiz(foo: Int) = thiz(
+    asynchronousChannelGroup = asynchronousChannelGroup,
+    channelOptions = channelOptions,
+    customDnsResolver = customDnsResolver,
+    retries = 0,
+    maxIdleDuration = Duration.Inf
+  )(F)
+}


### PR DESCRIPTION
Some trees (like Init) have multiple sets of arguments, and we need to identify the right group -- and the open paren/bracket for it. Fixes #3309.