### PR TITLE
Defn.Def: add Decl.Def and Defn.Macro as needed

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -82,7 +82,9 @@ case class Align(
     treeCategory: Map[String, String] = Map(
       "Defn.Val" -> "given/val/var/def",
       "Defn.Var" -> "given/val/var/def",
+      "Decl.Def" -> "given/val/var/def",
       "Defn.Def" -> "given/val/var/def",
+      "Defn.Macro" -> "given/val/var/def",
       "Defn.GivenAlias" -> "given/val/var/def",
       "Defn.Class" -> "class/object/trait/enum",
       "Defn.Object" -> "class/object/trait/enum",

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1244,6 +1244,7 @@ class FormatWriter(formatOps: FormatOps) {
         def unapply(tree: Tree): Option[(List[meta.Mod], Tree)] =
           tree match {
             case p: Defn.Def => Some(p.mods -> p.body)
+            case p: Defn.Macro => Some(p.mods -> p.body)
             case p: Defn.Given => Some(p.mods -> p.templ)
             case p: Defn.GivenAlias => Some(p.mods -> p.body)
             case p: Defn.Val => Some(p.mods -> p.rhs)
@@ -1863,6 +1864,7 @@ object FormatWriter {
     case t: Pkg.Object => t.name.toString
     // definitions
     case t: Defn.Def => t.name.toString
+    case t: Defn.Macro => t.name.toString
     case t: Defn.GivenAlias =>
       val label = t.name.toString
       if (label.isEmpty) "given" else label

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -128,12 +128,12 @@ object TreeOps {
     def loop(subtree: Tree): Unit = {
       subtree match {
         case t: Defn.Class => addDefn[KwClass](t.mods, t)
+        case t: Decl.Def => addDefn[KwDef](t.mods, t)
         case t: Defn.Def => addDefn[KwDef](t.mods, t)
+        case t: Defn.Macro => addDefn[KwDef](t.mods, t)
+        case t: Decl.Given => addDefn[KwGiven](t.mods, t)
         case t: Defn.Given => addDefn[KwGiven](t.mods, t)
         case t: Defn.GivenAlias => addDefn[KwGiven](t.mods, t)
-        case t: Defn.Macro => addDefn[KwDef](t.mods, t)
-        case t: Decl.Def => addDefn[KwDef](t.mods, t)
-        case t: Decl.Given => addDefn[KwGiven](t.mods, t)
         case t: Defn.Enum => addDefn[KwEnum](t.mods, t)
         case t: Defn.ExtensionGroup =>
           addDefnTokens(Nil, t, "extension", soft.KwExtension.unapply)
@@ -317,7 +317,7 @@ object TreeOps {
 
   def isDefDef(tree: Tree): Boolean =
     tree match {
-      case _: Decl.Def | _: Defn.Def => true
+      case _: Decl.Def | _: Defn.Def | _: Defn.Macro => true
       case _ => false
     }
 
@@ -325,9 +325,9 @@ object TreeOps {
   def defDefBody(tree: Tree): Option[Tree] =
     tree match {
       case d: Defn.Def => Some(d.body)
+      case d: Defn.Macro => Some(d.body)
       case d: Defn.Given => Some(d.templ)
       case d: Defn.GivenAlias => Some(d.body)
-      case d: Defn.Macro => Some(d.body)
       case d: Defn.Val => Some(d.rhs)
       case d: Defn.Var => d.rhs
       case t: Defn.Class => Some(t.templ)
@@ -348,6 +348,7 @@ object TreeOps {
     tree match {
       case d: Decl.Def => Some(d.decltpe)
       case d: Defn.Def => d.decltpe
+      case d: Defn.Macro => d.decltpe
       case d: Defn.Given => d.templ.inits.headOption.map(_.tpe)
       case d: Defn.GivenAlias => Some(d.decltpe)
       case d: Decl.Given => Some(d.decltpe)
@@ -720,8 +721,9 @@ object TreeOps {
           case _: Defn.Trait => DanglingParentheses.Exclude.`trait`
           case _: Defn.Enum => DanglingParentheses.Exclude.`enum`
           case _: Defn.ExtensionGroup => DanglingParentheses.Exclude.`extension`
-          case _: Defn.Def => DanglingParentheses.Exclude.`def`
-          case _: Defn.Given | _: Defn.GivenAlias =>
+          case _: Decl.Def | _: Defn.Def | _: Defn.Macro =>
+            DanglingParentheses.Exclude.`def`
+          case _: Decl.Given | _: Defn.Given | _: Defn.GivenAlias =>
             DanglingParentheses.Exclude.`given`
           case _ => null
         }


### PR DESCRIPTION
`Defn.Macro` in most cases should behave exactly like `Defn.Def`, and so should `Decl.Def` for method signature formatting. These additions cover somewhat obscure cases (since macros are generally rare and their bodies are simply a proxy for another method), but let's add them for completeness -- and correctness - sake.