### PR TITLE
TreeOps: don't look for nested lambda in block

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -558,9 +558,6 @@ object TreeOps {
   final def lastLambda(first: Term.FunctionTerm): Term.FunctionTerm =
     first.body match {
       case child: Term.FunctionTerm => lastLambda(child)
-      case block: Term.Block
-          if block.stats.headOption.exists(_.is[Term.FunctionTerm]) =>
-        lastLambda(block.stats.head.asInstanceOf[Term.FunctionTerm])
       case _ => first
     }
 

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -39,6 +39,17 @@ Thing() { implicit ctx => j =>
 Thing() { implicit ctx => j =>
   ???
 }
+<<< curried, with block
+Thing() { implicit ctx => { j =>
+      ???
+}}
+>>>
+Thing() {
+  implicit ctx =>
+    { j =>
+      ???
+    }
+}
 <<< curried break before first
 Thing() { implicit ctx => j => kkkkkkkkkk =>
       ???
@@ -47,6 +58,17 @@ Thing() { implicit ctx => j => kkkkkkkkkk =>
 Thing() {
   implicit ctx => j => kkkkkkkkkk =>
     ???
+}
+<<< curried break before first, with block
+Thing() { implicit ctx => j => { kkkkkkkkkk =>
+      ???
+}}
+>>>
+Thing() {
+  implicit ctx => j =>
+    { kkkkkkkkkk =>
+      ???
+    }
 }
 <<< curried insanity, fit as much on line as possible
 Thing() { implicit ctx => j => kkkkkkkkkkkkkkkkkkk => llllllllllll => mmmmmmmmmmmmmmmmmmm =>

--- a/scalafmt-tests/src/test/resources/unit/Lambda.stat
+++ b/scalafmt-tests/src/test/resources/unit/Lambda.stat
@@ -44,11 +44,10 @@ Thing() { implicit ctx => { j =>
       ???
 }}
 >>>
-Thing() {
-  implicit ctx =>
-    { j =>
-      ???
-    }
+Thing() { implicit ctx =>
+  { j =>
+    ???
+  }
 }
 <<< curried break before first
 Thing() { implicit ctx => j => kkkkkkkkkk =>
@@ -64,11 +63,10 @@ Thing() { implicit ctx => j => { kkkkkkkkkk =>
       ???
 }}
 >>>
-Thing() {
-  implicit ctx => j =>
-    { kkkkkkkkkk =>
-      ???
-    }
+Thing() { implicit ctx => j =>
+  { kkkkkkkkkk =>
+    ???
+  }
 }
 <<< curried insanity, fit as much on line as possible
 Thing() { implicit ctx => j => kkkkkkkkkkkkkkkkkkk => llllllllllll => mmmmmmmmmmmmmmmmmmm =>


### PR DESCRIPTION
Doing so was actually preventing folding of the first lambda, since the block rules force a newline.