### PR TITLE
FormatOps vertical multiline: explicit implicits

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1233,9 +1233,10 @@ class FormatOps(
       case Decision(FormatToken(LeftParenOrBracket(), _, m), ss)
           if allParenOwners.contains(m.leftOwner) =>
         ss.filter(!_.isActiveFor(SplitTag.VerticalMultilineSingleLine))
-      case Decision(ftd @ FormatToken(soft.ImplicitOrUsing(), _, _), _)
+      case Decision(ftd @ FormatToken(soft.ImplicitOrUsing(), _, m), _)
           if style.newlines.forceAfterImplicitParamListModifier &&
-            !tokens.isRightCommentThenBreak(ftd) =>
+            !tokens.isRightCommentThenBreak(ftd) &&
+            hasImplicitParamList(m.leftOwner) =>
         Seq(Split(Newline, 0))
     }
 

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -4277,17 +4277,14 @@ object a:
      )(b: B,
        bs: B*
      )(implicit
-       implicit
-       c: C) {}
+       implicit c: C) {}
    class F(
        a: A,
        as: A*
      )(b: B,
        bs: B*
-     )(implicit
-       c: C,
-       implicit
-       d: D) {}
+     )(implicit c: C,
+       implicit d: D) {}
    class F(
        a: A,
        as: A*
@@ -4296,8 +4293,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit
-       e: E) {}
+       implicit e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4381,18 +4377,15 @@ object a:
        bs: B*
      )(
        implicit
-       implicit
-       c: C) {}
+       implicit c: C) {}
    class F(
        a: A,
        as: A*
      )(b: B,
        bs: B*
      )(
-       implicit
-       c: C,
-       implicit
-       d: D) {}
+       implicit c: C,
+       implicit d: D) {}
    class F(
        a: A,
        as: A*
@@ -4402,8 +4395,7 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit
-       e: E) {}
+       implicit e: E) {}
 <<< interleaved, short
 maxColumn = 23
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -4088,17 +4088,14 @@ object a:
      )(b: B,
        bs: B*
      )(implicit
-       implicit
-       c: C) {}
+       implicit c: C) {}
    class F(
        a: A,
        as: A*
      )(b: B,
        bs: B*
-     )(implicit
-       c: C,
-       implicit
-       d: D) {}
+     )(implicit c: C,
+       implicit d: D) {}
    class F(
        a: A,
        as: A*
@@ -4107,8 +4104,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit
-       e: E) {}
+       implicit e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4192,18 +4188,15 @@ object a:
        bs: B*
      )(
        implicit
-       implicit
-       c: C) {}
+       implicit c: C) {}
    class F(
        a: A,
        as: A*
      )(b: B,
        bs: B*
      )(
-       implicit
-       c: C,
-       implicit
-       d: D) {}
+       implicit c: C,
+       implicit d: D) {}
    class F(
        a: A,
        as: A*
@@ -4213,8 +4206,7 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit
-       e: E) {}
+       implicit e: E) {}
 <<< interleaved, short
 maxColumn = 23
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -4316,17 +4316,14 @@ object a:
      )(b: B,
        bs: B*
      )(implicit
-       implicit
-       c: C) {}
+       implicit c: C) {}
    class F(
        a: A,
        as: A*
      )(b: B,
        bs: B*
-     )(implicit
-       c: C,
-       implicit
-       d: D) {}
+     )(implicit c: C,
+       implicit d: D) {}
    class F(
        a: A,
        as: A*
@@ -4335,8 +4332,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit
-       e: E) {}
+       implicit e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4420,18 +4416,15 @@ object a:
        bs: B*
      )(
        implicit
-       implicit
-       c: C) {}
+       implicit c: C) {}
    class F(
        a: A,
        as: A*
      )(b: B,
        bs: B*
      )(
-       implicit
-       c: C,
-       implicit
-       d: D) {}
+       implicit c: C,
+       implicit d: D) {}
    class F(
        a: A,
        as: A*
@@ -4441,8 +4434,7 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit
-       e: E) {}
+       implicit e: E) {}
 <<< interleaved, short
 maxColumn = 23
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -4408,17 +4408,14 @@ object a:
      )(b: B,
        bs: B*
      )(implicit
-       implicit
-       c: C) {}
+       implicit c: C) {}
    class F(
        a: A,
        as: A*
      )(b: B,
        bs: B*
-     )(implicit
-       c: C,
-       implicit
-       d: D) {}
+     )(implicit c: C,
+       implicit d: D) {}
    class F(
        a: A,
        as: A*
@@ -4427,8 +4424,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit
-       e: E) {}
+       implicit e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4512,18 +4508,15 @@ object a:
        bs: B*
      )(
        implicit
-       implicit
-       c: C) {}
+       implicit c: C) {}
    class F(
        a: A,
        as: A*
      )(b: B,
        bs: B*
      )(
-       implicit
-       c: C,
-       implicit
-       d: D) {}
+       implicit c: C,
+       implicit d: D) {}
    class F(
        a: A,
        as: A*
@@ -4533,8 +4526,7 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit
-       e: E) {}
+       implicit e: E) {}
 <<< interleaved, short
 maxColumn = 23
 ===

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -385,17 +385,14 @@ object a {
     )(b: B,
       bs: B*
     )(implicit
-      implicit
-      c: C) {}
+      implicit c: C) {}
   class F(
       a: A,
       as: A*
     )(b: B,
       bs: B*
-    )(implicit
-      c: C,
-      implicit
-      d: D) {}
+    )(implicit c: C,
+      implicit d: D) {}
   class F(
       a: A,
       as: A*
@@ -404,8 +401,7 @@ object a {
     )(implicit
       c: C,
       d: D,
-      implicit
-      e: E) {}
+      implicit e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierForce = [before]
 maxColumn = 40
@@ -461,18 +457,15 @@ object a {
       bs: B*
     )(
       implicit
-      implicit
-      c: C) {}
+      implicit c: C) {}
   class F(
       a: A,
       as: A*
     )(b: B,
       bs: B*
     )(
-      implicit
-      c: C,
-      implicit
-      d: D) {}
+      implicit c: C,
+      implicit d: D) {}
   class F(
       a: A,
       as: A*
@@ -482,6 +475,5 @@ object a {
       implicit
       c: C,
       d: D,
-      implicit
-      e: E) {}
+      implicit e: E) {}
 }


### PR DESCRIPTION
Specifically, implicitParamListModifierForce=after should not apply when `implicit` is explicit rather than applies once to the entire group. Helps with #3466.