### PR TITLE
FormatOps: don't support invalid param modifiers

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -638,9 +638,9 @@ object TreeOps {
   def getImplicitParamList(kwOwner: Tree): Option[Seq[Tree]] =
     kwOwner.parent match {
       case Some(Term.ArgClause(v, Some(`kwOwner`))) => Some(v)
-      case Some(Term.ParamClause(v @ head :: rest, Some(`kwOwner`)))
+      case Some(Term.ParamClause(v @ _ :: rest, Some(`kwOwner`)))
           if !kwOwner.is[Mod.Implicit] || rest.isEmpty ||
-            !noExplicitImplicit(head) || rest.exists(noExplicitImplicit) =>
+            rest.exists(noExplicitImplicit) =>
         Some(v)
       case _ => None
     }

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -572,14 +572,11 @@ maxColumn = 40
 newlines.implicitParamListModifierPrefer = before
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(
-      implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
       implicit d: D) {}
@@ -593,14 +590,11 @@ maxColumn = 40
 newlines.implicitParamListModifierPrefer = after
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(
-      implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
       implicit d: D) {}
@@ -615,15 +609,11 @@ maxColumn = 40
 newlines.implicitParamListModifierForce = [after]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(
-      implicit
-      implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
       implicit d: D) {}
@@ -638,14 +628,11 @@ maxColumn = 40
 newlines.implicitParamListModifierForce = [before]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(
-      implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
       implicit d: D) {}
@@ -659,15 +646,11 @@ maxColumn = 40
 newlines.implicitParamListModifierForce = [before,after]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(
-      implicit
-      implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
       implicit d: D) {}

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -572,91 +572,91 @@ maxColumn = 40
 newlines.implicitParamListModifierPrefer = before
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierPrefer = after
 maxColumn = 40
 newlines.implicitParamListModifierPrefer = after
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit
       c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierForce = [after]
 maxColumn = 40
 newlines.implicitParamListModifierForce = [after]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit
       c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierForce = [before]
 maxColumn = 40
 newlines.implicitParamListModifierForce = [before]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 newlines.implicitParamListModifierForce = [before,after]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(
       implicit
       c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3910,8 +3910,8 @@ maxColumn = 40
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3924,13 +3924,13 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierPrefer = before
 maxColumn = 40
@@ -3939,8 +3939,8 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3953,12 +3953,12 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierPrefer = after
 maxColumn = 40
@@ -3967,8 +3967,8 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3981,13 +3981,13 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [after]
 maxColumn = 40
@@ -3996,8 +3996,8 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -4014,13 +4014,13 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [before]
 maxColumn = 40
@@ -4029,8 +4029,8 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4047,12 +4047,12 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [before,after]
 maxColumn = 40
@@ -4061,8 +4061,8 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4081,13 +4081,13 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, vertical multiline
 maxColumn = 40
@@ -4096,8 +4096,8 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4123,7 +4123,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4132,7 +4132,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierPrefer = before
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4141,8 +4141,8 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4168,7 +4168,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4176,7 +4176,7 @@ object a:
        bs: B*
      )(implicit c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierPrefer = after
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4185,8 +4185,8 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4212,7 +4212,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4221,7 +4221,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4230,8 +4230,8 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4259,7 +4259,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4268,7 +4268,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4277,8 +4277,8 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4306,7 +4306,7 @@ object a:
        bs: B*
      )(
        implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4315,7 +4315,7 @@ object a:
      )(
        implicit c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4324,8 +4324,8 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4355,7 +4355,7 @@ object a:
        bs: B*
      )(
        implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4365,15 +4365,15 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, short
 maxColumn = 23
 ===
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4396,7 +4396,7 @@ object a:
        as: A*
    )(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(
        a: A,
@@ -4405,7 +4405,7 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, short, vertical multiline
 maxColumn = 23
@@ -4414,8 +4414,8 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4441,7 +4441,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4450,4 +4450,4 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3910,7 +3910,6 @@ maxColumn = 40
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3923,9 +3922,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -3943,7 +3939,6 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3956,9 +3951,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -3975,7 +3967,6 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3988,9 +3979,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4008,7 +3996,6 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4026,10 +4013,6 @@ object a:
        c: C
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
-   class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
    ) {}
@@ -4046,7 +4029,6 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4063,9 +4045,6 @@ object a:
    )[B](b: B, bs: B*)[C](
        implicit c: C
    ): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4082,7 +4061,6 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4101,10 +4079,6 @@ object a:
        implicit
        c: C
    ): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4122,7 +4096,6 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4144,12 +4117,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4174,7 +4141,6 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4196,12 +4162,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4225,7 +4185,6 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4247,12 +4206,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4277,7 +4230,6 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4306,13 +4258,6 @@ object a:
        as: A*
      )(b: B,
        bs: B*
-     )(implicit
-       implicit c: C) {}
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
      )(implicit c: C,
        implicit d: D) {}
    class F(
@@ -4332,7 +4277,6 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4355,13 +4299,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(
-       implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4387,7 +4324,6 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4412,14 +4348,6 @@ object a:
        implicit
        c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(
-       implicit
-       implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4444,7 +4372,6 @@ maxColumn = 23
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4468,13 +4395,6 @@ object a:
        a: A,
        as: A*
    )(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
-   class F(
-       a: A,
-       as: A*
-   )(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
    ) {}
@@ -4494,7 +4414,6 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4516,12 +4435,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3721,8 +3721,8 @@ maxColumn = 40
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3735,13 +3735,13 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierPrefer = before
 maxColumn = 40
@@ -3750,8 +3750,8 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3764,12 +3764,12 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierPrefer = after
 maxColumn = 40
@@ -3778,8 +3778,8 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3792,13 +3792,13 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [after]
 maxColumn = 40
@@ -3807,8 +3807,8 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3825,13 +3825,13 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [before]
 maxColumn = 40
@@ -3840,8 +3840,8 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -3858,12 +3858,12 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [before,after]
 maxColumn = 40
@@ -3872,8 +3872,8 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -3892,13 +3892,13 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, vertical multiline
 maxColumn = 40
@@ -3907,8 +3907,8 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -3934,7 +3934,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -3943,7 +3943,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierPrefer = before
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -3952,8 +3952,8 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -3979,7 +3979,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -3987,7 +3987,7 @@ object a:
        bs: B*
      )(implicit c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierPrefer = after
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -3996,8 +3996,8 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4023,7 +4023,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4032,7 +4032,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4041,8 +4041,8 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4070,7 +4070,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4079,7 +4079,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4088,8 +4088,8 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4117,7 +4117,7 @@ object a:
        bs: B*
      )(
        implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4126,7 +4126,7 @@ object a:
      )(
        implicit c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4135,8 +4135,8 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4166,7 +4166,7 @@ object a:
        bs: B*
      )(
        implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4176,15 +4176,15 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, short
 maxColumn = 23
 ===
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4207,7 +4207,7 @@ object a:
        as: A*
    )(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(
        a: A,
@@ -4216,7 +4216,7 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, short, vertical multiline
 maxColumn = 23
@@ -4225,8 +4225,8 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4252,7 +4252,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4261,4 +4261,4 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3721,7 +3721,6 @@ maxColumn = 40
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3734,9 +3733,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -3754,7 +3750,6 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3767,9 +3762,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -3786,7 +3778,6 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3799,9 +3790,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -3819,7 +3807,6 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3837,10 +3824,6 @@ object a:
        c: C
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
-   class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
    ) {}
@@ -3857,7 +3840,6 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3874,9 +3856,6 @@ object a:
    )[B](b: B, bs: B*)[C](
        implicit c: C
    ): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -3893,7 +3872,6 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3912,10 +3890,6 @@ object a:
        implicit
        c: C
    ): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -3933,7 +3907,6 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3955,12 +3928,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -3985,7 +3952,6 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4007,12 +3973,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4036,7 +3996,6 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4058,12 +4017,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4088,7 +4041,6 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4117,13 +4069,6 @@ object a:
        as: A*
      )(b: B,
        bs: B*
-     )(implicit
-       implicit c: C) {}
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
      )(implicit c: C,
        implicit d: D) {}
    class F(
@@ -4143,7 +4088,6 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4166,13 +4110,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(
-       implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4198,7 +4135,6 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4223,14 +4159,6 @@ object a:
        implicit
        c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(
-       implicit
-       implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4255,7 +4183,6 @@ maxColumn = 23
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4279,13 +4206,6 @@ object a:
        a: A,
        as: A*
    )(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
-   class F(
-       a: A,
-       as: A*
-   )(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
    ) {}
@@ -4305,7 +4225,6 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4327,12 +4246,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3949,8 +3949,8 @@ maxColumn = 40
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3963,13 +3963,13 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierPrefer = before
 maxColumn = 40
@@ -3978,8 +3978,8 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -3992,12 +3992,12 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierPrefer = after
 maxColumn = 40
@@ -4006,8 +4006,8 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -4020,13 +4020,13 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [after]
 maxColumn = 40
@@ -4035,8 +4035,8 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -4053,13 +4053,13 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [before]
 maxColumn = 40
@@ -4068,8 +4068,8 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4086,12 +4086,12 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [before,after]
 maxColumn = 40
@@ -4100,8 +4100,8 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4120,13 +4120,13 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, vertical multiline
 maxColumn = 40
@@ -4135,8 +4135,8 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4162,7 +4162,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4171,7 +4171,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierPrefer = before
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4180,8 +4180,8 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4207,7 +4207,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4215,7 +4215,7 @@ object a:
        bs: B*
      )(implicit c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierPrefer = after
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4224,8 +4224,8 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4251,7 +4251,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4260,7 +4260,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4269,8 +4269,8 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4298,7 +4298,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4307,7 +4307,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4316,8 +4316,8 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4345,7 +4345,7 @@ object a:
        bs: B*
      )(
        implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4354,7 +4354,7 @@ object a:
      )(
        implicit c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4363,8 +4363,8 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4394,7 +4394,7 @@ object a:
        bs: B*
      )(
        implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4404,15 +4404,15 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, short
 maxColumn = 23
 ===
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4438,7 +4438,7 @@ object a:
        as: A*
    )(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(
        a: A,
@@ -4447,7 +4447,7 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, short, vertical multiline
 maxColumn = 23
@@ -4456,8 +4456,8 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4483,7 +4483,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4492,4 +4492,4 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3949,7 +3949,6 @@ maxColumn = 40
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3962,9 +3961,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -3982,7 +3978,6 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -3995,9 +3990,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4014,7 +4006,6 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4027,9 +4018,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4047,7 +4035,6 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4065,10 +4052,6 @@ object a:
        c: C
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
-   class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
    ) {}
@@ -4085,7 +4068,6 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4102,9 +4084,6 @@ object a:
    )[B](b: B, bs: B*)[C](
        implicit c: C
    ): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4121,7 +4100,6 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4140,10 +4118,6 @@ object a:
        implicit
        c: C
    ): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4161,7 +4135,6 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4183,12 +4156,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4213,7 +4180,6 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4235,12 +4201,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4264,7 +4224,6 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4286,12 +4245,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4316,7 +4269,6 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4345,13 +4297,6 @@ object a:
        as: A*
      )(b: B,
        bs: B*
-     )(implicit
-       implicit c: C) {}
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
      )(implicit c: C,
        implicit d: D) {}
    class F(
@@ -4371,7 +4316,6 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4394,13 +4338,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(
-       implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4426,7 +4363,6 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4457,14 +4393,6 @@ object a:
      )(b: B,
        bs: B*
      )(
-       implicit
-       implicit c: C) {}
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(
        implicit c: C,
        implicit d: D) {}
    class F(
@@ -4483,7 +4411,6 @@ maxColumn = 23
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4510,13 +4437,6 @@ object a:
        a: A,
        as: A*
    )(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
-   class F(
-       a: A,
-       as: A*
-   )(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
    ) {}
@@ -4536,7 +4456,6 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4558,12 +4477,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -4041,7 +4041,6 @@ maxColumn = 40
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4054,9 +4053,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4074,7 +4070,6 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4087,9 +4082,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4106,7 +4098,6 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4119,9 +4110,6 @@ object a:
        b: B,
        bs: B*
    )[C](implicit c: C): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4139,7 +4127,6 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4157,10 +4144,6 @@ object a:
        c: C
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
-   class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
    ) {}
