### PR TITLE
RemoveScala3OptionalBraces: handle infix on rbrace

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5004,6 +5004,27 @@ object A:
    new Foo("xyz"):
       print("msg")
    .bar()
+<<< match inside infix chain, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  withEval.so(evalComment so { c =>
+    s"($c) "
+  }) +
+  this.match {
+    case MateAdvice(seq, _, _, _) => seq.desc
+    case CpAdvice(judgment, _, _) => judgment.toString
+  } + "."
+}
+>>>
+object a:
+   withEval.so(evalComment so { c =>
+     s"($c) "
+   }) +
+     this.match
+        case MateAdvice(seq, _, _, _) => seq.desc
+        case CpAdvice(judgment, _, _) => judgment.toString
+     + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5043,3 +5064,59 @@ def foo(url: String) =
     .map { img =>
       Html(s"""<img class="embed" src="$img" alt="$url"/>""")
     }
+<<< new anon as infix lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  } mapFutureList pager.withChaptersAndLiking(me)
+}
+>>>
+test does not parse
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) =
+        api.search(query, From(offset), Size(length))
+     mapFutureList pager.withChaptersAndLiking(me)
+                        ^
+<<< new anon as postfix lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  } mapFutureList
+}
+>>>
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) =
+        api.search(query, From(offset), Size(length))
+   mapFutureList
+<<< new anon as select lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  }.mapFutureList
+}
+>>>
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) =
+        api.search(query, From(offset), Size(length))
+   .mapFutureList

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5021,10 +5021,10 @@ object a:
    withEval.so(evalComment so { c =>
      s"($c) "
    }) +
-     this.match
-        case MateAdvice(seq, _, _, _) => seq.desc
-        case CpAdvice(judgment, _, _) => judgment.toString
-     + "."
+     this.match {
+       case MateAdvice(seq, _, _, _) => seq.desc
+       case CpAdvice(judgment, _, _) => judgment.toString
+     } + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5075,15 +5075,13 @@ object a {
   } mapFutureList pager.withChaptersAndLiking(me)
 }
 >>>
-test does not parse
 object a:
-   new AdapterLike[Study]:
-      def query = Query(text take 100, me.map(_.id))
-      def nbResults = api count query
-      def slice(offset: Int, length: Int) =
-        api.search(query, From(offset), Size(length))
-     mapFutureList pager.withChaptersAndLiking(me)
-                        ^
+   new AdapterLike[Study] {
+     def query = Query(text take 100, me.map(_.id))
+     def nbResults = api count query
+     def slice(offset: Int, length: Int) =
+       api.search(query, From(offset), Size(length))
+   } mapFutureList pager.withChaptersAndLiking(me)
 <<< new anon as postfix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5096,12 +5094,12 @@ object a {
 }
 >>>
 object a:
-   new AdapterLike[Study]:
-      def query = Query(text take 100, me.map(_.id))
-      def nbResults = api count query
-      def slice(offset: Int, length: Int) =
-        api.search(query, From(offset), Size(length))
-   mapFutureList
+   new AdapterLike[Study] {
+     def query = Query(text take 100, me.map(_.id))
+     def nbResults = api count query
+     def slice(offset: Int, length: Int) =
+       api.search(query, From(offset), Size(length))
+   } mapFutureList
 <<< new anon as select lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -4803,10 +4803,10 @@ object a {
 }
 >>>
 object a:
-   withEval.so(evalComment so { c => s"($c) " }) + this.match
-      case MateAdvice(seq, _, _, _) => seq.desc
-      case CpAdvice(judgment, _, _) => judgment.toString
-   + "."
+   withEval.so(evalComment so { c => s"($c) " }) + this.match {
+     case MateAdvice(seq, _, _, _) => seq.desc
+     case CpAdvice(judgment, _, _) => judgment.toString
+   } + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -4851,15 +4851,13 @@ object a {
   } mapFutureList pager.withChaptersAndLiking(me)
 }
 >>>
-test does not parse
 object a:
-   new AdapterLike[Study]:
-      def query = Query(text take 100, me.map(_.id))
-      def nbResults = api count query
-      def slice(offset: Int, length: Int) = api
-        .search(query, From(offset), Size(length))
-   mapFutureList pager.withChaptersAndLiking(me)
-                      ^
+   new AdapterLike[Study] {
+     def query = Query(text take 100, me.map(_.id))
+     def nbResults = api count query
+     def slice(offset: Int, length: Int) = api
+       .search(query, From(offset), Size(length))
+   } mapFutureList pager.withChaptersAndLiking(me)
 <<< new anon as postfix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -4872,12 +4870,12 @@ object a {
 }
 >>>
 object a:
