### PR TITLE
fix: enable scalafmt-dynamic to download snapshot versions

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
@@ -7,6 +7,7 @@ case class ScalafmtVersion(
     minor: Int,
     patch: Int,
     rc: Int = 0,
+    hash: String = "",
     snapshot: String = ""
 ) extends Comparable[ScalafmtVersion] {
   private val integerRepr: Int = {
@@ -22,6 +23,7 @@ case class ScalafmtVersion(
   override def toString: String =
     s"$major.$minor.$patch" +
       (if (rc > 0) s"-RC$rc" else "") +
+      (if (hash.nonEmpty) hash else "") +
       snapshot
 
   override def compareTo(o: ScalafmtVersion): Int = {
@@ -34,17 +36,18 @@ case class ScalafmtVersion(
 object ScalafmtVersion {
 
   private val versionRegex =
-    """(\d{1,2})\.(\d{1,2})\.(\d{1,2})(?:-RC(\d{1,2}))?([+].*|-SNAPSHOT)?""".r
+    """(\d{1,2})\.(\d{1,2})\.(\d{1,2})(?:-RC(\d{1,2}))?([+].+(?<!-SNAPSHOT))?(-SNAPSHOT)?""".r
 
   def parse(version: String): Option[ScalafmtVersion] =
     version match {
-      case versionRegex(major, minor, patch, rc, snapshot) =>
+      case versionRegex(major, minor, patch, rc, hash, snapshot) =>
         Try {
           ScalafmtVersion(
             positiveInt(major),
             positiveInt(minor),
             positiveInt(patch),
             if (rc == null) 0 else positiveInt(rc),
+            if (hash == null) "" else hash,
             if (snapshot == null) "" else snapshot
           )
         }.toOption

--- a/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/ScalafmtVersionSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/ScalafmtVersionSuite.scala
@@ -22,27 +22,35 @@ class ScalafmtVersionSuite extends FunSuite {
     )
     assertEquals(
       ScalafmtVersion.parse("2.2.3-SNAPSHOT"),
-      Some(ScalafmtVersion(2, 2, 3, 0, "-SNAPSHOT"))
+      Some(ScalafmtVersion(2, 2, 3, 0, "", "-SNAPSHOT"))
     )
     assertEquals(
       ScalafmtVersion.parse("2.0.0-RC1-SNAPSHOT"),
-      Some(ScalafmtVersion(2, 0, 0, 1, "-SNAPSHOT"))
+      Some(ScalafmtVersion(2, 0, 0, 1, "", "-SNAPSHOT"))
     )
     assertEquals(
       ScalafmtVersion.parse("2.2.2-SNAPSHOT"),
-      Some(ScalafmtVersion(2, 2, 2, 0, "-SNAPSHOT"))
+      Some(ScalafmtVersion(2, 2, 2, 0, "", "-SNAPSHOT"))
     )
     assertEquals(
       ScalafmtVersion.parse("99.99.99-RC99-SNAPSHOT"),
-      Some(ScalafmtVersion(99, 99, 99, 99, "-SNAPSHOT"))
+      Some(ScalafmtVersion(99, 99, 99, 99, "", "-SNAPSHOT"))
     )
     assertEquals(
       ScalafmtVersion.parse("99.99.99-RC99+foobar"),
-      Some(ScalafmtVersion(99, 99, 99, 99, "+foobar"))
+      Some(ScalafmtVersion(99, 99, 99, 99, "+foobar", ""))
+    )
+    assertEquals(
+      ScalafmtVersion.parse("99.99.99+foobar"),
+      Some(ScalafmtVersion(99, 99, 99, 0, "+foobar", ""))
     )
     assertEquals(
       ScalafmtVersion.parse("99.99.99+foobar"),
       Some(ScalafmtVersion(99, 99, 99, 0, "+foobar"))
+    )
+    assertEquals(
+      ScalafmtVersion.parse("3.5.9+41-60b84efb-SNAPSHOT"),
+      Some(ScalafmtVersion(3, 5, 9, 0, "+41-60b84efb", "-SNAPSHOT"))
     )
   }
 
@@ -56,6 +64,10 @@ class ScalafmtVersionSuite extends FunSuite {
     assertEquals(
       ScalafmtVersion.parse("2.2.2-RC2-SNAPSHOT").get.toString,
       "2.2.2-RC2-SNAPSHOT"
+    )
+    assertEquals(
+      ScalafmtVersion.parse("3.5.9+41-60b84efb-SNAPSHOT").get.toString,
+      "3.5.9+41-60b84efb-SNAPSHOT"
     )
   }
 


### PR DESCRIPTION
see: https://github.com/scalameta/scalafmt/issues/3326#issuecomment-1269587121

scalafmt failed to parse version like "3.5.9+41-60b84efb-SNAPSHOT" because when we implemented this logic back then,
we expect scalafmt to version something like 3.5.9-RC1-SNAPSHOT (not expected hash between RC version and snapshot)

This commit enables scalafmt to download snapshot version sonatype's snapshot repo is added by default.
https://github.com/scalameta/scalafmt/blob/60b84efb6ee1f424ccadd2b132677f5fd1724a7e/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/CoursierDependencyDownloader.scala#L30-L33