### PR TITLE
FormatOps: fix `verticalMultiline.arityThreshold`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1299,20 +1299,19 @@ class FormatOps(
       Seq(slbSplit, noSplit.andPolicy(noSlbPolicy), nlSplit)
     } else {
       val rightIsImplicit = r.is[soft.ImplicitOrUsing]
-      val nlOnly =
-        if (rightIsImplicit)
-          style.newlines.forceBeforeImplicitParamListModifier
-        else
-          style.verticalMultiline.newlineAfterOpenParen
+      val implicitNL = rightIsImplicit &&
+        style.newlines.forceBeforeImplicitParamListModifier
       val implicitParams =
         if (!rightIsImplicit) Nil
         else getImplicitParamList(ft.meta.rightOwner).getOrElse(Nil)
-      val noSlb = nlOnly || aboveArityThreshold || ft.hasBreak &&
+      val noSlb = implicitNL || aboveArityThreshold || ft.hasBreak &&
         !style.newlines.sourceIgnored && style.optIn.configStyleArguments ||
         implicitParams.nonEmpty &&
         style.newlines.forceAfterImplicitParamListModifier
-      val nlMod = NewlineT(alt = if (nlOnly) None else Some(slbSplit.modExt))
-      val spaceImplicit = !nlOnly && implicitParams.lengthCompare(1) > 0 &&
+      val nlNoAlt = implicitNL ||
+        !rightIsImplicit && style.verticalMultiline.newlineAfterOpenParen
+      val nlMod = NewlineT(alt = if (nlNoAlt) None else Some(slbSplit.modExt))
+      val spaceImplicit = !implicitNL && implicitParams.lengthCompare(1) > 0 &&
         style.newlines.notBeforeImplicitParamListModifier
       Seq(
         // If we can fit all in one block, make it so

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -71,9 +71,7 @@ object Log {
 }
 >>>
 object Log {
-  def redactIds(
-    s: String
-  ): String = s.replaceAll("\\d{5,}", "<redacted>")
+  def redactIds(s: String): String = s.replaceAll("\\d{5,}", "<redacted>")
 }
 <<< #3509 2
 verticalMultiline.arityThreshold = 5

--- a/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/VerticalMultilineDefnSite.stat
@@ -62,3 +62,27 @@ object a {
         F.mkRef(Map.empty[Key, Item]).map(new Dummy.Impl(_))
       )
 }
+<<< #3509 1
+verticalMultiline.arityThreshold = 5
+verticalMultiline.newlineAfterOpenParen = true
+===
+object Log {
+  def redactIds(s: String): String = s.replaceAll("\\d{5,}", "<redacted>")
+}
+>>>
+object Log {
+  def redactIds(
+    s: String
+  ): String = s.replaceAll("\\d{5,}", "<redacted>")
+}
+<<< #3509 2
+verticalMultiline.arityThreshold = 5
+verticalMultiline.newlineAfterOpenParen = false
+===
+object Log {
+  def redactIds(s: String): String = s.replaceAll("\\d{5,}", "<redacted>")
+}
+>>>
+object Log {
+  def redactIds(s: String): String = s.replaceAll("\\d{5,}", "<redacted>")
+}


### PR DESCRIPTION
Specifically how it interacts with `newlineAfterOpenParen`. Fixes #3509.