### PR TITLE
Router: improve handling of parens in functions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -907,10 +907,25 @@ class Router(formatOps: FormatOps) {
               isDefnSite(leftOwner)
           } =>
         val close = matching(open)
+        val tupleSite = isTuple(leftOwner)
+        val anyDefnSite = isDefnSite(leftOwner)
+        val defnSite = !tupleSite && anyDefnSite
+
         val TreeArgs(lhs, args) = getApplyArgs(formatToken, false)
         // In long sequence of select/apply, we penalize splitting on
         // parens furthest to the right.
-        val lhsPenalty = treeDepth(lhs)
+        val leftOwnerIsEnclosed = defnSite && // callSite is definitely not
+          tokens.getHeadIfEnclosed(lhs).contains(tok)
+        val lhsPenalty =
+          if (lhs == leftOwner && leftOwnerIsEnclosed) treeDepth(lhs)
+          else
+            lhs match {
+              case t: Term.FunctionTerm => maxTreeDepth(t.params)
+              case t: Term.PolyFunction => maxTreeDepth(t.tparams)
+              case t: Type.FunctionType => maxTreeDepth(t.params)
+              case t: Type.PolyFunction => maxTreeDepth(t.tparams)
+              case _ => treeDepth(lhs)
+            }
 
         // XXX: sometimes we have zero args, so multipleArgs != !singleArgument
         val numArgs = args.length
@@ -925,16 +940,15 @@ class Router(formatOps: FormatOps) {
         val onlyConfigStyle = mustUseConfigStyle(formatToken)
 
         val sourceIgnored = style.newlines.sourceIgnored
-        val isSingleEnclosedArgument =
-          singleArgument && tokens.isEnclosedInMatching(args(0))
+        val (onlyArgument, isSingleEnclosedArgument) =
+          if (singleArgument) {
+            val arg = args(0)
+            (arg, tokens.isEnclosedInMatching(arg))
+          } else (null, false)
         val useConfigStyle = onlyConfigStyle || (sourceIgnored &&
           style.optIn.configStyleArguments && !isSingleEnclosedArgument)
 
         val nestedPenalty = 1 + nestedApplies(leftOwner) + lhsPenalty
-
-        val tupleSite = isTuple(leftOwner)
-        val anyDefnSite = isDefnSite(leftOwner)
-        val defnSite = !tupleSite && anyDefnSite
 
         val indent =
           if (anyDefnSite)
@@ -1041,17 +1055,18 @@ class Router(formatOps: FormatOps) {
             insideBlock[T.LeftBracket](excludeBeg, close)
           } else if (
             multipleArgs ||
-            !isSingleEnclosedArgument &&
+            (!isSingleEnclosedArgument || leftOwnerIsEnclosed) &&
             style.newlines.source.eq(Newlines.unfold)
           )
             TokenRanges.empty
           else if (
             style.newlines.source.eq(Newlines.fold) && {
               isSingleEnclosedArgument ||
-              singleArgument && isExcludedTree(args(0))
+              singleArgument && isExcludedTree(onlyArgument)
             }
           )
-            parensTuple(tokens.getLast(args(0)).left)
+            if (onlyArgument eq leftOwner) TokenRanges(TokenRange(open, close))
+            else parensTuple(tokens.getLast(onlyArgument).left)
           else insideBracesBlock(tok, close)
 
         def singleLine(
@@ -1083,7 +1098,10 @@ class Router(formatOps: FormatOps) {
 
         val keepNoNL = style.newlines.source.eq(Newlines.keep) && tok.noBreak
         val preferNoSplit = keepNoNL && singleArgument
-        val oneArgOneLine = newlinePolicy & splitOneArgOneLine(close, leftOwner)
+        val oneArgOneLine = newlinePolicy & {
+          if (leftOwnerIsEnclosed) Policy.NoPolicy
+          else splitOneArgOneLine(close, leftOwner)
+        }
         val extraOneArgPerLineIndent =
           if (multipleArgs && style.poorMansTrailingCommasInConfigStyle)
             Indent(Num(2), right, After)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -553,9 +553,13 @@ object TreeOps {
     */
   // TODO(olafur) inefficient, precalculate?
 
-  def treeDepth(tree: Tree): Int =
-    if (tree.children.isEmpty) 0
-    else 1 + tree.children.map(treeDepth).max
+  def treeDepth(tree: Tree): Int = {
+    val children = tree.children
+    if (children.isEmpty) 0 else 1 + maxTreeDepth(children)
+  }
+
+  def maxTreeDepth(trees: Seq[Tree]): Int =
+    trees.foldLeft(0) { case (res, t) => math.max(res, treeDepth(t)) }
 
   @tailrec
   final def lastLambda(first: Term.FunctionTerm): Term.FunctionTerm =

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -6698,10 +6698,9 @@ object a {
   var sessionCheckFuncs
       : List[(Map[String, SessionInfo], SessionInfo => Unit) => Unit] =
     (
-        (
-            ses: Map[String, SessionInfo],
-            destroyer: SessionInfo => Unit
-        ) => { foo }
+        (ses: Map[String, SessionInfo], destroyer: SessionInfo => Unit) => {
+          foo
+        }
     ) :: Nil
 }
 <<< SM 7.4.0: 38
@@ -6748,13 +6747,8 @@ object a {
 object a {
   def curried: T1 => T2 => T3 => T4 => T5 => T6 => R = { (x1: T1) =>
     (
-        (
-            x2: T2,
-            x3: T3,
-            x4: T4,
-            x5: T5,
-            x6: T6
-        ) => self.apply(x1, x2, x3, x4, x5, x6)
+        (x2: T2, x3: T3, x4: T4, x5: T5, x6: T6) =>
+          self.apply(x1, x2, x3, x4, x5, x6)
     ).curried
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -7226,10 +7226,7 @@ object a {
   var sessionCheckFuncs
       : List[(Map[String, SessionInfo], SessionInfo => Unit) => Unit] =
     (
-        (
-            ses: Map[String, SessionInfo],
-            destroyer: SessionInfo => Unit
-        ) => {
+        (ses: Map[String, SessionInfo], destroyer: SessionInfo => Unit) => {
           foo
         }
     ) :: Nil
@@ -7280,13 +7277,8 @@ object a {
 object a {
   def curried: T1 => T2 => T3 => T4 => T5 => T6 => R = { (x1: T1) =>
     (
-        (
-            x2: T2,
-            x3: T3,
-            x4: T4,
-            x5: T5,
-            x6: T6
-        ) => self.apply(x1, x2, x3, x4, x5, x6)
+        (x2: T2, x3: T3, x4: T4, x5: T5, x6: T6) =>
+          self.apply(x1, x2, x3, x4, x5, x6)
     ).curried
   }
 }
@@ -7333,12 +7325,14 @@ object a {
 }
 >>>
 object a {
-  ((a: A) => {
-    class N extends M[a.C] {
-      def m(x: a.C) = true
-    }
-    new N: M[Null]
-  }).apply(a).m(null) // NPE, missing bridge
+  (
+      (a: A) => {
+        class N extends M[a.C] {
+          def m(x: a.C) = true
+        }
+        new N: M[Null]
+      }
+  ).apply(a).m(null) // NPE, missing bridge
 }
 <<< SM 7.4.0: 42.1
 maxColumn = 76


### PR DESCRIPTION
Since parens surrounding function parameters are actually part of the entire function tree, let's fix two problems:

- for parens around function parameters, fix the LHS depth computation to consider only the parameter trees, not the entire function
- for parens around the entire function, don't force one-arg-per-line logic since it is only intended for the parameters

Helps with #3417.