### PR TITLE
TreeOps: consistency for apply/infix lookalikes

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1001,7 +1001,7 @@ class Router(formatOps: FormatOps) {
         val splitsForAssign =
           if (defnSite || isBracket || keepConfigStyleSplit) None
           else
-            getAssignAtSingleArgCallSite(leftOwner).map { assign =>
+            getAssignAtSingleArgCallSite(args).map { assign =>
               val assignToken = assign.rhs match {
                 case b: Term.Block => tokens.getHead(b)
                 case _ => tokens(assign.tokens.find(_.is[T.Equals]).get)
@@ -1284,7 +1284,7 @@ class Router(formatOps: FormatOps) {
         val noNoSplitIndents = nlOnly ||
           singleArgAsInfix.isDefined ||
           isSingleArg && oneline && !needOnelinePolicy ||
-          !isBracket && getAssignAtSingleArgCallSite(leftOwner).isDefined
+          !isBracket && getAssignAtSingleArgCallSite(args).isDefined
         val noSplitIndents =
           if (noNoSplitIndents) Nil
           else if (isSingleArg && !style.binPack.indentCallSiteSingleArg) Nil

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -446,6 +446,7 @@ object TreeOps {
       case Term.ApplyInfix(_, op, _, List(arg))
           if op.pos.end <= ft.left.start => // parens used to belong to rhs
         isCallSite(arg)
+      case Pat.ExtractInfix(_, op, _ :: Nil) => op.pos.end <= ft.left.start
       case t => isCallSite(t)
     }
 
@@ -609,9 +610,9 @@ object TreeOps {
       case _ => false
     }
 
-  def getAssignAtSingleArgCallSite(tree: Tree): Option[Term.Assign] =
-    tree match {
-      case Term.Apply(_, List(fun: Term.Assign)) => Some(fun)
+  def getAssignAtSingleArgCallSite(args: Seq[Tree]): Option[Term.Assign] =
+    args match {
+      case Seq(fun: Term.Assign) => Some(fun)
       case _ => None
     }
 

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1263,7 +1263,8 @@ object WrapperToHaveStatTestCaseParserWorking {
       someInt = 5
     ) @annot3
     @deprecated(value =
-      "bar") def bar2 = 1
+      "bar"
+    ) def bar2 = 1
   }
 
   @annot @annot2
@@ -1327,7 +1328,8 @@ object WrapperToHaveStatTestCaseParserWorking {
       someInt = 5
     ) @annot3
     @deprecated(value =
-      "bar") def bar2 = 1
+      "bar"
+    ) def bar2 = 1
   }
 
   @annot @annot2

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -925,7 +925,8 @@ object a {
 >>>
 object a {
   a match {
-    case foo bar (baz @ qux) =>
+    case foo bar (
+          baz @ qux) =>
   }
 }
 <<< [from scala-js] changed with incorect overflow detection


### PR DESCRIPTION
Use an equivalent rule for Pat.ExtractInfix as for Term.ApplyInfix; similarly, treat arguments to Init the same as Term.Apply.