### PR TITLE
Fix docs/configuration.md indentOperator section

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -848,7 +848,7 @@ indentOperator.includeRegex
 - `default`
   - use defaults for all fields
 - `spray` (also `akka`)
-  - set `include = "^.*=$"`, `exclude = "^$"`
+  - set `indentOperator.excludeRegex = "^$"` and `indentOperator.includeRegex = "^.*=$"`
 
 ## Alignment
 


### PR DESCRIPTION
The line I changed wasn't updated after renaming (`exclude` -> `excludeRegex`, `include` -> `includeRegex`) since v3.1.0.

I also changed the order of them in this line to follow the same order that they were explained in this document.