### PR TITLE
Use explicit type annotation in implicit defs

### DIFF
--- a/scalafmt-config/jvm/src/main/scala/org/scalafmt/config/PlatformConfig.scala
+++ b/scalafmt-config/jvm/src/main/scala/org/scalafmt/config/PlatformConfig.scala
@@ -1,6 +1,8 @@
 package org.scalafmt.config
 
+import metaconfig.MetaconfigParser
+
 object PlatformConfig {
-  implicit val parser =
+  implicit val parser: MetaconfigParser =
     metaconfig.typesafeconfig.typesafeConfigMetaconfigParser
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -122,7 +122,7 @@ object Align {
   val more: Align = some.copy(tokens = AlignToken.default)
   implicit lazy val surface: Surface[Align] = generic.deriveSurface[Align]
   implicit lazy val encoder: ConfEncoder[Align] = generic.deriveEncoder
-  implicit lazy val decoder =
+  implicit lazy val decoder: ConfDecoderEx[Align] =
     Presets.mapDecoder(generic.deriveDecoderEx(default).noTypos, "align")
 
   // only for the truest vertical aligners, this setting is open for changes,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
@@ -49,8 +49,8 @@ object AlignToken {
     def getMatcher: Matcher =
       new Matcher(regex.map(pattern), parents.map(pattern))
   }
-  implicit val ownerSurface = generic.deriveSurface[Owner]
-  implicit val ownerCodec = generic.deriveCodecEx(Owner())
+  implicit val ownerSurface: Surface[Owner] = generic.deriveSurface[Owner]
+  implicit val ownerCodec: ConfCodecEx[Owner] = generic.deriveCodecEx(Owner())
 
   implicit lazy val surface: Surface[AlignToken] =
     generic.deriveSurface[AlignToken]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/BinPack.scala
@@ -75,7 +75,7 @@ object BinPack {
     parentConstructors = ParentCtors.Always
   )
 
-  implicit val decoder =
+  implicit val decoder: ConfDecoderEx[BinPack] =
     Presets.mapDecoder(generic.deriveDecoderEx(BinPack()).noTypos, "binPack") {
       case Conf.Bool(true) => enabled
       case Conf.Bool(false) => BinPack()

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Comments.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Comments.scala
@@ -26,7 +26,8 @@ object Comments {
 
   implicit val surface: generic.Surface[Comments] =
     generic.deriveSurface[Comments]
-  implicit val codec = generic.deriveCodecEx(Comments()).noTypos
+  implicit val codec: ConfCodecEx[Comments] =
+    generic.deriveCodecEx(Comments()).noTypos
 
   sealed abstract class Wrap
   object Wrap {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
@@ -51,7 +51,8 @@ object Docstrings {
 
   implicit val surface: generic.Surface[Docstrings] =
     generic.deriveSurface[Docstrings]
-  implicit val codec = generic.deriveCodecEx(Docstrings()).noTypos
+  implicit val codec: ConfCodecEx[Docstrings] =
+    generic.deriveCodecEx(Docstrings()).noTypos
 
   sealed abstract class Style {
     def skipFirstLine: Boolean

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -82,7 +82,7 @@ object IndentOperator {
   implicit lazy val encoder: ConfEncoder[IndentOperator] =
     generic.deriveEncoder
 
-  implicit val decoder = Presets.mapDecoder(
+  implicit val decoder: ConfDecoderEx[IndentOperator] = Presets.mapDecoder(
     generic.deriveDecoderEx(default).noTypos,
     "indentOperator"
   ) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/NamedDialect.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/NamedDialect.scala
@@ -1,5 +1,7 @@
 package org.scalafmt.config
 
+import metaconfig.ConfCodecEx
+
 import scala.meta.Dialect
 import scala.meta.dialects._
 
@@ -44,7 +46,7 @@ object NamedDialect {
       |""".stripMargin
   }
 
-  implicit val codec =
+  implicit val codec: ConfCodecEx[NamedDialect] =
     ReaderUtil.oneOf(known.map(x => sourcecode.Text(x, x.name)): _*)
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -486,9 +486,10 @@ object Newlines {
     def isEmpty: Boolean = before == 0 && after == 0
   }
   object NumBlanks {
-    implicit val surface = generic.deriveSurface[NumBlanks]
-    implicit val encoder = generic.deriveEncoder[NumBlanks]
-    implicit val decoder = {
+    implicit val surface: Surface[NumBlanks] = generic.deriveSurface[NumBlanks]
+    implicit val encoder: ConfEncoder[NumBlanks] =
+      generic.deriveEncoder[NumBlanks]
+    implicit val decoder: ConfDecoderEx[NumBlanks] = {
       val base = generic.deriveDecoderEx(NumBlanks()).noTypos
       ConfDecoderEx.from[NumBlanks] {
         case (_, Conf.Num(num)) if num.isWhole =>
@@ -519,7 +520,8 @@ object Newlines {
     lazy val pattern = regex.map(_.r.pattern)
   }
   object TopStatBlanks {
-    implicit val surface = generic.deriveSurface[TopStatBlanks]
+    implicit val surface: Surface[TopStatBlanks] =
+      generic.deriveSurface[TopStatBlanks]
     implicit val codec: ConfCodecEx[TopStatBlanks] =
       generic.deriveCodecEx(TopStatBlanks()).noTypos
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtParser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtParser.scala
@@ -1,5 +1,7 @@
 package org.scalafmt.config
 
+import metaconfig.ConfCodecEx
+
 import scala.meta._
 import scala.meta.parsers.Parse
 import scala.meta.parsers.Parsed
@@ -11,7 +13,8 @@ object ScalafmtParser {
   case object Stat extends ScalafmtParser(Parse.parseStat)
   case object Source extends ScalafmtParser(SourceParser)
 
-  implicit val codec = ReaderUtil.oneOf[ScalafmtParser](Case, Stat, Source)
+  implicit val codec: ConfCodecEx[ScalafmtParser] =
+    ReaderUtil.oneOf[ScalafmtParser](Case, Stat, Source)
 
   private object SourceParser extends Parse[Tree] {
     override def apply(input: Input, dialect: Dialect): Parsed[Tree] = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -26,8 +26,8 @@ private class BestFirstSearch private (
   import formatOps._
   import formatOps.runner.optimizer._
 
-  implicit val stateOrdering = State.Ordering
-  implicit val tokens = formatOps.tokens
+  implicit val stateOrdering: Ordering[State] = State.Ordering
+  implicit val tokens: FormatTokens = formatOps.tokens
 
   /** Precomputed table of splits for each token.
     */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -39,7 +39,7 @@ class FormatOps(
     getStyleAndOwners(topSourceTree, baseStyle)
 
   val runner: ScalafmtRunner = initStyle.runner
-  implicit val dialect = initStyle.dialect
+  implicit val dialect: Dialect = initStyle.dialect
   val (tokens, styleMap) = FormatTokens(topSourceTree.tokens, owners)(initStyle)
   import tokens.{
     matching,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -434,7 +434,7 @@ class FormatWriter(formatOps: FormatOps) {
 
     class Entry(val i: Int) {
       val curr = locations(i)
-      private implicit val style = curr.style
+      private implicit val style: ScalafmtConfig = curr.style
       def previous = locations(math.max(i - 1, 0))
 
       @inline def tok = curr.formatToken

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -17,7 +17,7 @@ case class RewriteCtx(
     input: Input,
     tree: Tree
 ) {
-  implicit val dialect = style.dialect
+  implicit val dialect: Dialect = style.dialect
 
   private val patchBuilder = mutable.Map.empty[(Int, Int), TokenPatch]
 
@@ -111,7 +111,7 @@ abstract class RewriteFactory extends Rewrite {
 
 abstract class RewriteSession(implicit ctx: RewriteCtx) {
   def rewrite(tree: Tree): Unit
-  implicit val dialect = ctx.dialect
+  implicit val dialect: Dialect = ctx.dialect
 }
 
 object RewriteSession {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -1,6 +1,6 @@
 package org.scalafmt.rewrite
 
-import org.scalafmt.config.RewriteSettings
+import org.scalafmt.config.{RewriteSettings, SortSettings}
 import org.scalafmt.util.TreeOps
 
 import scala.meta._
@@ -16,7 +16,8 @@ object SortModifiers extends RewriteFactory {
 
 class SortModifiers(implicit ctx: RewriteCtx) extends RewriteSession {
 
-  private implicit val order = ctx.style.rewrite.sortModifiers.order
+  private val order: Seq[SortSettings.ModKey] =
+    ctx.style.rewrite.sortModifiers.order
 
   override def rewrite(tree: Tree): Unit =
     tree match {


### PR DESCRIPTION
Causes warnings in recent versions of 2.13 compiler.