-   new AdapterLike[Study]:
-      def query = Query(text take 100, me.map(_.id))
-      def nbResults = api count query
-      def slice(offset: Int, length: Int) = api
-        .search(query, From(offset), Size(length))
-   mapFutureList
+   new AdapterLike[Study] {
+     def query = Query(text take 100, me.map(_.id))
+     def nbResults = api count query
+     def slice(offset: Int, length: Int) = api
+       .search(query, From(offset), Size(length))
+   } mapFutureList
 <<< new anon as select lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -4789,6 +4789,24 @@ object A:
    new Foo("xyz"):
       print("msg")
    .bar()
+<<< match inside infix chain, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  withEval.so(evalComment so { c =>
+    s"($c) "
+  }) +
+  this.match {
+    case MateAdvice(seq, _, _, _) => seq.desc
+    case CpAdvice(judgment, _, _) => judgment.toString
+  } + "."
+}
+>>>
+object a:
+   withEval.so(evalComment so { c => s"($c) " }) + this.match
+      case MateAdvice(seq, _, _, _) => seq.desc
+      case CpAdvice(judgment, _, _) => judgment.toString
+   + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -4822,3 +4840,59 @@ def foo(url: String) = url.match
    case "foo" => Some("")
    case _     => None
 .map { img => Html(s"""<img class="embed" src="$img" alt="$url"/>""") }
+<<< new anon as infix lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  } mapFutureList pager.withChaptersAndLiking(me)
+}
+>>>
+test does not parse
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) = api
+        .search(query, From(offset), Size(length))
+   mapFutureList pager.withChaptersAndLiking(me)
+                      ^
+<<< new anon as postfix lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  } mapFutureList
+}
+>>>
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) = api
+        .search(query, From(offset), Size(length))
+   mapFutureList
+<<< new anon as select lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  }.mapFutureList
+}
+>>>
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) = api
+        .search(query, From(offset), Size(length))
+   .mapFutureList

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5036,6 +5036,27 @@ object A:
    new Foo("xyz"):
       print("msg")
    .bar()
+<<< match inside infix chain, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  withEval.so(evalComment so { c =>
+    s"($c) "
+  }) +
+  this.match {
+    case MateAdvice(seq, _, _, _) => seq.desc
+    case CpAdvice(judgment, _, _) => judgment.toString
+  } + "."
+}
+>>>
+object a:
+   withEval.so(evalComment so { c =>
+     s"($c) "
+   }) +
+     this.match
+        case MateAdvice(seq, _, _, _) => seq.desc
+        case CpAdvice(judgment, _, _) => judgment.toString
+     + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5074,3 +5095,59 @@ def foo(url: String) =
   .map { img =>
     Html(s"""<img class="embed" src="$img" alt="$url"/>""")
   }
+<<< new anon as infix lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  } mapFutureList pager.withChaptersAndLiking(me)
+}
+>>>
+test does not parse
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) =
+        api.search(query, From(offset), Size(length))
+     mapFutureList pager.withChaptersAndLiking(me)
+                        ^
+<<< new anon as postfix lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  } mapFutureList
+}
+>>>
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) =
+        api.search(query, From(offset), Size(length))
+   mapFutureList
+<<< new anon as select lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  }.mapFutureList
+}
+>>>
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) =
+        api.search(query, From(offset), Size(length))
+   .mapFutureList

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5053,10 +5053,10 @@ object a:
    withEval.so(evalComment so { c =>
      s"($c) "
    }) +
-     this.match
-        case MateAdvice(seq, _, _, _) => seq.desc
-        case CpAdvice(judgment, _, _) => judgment.toString
-     + "."
+     this.match {
+       case MateAdvice(seq, _, _, _) => seq.desc
+       case CpAdvice(judgment, _, _) => judgment.toString
+     } + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5106,15 +5106,13 @@ object a {
   } mapFutureList pager.withChaptersAndLiking(me)
 }
 >>>
-test does not parse
 object a:
-   new AdapterLike[Study]:
-      def query = Query(text take 100, me.map(_.id))
-      def nbResults = api count query
-      def slice(offset: Int, length: Int) =
-        api.search(query, From(offset), Size(length))
-     mapFutureList pager.withChaptersAndLiking(me)
-                        ^
+   new AdapterLike[Study] {
+     def query = Query(text take 100, me.map(_.id))
+     def nbResults = api count query
+     def slice(offset: Int, length: Int) =
+       api.search(query, From(offset), Size(length))
+   } mapFutureList pager.withChaptersAndLiking(me)
 <<< new anon as postfix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5127,12 +5125,12 @@ object a {
 }
 >>>
 object a:
