### PR TITLE
Router: indent trailing fewer braces, too

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -554,12 +554,12 @@ object a {
 >>>
 object a {
   val b = c + (d.match
-    case true  => true
-    case false => false
+      case true  => true
+      case false => false
   )
   val b = c + (d.match
-    case true  => true
-    case false => false
+      case true  => true
+      case false => false
   ) + e
   val b = c + (d match
     case true  => true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3609,7 +3609,7 @@ object a:
 object a:
    def f(): Unit =
      List(1, 2, 3).foldLeft(1):
-        case (a, b) => a + b
+          case (a, b) => a + b
 <<< coloneol in fewer braces 1, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3617,12 +3617,12 @@ indent.main = 4
 object a:
   def f(): Unit =
     List(1, 2, 3).foldLeft(1):
-      case (a, b) => a + b
+          case (a, b) => a + b
 >>>
 object a:
    def f(): Unit =
        List(1, 2, 3).foldLeft(1):
-          case (a, b) => a + b
+              case (a, b) => a + b
 <<< coloneol in fewer braces 2
 maxColumn = 80
 ===
@@ -3679,8 +3679,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-         case a: Int =>
-         case _      =>
+           case a: Int =>
+           case _      =>
       otherTerm()
 <<< coloneol in fewer braces 3, main > sig
 maxColumn = 80
@@ -3696,8 +3696,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-         case a: Int =>
-         case _      =>
+             case a: Int =>
+             case _      =>
       otherTerm()
 <<< match with eol
 maxColumn = 80
@@ -3865,7 +3865,7 @@ class test:
 >>>
 class test:
    baz.qux:
-      2 + 2
+        2 + 2
 <<< #3489 3
 class test:
   foo.bar:
@@ -3923,7 +3923,7 @@ class test:
    bar(
      2 + 2
    ).baz.qux:
-      3 + 3
+        3 + 3
 <<< #3489 8
 class test:
   bar.baz:
@@ -3945,8 +3945,8 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
+        case bar => ""
+        case baz => ""
 <<< #3489 10
 class test:
   foo.match

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3433,7 +3433,7 @@ object a:
 >>>
 object a:
    def f(): Unit = List(1, 2, 3).foldLeft(1):
-      case (a, b) => a + b
+        case (a, b) => a + b
 <<< coloneol in fewer braces 1, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3445,7 +3445,7 @@ object a:
 >>>
 object a:
    def f(): Unit = List(1, 2, 3).foldLeft(1):
-      case (a, b) => a + b
+          case (a, b) => a + b
 <<< coloneol in fewer braces 2
 maxColumn = 80
 ===
@@ -3498,8 +3498,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-         case a: Int =>
-         case _      =>
+           case a: Int =>
+           case _      =>
       otherTerm()
 <<< coloneol in fewer braces 3, main > sig
 maxColumn = 80
@@ -3515,8 +3515,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-         case a: Int =>
-         case _      =>
+             case a: Int =>
+             case _      =>
       otherTerm()
 <<< match with eol
 maxColumn = 80
@@ -3674,7 +3674,7 @@ class test:
 >>>
 class test:
    baz.qux:
-      2 + 2
+        2 + 2
 <<< #3489 3
 class test:
   foo.bar:
@@ -3729,7 +3729,7 @@ class test:
 >>>
 class test:
    bar(2 + 2).baz.qux:
-      3 + 3
+        3 + 3
 <<< #3489 8
 class test:
   bar.baz:
@@ -3750,8 +3750,8 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
+        case bar => ""
+        case baz => ""
 <<< #3489 10
 class test:
   foo.match

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3591,7 +3591,7 @@ object a:
 object a:
    def f(): Unit =
      List(1, 2, 3).foldLeft(1):
-        case (a, b) => a + b
+          case (a, b) => a + b
 <<< coloneol in fewer braces 1, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3604,7 +3604,7 @@ object a:
 object a:
    def f(): Unit =
        List(1, 2, 3).foldLeft(1):
-          case (a, b) => a + b
+              case (a, b) => a + b
 <<< coloneol in fewer braces 2
 maxColumn = 80
 ===
@@ -3659,8 +3659,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-         case a: Int =>
-         case _      =>
+           case a: Int =>
+           case _      =>
       otherTerm()
 <<< coloneol in fewer braces 3, main > sig
 maxColumn = 80
@@ -3676,8 +3676,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-         case a: Int =>
-         case _      =>
+             case a: Int =>
+             case _      =>
       otherTerm()
 <<< match with eol
 maxColumn = 80
@@ -3841,7 +3841,7 @@ class test:
 >>>
 class test:
    baz.qux:
-      2 + 2
+        2 + 2
 <<< #3489 3
 class test:
   foo.bar:
@@ -3920,8 +3920,8 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
+        case bar => ""
+        case baz => ""
 <<< #3489 10
 class test:
   foo.match

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3732,8 +3732,8 @@ object a:
 object a:
    def f(): Unit =
      List(1, 2, 3).foldLeft(1):
-        case (a, b) =>
-          a + b
+          case (a, b) =>
+            a + b
 <<< coloneol in fewer braces 1, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3741,13 +3741,13 @@ indent.main = 4
 object a:
   def f(): Unit =
     List(1, 2, 3).foldLeft(1):
-      case (a, b) => a + b
+          case (a, b) => a + b
 >>>
 object a:
    def f(): Unit =
        List(1, 2, 3).foldLeft(1):
-          case (a, b) =>
-              a + b
+              case (a, b) =>
+                  a + b
 <<< coloneol in fewer braces 2
 maxColumn = 80
 ===
@@ -3802,8 +3802,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-         case a: Int =>
-         case _      =>
+           case a: Int =>
+           case _      =>
       otherTerm()
 <<< coloneol in fewer braces 3, main > sig
 maxColumn = 80
@@ -3819,8 +3819,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-         case a: Int =>
-         case _      =>
+             case a: Int =>
+             case _      =>
       otherTerm()
 <<< match with eol
 maxColumn = 80
@@ -3994,7 +3994,7 @@ class test:
 >>>
 class test:
    baz.qux:
-      2 + 2
+        2 + 2
 <<< #3489 3
 class test:
   foo.bar:
@@ -4075,10 +4075,10 @@ class test:
 >>>
 class test:
    foo.match
-      case bar =>
-        ""
-      case baz =>
-        ""
+        case bar =>
+          ""
+        case baz =>
+          ""
 <<< #3489 10
 class test:
   foo.match


### PR DESCRIPTION
Previously, we applied a space indent when fewer braces were followed by another select. This takes care of the case when there are no more selects.

Towards #3489.