### PR TITLE
TreeOps: fix ownership of enclosed trees

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -6484,7 +6484,7 @@ object a {
 }
 >>>
 object a {
-  info (
+  info(
     "ZKConsumerConnector shutdown completed in " +
       (System
         .nanoTime() - startTime) / 1000000 + " ms"

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -6199,9 +6199,11 @@ object a {
 }
 >>>
 object a {
-  info ("ZKConsumerConnector shutdown completed in " +
-    (System.nanoTime() -
-    startTime) / 1000000 + " ms")
+  info(
+    "ZKConsumerConnector shutdown completed in " +
+      (System.nanoTime() - startTime) /
+      1000000 + " ms"
+  )
 }
 <<< SM 4.7.0: 18
 maxColumn = 80

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -6492,7 +6492,7 @@ object a {
 }
 >>>
 object a {
-  info (
+  info(
     "ZKConsumerConnector shutdown completed in " +
       (System.nanoTime() - startTime) / 1000000 + " ms"
   )

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -6665,9 +6665,11 @@ object a {
 }
 >>>
 object a {
-  info ("ZKConsumerConnector shutdown completed in " +
-    (System.nanoTime() -
-    startTime) / 1000000 + " ms")
+  info(
+    "ZKConsumerConnector shutdown completed in " +
+      (System.nanoTime() - startTime) /
+      1000000 + " ms"
+  )
 }
 <<< SM 4.7.0: 18
 maxColumn = 80


### PR DESCRIPTION
- exclude only last right paren (control expressions like if/while/for)
- ignore empty tokens (Xml.End, Interpolation.End)
- allow procedure-syntax Decl.Def (no type)
- detect top-level invocation directly, not via elemIdx