### PR TITLE
Update diff-branch arg saying it supports valid git ref

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -140,7 +140,8 @@ object CliArgParser {
       opt[String]("diff-branch")
         .action((branch, c) => c.copy(mode = Option(DiffFiles(branch))))
         .text(
-          "If set, only format edited files in git diff against provided branch. Has no effect if mode set to `changed`."
+          "If set, only format edited files in git diff against provided valid git reference. Has no effect if mode " +
+            "set to `changed`."
         )
       opt[Unit]("build-info")
         .action((_, _) => { println(buildInfo); sys.exit })


### PR DESCRIPTION
This is just a nice to have PR resulting from the discussion at https://github.com/scalameta/scalafmt/issues/3344. When I first read the help output for the cli arg I naively assumed it only worked with local branches, this makes it more clear and should avoid silly questions.