### PR TITLE
Bump coursier version to 2.1.2.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val metaconfigV = "0.11.1"
   val scalametaV  = "4.7.6"
   val scalacheckV = "1.17.0"
-  val coursier    = "1.0.3"
+  val coursier    = "2.1.2"
   val munitV      = "0.7.29"
 
   val scalapb = Def.setting {


### PR DESCRIPTION
Fixing https://github.com/scalameta/scalafmt/issues/2793, which was fixed in coursier 2.1.0-RC2.