### PR TITLE
Router: handle parameter `indent.fewerBraces`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -589,6 +589,82 @@ foo // c1
 }
 ```
 
+#### `indent.fewerBraces`
+
+This parameter controls whether extra `indent.main` is added
+to the sole argument of a method call using the "fewer braces"
+syntax. The following values are supported:
+
+- `always`: always applies extra indent
+- `never`: doesn't apply any extra indent
+- `beforeSelect`: applies extra indent only to fewer-braces
+  expressions followed by a `.select`
+
+```scala mdoc:defaults
+indent.fewerBraces
+```
+
+> In Scala 3.3.0, only `never` provides compiler-compatible code.
+> Other options will work in 3.3.1-RC1 and later
+> (see [Parser section](https://github.com/lampepfl/dotty/releases/tag/3.3.1-RC1)).
+
+```scala mdoc:scalafmt
+runner.dialect = Scala3
+indent.significant = 3
+indent.fewerBraces = always
+---
+bar:
+  2 + 2
+
+foo.bar:
+  2 + 2
+
+foo:
+  2 + 2
+.bar:
+  3 + 3
+.baz // c
+.qux
+```
+
+```scala mdoc:scalafmt
+runner.dialect = Scala3
+indent.significant = 3
+indent.fewerBraces = never
+---
+bar:
+  2 + 2
+
+foo.bar:
+  2 + 2
+
+foo:
+  2 + 2
+.bar:
+  3 + 3
+.baz // c
+.qux
+```
+
+```scala mdoc:scalafmt
+runner.dialect = Scala3
+indent.significant = 3
+indent.fewerBraces = beforeSelect
+---
+bar:
+  2 + 2
+
+foo.bar:
+  2 + 2
+
+foo:
+  2 + 2
+.bar:
+  3 + 3
+.baz // c
+.qux
+```
+
 ### Indent for `binPack.unsafeCallSite`
 
 Normally, even when binpacking, there's a new level of indentation added for

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
@@ -32,6 +32,7 @@ case class Indents(
     private[config] val ctorSite: Option[Int] = None,
     extraBeforeOpenParenDefnSite: Int = 0,
     relativeToLhsLastLine: Seq[Indents.RelativeToLhs] = Nil,
+    fewerBraces: Indents.FewerBraces = Indents.FewerBraces.never,
     @annotation.ExtraName("deriveSite")
     extendSite: Int = 4,
     withSiteRelativeToExtends: Int = 0,
@@ -62,4 +63,15 @@ object Indents {
     implicit val reader: ConfCodecEx[RelativeToLhs] = ReaderUtil
       .oneOf[RelativeToLhs](`match`, `infix`)
   }
+
+  sealed abstract class FewerBraces
+  object FewerBraces {
+    case object never extends FewerBraces
+    case object always extends FewerBraces
+    case object beforeSelect extends FewerBraces
+
+    implicit val reader: ConfCodecEx[FewerBraces] = ReaderUtil
+      .oneOf[FewerBraces](never, always, beforeSelect)
+  }
+
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1,7 +1,7 @@
 package org.scalafmt.internal
 
 import org.scalafmt.Error.UnexpectedTree
-import org.scalafmt.config.{Align, BinPack}
+import org.scalafmt.config.{Align, BinPack, Indents}
 import org.scalafmt.config.{ImportSelectors, Newlines, ScalafmtConfig, Spaces}
 import org.scalafmt.internal.ExpiresOn.{After, Before}
 import org.scalafmt.internal.Length.{Num, StateColumn}
@@ -1770,11 +1770,18 @@ class Router(formatOps: FormatOps) {
         val baseSplits = style.newlines.getSelectChains match {
           case Newlines.classic =>
             def getNlMod = {
-              val endSelect = nextSelect.fold(expire) { x =>
-                nextDotIfSig.fold(getLastNonTrivialToken(x.qual))(_.left)
+              val endSelect = nextDotIfSig.fold {
+                nextSelect.fold {
+                  val ko = style.indent.fewerBraces ==
+                    Indents.FewerBraces.always && checkFewerBraces(expireTree)
+                  if (ko) None else Some(expire)
+                } { ns => Some(getLastNonTrivialToken(ns.qual)) }
+              } { nd =>
+                val ok = style.indent.fewerBraces == Indents.FewerBraces.never
+                if (ok) Some(nd.left) else None
               }
-              val altIndent = Indent(-indentLen, endSelect, After)
-              NewlineT(alt = Some(ModExt(NoSplit).withIndent(altIndent)))
+              val altIndent = endSelect.map(Indent(-indentLen, _, After))
+              NewlineT(alt = Some(ModExt(NoSplit).withIndentOpt(altIndent)))
             }
 
             val prevChain = inSelectChain(prevSelect, thisSelect, expireTree)
@@ -1902,8 +1909,8 @@ class Router(formatOps: FormatOps) {
         }
 
         // trigger indent only on the first newline
-        val noIndent =
-          checkFewerBraces(thisSelect.qual)
+        val fbIndent = style.indent.fewerBraces != Indents.FewerBraces.never
+        val noIndent = !fbIndent && checkFewerBraces(thisSelect.qual)
         val nlIndent =
           if (noIndent) Indent.Empty else Indent(indentLen, expire, After)
         val spcPolicy = delayedBreakPolicyOpt
@@ -1913,9 +1920,16 @@ class Router(formatOps: FormatOps) {
             // will break
             baseSplits.map(_.withIndent(nlIndent).andFirstPolicyOpt(nlPolicy))
           else {
+            val spcIndent = nextDotIfSig.fold {
+              val ok = style.indent.fewerBraces == Indents.FewerBraces.always &&
+                nextSelect.isEmpty && checkFewerBraces(expireTree)
+              if (ok) nlIndent else Indent.empty
+            } { x =>
+              if (fbIndent) Indent(indentLen, x.left, Before) else Indent.Empty
+            }
             baseSplits.map { s =>
               if (s.isNL) s.withIndent(nlIndent).andFirstPolicyOpt(nlPolicy)
-              else s.andFirstPolicyOpt(spcPolicy)
+              else s.withIndent(spcIndent).andFirstPolicyOpt(spcPolicy)
             }
           }
 

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3850,7 +3850,9 @@ class test:
   2 + 2
  .baz.qux:
   3 + 3
-<<< #3489 1
+<<< #3489 1 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
     2 + 2
@@ -3858,7 +3860,9 @@ class test:
 class test:
    bar:
       2 + 2
-<<< #3489 2
+<<< #3489 2 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   baz.qux:
     2 + 2
@@ -3866,7 +3870,303 @@ class test:
 class test:
    baz.qux:
       2 + 2
-<<< #3489 3
+<<< #3489 3 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.bar:
+    2 + 2
+  .baz
+>>>
+class test:
+   foo
+     .bar:
+        2 + 2
+     .baz
+<<< #3489 4 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+<<< #3489 5 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  bar:
+     2 + 2
+    .baz:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz:
+      3 + 3
+<<< #3489 6 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  bar:
+     2 + 2
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz.qux:
+      3 + 3
+<<< #3489 7 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  bar (
+     2 + 2
+     )
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar(
+     2 + 2
+   ).baz.qux:
+      3 + 3
+<<< #3489 8 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  bar.baz:
+     2 + 2
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar
+     .baz:
+        2 + 2
+     .qux:
+        3 + 3
+<<< #3489 9 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+<<< #3489 10 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux
+>>>
+class test:
+   foo
+     .match
+        case bar => ""
+        case baz => ""
+     .qux
+<<< #3489 11 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux:
+       3 + 3
+>>>
+class test:
+   foo
+     .match
+        case bar => ""
+        case baz => ""
+     .qux:
+        3 + 3
+<<< #3489 1 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+    2 + 2
+>>>
+class test:
+   bar:
+      2 + 2
+<<< #3489 2 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  baz.qux:
+    2 + 2
+>>>
+class test:
+   baz.qux:
+      2 + 2
+<<< #3489 3 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.bar:
+    2 + 2
+  .baz
+>>>
+class test:
+   foo
+     .bar:
+        2 + 2
+     .baz
+<<< #3489 4 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+<<< #3489 5 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz:
+      3 + 3
+<<< #3489 6 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz.qux:
+      3 + 3
+<<< #3489 7 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar (
+     2 + 2
+     )
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar(
+     2 + 2
+   ).baz.qux:
+      3 + 3
+<<< #3489 8 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar.baz:
+     2 + 2
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar
+     .baz:
+        2 + 2
+     .qux:
+        3 + 3
+<<< #3489 9 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+<<< #3489 10 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux
+>>>
+class test:
+   foo
+     .match
+        case bar => ""
+        case baz => ""
+     .qux
+<<< #3489 11 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux:
+       3 + 3
+>>>
+class test:
+   foo
+     .match
+        case bar => ""
+        case baz => ""
+     .qux:
+        3 + 3
+<<< #3489 1 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+    2 + 2
+>>>
+class test:
+   bar:
+      2 + 2
+<<< #3489 2 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  baz.qux:
+    2 + 2
+>>>
+class test:
+   baz.qux:
+      2 + 2
+<<< #3489 3 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.bar:
     2 + 2
@@ -3879,7 +4179,9 @@ class test:
         2 + 2
      .baz
      .qux
-<<< #3489 4
+<<< #3489 4 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   bar:
      2 + 2
@@ -3890,7 +4192,9 @@ class test:
    bar:
       2 + 2
    .baz.qux
-<<< #3489 5
+<<< #3489 5 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   bar:
      2 + 2
@@ -3902,7 +4206,9 @@ class test:
       2 + 2
    .baz:
       3 + 3
-<<< #3489 6
+<<< #3489 6 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   bar:
      2 + 2
@@ -3916,7 +4222,9 @@ class test:
    .baz
      .qux:
         3 + 3
-<<< #3489 7
+<<< #3489 7 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   bar (
      2 + 2
@@ -3929,7 +4237,9 @@ class test:
      2 + 2
    ).baz.qux:
       3 + 3
-<<< #3489 8
+<<< #3489 8 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   bar.baz:
      2 + 2
@@ -3942,7 +4252,9 @@ class test:
         2 + 2
      .qux:
         3 + 3
-<<< #3489 9
+<<< #3489 9 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.match
      case bar => ""
@@ -3952,7 +4264,9 @@ class test:
    foo.match
       case bar => ""
       case baz => ""
-<<< #3489 10
+<<< #3489 10 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.match
      case bar => ""
@@ -3965,7 +4279,9 @@ class test:
         case bar => ""
         case baz => ""
      .qux
-<<< #3489 11
+<<< #3489 11 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.match
      case bar => ""
@@ -4611,7 +4927,45 @@ extension (s: String)
    /** ... */
    def foo(): Unit = ???
    def bar(): Unit = ???
-<<< #3527
+<<< #3527 fewerBraces = always
+indent.fewerBraces = always
+===
+def foo(xs: List[Int]) =
+  xs.map: x =>
+    x + 1
+  .toSet
+  .filter: x =>
+    x > 0
+  .toList
+>>>
+def foo(xs: List[Int]) =
+  xs.map: x =>
+     x + 1
+  .toSet
+    .filter: x =>
+       x > 0
+    .toList
+<<< #3527 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+def foo(xs: List[Int]) =
+  xs.map: x =>
+    x + 1
+  .toSet
+  .filter: x =>
+    x > 0
+  .toList
+>>>
+def foo(xs: List[Int]) =
+  xs.map: x =>
+     x + 1
+  .toSet
+    .filter: x =>
+       x > 0
+    .toList
+<<< #3527 fewerBraces = never
+indent.fewerBraces = never
+===
 def foo(xs: List[Int]) =
   xs.map: x =>
     x + 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -3859,7 +3859,7 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
+        2 + 2
 <<< #3489 2 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3869,7 +3869,7 @@ class test:
 >>>
 class test:
    baz.qux:
-      2 + 2
+        2 + 2
 <<< #3489 3 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3893,8 +3893,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 5 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3906,9 +3906,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz:
-      3 + 3
+        2 + 2
+     .baz:
+        3 + 3
 <<< #3489 6 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3920,9 +3920,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz.qux:
-      3 + 3
+        2 + 2
+     .baz.qux:
+        3 + 3
 <<< #3489 7 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3937,7 +3937,7 @@ class test:
    bar(
      2 + 2
    ).baz.qux:
-      3 + 3
+        3 + 3
 <<< #3489 8 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3963,8 +3963,8 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
+        case bar => ""
+        case baz => ""
 <<< #3489 10 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -4040,8 +4040,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 5 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4053,9 +4053,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz:
-      3 + 3
+        2 + 2
+     .baz:
+        3 + 3
 <<< #3489 6 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4067,9 +4067,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz.qux:
-      3 + 3
+        2 + 2
+     .baz.qux:
+        3 + 3
 <<< #3489 7 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4940,8 +4940,8 @@ def foo(xs: List[Int]) =
 >>>
 def foo(xs: List[Int]) =
   xs.map: x =>
-     x + 1
-  .toSet
+       x + 1
+    .toSet
     .filter: x =>
        x > 0
     .toList
@@ -4958,8 +4958,8 @@ def foo(xs: List[Int]) =
 >>>
 def foo(xs: List[Int]) =
   xs.map: x =>
-     x + 1
-  .toSet
+       x + 1
+    .toSet
     .filter: x =>
        x > 0
     .toList

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3668,7 +3668,7 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
+        2 + 2
 <<< #3489 2 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3678,7 +3678,7 @@ class test:
 >>>
 class test:
    baz.qux:
-      2 + 2
+        2 + 2
 <<< #3489 3 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3689,8 +3689,8 @@ class test:
 >>>
 class test:
    foo.bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 4 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3701,8 +3701,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 5 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3714,9 +3714,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz:
-      3 + 3
+        2 + 2
+     .baz:
+        3 + 3
 <<< #3489 6 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3728,9 +3728,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz.qux:
-      3 + 3
+        2 + 2
+     .baz.qux:
+        3 + 3
 <<< #3489 7 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3743,7 +3743,7 @@ class test:
 >>>
 class test:
    bar(2 + 2).baz.qux:
-      3 + 3
+        3 + 3
 <<< #3489 8 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3755,9 +3755,9 @@ class test:
 >>>
 class test:
    bar.baz:
-      2 + 2
-   .qux:
-      3 + 3
+        2 + 2
+     .qux:
+        3 + 3
 <<< #3489 9 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3768,8 +3768,8 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
+        case bar => ""
+        case baz => ""
 <<< #3489 10 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3781,9 +3781,9 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
-   .qux
+        case bar => ""
+        case baz => ""
+     .qux
 <<< #3489 11 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3796,10 +3796,10 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
-   .qux:
-      3 + 3
+        case bar => ""
+        case baz => ""
+     .qux:
+        3 + 3
 <<< #3489 1 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -3830,8 +3830,8 @@ class test:
 >>>
 class test:
    foo.bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 4 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -3842,8 +3842,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 5 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -3855,9 +3855,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz:
-      3 + 3
+        2 + 2
+     .baz:
+        3 + 3
 <<< #3489 6 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -3869,9 +3869,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz.qux:
-      3 + 3
+        2 + 2
+     .baz.qux:
+        3 + 3
 <<< #3489 7 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -3896,9 +3896,9 @@ class test:
 >>>
 class test:
    bar.baz:
-      2 + 2
-   .qux:
-      3 + 3
+        2 + 2
+     .qux:
+        3 + 3
 <<< #3489 9 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -3922,9 +3922,9 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
-   .qux
+        case bar => ""
+        case baz => ""
+     .qux
 <<< #3489 11 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -3937,10 +3937,10 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
-   .qux:
-      3 + 3
+        case bar => ""
+        case baz => ""
+     .qux:
+        3 + 3
 <<< #3489 1 fewerBraces = never
 indent.fewerBraces = never
 ===
@@ -4730,10 +4730,10 @@ def foo(xs: List[Int]) =
   .toList
 >>>
 def foo(xs: List[Int]) = xs.map: x =>
-   x + 1
-.toSet.filter: x =>
-   x > 0
-.toList
+     x + 1
+  .toSet.filter: x =>
+     x > 0
+  .toList
 <<< #3527 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4746,10 +4746,10 @@ def foo(xs: List[Int]) =
   .toList
 >>>
 def foo(xs: List[Int]) = xs.map: x =>
-   x + 1
-.toSet.filter: x =>
-   x > 0
-.toList
+     x + 1
+  .toSet.filter: x =>
+     x > 0
+  .toList
 <<< #3527 fewerBraces = never
 indent.fewerBraces = never
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -3659,7 +3659,9 @@ class test:
   2 + 2
  .baz.qux:
   3 + 3
-<<< #3489 1
+<<< #3489 1 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
     2 + 2
@@ -3667,7 +3669,9 @@ class test:
 class test:
    bar:
       2 + 2
-<<< #3489 2
+<<< #3489 2 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   baz.qux:
     2 + 2
@@ -3675,30 +3679,33 @@ class test:
 class test:
    baz.qux:
       2 + 2
-<<< #3489 3
+<<< #3489 3 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   foo.bar:
     2 + 2
   .baz
-  .qux
 >>>
 class test:
    foo.bar:
       2 + 2
-   .baz.qux
-<<< #3489 4
+   .baz
+<<< #3489 4 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
      2 + 2
-    .baz // c
-  .qux
+    .baz
 >>>
 class test:
    bar:
       2 + 2
-   .baz // c
-     .qux
-<<< #3489 5
+   .baz
+<<< #3489 5 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
      2 + 2
@@ -3710,7 +3717,294 @@ class test:
       2 + 2
    .baz:
       3 + 3
-<<< #3489 6
+<<< #3489 6 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  bar:
+     2 + 2
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz.qux:
+      3 + 3
+<<< #3489 7 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  bar (
+     2 + 2
+     )
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar(2 + 2).baz.qux:
+      3 + 3
+<<< #3489 8 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  bar.baz:
+     2 + 2
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar.baz:
+      2 + 2
+   .qux:
+      3 + 3
+<<< #3489 9 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+<<< #3489 10 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+   .qux
+<<< #3489 11 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux:
+       3 + 3
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+   .qux:
+      3 + 3
+<<< #3489 1 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+    2 + 2
+>>>
+class test:
+   bar:
+      2 + 2
+<<< #3489 2 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  baz.qux:
+    2 + 2
+>>>
+class test:
+   baz.qux:
+      2 + 2
+<<< #3489 3 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.bar:
+    2 + 2
+  .baz
+>>>
+class test:
+   foo.bar:
+      2 + 2
+   .baz
+<<< #3489 4 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+<<< #3489 5 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz:
+      3 + 3
+<<< #3489 6 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz.qux:
+      3 + 3
+<<< #3489 7 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar (
+     2 + 2
+     )
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar(2 + 2).baz.qux:
+      3 + 3
+<<< #3489 8 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar.baz:
+     2 + 2
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar.baz:
+      2 + 2
+   .qux:
+      3 + 3
+<<< #3489 9 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+<<< #3489 10 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+   .qux
+<<< #3489 11 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux:
+       3 + 3
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+   .qux:
+      3 + 3
+<<< #3489 1 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+    2 + 2
+>>>
+class test:
+   bar:
+      2 + 2
+<<< #3489 2 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  baz.qux:
+    2 + 2
+>>>
+class test:
+   baz.qux:
+      2 + 2
+<<< #3489 3 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  foo.bar:
+    2 + 2
+  .baz
+  .qux
+>>>
+class test:
+   foo.bar:
+      2 + 2
+   .baz.qux
+<<< #3489 4 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+     2 + 2
+    .baz // c
+  .qux
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz // c
+     .qux
+<<< #3489 5 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+     2 + 2
+    .baz:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz:
+      3 + 3
+<<< #3489 6 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   bar:
      2 + 2
@@ -3724,7 +4018,9 @@ class test:
    .baz // c
      .qux:
         3 + 3
-<<< #3489 7
+<<< #3489 7 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   bar (
      2 + 2
@@ -3735,7 +4031,9 @@ class test:
 class test:
    bar(2 + 2).baz.qux:
       3 + 3
-<<< #3489 8
+<<< #3489 8 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   bar.baz:
      2 + 2
@@ -3747,7 +4045,9 @@ class test:
       2 + 2
    .qux:
       3 + 3
-<<< #3489 9
+<<< #3489 9 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.match
      case bar => ""
@@ -3757,7 +4057,9 @@ class test:
    foo.match
       case bar => ""
       case baz => ""
-<<< #3489 10
+<<< #3489 10 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.match
      case bar => ""
@@ -3769,7 +4071,9 @@ class test:
       case bar => ""
       case baz => ""
    .qux
-<<< #3489 11
+<<< #3489 11 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.match
      case bar => ""
@@ -4414,7 +4718,41 @@ extension (s: String)
    /** ... */
    def foo(): Unit = ???
    def bar(): Unit = ???
-<<< #3527
+<<< #3527 fewerBraces = always
+indent.fewerBraces = always
+===
+def foo(xs: List[Int]) =
+  xs.map: x =>
+    x + 1
+  .toSet
+  .filter: x =>
+    x > 0
+  .toList
+>>>
+def foo(xs: List[Int]) = xs.map: x =>
+   x + 1
+.toSet.filter: x =>
+   x > 0
+.toList
+<<< #3527 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+def foo(xs: List[Int]) =
+  xs.map: x =>
+    x + 1
+  .toSet
+  .filter: x =>
+    x > 0
+  .toList
+>>>
+def foo(xs: List[Int]) = xs.map: x =>
+   x + 1
+.toSet.filter: x =>
+   x > 0
+.toList
+<<< #3527 fewerBraces = never
+indent.fewerBraces = never
+===
 def foo(xs: List[Int]) =
   xs.map: x =>
     x + 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3835,7 +3835,7 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
+        2 + 2
 <<< #3489 2 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3845,7 +3845,7 @@ class test:
 >>>
 class test:
    baz.qux:
-      2 + 2
+        2 + 2
 <<< #3489 3 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3856,8 +3856,8 @@ class test:
 >>>
 class test:
    foo.bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 4 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3868,8 +3868,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 5 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3881,9 +3881,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz:
-      3 + 3
+        2 + 2
+     .baz:
+        3 + 3
 <<< #3489 6 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3895,9 +3895,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz.qux:
-      3 + 3
+        2 + 2
+     .baz.qux:
+        3 + 3
 <<< #3489 7 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3925,9 +3925,9 @@ class test:
 >>>
 class test:
    bar.baz:
-      2 + 2
-   .qux:
-      3 + 3
+        2 + 2
+     .qux:
+        3 + 3
 <<< #3489 9 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3938,8 +3938,8 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
+        case bar => ""
+        case baz => ""
 <<< #3489 10 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3951,9 +3951,9 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
-   .qux
+        case bar => ""
+        case baz => ""
+     .qux
 <<< #3489 11 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3966,10 +3966,10 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
-   .qux:
-      3 + 3
+        case bar => ""
+        case baz => ""
+     .qux:
+        3 + 3
 <<< #3489 1 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4000,8 +4000,8 @@ class test:
 >>>
 class test:
    foo.bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 4 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4012,8 +4012,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 5 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4025,9 +4025,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz:
-      3 + 3
+        2 + 2
+     .baz:
+        3 + 3
 <<< #3489 6 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4039,9 +4039,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz.qux:
-      3 + 3
+        2 + 2
+     .baz.qux:
+        3 + 3
 <<< #3489 7 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4069,9 +4069,9 @@ class test:
 >>>
 class test:
    bar.baz:
-      2 + 2
-   .qux:
-      3 + 3
+        2 + 2
+     .qux:
+        3 + 3
 <<< #3489 9 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4095,9 +4095,9 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
-   .qux
+        case bar => ""
+        case baz => ""
+     .qux
 <<< #3489 11 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4110,10 +4110,10 @@ class test:
 >>>
 class test:
    foo.match
-      case bar => ""
-      case baz => ""
-   .qux:
-      3 + 3
+        case bar => ""
+        case baz => ""
+     .qux:
+        3 + 3
 <<< #3489 1 fewerBraces = never
 indent.fewerBraces = never
 ===
@@ -4972,8 +4972,8 @@ def foo(xs: List[Int]) =
 >>>
 def foo(xs: List[Int]) =
   xs.map: x =>
-     x + 1
-  .toSet
+       x + 1
+    .toSet
     .filter: x =>
        x > 0
     .toList
@@ -4990,8 +4990,8 @@ def foo(xs: List[Int]) =
 >>>
 def foo(xs: List[Int]) =
   xs.map: x =>
-     x + 1
-  .toSet
+       x + 1
+    .toSet
     .filter: x =>
        x > 0
     .toList

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3826,7 +3826,9 @@ class test:
   2 + 2
  .baz.qux:
   3 + 3
-<<< #3489 1
+<<< #3489 1 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
     2 + 2
@@ -3834,7 +3836,9 @@ class test:
 class test:
    bar:
       2 + 2
-<<< #3489 2
+<<< #3489 2 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   baz.qux:
     2 + 2
@@ -3842,31 +3846,33 @@ class test:
 class test:
    baz.qux:
       2 + 2
-<<< #3489 3
+<<< #3489 3 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   foo.bar:
     2 + 2
   .baz
-  .qux
 >>>
 class test:
    foo.bar:
       2 + 2
    .baz
-     .qux
-<<< #3489 4
+<<< #3489 4 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
      2 + 2
     .baz
-  .qux
 >>>
 class test:
    bar:
       2 + 2
    .baz
-     .qux
-<<< #3489 5
+<<< #3489 5 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
      2 + 2
@@ -3878,21 +3884,23 @@ class test:
       2 + 2
    .baz:
       3 + 3
-<<< #3489 6
+<<< #3489 6 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
      2 + 2
-    .baz
-    .qux:
+    .baz.qux:
        3 + 3
 >>>
 class test:
    bar:
       2 + 2
-   .baz
-     .qux:
-        3 + 3
-<<< #3489 7
+   .baz.qux:
+      3 + 3
+<<< #3489 7 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar (
      2 + 2
@@ -3906,7 +3914,9 @@ class test:
    )
      .baz.qux:
         3 + 3
-<<< #3489 8
+<<< #3489 8 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar.baz:
      2 + 2
@@ -3918,7 +3928,9 @@ class test:
       2 + 2
    .qux:
       3 + 3
-<<< #3489 9
+<<< #3489 9 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   foo.match
      case bar => ""
@@ -3928,7 +3940,9 @@ class test:
    foo.match
       case bar => ""
       case baz => ""
-<<< #3489 10
+<<< #3489 10 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   foo.match
      case bar => ""
@@ -3940,7 +3954,303 @@ class test:
       case bar => ""
       case baz => ""
    .qux
-<<< #3489 11
+<<< #3489 11 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux:
+       3 + 3
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+   .qux:
+      3 + 3
+<<< #3489 1 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+    2 + 2
+>>>
+class test:
+   bar:
+      2 + 2
+<<< #3489 2 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  baz.qux:
+    2 + 2
+>>>
+class test:
+   baz.qux:
+      2 + 2
+<<< #3489 3 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.bar:
+    2 + 2
+  .baz
+>>>
+class test:
+   foo.bar:
+      2 + 2
+   .baz
+<<< #3489 4 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+<<< #3489 5 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz:
+      3 + 3
+<<< #3489 6 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz.qux:
+      3 + 3
+<<< #3489 7 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar (
+     2 + 2
+     )
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar(
+     2 + 2
+   )
+     .baz.qux:
+        3 + 3
+<<< #3489 8 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar.baz:
+     2 + 2
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar.baz:
+      2 + 2
+   .qux:
+      3 + 3
+<<< #3489 9 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+<<< #3489 10 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+   .qux
+<<< #3489 11 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux:
+       3 + 3
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+   .qux:
+      3 + 3
+<<< #3489 1 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+    2 + 2
+>>>
+class test:
+   bar:
+      2 + 2
+<<< #3489 2 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  baz.qux:
+    2 + 2
+>>>
+class test:
+   baz.qux:
+      2 + 2
+<<< #3489 3 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  foo.bar:
+    2 + 2
+  .baz
+  .qux
+>>>
+class test:
+   foo.bar:
+      2 + 2
+   .baz
+     .qux
+<<< #3489 4 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+  .qux
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+     .qux
+<<< #3489 5 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+     2 + 2
+    .baz:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz:
+      3 + 3
+<<< #3489 6 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+     .qux:
+        3 + 3
+<<< #3489 7 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar (
+     2 + 2
+     )
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar(
+     2 + 2
+   )
+     .baz.qux:
+        3 + 3
+<<< #3489 8 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar.baz:
+     2 + 2
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar.baz:
+      2 + 2
+   .qux:
+      3 + 3
+<<< #3489 9 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+<<< #3489 10 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux
+>>>
+class test:
+   foo.match
+      case bar => ""
+      case baz => ""
+   .qux
+<<< #3489 11 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.match
      case bar => ""
@@ -4649,7 +4959,45 @@ extension (s: String)
    /** ... */
    def foo(): Unit = ???
    def bar(): Unit = ???
-<<< #3527
+<<< #3527 fewerBraces = always
+indent.fewerBraces = always
+===
+def foo(xs: List[Int]) =
+  xs.map: x =>
+    x + 1
+  .toSet
+  .filter: x =>
+    x > 0
+  .toList
+>>>
+def foo(xs: List[Int]) =
+  xs.map: x =>
+     x + 1
+  .toSet
+    .filter: x =>
+       x > 0
+    .toList
+<<< #3527 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+def foo(xs: List[Int]) =
+  xs.map: x =>
+    x + 1
+  .toSet
+  .filter: x =>
+    x > 0
+  .toList
+>>>
+def foo(xs: List[Int]) =
+  xs.map: x =>
+     x + 1
+  .toSet
+    .filter: x =>
+       x > 0
+    .toList
+<<< #3527 fewerBraces = never
+indent.fewerBraces = never
+===
 def foo(xs: List[Int]) =
   xs.map: x =>
     x + 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3979,7 +3979,9 @@ class test:
  .baz
    .qux:
     3 + 3
-<<< #3489 1
+<<< #3489 1 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
     2 + 2
@@ -3987,7 +3989,9 @@ class test:
 class test:
    bar:
       2 + 2
-<<< #3489 2
+<<< #3489 2 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   baz.qux:
     2 + 2
@@ -3995,32 +3999,34 @@ class test:
 class test:
    baz.qux:
       2 + 2
-<<< #3489 3
+<<< #3489 3 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   foo.bar:
     2 + 2
   .baz
-  .qux
 >>>
 class test:
    foo
      .bar:
         2 + 2
      .baz
-     .qux
-<<< #3489 4
+<<< #3489 4 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
      2 + 2
     .baz
-  .qux
 >>>
 class test:
    bar:
       2 + 2
    .baz
-     .qux
-<<< #3489 5
+<<< #3489 5 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
      2 + 2
@@ -4032,12 +4038,13 @@ class test:
       2 + 2
    .baz:
       3 + 3
-<<< #3489 6
+<<< #3489 6 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar:
      2 + 2
-    .baz
-    .qux:
+    .baz.qux:
        3 + 3
 >>>
 class test:
@@ -4046,7 +4053,9 @@ class test:
    .baz
      .qux:
         3 + 3
-<<< #3489 7
+<<< #3489 7 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar (
      2 + 2
@@ -4059,7 +4068,9 @@ class test:
      .baz
      .qux:
         3 + 3
-<<< #3489 8
+<<< #3489 8 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   bar.baz:
      2 + 2
@@ -4072,7 +4083,9 @@ class test:
         2 + 2
      .qux:
         3 + 3
-<<< #3489 9
+<<< #3489 9 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   foo.match
      case bar => ""
@@ -4084,7 +4097,9 @@ class test:
         ""
       case baz =>
         ""
-<<< #3489 10
+<<< #3489 10 fewerBraces = always
+indent.fewerBraces = always
+===
 class test:
   foo.match
      case bar => ""
@@ -4099,7 +4114,322 @@ class test:
         case baz =>
           ""
      .qux
-<<< #3489 11
+<<< #3489 11 fewerBraces = always
+indent.fewerBraces = always
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux:
+       3 + 3
+>>>
+class test:
+   foo
+     .match
+        case bar =>
+          ""
+        case baz =>
+          ""
+     .qux:
+        3 + 3
+<<< #3489 1 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+    2 + 2
+>>>
+class test:
+   bar:
+      2 + 2
+<<< #3489 2 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  baz.qux:
+    2 + 2
+>>>
+class test:
+   baz.qux:
+      2 + 2
+<<< #3489 3 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.bar:
+    2 + 2
+  .baz
+>>>
+class test:
+   foo
+     .bar:
+        2 + 2
+     .baz
+<<< #3489 4 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+<<< #3489 5 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz:
+      3 + 3
+<<< #3489 6 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar:
+     2 + 2
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+     .qux:
+        3 + 3
+<<< #3489 7 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar (
+     2 + 2
+     )
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar(2 + 2)
+     .baz
+     .qux:
+        3 + 3
+<<< #3489 8 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  bar.baz:
+     2 + 2
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar
+     .baz:
+        2 + 2
+     .qux:
+        3 + 3
+<<< #3489 9 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+>>>
+class test:
+   foo.match
+      case bar =>
+        ""
+      case baz =>
+        ""
+<<< #3489 10 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux
+>>>
+class test:
+   foo
+     .match
+        case bar =>
+          ""
+        case baz =>
+          ""
+     .qux
+<<< #3489 11 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux:
+       3 + 3
+>>>
+class test:
+   foo
+     .match
+        case bar =>
+          ""
+        case baz =>
+          ""
+     .qux:
+        3 + 3
+<<< #3489 1 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+    2 + 2
+>>>
+class test:
+   bar:
+      2 + 2
+<<< #3489 2 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  baz.qux:
+    2 + 2
+>>>
+class test:
+   baz.qux:
+      2 + 2
+<<< #3489 3 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  foo.bar:
+    2 + 2
+  .baz
+  .qux
+>>>
+class test:
+   foo
+     .bar:
+        2 + 2
+     .baz
+     .qux
+<<< #3489 4 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+  .qux
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+     .qux
+<<< #3489 5 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+     2 + 2
+    .baz:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz:
+      3 + 3
+<<< #3489 6 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar:
+     2 + 2
+    .baz
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar:
+      2 + 2
+   .baz
+     .qux:
+        3 + 3
+<<< #3489 7 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar (
+     2 + 2
+     )
+    .baz.qux:
+       3 + 3
+>>>
+class test:
+   bar(2 + 2)
+     .baz
+     .qux:
+        3 + 3
+<<< #3489 8 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  bar.baz:
+     2 + 2
+    .qux:
+       3 + 3
+>>>
+class test:
+   bar
+     .baz:
+        2 + 2
+     .qux:
+        3 + 3
+<<< #3489 9 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+>>>
+class test:
+   foo.match
+      case bar =>
+        ""
+      case baz =>
+        ""
+<<< #3489 10 fewerBraces = never
+indent.fewerBraces = never
+===
+class test:
+  foo.match
+     case bar => ""
+     case baz => ""
+  .qux
+>>>
+class test:
+   foo
+     .match
+        case bar =>
+          ""
+        case baz =>
+          ""
+     .qux
+<<< #3489 11 fewerBraces = never
+indent.fewerBraces = never
+===
 class test:
   foo.match
      case bar => ""
@@ -4750,7 +5080,45 @@ extension (s: String)
    /** ... */
    def foo(): Unit = ???
    def bar(): Unit = ???
-<<< #3527
+<<< #3527 fewerBraces = always
+indent.fewerBraces = always
+===
+def foo(xs: List[Int]) =
+  xs.map: x =>
+    x + 1
+  .toSet
+  .filter: x =>
+    x > 0
+  .toList
+>>>
+def foo(xs: List[Int]) =
+  xs.map: x =>
+       x + 1
+    .toSet
+    .filter: x =>
+       x > 0
+    .toList
+<<< #3527 fewerBraces = beforeSelect
+indent.fewerBraces = beforeSelect
+===
+def foo(xs: List[Int]) =
+  xs.map: x =>
+    x + 1
+  .toSet
+  .filter: x =>
+    x > 0
+  .toList
+>>>
+def foo(xs: List[Int]) =
+  xs.map: x =>
+       x + 1
+    .toSet
+    .filter: x =>
+       x > 0
+    .toList
+<<< #3527 fewerBraces = never
+indent.fewerBraces = never
+===
 def foo(xs: List[Int]) =
   xs.map: x =>
     x + 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -3988,7 +3988,7 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
+        2 + 2
 <<< #3489 2 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -3998,7 +3998,7 @@ class test:
 >>>
 class test:
    baz.qux:
-      2 + 2
+        2 + 2
 <<< #3489 3 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -4022,8 +4022,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 5 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -4035,9 +4035,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz:
-      3 + 3
+        2 + 2
+     .baz:
+        3 + 3
 <<< #3489 6 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -4049,8 +4049,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
      .qux:
         3 + 3
 <<< #3489 7 fewerBraces = always
@@ -4093,10 +4093,10 @@ class test:
 >>>
 class test:
    foo.match
-      case bar =>
-        ""
-      case baz =>
-        ""
+        case bar =>
+          ""
+        case baz =>
+          ""
 <<< #3489 10 fewerBraces = always
 indent.fewerBraces = always
 ===
@@ -4176,8 +4176,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
 <<< #3489 5 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4189,9 +4189,9 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz:
-      3 + 3
+        2 + 2
+     .baz:
+        3 + 3
 <<< #3489 6 fewerBraces = beforeSelect
 indent.fewerBraces = beforeSelect
 ===
@@ -4203,8 +4203,8 @@ class test:
 >>>
 class test:
    bar:
-      2 + 2
-   .baz
+        2 + 2
+     .baz
      .qux:
         3 + 3
 <<< #3489 7 fewerBraces = beforeSelect


### PR DESCRIPTION
Now that dotty compiler supports indented fewer-braces chains since v3.3.1-RC1, let's implement this formatting. For #3489.