### PR TITLE
Router: use implicit rule for vertical multiline

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2427,12 +2427,11 @@ class Router(formatOps: FormatOps) {
         }
 
       case FormatToken(soft.ImplicitOrUsing(), _, ImplicitUsingOnLeft(params))
-          if style.binPack.unsafeDefnSite.isNever &&
-            !style.verticalMultiline.atDefnSite =>
+          if style.binPack.unsafeDefnSite.isNever =>
         val spaceSplit = Split(Space, 0)
           .notIf(style.newlines.forceAfterImplicitParamListModifier)
           .withPolicy(
-            SingleLineBlock(params.tokens.last),
+            SingleLineBlock(params.tokens.last, rank = 1),
             style.newlines.notPreferAfterImplicitParamListModifier
           )
         Seq(

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -438,3 +438,177 @@ object a {
       d: D,
       implicit val e: E) {}
 }
+<<< #3520 implicitParamListModifierForce = [after], no VML
+verticalMultiline.atDefnSite = no
+newlines.implicitParamListModifierForce = [after]
+===
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit b: Int  // c
+  ): Int =
+    a + b
+}
+>>>
+object Foo {
+  def bar(a: Int)(implicit
+      b: Int
+  ): Int =
+    a + b
+  def bar(a: Int)(implicit
+      b: Int // c
+  ): Int =
+    a + b
+}
+<<< #3520 implicitParamListModifierForce = [after]
+newlines.implicitParamListModifierForce = [after]
+===
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit b: Int  // c
+  ): Int =
+    a + b
+}
+>>>
+object Foo {
+  def bar(
+      a: Int
+    )(implicit
+      b: Int
+    ): Int =
+    a + b
+  def bar(
+      a: Int
+    )(implicit
+      b: Int // c
+    ): Int =
+    a + b
+}
+<<< #3520 implicitParamListModifierForce = [before], no VML
+verticalMultiline.atDefnSite = no
+newlines.implicitParamListModifierForce = [before]
+===
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit b: Int  // c
+  ): Int =
+    a + b
+}
+>>>
+object Foo {
+  def bar(a: Int)(
+      implicit b: Int
+  ): Int =
+    a + b
+  def bar(a: Int)(
+      implicit b: Int // c
+  ): Int =
+    a + b
+}
+<<< #3520 implicitParamListModifierForce = [before]
+newlines.implicitParamListModifierForce = [before]
+===
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit b: Int  // c
+  ): Int =
+    a + b
+}
+>>>
+object Foo {
+  def bar(
+      a: Int
+    )(
+      implicit b: Int
+    ): Int =
+    a + b
+  def bar(
+      a: Int
+    )(
+      implicit b: Int // c
+    ): Int =
+    a + b
+}
+<<< #3520 implicitParamListModifierPrefer = after, no VML
+verticalMultiline.atDefnSite = no
+newlines.implicitParamListModifierPrefer = after
+===
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit b: Int  // c
+  ): Int =
+    a + b
+}
+>>>
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit
+      b: Int // c
+  ): Int =
+    a + b
+}
+<<< #3520 implicitParamListModifierPrefer = after
+newlines.implicitParamListModifierPrefer = after
+===
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit b: Int  // c
+  ): Int =
+    a + b
+}
+>>>
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(
+      a: Int
+    )(implicit b: Int // c
+    ): Int =
+    a + b
+}
+<<< #3520 implicitParamListModifierPrefer = before, no VML
+verticalMultiline.atDefnSite = no
+newlines.implicitParamListModifierPrefer = before
+===
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit b: Int  // c
+  ): Int =
+    a + b
+}
+>>>
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(
+      implicit b: Int // c
+  ): Int =
+    a + b
+}
+<<< #3520 implicitParamListModifierPrefer = before
+newlines.implicitParamListModifierPrefer = before
+===
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(a: Int)(implicit b: Int  // c
+  ): Int =
+    a + b
+}
+>>>
+object Foo {
+  def bar(a: Int)(implicit b: Int): Int =
+    a + b
+  def bar(
+      a: Int
+    )(implicit b: Int // c
+    ): Int =
+    a + b
+}

--- a/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
+++ b/scalafmt-tests/src/test/resources/vertical-multiline/verticalMultiline.stat
@@ -568,7 +568,8 @@ object Foo {
     a + b
   def bar(
       a: Int
-    )(implicit b: Int // c
+    )(implicit
+      b: Int // c
     ): Int =
     a + b
 }


### PR DESCRIPTION
Also, set a higher rank (policy applied later). Fixes #3520.