@@ -4177,7 +4160,6 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4194,9 +4176,6 @@ object a:
    )[B](b: B, bs: B*)[C](
        implicit c: C
    ): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4213,7 +4192,6 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4232,10 +4210,6 @@ object a:
        implicit
        c: C
    ): B = ???
-   class F(a: A, as: A*)(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
@@ -4253,7 +4227,6 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4275,12 +4248,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4305,7 +4272,6 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4327,12 +4293,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4356,7 +4316,6 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4378,12 +4337,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4408,7 +4361,6 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4437,13 +4389,6 @@ object a:
        as: A*
      )(b: B,
        bs: B*
-     )(implicit
-       implicit c: C) {}
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
      )(implicit c: C,
        implicit d: D) {}
    class F(
@@ -4463,7 +4408,6 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4486,13 +4430,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(
-       implicit implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4518,7 +4455,6 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4543,14 +4479,6 @@ object a:
        implicit
        c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(
-       implicit
-       implicit c: C) {}
    class F(
        a: A,
        as: A*
@@ -4575,7 +4503,6 @@ maxColumn = 23
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4599,13 +4526,6 @@ object a:
        a: A,
        as: A*
    )(b: B, bs: B*)(
-       implicit
-       implicit c: C
-   ) {}
-   class F(
-       a: A,
-       as: A*
-   )(b: B, bs: B*)(
        implicit c: C,
        implicit d: D
    ) {}
@@ -4625,7 +4545,6 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 >>>
@@ -4647,12 +4566,6 @@ object a:
      )[C](
        implicit c: C
      ): B = ???
-   class F(
-       a: A,
-       as: A*
-     )(b: B,
-       bs: B*
-     )(implicit implicit c: C) {}
    class F(
        a: A,
        as: A*

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -4041,8 +4041,8 @@ maxColumn = 40
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -4055,13 +4055,13 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierPrefer = before
 maxColumn = 40
@@ -4070,8 +4070,8 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -4084,12 +4084,12 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierPrefer = after
 maxColumn = 40
@@ -4098,8 +4098,8 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -4112,13 +4112,13 @@ object a:
    )[C](implicit c: C): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [after]
 maxColumn = 40
@@ -4127,8 +4127,8 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](a: A, as: A*)[B](
@@ -4145,13 +4145,13 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [before]
 maxColumn = 40
@@ -4160,8 +4160,8 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4178,12 +4178,12 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, implicitParamListModifierForce = [before,after]
 maxColumn = 40
@@ -4192,8 +4192,8 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4212,13 +4212,13 @@ object a:
    ): B = ???
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(a: A, as: A*)(b: B, bs: B*)(
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, vertical multiline
 maxColumn = 40
@@ -4227,8 +4227,8 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4254,7 +4254,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4263,7 +4263,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierPrefer = before
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4272,8 +4272,8 @@ newlines.implicitParamListModifierPrefer = before
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4299,7 +4299,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4307,7 +4307,7 @@ object a:
        bs: B*
      )(implicit c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierPrefer = after
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4316,8 +4316,8 @@ newlines.implicitParamListModifierPrefer = after
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4343,7 +4343,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4352,7 +4352,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4361,8 +4361,8 @@ newlines.implicitParamListModifierForce = [after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4390,7 +4390,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4399,7 +4399,7 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4408,8 +4408,8 @@ newlines.implicitParamListModifierForce = [before]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4437,7 +4437,7 @@ object a:
        bs: B*
      )(
        implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4446,7 +4446,7 @@ object a:
      )(
        implicit c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, vertical multiline, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 verticalMultiline.atDefnSite = true
@@ -4455,8 +4455,8 @@ newlines.implicitParamListModifierForce = [before,after]
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4486,7 +4486,7 @@ object a:
        bs: B*
      )(
        implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4496,15 +4496,15 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}
 <<< interleaved, short
 maxColumn = 23
 ===
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4527,7 +4527,7 @@ object a:
        as: A*
    )(b: B, bs: B*)(
        implicit c: C,
-       implicit d: D
+       implicit val d: D
    ) {}
    class F(
        a: A,
@@ -4536,7 +4536,7 @@ object a:
        implicit
        c: C,
        d: D,
-       implicit e: E
+       implicit val e: E
    ) {}
 <<< interleaved, short, vertical multiline
 maxColumn = 23
