### PR TITLE
Router: don't add extra indent for fewer braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2076,28 +2076,17 @@ class FormatOps(
                 .withSingleLine(opt)
                 .andPolicy(decideNewlinesOnlyAfterToken(opt))
             }
-            val indent = t.parent match {
-              case Some(p: Term.Apply) =>
-                @tailrec
-                def isSelect(ma: Member.Apply): Boolean = ma.fun match {
-                  case x: Member.Apply => isSelect(x)
-                  case x => x.is[Term.Select]
-                }
-                if (isSelect(p)) None // select is taken care off elsewhere
-                else Some(style.indent.main + style.indent.getSignificant)
-              case _ => None
-            }
             Some(new OptionalBracesRegion {
               def owner = t.parent
               def splits = Some(t.values match {
                 case (tf: Term.FunctionTerm) :: Nil
                     if !style.newlines.alwaysBeforeCurlyLambdaParams &&
                       t.parent.exists(_.is[Term.Apply]) =>
-                  getSplits(ft, t, forceNL = false, indentOpt = indent) match {
+                  getSplits(ft, t, forceNL = false) match {
                     case s +: rs if !s.isNL => funcSplit(tf)(s.fileLine) +: rs
                     case ss => ss
                   }
-                case _ => getSplits(ft, t, forceNL = true, indentOpt = indent)
+                case _ => getSplits(ft, t, forceNL = true)
               })
               def rightBrace = treeLast(t)
             })

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -554,12 +554,12 @@ object a {
 >>>
 object a {
   val b = c + (d.match
-      case true  => true
-      case false => false
+    case true  => true
+    case false => false
   )
   val b = c + (d.match
-      case true  => true
-      case false => false
+    case true  => true
+    case false => false
   ) + e
   val b = c + (d match
     case true  => true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3609,7 +3609,7 @@ object a:
 object a:
    def f(): Unit =
      List(1, 2, 3).foldLeft(1):
-          case (a, b) => a + b
+        case (a, b) => a + b
 <<< coloneol in fewer braces 1, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3622,7 +3622,7 @@ object a:
 object a:
    def f(): Unit =
        List(1, 2, 3).foldLeft(1):
-              case (a, b) => a + b
+          case (a, b) => a + b
 <<< coloneol in fewer braces 2
 maxColumn = 80
 ===
@@ -3679,8 +3679,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-           case a: Int =>
-           case _      =>
+         case a: Int =>
+         case _      =>
       otherTerm()
 <<< coloneol in fewer braces 3, main > sig
 maxColumn = 80
@@ -3696,8 +3696,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-             case a: Int =>
-             case _      =>
+         case a: Int =>
+         case _      =>
       otherTerm()
 <<< match with eol
 maxColumn = 80
@@ -3792,8 +3792,8 @@ def test(): String =
 >>>
 def test(): String =
   Block:
-       2 + 2
-    .toString
+     2 + 2
+  .toString
 <<< #3448 2
 indent.significant = 1
 ===
@@ -3804,8 +3804,8 @@ def test(): String =
 >>>
 def test(): String =
   Block:
-     2 + 2
-    .toString
+   2 + 2
+  .toString
 <<< #3448 3
 indent.significant = 1
 ===
@@ -3833,9 +3833,9 @@ def test(): String =
 >>>
 def test(): String =
   bar:
-     2 + 2
-    .baz.qux:
-     3 + 3
+   2 + 2
+  .baz.qux:
+   3 + 3
 <<< #3448 5
 indent.significant = 1
 ===
@@ -3847,9 +3847,9 @@ class test:
 >>>
 class test:
  bar:
-    2 + 2
-   .baz.qux:
-    3 + 3
+  2 + 2
+ .baz.qux:
+  3 + 3
 <<< #3489 1
 class test:
   bar:
@@ -3857,7 +3857,7 @@ class test:
 >>>
 class test:
    bar:
-        2 + 2
+      2 + 2
 <<< #3489 2
 class test:
   baz.qux:
@@ -3865,28 +3865,31 @@ class test:
 >>>
 class test:
    baz.qux:
-        2 + 2
+      2 + 2
 <<< #3489 3
 class test:
   foo.bar:
     2 + 2
   .baz
+  .qux
 >>>
 class test:
    foo
      .bar:
         2 + 2
      .baz
+     .qux
 <<< #3489 4
 class test:
   bar:
      2 + 2
     .baz
+  .qux
 >>>
 class test:
    bar:
-        2 + 2
-     .baz
+      2 + 2
+   .baz.qux
 <<< #3489 5
 class test:
   bar:
@@ -3896,20 +3899,22 @@ class test:
 >>>
 class test:
    bar:
-        2 + 2
-     .baz:
-        3 + 3
+      2 + 2
+   .baz:
+      3 + 3
 <<< #3489 6
 class test:
   bar:
      2 + 2
-    .baz.qux:
+    .baz
+    .qux:
        3 + 3
 >>>
 class test:
    bar:
-        2 + 2
-     .baz.qux:
+      2 + 2
+   .baz
+     .qux:
         3 + 3
 <<< #3489 7
 class test:
@@ -3923,7 +3928,7 @@ class test:
    bar(
      2 + 2
    ).baz.qux:
-        3 + 3
+      3 + 3
 <<< #3489 8
 class test:
   bar.baz:
@@ -3945,8 +3950,8 @@ class test:
 >>>
 class test:
    foo.match
-        case bar => ""
-        case baz => ""
+      case bar => ""
+      case baz => ""
 <<< #3489 10
 class test:
   foo.match

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3433,7 +3433,7 @@ object a:
 >>>
 object a:
    def f(): Unit = List(1, 2, 3).foldLeft(1):
-        case (a, b) => a + b
+      case (a, b) => a + b
 <<< coloneol in fewer braces 1, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3445,7 +3445,7 @@ object a:
 >>>
 object a:
    def f(): Unit = List(1, 2, 3).foldLeft(1):
-          case (a, b) => a + b
+      case (a, b) => a + b
 <<< coloneol in fewer braces 2
 maxColumn = 80
 ===
@@ -3460,11 +3460,11 @@ object a:
 >>>
 object a:
    def f(): Unit = List(1, 2, 3).foo: a =>
-        a + 2
-     .foo: a =>
-        2 + a
-     .apply:
-        12 + 3
+      a + 2
+   .foo: a =>
+      2 + a
+   .apply:
+      12 + 3
 <<< coloneol in fewer braces 2, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3480,11 +3480,11 @@ object a:
 >>>
 object a:
    def f(): Unit = List(1, 2, 3).foo: a =>
-          a + 2
-       .foo: a =>
-          2 + a
-       .apply:
-          12 + 3
+      a + 2
+   .foo: a =>
+      2 + a
+   .apply:
+      12 + 3
 <<< coloneol in fewer braces 3
 maxColumn = 80
 ===
@@ -3498,8 +3498,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-           case a: Int =>
-           case _      =>
+         case a: Int =>
+         case _      =>
       otherTerm()
 <<< coloneol in fewer braces 3, main > sig
 maxColumn = 80
@@ -3515,8 +3515,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-             case a: Int =>
-             case _      =>
+         case a: Int =>
+         case _      =>
       otherTerm()
 <<< match with eol
 maxColumn = 80
@@ -3532,11 +3532,11 @@ object a:
 >>>
 object a:
    def f(): Unit = List(1, 2, 3).match
-        case _ => a + 2
-     .foo: a =>
-        2 + a
-     .apply:
-        12 + 3
+      case _ => a + 2
+   .foo: a =>
+      2 + a
+   .apply:
+      12 + 3
 <<< match with eol, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3552,11 +3552,11 @@ object a:
 >>>
 object a:
    def f(): Unit = List(1, 2, 3).match
-          case _ => a + 2
-       .foo: a =>
-          2 + a
-       .apply:
-          12 + 3
+      case _ => a + 2
+   .foo: a =>
+      2 + a
+   .apply:
+      12 + 3
 <<< coloneol in refined types
 maxColumn = 80
 ===
@@ -3606,8 +3606,8 @@ def test(): String =
   .toString
 >>>
 def test(): String = Block:
-     2 + 2
-  .toString
+   2 + 2
+.toString
 <<< #3448 2
 indent.significant = 1
 ===
@@ -3617,8 +3617,8 @@ def test(): String =
   .toString
 >>>
 def test(): String = Block:
-   2 + 2
-  .toString
+ 2 + 2
+.toString
 <<< #3448 3
 indent.significant = 1
 ===
@@ -3629,9 +3629,9 @@ def test(): String =
    3 + 3
 >>>
 def test(): String = foo.bar:
-   2 + 2
-  .baz.qux:
-   3 + 3
+ 2 + 2
+.baz.qux:
+ 3 + 3
 <<< #3448 4
 indent.significant = 1
 ===
@@ -3642,9 +3642,9 @@ def test(): String =
     3 + 3
 >>>
 def test(): String = bar:
-   2 + 2
-  .baz.qux:
-   3 + 3
+ 2 + 2
+.baz.qux:
+ 3 + 3
 <<< #3448 5
 indent.significant = 1
 ===
@@ -3656,9 +3656,9 @@ class test:
 >>>
 class test:
  bar:
-    2 + 2
-   .baz.qux:
-    3 + 3
+  2 + 2
+ .baz.qux:
+  3 + 3
 <<< #3489 1
 class test:
   bar:
@@ -3666,7 +3666,7 @@ class test:
 >>>
 class test:
    bar:
-        2 + 2
+      2 + 2
 <<< #3489 2
 class test:
   baz.qux:
@@ -3674,27 +3674,30 @@ class test:
 >>>
 class test:
    baz.qux:
-        2 + 2
+      2 + 2
 <<< #3489 3
 class test:
   foo.bar:
     2 + 2
   .baz
+  .qux
 >>>
 class test:
    foo.bar:
-        2 + 2
-     .baz
+      2 + 2
+   .baz.qux
 <<< #3489 4
 class test:
   bar:
      2 + 2
-    .baz
+    .baz // c
+  .qux
 >>>
 class test:
    bar:
-        2 + 2
-     .baz
+      2 + 2
+   .baz // c
+     .qux
 <<< #3489 5
 class test:
   bar:
@@ -3704,20 +3707,22 @@ class test:
 >>>
 class test:
    bar:
-        2 + 2
-     .baz:
-        3 + 3
+      2 + 2
+   .baz:
+      3 + 3
 <<< #3489 6
 class test:
   bar:
      2 + 2
-    .baz.qux:
+    .baz // c
+    .qux:
        3 + 3
 >>>
 class test:
    bar:
-        2 + 2
-     .baz.qux:
+      2 + 2
+   .baz // c
+     .qux:
         3 + 3
 <<< #3489 7
 class test:
@@ -3729,7 +3734,7 @@ class test:
 >>>
 class test:
    bar(2 + 2).baz.qux:
-        3 + 3
+      3 + 3
 <<< #3489 8
 class test:
   bar.baz:
@@ -3739,9 +3744,9 @@ class test:
 >>>
 class test:
    bar.baz:
-        2 + 2
-     .qux:
-        3 + 3
+      2 + 2
+   .qux:
+      3 + 3
 <<< #3489 9
 class test:
   foo.match
@@ -3750,8 +3755,8 @@ class test:
 >>>
 class test:
    foo.match
-        case bar => ""
-        case baz => ""
+      case bar => ""
+      case baz => ""
 <<< #3489 10
 class test:
   foo.match
@@ -3761,9 +3766,9 @@ class test:
 >>>
 class test:
    foo.match
-        case bar => ""
-        case baz => ""
-     .qux
+      case bar => ""
+      case baz => ""
+   .qux
 <<< #3489 11
 class test:
   foo.match
@@ -3774,10 +3779,10 @@ class test:
 >>>
 class test:
    foo.match
-        case bar => ""
-        case baz => ""
-     .qux:
-        3 + 3
+      case bar => ""
+      case baz => ""
+   .qux:
+      3 + 3
 <<< overflowing type
 object types:
   type GOutputStreamClass = CStruct21[GObjectClass, CFuncPtr5[Ptr[GOutputStream], Ptr[Byte], gsize, Ptr[GCancellable], Ptr[Ptr[GError]], gssize], CFuncPtr5[Ptr[GOutputStream], Ptr[GInputStream], GOutputStreamSpliceFlags, Ptr[GCancellable], Ptr[Ptr[GError]], gssize], CFuncPtr3[Ptr[GOutputStream], Ptr[GCancellable], Ptr[Ptr[GError]], gboolean], CFuncPtr3[Ptr[GOutputStream], Ptr[GCancellable], Ptr[Ptr[GError]], gboolean], CFuncPtr7[Ptr[GOutputStream], Ptr[Byte], gsize, CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr3[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[Ptr[GError]], gssize], CFuncPtr7[Ptr[GOutputStream], Ptr[GInputStream], GOutputStreamSpliceFlags, CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr3[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[Ptr[GError]], gssize], CFuncPtr5[Ptr[GOutputStream], CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr3[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[Ptr[GError]], gboolean], CFuncPtr5[Ptr[GOutputStream], CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr3[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[Ptr[GError]], gboolean], CFuncPtr6[Ptr[GOutputStream], Ptr[GOutputVector], gsize, Ptr[gsize], Ptr[GCancellable], Ptr[Ptr[GError]], gboolean], CFuncPtr7[Ptr[GOutputStream], Ptr[GOutputVector], gsize, CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr4[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[gsize], Ptr[Ptr[GError]], gboolean], CFuncPtr0[Unit], CFuncPtr0[Unit], CFuncPtr0[Unit], CFuncPtr0[Unit], CFuncPtr0[Unit]]

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3591,7 +3591,7 @@ object a:
 object a:
    def f(): Unit =
      List(1, 2, 3).foldLeft(1):
-          case (a, b) => a + b
+        case (a, b) => a + b
 <<< coloneol in fewer braces 1, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3604,7 +3604,7 @@ object a:
 object a:
    def f(): Unit =
        List(1, 2, 3).foldLeft(1):
-              case (a, b) => a + b
+          case (a, b) => a + b
 <<< coloneol in fewer braces 2
 maxColumn = 80
 ===
@@ -3620,11 +3620,11 @@ object a:
 object a:
    def f(): Unit =
      List(1, 2, 3).foo: a =>
-          a + 2
-       .foo: a =>
-          2 + a
-       .apply:
-          12 + 3
+        a + 2
+     .foo: a =>
+        2 + a
+     .apply:
+        12 + 3
 <<< coloneol in fewer braces 2, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3641,11 +3641,11 @@ object a:
 object a:
    def f(): Unit =
        List(1, 2, 3).foo: a =>
-              a + 2
-           .foo: a =>
-              2 + a
-           .apply:
-              12 + 3
+          a + 2
+       .foo: a =>
+          2 + a
+       .apply:
+          12 + 3
 <<< coloneol in fewer braces 3
 maxColumn = 80
 ===
@@ -3659,8 +3659,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-           case a: Int =>
-           case _      =>
+         case a: Int =>
+         case _      =>
       otherTerm()
 <<< coloneol in fewer braces 3, main > sig
 maxColumn = 80
@@ -3676,8 +3676,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-             case a: Int =>
-             case _      =>
+         case a: Int =>
+         case _      =>
       otherTerm()
 <<< match with eol
 maxColumn = 80
@@ -3694,11 +3694,11 @@ object a:
 object a:
    def f(): Unit =
      List(1, 2, 3).match
-          case _ => a + 2
-       .foo: a =>
-          2 + a
-       .apply:
-          12 + 3
+        case _ => a + 2
+     .foo: a =>
+        2 + a
+     .apply:
+        12 + 3
 <<< match with eol, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3715,11 +3715,11 @@ object a:
 object a:
    def f(): Unit =
        List(1, 2, 3).match
-              case _ => a + 2
-           .foo: a =>
-              2 + a
-           .apply:
-              12 + 3
+          case _ => a + 2
+       .foo: a =>
+          2 + a
+       .apply:
+          12 + 3
 <<< coloneol in refined types
 maxColumn = 80
 ===
@@ -3770,8 +3770,8 @@ def test(): String =
 >>>
 def test(): String =
   Block:
-       2 + 2
-    .toString
+     2 + 2
+  .toString
 <<< #3448 2
 indent.significant = 1
 ===
@@ -3782,8 +3782,8 @@ def test(): String =
 >>>
 def test(): String =
   Block:
-     2 + 2
-    .toString
+   2 + 2
+  .toString
 <<< #3448 3
 indent.significant = 1
 ===
@@ -3795,9 +3795,9 @@ def test(): String =
 >>>
 def test(): String =
   foo.bar:
-     2 + 2
-    .baz.qux:
-     3 + 3
+   2 + 2
+  .baz.qux:
+   3 + 3
 <<< #3448 4
 indent.significant = 1
 ===
@@ -3809,9 +3809,9 @@ def test(): String =
 >>>
 def test(): String =
   bar:
-     2 + 2
-    .baz.qux:
-     3 + 3
+   2 + 2
+  .baz.qux:
+   3 + 3
 <<< #3448 5
 indent.significant = 1
 ===
@@ -3823,9 +3823,9 @@ class test:
 >>>
 class test:
  bar:
-    2 + 2
-   .baz.qux:
-    3 + 3
+  2 + 2
+ .baz.qux:
+  3 + 3
 <<< #3489 1
 class test:
   bar:
@@ -3833,7 +3833,7 @@ class test:
 >>>
 class test:
    bar:
-        2 + 2
+      2 + 2
 <<< #3489 2
 class test:
   baz.qux:
@@ -3841,27 +3841,31 @@ class test:
 >>>
 class test:
    baz.qux:
-        2 + 2
+      2 + 2
 <<< #3489 3
 class test:
   foo.bar:
     2 + 2
   .baz
+  .qux
 >>>
 class test:
    foo.bar:
-        2 + 2
-     .baz
+      2 + 2
+   .baz
+     .qux
 <<< #3489 4
 class test:
   bar:
      2 + 2
     .baz
+  .qux
 >>>
 class test:
    bar:
-        2 + 2
-     .baz
+      2 + 2
+   .baz
+     .qux
 <<< #3489 5
 class test:
   bar:
@@ -3871,20 +3875,22 @@ class test:
 >>>
 class test:
    bar:
-        2 + 2
-     .baz:
-        3 + 3
+      2 + 2
+   .baz:
+      3 + 3
 <<< #3489 6
 class test:
   bar:
      2 + 2
-    .baz.qux:
+    .baz
+    .qux:
        3 + 3
 >>>
 class test:
    bar:
-        2 + 2
-     .baz.qux:
+      2 + 2
+   .baz
+     .qux:
         3 + 3
 <<< #3489 7
 class test:
@@ -3909,9 +3915,9 @@ class test:
 >>>
 class test:
    bar.baz:
-        2 + 2
-     .qux:
-        3 + 3
+      2 + 2
+   .qux:
+      3 + 3
 <<< #3489 9
 class test:
   foo.match
@@ -3920,8 +3926,8 @@ class test:
 >>>
 class test:
    foo.match
-        case bar => ""
-        case baz => ""
+      case bar => ""
+      case baz => ""
 <<< #3489 10
 class test:
   foo.match
@@ -3931,9 +3937,9 @@ class test:
 >>>
 class test:
    foo.match
-        case bar => ""
-        case baz => ""
-     .qux
+      case bar => ""
+      case baz => ""
+   .qux
 <<< #3489 11
 class test:
   foo.match
@@ -3944,10 +3950,10 @@ class test:
 >>>
 class test:
    foo.match
-        case bar => ""
-        case baz => ""
-     .qux:
-        3 + 3
+      case bar => ""
+      case baz => ""
+   .qux:
+      3 + 3
 <<< overflowing type
 object types:
   type GOutputStreamClass = CStruct21[GObjectClass, CFuncPtr5[Ptr[GOutputStream], Ptr[Byte], gsize, Ptr[GCancellable], Ptr[Ptr[GError]], gssize], CFuncPtr5[Ptr[GOutputStream], Ptr[GInputStream], GOutputStreamSpliceFlags, Ptr[GCancellable], Ptr[Ptr[GError]], gssize], CFuncPtr3[Ptr[GOutputStream], Ptr[GCancellable], Ptr[Ptr[GError]], gboolean], CFuncPtr3[Ptr[GOutputStream], Ptr[GCancellable], Ptr[Ptr[GError]], gboolean], CFuncPtr7[Ptr[GOutputStream], Ptr[Byte], gsize, CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr3[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[Ptr[GError]], gssize], CFuncPtr7[Ptr[GOutputStream], Ptr[GInputStream], GOutputStreamSpliceFlags, CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr3[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[Ptr[GError]], gssize], CFuncPtr5[Ptr[GOutputStream], CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr3[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[Ptr[GError]], gboolean], CFuncPtr5[Ptr[GOutputStream], CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr3[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[Ptr[GError]], gboolean], CFuncPtr6[Ptr[GOutputStream], Ptr[GOutputVector], gsize, Ptr[gsize], Ptr[GCancellable], Ptr[Ptr[GError]], gboolean], CFuncPtr7[Ptr[GOutputStream], Ptr[GOutputVector], gsize, CInt, Ptr[GCancellable], GAsyncReadyCallback, gpointer, Unit], CFuncPtr4[Ptr[GOutputStream], Ptr[GAsyncResult], Ptr[gsize], Ptr[Ptr[GError]], gboolean], CFuncPtr0[Unit], CFuncPtr0[Unit], CFuncPtr0[Unit], CFuncPtr0[Unit], CFuncPtr0[Unit]]

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3732,8 +3732,8 @@ object a:
 object a:
    def f(): Unit =
      List(1, 2, 3).foldLeft(1):
-          case (a, b) =>
-            a + b
+        case (a, b) =>
+          a + b
 <<< coloneol in fewer braces 1, main > sig
 maxColumn = 80
 indent.main = 4
@@ -3746,8 +3746,8 @@ object a:
 object a:
    def f(): Unit =
        List(1, 2, 3).foldLeft(1):
-              case (a, b) =>
-                  a + b
+          case (a, b) =>
+              a + b
 <<< coloneol in fewer braces 2
 maxColumn = 80
 ===
@@ -3802,8 +3802,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-           case a: Int =>
-           case _      =>
+         case a: Int =>
+         case _      =>
       otherTerm()
 <<< coloneol in fewer braces 3, main > sig
 maxColumn = 80
@@ -3819,8 +3819,8 @@ object a:
 object a:
    def f(): Unit =
       List(1, 2, 3).foo:
-             case a: Int =>
-             case _      =>
+         case a: Int =>
+         case _      =>
       otherTerm()
 <<< match with eol
 maxColumn = 80
@@ -3921,8 +3921,8 @@ def test(): String =
 >>>
 def test(): String =
   Block:
-       2 + 2
-    .toString
+     2 + 2
+  .toString
 <<< #3448 2
 indent.significant = 1
 ===
@@ -3933,8 +3933,8 @@ def test(): String =
 >>>
 def test(): String =
   Block:
-     2 + 2
-    .toString
+   2 + 2
+  .toString
 <<< #3448 3
 indent.significant = 1
 ===
@@ -3960,8 +3960,8 @@ def test(): String =
     3 + 3
 >>>
 def test(): String = bar:
-   2 + 2
-  .baz
+ 2 + 2
+.baz
   .qux:
    3 + 3
 <<< #3448 5
@@ -3975,8 +3975,8 @@ class test:
 >>>
 class test:
  bar:
-    2 + 2
-   .baz
+  2 + 2
+ .baz
    .qux:
     3 + 3
 <<< #3489 1
@@ -3986,7 +3986,7 @@ class test:
 >>>
 class test:
    bar:
-        2 + 2
+      2 + 2
 <<< #3489 2
 class test:
   baz.qux:
@@ -3994,28 +3994,32 @@ class test:
 >>>
 class test:
    baz.qux:
-        2 + 2
+      2 + 2
 <<< #3489 3
 class test:
   foo.bar:
     2 + 2
   .baz
+  .qux
 >>>
 class test:
    foo
      .bar:
         2 + 2
      .baz
+     .qux
 <<< #3489 4
 class test:
   bar:
      2 + 2
     .baz
+  .qux
 >>>
 class test:
    bar:
-        2 + 2
-     .baz
+      2 + 2
+   .baz
+     .qux
 <<< #3489 5
 class test:
   bar:
@@ -4025,20 +4029,21 @@ class test:
 >>>
 class test:
    bar:
-        2 + 2
-     .baz:
-        3 + 3
+      2 + 2
+   .baz:
+      3 + 3
 <<< #3489 6
 class test:
   bar:
      2 + 2
-    .baz.qux:
+    .baz
+    .qux:
        3 + 3
 >>>
 class test:
    bar:
-        2 + 2
-     .baz
+      2 + 2
+   .baz
      .qux:
         3 + 3
 <<< #3489 7
@@ -4075,10 +4080,10 @@ class test:
 >>>
 class test:
    foo.match
-        case bar =>
-          ""
-        case baz =>
-          ""
+      case bar =>
+        ""
+      case baz =>
+        ""
 <<< #3489 10
 class test:
   foo.match


### PR DESCRIPTION
And don't indent select after them, as that's not yet supported by the compiler. Fixes #3489.