### PR TITLE
ScalafmtRunner: always allow top-level terms

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -177,7 +177,7 @@ case class ScalafmtConfig(
   )
 
   def forSbt: ScalafmtConfig =
-    copy(runner = runner.forSbt, rewrite = rewrite.forSbt)
+    copy(rewrite = rewrite.forSbt)
 
   private lazy val expandedFileOverride = Try {
     val langPrefix = "lang:"
@@ -237,7 +237,7 @@ case class ScalafmtConfig(
   private[scalafmt] lazy val docstringsWrapMaxColumn: Int =
     docstrings.wrapMaxColumn.getOrElse(maxColumn)
 
-  @inline private[scalafmt] def dialect = runner.getDialect
+  @inline private[scalafmt] def dialect = runner.getDialectForParser
 
   private[scalafmt] def getTrailingCommas = rewrite.trailingCommas.style
 

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/ErrorTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/ErrorTest.scala
@@ -5,13 +5,13 @@ import org.scalafmt.Scalafmt
 import munit.FunSuite
 
 class ErrorTest extends FunSuite {
-  test("errors are caught") {
-    val nonSourceFile = Seq(
-      "class A {",
-      "val x = 1",
-      "println(1)"
-    )
-    nonSourceFile.foreach { original =>
+  private val nonSourceFile = Seq(
+    "class A {",
+    "val x + 1",
+    "println 1"
+  )
+  nonSourceFile.foreach { original =>
+    test(s"errors are caught: $original") {
       Scalafmt.format(original, HasTests.unitTest40) match {
         case _: Formatted.Success => fail("expected failure, got success")
         case _ =>

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/FormatAssertions.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/FormatAssertions.scala
@@ -22,7 +22,7 @@ trait FormatAssertions {
   ): Unit =
     assertFormatPreservesAst(filename, original, obtained)(
       runner.getParser,
-      runner.getDialect
+      runner.getDialectForParser
     )
 
   def assertFormatPreservesAst[T <: Tree](


### PR DESCRIPTION
The formatter's job is not to validate code but to format it.