### PR TITLE
FormatOps vertical multiline: fix implicit prefer

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitTag.scala
@@ -14,5 +14,6 @@ object SplitTag {
   case object SelectChainSecondNL extends SplitTag
   case object InfixChainNoNL extends SplitTag
   case object OnelineWithChain extends SplitTag
+  case object VerticalMultilineSingleLine extends SplitTag
 
 }

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -11,7 +11,8 @@ def format_![T <: Tree](
   foo: Int
 )(f: A => B,
   k: D
-)(implicit ev: Parse[T],
+)(implicit
+  ev: Parse[T],
   ev2: EC
 ): String
 <<< #1462

--- a/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/excludeDanglingInDef.stat
@@ -72,7 +72,8 @@ def getListing(
     b: String,
     c: String,
     d: String
-  )(implicit e: String,
+  )(implicit
+    e: String,
     g: String,
     f: String): Future[String] = {
   a + b + c + d + e + g + f

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -11,7 +11,8 @@ def format_![T <: Tree](
     foo: Int
   )(f: A => B,
     k: D
-  )(implicit ev: Parse[T],
+  )(implicit
+    ev: Parse[T],
     ev2: EC
   ): String
 
@@ -39,7 +40,8 @@ def format_![T <: Tree](
 def format_![T <: Tree](
     code: String,
     code2: String
-  )(implicit ev: Parse[T],
+  )(implicit
+    ev: Parse[T],
     ex: D
   ): String = 1
 
@@ -54,7 +56,8 @@ def format_![T <: Tree](
     code: String,
     foo: Int
   )(f: A => B
-  )(implicit ev: Parse[T],
+  )(implicit
+    ev: Parse[T],
     ev2: EC
   ): String
 
@@ -71,9 +74,8 @@ def format_![
     T <: Tree // Some type comment
   ](code: String, // The code!
     code2: String
-  )(implicit ev: Parse[
-      T
-    ], // The Parser!!! Some very long comment that goes over limit
+  )(implicit
+    ev: Parse[T], // The Parser!!! Some very long comment that goes over limit
     ex: D
   ): String = 1
 
@@ -104,7 +106,8 @@ def format_![T <: Tree](
     updatedAt: Instant = Instant.now(),
     user: User = new User { def someFunc(): RT = () },
     createdAt: Instant = Default.getInstant(a)(b)
-  )(implicit ev: Parse[T],
+  )(implicit
+    ev: Parse[T],
     ev2: EC
   ): String
 
@@ -119,7 +122,8 @@ final class UserProfile(
     address: Address,
     profession: Profession,
     school: School
-  )(implicit ctx: Context,
+  )(implicit
+    ctx: Context,
     ec: Executor)
   extends Profile
   with UserSettings
@@ -133,7 +137,8 @@ override def load()(implicit taskCtx: Context,
     ): Future[Seq[A] Or B]
 >>>
 override def load(
-  )(implicit taskCtx: Context,
+  )(implicit
+    taskCtx: Context,
     ec: ExecutionContext
   ): Future[Seq[A] Or B]
 
@@ -145,7 +150,8 @@ override def load(code: String)()(implicit taskCtx: Context,
 override def load(
     code: String
   )(
-  )(implicit taskCtx: Context,
+  )(implicit
+    taskCtx: Context,
     ec: ExecutionContext
   ): Future[Seq[A] Or B]
 


### PR DESCRIPTION
The case of implicitParamListModifierPrefer=after setting (default) was incorrectly handled with vertical multiline. The test changes show that it wasn't working for cases with multiple parameters in a group.

Helps with #3466.