### PR TITLE
FormatOps vertical multiline: fix implicit force

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3996,7 +3996,9 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit c: C
+     ): B = ???
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4017,7 +4019,10 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit
+       c: C
+     ): B = ???
 <<< interleaved, short
 maxColumn = 23
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3807,7 +3807,9 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit c: C
+     ): B = ???
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -3828,7 +3830,10 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit
+       c: C
+     ): B = ???
 <<< interleaved, short
 maxColumn = 23
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -4035,7 +4035,9 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit c: C
+     ): B = ???
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4056,7 +4058,10 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit
+       c: C
+     ): B = ???
 <<< interleaved, short
 maxColumn = 23
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -4127,7 +4127,9 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit c: C
+     ): B = ???
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4148,7 +4150,10 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit
+       c: C
+     ): B = ???
 <<< interleaved, short
 maxColumn = 23
 ===


### PR DESCRIPTION
Handles `using/implicit` after a secondary bracket clause (possible with interleaved parameter clauses), if `implicitParamListModifierForce=before` was set, consistently with how they are handled after a paren clause.

For that, separates rules for bracket and paren cases. Helps with #3466.