### PR TITLE
Use Resolver.sonatypeOssRepos instead of Resolver.sonatypeRepo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,8 @@ inThisBuild(
     scalaVersion := scala213,
     crossScalaVersions := List(scala213, scala212),
     resolvers ++= Seq(
-      Resolver.sonatypeRepo("releases"),
-      Resolver.sonatypeRepo("snapshots")
+      Resolver.sonatypeOssRepos("releases"),
+      Resolver.sonatypeOssRepos("snapshots")
     ),
     libraryDependencies ++= List(
       munit.value % Test,


### PR DESCRIPTION
> Deprecates Resolver.sonatypeRepo and adds Resolver.sonatypeOssRepos, which includes https://s01.oss.sonatype.org/ by [@armanbilge](https://github.com/armanbilge) in https://github.com/sbt/librarymanagement/pull/393

cf. https://github.com/sbt/sbt/releases/tag/v1.7.0