### PR TITLE
Fix proposed version syntax

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -96,7 +96,7 @@ object Cli {
     "true" == System.getProperty("scalafmt.native-image", "false")
 
   private def getProposedConfigVersion(options: CliOptions): String =
-    s"version = '$stableVersion'"
+    s"version = $stableVersion"
 
   private def findRunner(
       options: CliOptions

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -134,7 +134,7 @@ object Cli {
             |This Scalafmt installation has version '$stableVersion' and the version configured in '${options.configPath}' is '$v'.
             |To fix this problem, add the following line to .scalafmt.conf:
             |```
-            |version = '$stableVersion'
+            |version = $stableVersion
             |```
             |
             |NOTE: this error happens only when running a native Scalafmt binary.


### PR DESCRIPTION
Follow up to https://github.com/scalameta/scalafmt/pull/3544, the proposed version string looks something like:
`version = '3.7.4'`

While scalafmt only accepts strings formatted like:
`version = 3.7.4`

Curiously enough, the original issue (https://github.com/scalameta/scalafmt/issues/3543) had it right 😅 