### PR TITLE
chore: Release scalafmt on JDK 8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'temurin'
           cache: 'sbt'
       - name: Publish ${{ github.ref }}


### PR DESCRIPTION
Otherwise any tool running on JDK 8 will fail.