### PR TITLE
Router: always add space between `(` and comment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2129,7 +2129,7 @@ class Router(formatOps: FormatOps) {
                 Num(if (willBreak) style.indent.main else 0)
               }
           }
-          val useSpace = style.spaces.inParentheses
+          val useSpace = style.spaces.inParentheses || right.is[T.Comment]
           Split(Space(useSpace), 0).withIndent(indent, close, Before)
         }
         def spaceSplit(implicit fileLine: FileLine) =

--- a/scalafmt-tests/src/test/resources/default/For.stat
+++ b/scalafmt-tests/src/test/resources/default/For.stat
@@ -97,7 +97,7 @@ for ((l, r) ← /* c1 */ ( /* c2 */ Seq(
 ) checkOne(looker, l, r)
 >>>
 for (
-    (l, r) ← /* c1 */ (/* c2 */ Seq(
+    (l, r) ← /* c1 */ ( /* c2 */ Seq(
           SelectString("a/b/c") -> None,
           SelectString("akka://all-systems/Nobody") -> None,
           SelectPath(system / "hallo") -> None,
@@ -140,7 +140,7 @@ for ((l, r) ← /* c1 */ ( /* c2 */Seq(
 ) checkOne(looker, l, r)
 >>>
 for (
-    (l, r) ← /* c1 */ (/* c2 */ Seq(
+    (l, r) ← /* c1 */ ( /* c2 */ Seq(
           SelectString("a/b/c") -> None,
           SelectString("akka://all-systems/Nobody") -> None,
           SelectPath(system / "hallo") -> None,

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix3.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix3.stat
@@ -184,7 +184,7 @@ object a {
     /* c2 */
   )
   b.c( /* c1 */
-    /* c2 */ (/* c3 */ )
+    /* c2 */ ( /* c3 */ )
   )
   b.c( /* c1 */
     /* c2 */ d,
@@ -194,7 +194,7 @@ object a {
     /* c2 */ ( /* c3 */ d, e)
   )
   b.c( /* c1 */
-    (/* c2 */ c + d /* c3 */ ).foo
+    ( /* c2 */ c + d /* c3 */ ).foo
   )
 }
 <<< args with parens, targs and comments
@@ -228,7 +228,7 @@ object a {
 >>>
 object a {
   b.c[A]( /* c1 */
-    /* c2 */ (/* c3 */ )
+    /* c2 */ ( /* c3 */ )
   )
 }
 <<< args with tuple, targs and comments

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -807,19 +807,19 @@ object a {
 >>>
 object a {
   b c /* c1 */
-    (/* c2 */ )
+    ( /* c2 */ )
   b c /* c1 */
-    (/* c2 */ (/* c3 */ ))
+    ( /* c2 */ ( /* c3 */ ))
   b c /* c1 */
-    (/* c2 */ (/* c3 */ /* c4 */ ))
+    ( /* c2 */ ( /* c3 */ /* c4 */ ))
   b c /* c1 */
-    (/* c2 */ d, e)
+    ( /* c2 */ d, e)
   b c /* c1 */
-    (/* c2 */ ( /* c3 */ d, e))
+    ( /* c2 */ ( /* c3 */ d, e))
   b c /* c1 */
-    (/* c2 */ ( /* c3 */ /* c4 */ d, e))
+    ( /* c2 */ ( /* c3 */ /* c4 */ d, e))
   b c /* c1 */
-    (/* c2 */ c + d /* c3 */ ).foo
+    ( /* c2 */ c + d /* c3 */ ).foo
 }
 <<< infix with parens, targs and comments
 object a {
@@ -834,10 +834,10 @@ object a {
 object a {
   b c /* c1 */
     [A] /* c2 */
-    (/* c3 */ )
+    ( /* c3 */ )
   b c /* c1 */
     [A] /* c2 */
-    (/* c3 */ d, e)
+    ( /* c3 */ d, e)
 }
 <<< if with/without then
 runner.dialect = scala3


### PR DESCRIPTION
That is done in some places and missed in others; and there's always a space between a comment and a `)`.