### PR TITLE
TreeOps: get the whole implicit clause, not values

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1301,9 +1301,9 @@ class FormatOps(
       val rightIsImplicit = r.is[soft.ImplicitOrUsing]
       val implicitNL = rightIsImplicit &&
         style.newlines.forceBeforeImplicitParamListModifier
-      val implicitParams =
-        if (!rightIsImplicit) Nil
-        else getImplicitParamList(ft.meta.rightOwner).getOrElse(Nil)
+      val implicitParams = if (rightIsImplicit) {
+        getImplicitParamList(ft.meta.rightOwner).fold(Nil: List[Tree])(_.values)
+      } else Nil
       val noSlb = implicitNL || aboveArityThreshold || ft.hasBreak &&
         !style.newlines.sourceIgnored && style.optIn.configStyleArguments ||
         implicitParams.nonEmpty &&

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2432,7 +2432,7 @@ class Router(formatOps: FormatOps) {
         val spaceSplit = Split(Space, 0)
           .notIf(style.newlines.forceAfterImplicitParamListModifier)
           .withPolicy(
-            SingleLineBlock(params.last.tokens.last),
+            SingleLineBlock(params.tokens.last),
             style.newlines.notPreferAfterImplicitParamListModifier
           )
         Seq(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -635,10 +635,10 @@ object TreeOps {
     param.mods.forall(noExplicitImplicit(pStart, true))
   }
 
-  def getImplicitParamList(kwOwner: Tree): Option[Seq[Tree]] =
+  def getImplicitParamList(kwOwner: Tree): Option[Member.SyntaxValuesClause] =
     kwOwner.parent match {
-      case Some(Term.ArgClause(v, Some(`kwOwner`))) => Some(v)
-      case Some(Term.ParamClause(v @ _ :: rest, Some(`kwOwner`)))
+      case Some(v @ Term.ArgClause(_, Some(`kwOwner`))) => Some(v)
+      case Some(v @ Term.ParamClause(_ :: rest, Some(`kwOwner`)))
           if !kwOwner.is[Mod.Implicit] || rest.isEmpty ||
             rest.exists(noExplicitImplicit) =>
         Some(v)


### PR DESCRIPTION
Towards #3520.