### PR TITLE
docs: add a example of how to use sbt scalafmtOnly

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,7 +138,7 @@ version = @STABLE_VERSION@
   formatted.
 - `scalafmtSbt`: Format `*.sbt` and `project/*.scala` files.
 - `scalafmtSbtCheck`: Check if the files have been formatted by `scalafmtSbt`.
-- `scalafmtOnly <file>...`: Format specified files listed. It's important to pass as parameters as a single string, example: `sbt 'scalafmtOnly src/scala/mypkg/MyClass1.scala'`
+- `scalafmtOnly <file>...`: Format specified files listed. It's important to pass all parameters as a single string, example: `sbt 'scalafmtOnly src/scala/mypkg/MyClass1.scala'`
 - `scalafmtAll` or `scalafmtCheckAll`: Execute the `scalafmt` or `scalafmtCheck`
   task for all configurations in which it is enabled (since v2.0.0-RC5)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,7 +138,7 @@ version = @STABLE_VERSION@
   formatted.
 - `scalafmtSbt`: Format `*.sbt` and `project/*.scala` files.
 - `scalafmtSbtCheck`: Check if the files have been formatted by `scalafmtSbt`.
-- `scalafmtOnly <file>...`: Format specified files listed.
+- `scalafmtOnly <file>...`: Format specified files listed. It's important to pass as parameters as a single string, example: `sbt 'scalafmtOnly src/scala/mypkg/MyClass1.scala'`
 - `scalafmtAll` or `scalafmtCheckAll`: Execute the `scalafmt` or `scalafmtCheck`
   task for all configurations in which it is enabled (since v2.0.0-RC5)
 


### PR DESCRIPTION
The documentation do not keep clear that the `sbt` parameter must be a single string.

ref: https://github.com/scalameta/sbt-scalafmt/issues/253#issuecomment-1419413773