-   new AdapterLike[Study]:
-      def query = Query(text take 100, me.map(_.id))
-      def nbResults = api count query
-      def slice(offset: Int, length: Int) =
-        api.search(query, From(offset), Size(length))
-   mapFutureList
+   new AdapterLike[Study] {
+     def query = Query(text take 100, me.map(_.id))
+     def nbResults = api count query
+     def slice(offset: Int, length: Int) =
+       api.search(query, From(offset), Size(length))
+   } mapFutureList
 <<< new anon as select lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -5176,12 +5176,12 @@ object a:
        s"($c) "
      }
    ) +
-     this.match
-        case MateAdvice(seq, _, _, _) =>
-          seq.desc
-        case CpAdvice(judgment, _, _) =>
-          judgment.toString
-     + "."
+     this.match {
+       case MateAdvice(seq, _, _, _) =>
+         seq.desc
+       case CpAdvice(judgment, _, _) =>
+         judgment.toString
+     } + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5236,15 +5236,13 @@ object a {
   } mapFutureList pager.withChaptersAndLiking(me)
 }
 >>>
-test does not parse
 object a:
-   new AdapterLike[Study]:
-      def query = Query(text take 100, me.map(_.id))
-      def nbResults = api count query
-      def slice(offset: Int, length: Int) = api
-        .search(query, From(offset), Size(length))
-   mapFutureList pager.withChaptersAndLiking(me)
-                      ^
+   new AdapterLike[Study] {
+     def query = Query(text take 100, me.map(_.id))
+     def nbResults = api count query
+     def slice(offset: Int, length: Int) = api
+       .search(query, From(offset), Size(length))
+   } mapFutureList pager.withChaptersAndLiking(me)
 <<< new anon as postfix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5257,12 +5255,12 @@ object a {
 }
 >>>
 object a:
-   new AdapterLike[Study]:
-      def query = Query(text take 100, me.map(_.id))
-      def nbResults = api count query
-      def slice(offset: Int, length: Int) = api
-        .search(query, From(offset), Size(length))
-   mapFutureList
+   new AdapterLike[Study] {
+     def query = Query(text take 100, me.map(_.id))
+     def nbResults = api count query
+     def slice(offset: Int, length: Int) = api
+       .search(query, From(offset), Size(length))
+   } mapFutureList
 <<< new anon as select lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -5157,6 +5157,31 @@ object A:
    new Foo("xyz"):
       print("msg")
    .bar()
+<<< match inside infix chain, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  withEval.so(evalComment so { c =>
+    s"($c) "
+  }) +
+  this.match {
+    case MateAdvice(seq, _, _, _) => seq.desc
+    case CpAdvice(judgment, _, _) => judgment.toString
+  } + "."
+}
+>>>
+object a:
+   withEval.so(
+     evalComment so { c =>
+       s"($c) "
+     }
+   ) +
+     this.match
+        case MateAdvice(seq, _, _, _) =>
+          seq.desc
+        case CpAdvice(judgment, _, _) =>
+          judgment.toString
+     + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===
@@ -5200,3 +5225,59 @@ def foo(url: String) =
     .map { img =>
       Html(s"""<img class="embed" src="$img" alt="$url"/>""")
     }
+<<< new anon as infix lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  } mapFutureList pager.withChaptersAndLiking(me)
+}
+>>>
+test does not parse
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) = api
+        .search(query, From(offset), Size(length))
+   mapFutureList pager.withChaptersAndLiking(me)
+                      ^
+<<< new anon as postfix lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  } mapFutureList
+}
+>>>
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) = api
+        .search(query, From(offset), Size(length))
+   mapFutureList
+<<< new anon as select lhs, with rewrite
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a {
+  new AdapterLike[Study] {
+    def query                           = Query(text take 100, me.map(_.id))
+    def nbResults                       = api count query
+    def slice(offset: Int, length: Int) = api.search(query, From(offset), Size(length))
+  }.mapFutureList
+}
+>>>
+object a:
+   new AdapterLike[Study]:
+      def query = Query(text take 100, me.map(_.id))
+      def nbResults = api count query
+      def slice(offset: Int, length: Int) = api
+        .search(query, From(offset), Size(length))
+   .mapFutureList


### PR DESCRIPTION
Instead of handling a specific owner of the left brace (previously, it was a Term.Match only), let's instead look for infix when we encounter the right brace instead, and ensure that the next token is not the op of an infix.

This also handles the case when Term.Match was not an LHS but in the middle of an infix chain.

Follow-on to #3573.