### PR TITLE
Documentation: Remove troubleshooting from FAQ title

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 ---
 id: faq
-title: FAQ / Troubleshooting
+title: FAQ
 ---
 
 ## Why not Scalariform?

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -18,7 +18,7 @@
         "title": "Contributing to the website"
       },
       "faq": {
-        "title": "FAQ / Troubleshooting"
+        "title": "FAQ"
       },
       "gotchas": {
         "title": "Gotchas"


### PR DESCRIPTION
This page seems more like an FAQ page rather than troubleshooting. This PR renames the FAQ / Troubleshooting page to only FAQ.