### PR TITLE
FormatOps: enclosing parens owned by enclosed tree

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2063,14 +2063,14 @@ class FormatOps(
         indentOpt: Option[Int] = None
     )(implicit fileLine: FileLine, style: ScalafmtConfig): Seq[Split] = {
       val treeTokens = tree.tokens
-      val end = tokens.getLast(treeTokens)
+      val end = tokens.getLast(treeTokens, tree)
       val slbExpire = nextNonCommentSameLine(end).left
       val closeOpt =
         if (isTuple(tree)) None
         else {
           val maybeClose = prevNonComment(end)
           tokens
-            .getClosingIfInParens(maybeClose)(tokens.getHead(treeTokens))
+            .getClosingIfInParens(maybeClose)(tokens.getHead(treeTokens, tree))
             .map(prevNonComment(_).left)
         }
       def nlPolicy(implicit fileLine: FileLine) =


### PR DESCRIPTION
Regardless of how `scalameta` treats enclosing parens (whether owned by the tree they enclose, or by its parent), let's assign the enclosed tree as the owner. Exceptions include cases where parens are an integral part of the parent (tuple, if/while conditions etc.)