### PR TITLE
FormatOps vertical multiline: one-param implicits

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1290,19 +1290,21 @@ class FormatOps(
       Seq(slbSplit, noSplit.andPolicy(noSlbPolicy), nlSplit)
     } else {
       val rightIsImplicit = r.is[soft.ImplicitOrUsing]
-      val opensImplicit = rightIsImplicit &&
-        getImplicitParamList(ft.meta.rightOwner).exists(_.lengthCompare(1) > 0)
       val nlOnly =
         if (rightIsImplicit)
           style.newlines.forceBeforeImplicitParamListModifier
         else
           style.verticalMultiline.newlineAfterOpenParen
+      val implicitParams =
+        if (!rightIsImplicit) Nil
+        else getImplicitParamList(ft.meta.rightOwner).getOrElse(Nil)
       val noSlb = nlOnly || aboveArityThreshold || ft.hasBreak &&
         !style.newlines.sourceIgnored && style.optIn.configStyleArguments ||
-        opensImplicit && style.newlines.forceAfterImplicitParamListModifier
+        implicitParams.nonEmpty &&
+        style.newlines.forceAfterImplicitParamListModifier
       val nlMod = NewlineT(alt = if (nlOnly) None else Some(slbSplit.modExt))
-      val spaceImplicit =
-        opensImplicit && style.newlines.notBeforeImplicitParamListModifier
+      val spaceImplicit = !nlOnly && implicitParams.lengthCompare(1) > 0 &&
+        style.newlines.notBeforeImplicitParamListModifier
       Seq(
         // If we can fit all in one block, make it so
         slbSplit.notIf(noSlb),

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -4085,7 +4085,10 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit
+       c: C
+     ): B = ???
    class F(
        a: A,
        as: A*

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3896,7 +3896,10 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit
+       c: C
+     ): B = ???
    class F(
        a: A,
        as: A*

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -4124,7 +4124,10 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit
+       c: C
+     ): B = ???
    class F(
        a: A,
        as: A*

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -4216,7 +4216,10 @@ object a:
    def f[A](a: A, as: A*)[B](
        b: B,
        bs: B*
-     )[C](implicit c: C): B = ???
+     )[C](
+       implicit
+       c: C
+     ): B = ???
    class F(
        a: A,
        as: A*


### PR DESCRIPTION
Follow-on to https://github.com/scalameta/scalafmt/pull/3469, where some single-param implicit groups were handled incorrectly.

Earlier, if implicitParamListModifierForce=after was used, we would only prohibit single-line formatting for multi-param groups, thus excluding single-param groups.

Helps with #3466.