### PR TITLE
PolicyOps: unindent correctly in binpacking

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -390,15 +390,6 @@ class FormatOps(
     if (r.is[T.LeftBrace]) SplitTag.OneArgPerLine.activateOnly(s)
     else Decision.onlyNewlineSplits(s)
 
-  def UnindentAtExclude(
-      exclude: Set[T],
-      indent: Length
-  ): Policy.Pf = {
-    case Decision(t, s) if exclude.contains(t.left) =>
-      val close = matching(t.left)
-      s.map(_.withIndent(indent, close, ExpiresOn.After))
-  }
-
   def penalizeNewlineByNesting(from: T, to: T)(implicit
       fileLine: FileLine
   ): Policy = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1339,10 +1339,7 @@ class Router(formatOps: FormatOps) {
               if (oneline) nextCommaOneline.orElse(Some(close))
               else if (style.newlines.source.eq(Newlines.fold)) None
               else findComma(formatToken).orElse(Some(close))
-            def unindentPolicy = Policy.on(close) {
-              val excludeOpen = exclude.ranges.map(_.lt).toSet
-              UnindentAtExclude(excludeOpen, Num(-indentLen))
-            }
+            def unindentPolicy = unindentAtExclude(exclude, Num(-indentLen))
             val noSplitPolicy = if (needOnelinePolicy) {
               val alignPolicy = if (noSplitIndents.exists(_.hasStateColumn)) {
                 nextCommaOnelinePolicy.map(_ & penalizeNewlinesPolicy)

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1948,3 +1948,69 @@ class a {
     maxIdleDuration = Duration.Inf
   )(F)
 }
+<<< binPack unsafeCallSite, !indentOnce
+binPack.unsafeCallSite = always
+binPack.indentCallSiteOnce = false
+indent.callSite = 2
+align.preset = none
+===
+object a {
+  val ref = foo(bar((_, _) =>
+    baz1 { qux1 =>
+      noop1
+    } baz2 { qux2 =>
+      noop2
+    } baz3 //
+      { qux3 =>
+        noop3
+      } baz4 { qux4 =>
+        noop4
+      }))
+}
+>>>
+object a {
+  val ref = foo(bar((_, _) =>
+      baz1 { qux1 =>
+      noop1
+    } baz2 { qux2 =>
+      noop2
+    } baz3 //
+        { qux3 =>
+        noop3
+      } baz4 { qux4 =>
+        noop4
+      }))
+}
+<<< binPack unsafeCallSite, indentOnce
+binPack.unsafeCallSite = always
+binPack.indentCallSiteOnce = true
+indent.callSite = 2
+align.preset = none
+===
+object a {
+  val ref = foo(bar((_, _) =>
+    baz1 { qux1 =>
+      noop1
+    } baz2 { qux2 =>
+      noop2
+    } baz3 //
+      { qux3 =>
+        noop3
+      } baz4 { qux4 =>
+        noop4
+      }))
+}
+>>>
+object a {
+  val ref = foo(bar((_, _) =>
+      baz1 { qux1 =>
+      noop1
+    } baz2 { qux2 =>
+      noop2
+    } baz3 //
+        { qux3 =>
+        noop3
+      } baz4 { qux4 =>
+        noop4
+      }))
+}

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1971,15 +1971,15 @@ object a {
 object a {
   val ref = foo(bar((_, _) =>
       baz1 { qux1 =>
-      noop1
-    } baz2 { qux2 =>
-      noop2
-    } baz3 //
+        noop1
+      } baz2 { qux2 =>
+        noop2
+      } baz3 //
         { qux3 =>
-        noop3
-      } baz4 { qux4 =>
-        noop4
-      }))
+          noop3
+        } baz4 { qux4 =>
+          noop4
+        }))
 }
 <<< binPack unsafeCallSite, indentOnce
 binPack.unsafeCallSite = always
@@ -2004,13 +2004,13 @@ object a {
 object a {
   val ref = foo(bar((_, _) =>
       baz1 { qux1 =>
-      noop1
-    } baz2 { qux2 =>
-      noop2
-    } baz3 //
+        noop1
+      } baz2 { qux2 =>
+        noop2
+      } baz3 //
         { qux3 =>
-        noop3
-      } baz4 { qux4 =>
-        noop4
-      }))
+          noop3
+        } baz4 { qux4 =>
+          noop4
+        }))
 }


### PR DESCRIPTION
Apply it only if there are no breaks before start of exclude range.