### PR TITLE
FormatTokensRewrite: turn Replacement into class

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ConvertToNewScala3Syntax.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ConvertToNewScala3Syntax.scala
@@ -108,7 +108,7 @@ private class ConvertToNewScala3Syntax(ftoks: FormatTokens)
   ): Option[(Replacement, Replacement)] = Option {
     ft.right match {
 
-      case x: Token.RightParen if left.isLeft =>
+      case x: Token.RightParen if left.how eq ReplacementType.Remove =>
         ft.meta.rightOwner match {
           case _: Term.If =>
             if (!ftoks.nextNonComment(ftoks.next(ft)).right.is[Token.KwThen])

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -47,28 +47,28 @@ class FormatTokensRewrite(
       result ++= arr.view.slice(beg, end)
     }
     getRewrittenTokens.foreach { repl =>
-      val ft = repl match {
-        case Right(x) => x
-        case Left(idx) => arr(idx)
-      }
-      copySlice(ft.meta.idx)
+      val ft = repl.ft
+      val idx = ft.meta.idx
+      val ftOld = arr(idx)
+      val rtOld = ftOld.right
+      @inline def mapOld() = tokenMap += FormatTokens.thash(rtOld) -> appended
+      copySlice(idx)
       def append(): Unit = {
-        val oldFt = arr(ft.meta.idx)
-        if (oldFt.right ne ft.right)
-          tokenMap += FormatTokens.thash(oldFt.right) -> appended
+        if (rtOld ne ft.right) mapOld()
         appended += 1
         result += ft
       }
       def remove(): Unit = {
-        tokenMap += FormatTokens.thash(ft.right) -> appended
-        val nextFt = ftoks.next(ft)
+        mapOld()
+        val nextIdx = idx + 1
+        val nextFt = ftoks.at(nextIdx)
         val rtMeta = nextFt.meta
-        mergeWhitespaceLeftToRight(ft.meta, rtMeta).foreach { bw =>
-          arr(nextFt.meta.idx) = nextFt.copy(meta = rtMeta.copy(between = bw))
+        mergeWhitespaceLeftToRight(ftOld.meta, rtMeta).foreach { bw =>
+          arr(nextIdx) = nextFt.copy(meta = rtMeta.copy(between = bw))
         }
         removed += 1
       }
-      if (repl.isLeft) remove() else append()
+      if (repl.how eq ReplacementType.Remove) remove() else append()
     }
 
     if (appended + removed == 0) ftoks
@@ -234,10 +234,19 @@ object FormatTokensRewrite {
     else new FormatTokensRewrite(ftoks, styleMap, rules).rewrite
   }
 
-  private[rewrite] type Replacement = Either[Int, FormatToken]
+  private[rewrite] class Replacement(
+      val ft: FormatToken,
+      val how: ReplacementType
+  )
+
+  private[rewrite] sealed trait ReplacementType
+  private[rewrite] object ReplacementType {
+    object Remove extends ReplacementType
+    object Replace extends ReplacementType
+  }
 
   private[rewrite] def removeToken(implicit ft: FormatToken): Replacement =
-    Left(ft.meta.idx)
+    new Replacement(ft, ReplacementType.Remove)
 
   private[rewrite] def replaceToken(
       text: String,
@@ -245,7 +254,8 @@ object FormatTokensRewrite {
   )(tok: T)(implicit ft: FormatToken): Replacement = {
     val mOld = ft.meta.right
     val mNew = mOld.copy(text = text, owner = owner.getOrElse(mOld.owner))
-    Right(ft.copy(right = tok, meta = ft.meta.copy(right = mNew)))
+    val ftNew = ft.copy(right = tok, meta = ft.meta.copy(right = mNew))
+    new Replacement(ftNew, ReplacementType.Replace)
   }
 
   private[rewrite] def replaceTokenBy(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
@@ -94,7 +94,9 @@ private class PreferCurlyFors(ftoks: FormatTokens)
       style: ScalafmtConfig
   ): Option[(Replacement, Replacement)] =
     ft.right match {
-      case x: Token.RightParen if left.exists(_.right.is[Token.LeftBrace]) =>
+      case x: Token.RightParen
+          if left.how == ReplacementType.Replace &&
+            left.ft.right.is[Token.LeftBrace] =>
         val right =
           replaceToken("}")(new Token.RightBrace(x.input, x.dialect, x.start))
         Some((left, right))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -170,8 +170,9 @@ class RedundantBraces(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
   private def onRightBrace(
       left: Replacement
   )(implicit ft: FormatToken): (Replacement, Replacement) =
-    left match {
-      case Right(lft @ FormatToken(_, _: Token.LeftParen, _)) =>
+    left.ft match {
+      case lft @ FormatToken(_, _: Token.LeftParen, _)
+          if left.how eq ReplacementType.Replace =>
         val right = replaceTokenBy("}", ft.meta.rightOwner.parent) { rt =>
           // shifted right
           new Token.RightBrace(rt.input, rt.dialect, rt.start + 1)
@@ -432,7 +433,9 @@ class RedundantBraces(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
               ftoks.matchingOpt(x) match {
                 case Some(y) if y ne stat.tokens.last =>
                   redundantParensFunc.exists { parensRule =>
-                    parensRule.onToken(ftoks(x, -1), style).exists(_.isLeft)
+                    parensRule.onToken(ftoks(x, -1), style).exists {
+                      _.how eq ReplacementType.Remove
+                    }
                   }
                 case _ => true
               }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -86,7 +86,7 @@ class RedundantParens(ftoks: FormatTokens) extends FormatTokensRewrite.Rule {
       style: ScalafmtConfig
   ): Option[(Replacement, Replacement)] =
     ft.right match {
-      case _: Token.RightParen if left.isLeft =>
+      case _: Token.RightParen if left.how eq ReplacementType.Remove =>
         Some((left, removeToken))
       case _ => None
     }


### PR DESCRIPTION
We now need to extend this functionality, and the existing simple Either is no longer sufficient.
Towards #3496.