### PR TITLE
Router: use template to break before `extends`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -374,6 +374,13 @@ class FormatOps(
     new Policy.Delay(policy, Policy.End.Before(from))
   }
 
+  val WithTemplateOnLeft = new ExtractFromMeta(ft =>
+    ft.meta.leftOwner match {
+      case lo: Stat.WithTemplate => Some(lo.templ)
+      case _ => None
+    }
+  )
+
   def templateCurlyFt(template: Template): Option[FormatToken] =
     getStartOfTemplateBody(template).map(tokenBefore)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -123,16 +123,6 @@ object TokenOps {
       case _ => None
     }
 
-  def defnBeforeTemplate(tree: Tree): Option[Tree] =
-    tree match {
-      case t: Defn.Object => Some(t.name)
-      case t: Defn.Class => Some(t.ctor)
-      case t: Defn.Trait => Some(t.ctor)
-      case t: Defn.Enum => Some(t.ctor)
-      case t: Pkg.Object => Some(t.name)
-      case _ => None
-    }
-
   val formatOnCode = Set(
     "@formatter:on", // IntelliJ
     "format: on" // scalariform


### PR DESCRIPTION
In older versions of scalameta, `extends` was not part of template, and we had to identify the tree just preceding it.

Also, make sure to handle cases when the template is empty (in that case there's no reason to break before a non-existent `extends`).

Fixes #3580.