@@ -4545,8 +4545,8 @@ verticalMultiline.atDefnSite = true
 object a:
   def f[A](a: A, as: A*)[B](b: B, bs: B*)(implicit c: C): B = ???
   def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 >>>
 object a:
    def f[A](
@@ -4572,7 +4572,7 @@ object a:
      )(b: B,
        bs: B*
      )(implicit c: C,
-       implicit d: D) {}
+       implicit val d: D) {}
    class F(
        a: A,
        as: A*
@@ -4581,4 +4581,4 @@ object a:
      )(implicit
        c: C,
        d: D,
-       implicit e: E) {}
+       implicit val e: E) {}

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -306,18 +306,11 @@ maxColumn = 40
 newlines.implicitParamListModifierPrefer = before
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(
-      a: A,
-      as: A*
-    )(b: B,
-      bs: B*
-    )(implicit implicit c: C) {}
   class F(
       a: A,
       as: A*
@@ -339,18 +332,11 @@ maxColumn = 40
 newlines.implicitParamListModifierPrefer = after
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(
-      a: A,
-      as: A*
-    )(b: B,
-      bs: B*
-    )(implicit implicit c: C) {}
   class F(
       a: A,
       as: A*
@@ -373,19 +359,11 @@ maxColumn = 40
 newlines.implicitParamListModifierForce = [after]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(
-      a: A,
-      as: A*
-    )(b: B,
-      bs: B*
-    )(implicit
-      implicit c: C) {}
   class F(
       a: A,
       as: A*
@@ -408,19 +386,11 @@ maxColumn = 40
 newlines.implicitParamListModifierForce = [before]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(
-      a: A,
-      as: A*
-    )(b: B,
-      bs: B*
-    )(
-      implicit implicit c: C) {}
   class F(
       a: A,
       as: A*
@@ -444,20 +414,11 @@ maxColumn = 40
 newlines.implicitParamListModifierForce = [before,after]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit implicit c: C) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
   class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
 }
 >>>
 object a {
-  class F(
-      a: A,
-      as: A*
-    )(b: B,
-      bs: B*
-    )(
-      implicit
-      implicit c: C) {}
   class F(
       a: A,
       as: A*

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -306,8 +306,8 @@ maxColumn = 40
 newlines.implicitParamListModifierPrefer = before
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
@@ -317,7 +317,7 @@ object a {
     )(b: B,
       bs: B*
     )(implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(
       a: A,
       as: A*
@@ -325,15 +325,15 @@ object a {
       bs: B*
     )(implicit c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierPrefer = after
 maxColumn = 40
 newlines.implicitParamListModifierPrefer = after
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
@@ -343,7 +343,7 @@ object a {
     )(b: B,
       bs: B*
     )(implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(
       a: A,
       as: A*
@@ -352,15 +352,15 @@ object a {
     )(implicit
       c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierForce = [after]
 maxColumn = 40
 newlines.implicitParamListModifierForce = [after]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
@@ -370,7 +370,7 @@ object a {
     )(b: B,
       bs: B*
     )(implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(
       a: A,
       as: A*
@@ -379,15 +379,15 @@ object a {
     )(implicit
       c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierForce = [before]
 maxColumn = 40
 newlines.implicitParamListModifierForce = [before]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
@@ -398,7 +398,7 @@ object a {
       bs: B*
     )(
       implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(
       a: A,
       as: A*
@@ -407,15 +407,15 @@ object a {
     )(
       implicit c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }
 <<< explicit implicits, implicitParamListModifierForce = [before,after]
 maxColumn = 40
 newlines.implicitParamListModifierForce = [before,after]
 ===
 object a {
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit d: D) {}
-  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit e: E) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, implicit val d: D) {}
+  class F(a: A, as: A*)(b: B, bs: B*)(implicit c: C, d: D, implicit val e: E) {}
 }
 >>>
 object a {
@@ -426,7 +426,7 @@ object a {
       bs: B*
     )(
       implicit c: C,
-      implicit d: D) {}
+      implicit val d: D) {}
   class F(
       a: A,
       as: A*
@@ -436,5 +436,5 @@ object a {
       implicit
       c: C,
       d: D,
-      implicit e: E) {}
+      implicit val e: E) {}
 }


### PR DESCRIPTION
Specifically, scala syntax prohibits repeated modifiers (in this case, repeated `implicit` on the first parameter) and requires `val` or `var` on parameters with explicit modifiers. The respective parser change will come in scalameta v4.7.5.
