### PR TITLE
TreeOps: skip empty types in defDefReturnType

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -350,7 +350,7 @@ object TreeOps {
   }
 
   @tailrec
-  def defDefReturnType(tree: Tree): Option[Type] =
+  private def defDefReturnTypeImpl(tree: Tree): Option[Type] =
     tree match {
       case d: Decl.Def => Some(d.decltpe)
       case d: Defn.Def => d.decltpe
@@ -363,11 +363,14 @@ object TreeOps {
       case _: Pat.Var | _: Term.Name | _: Member.ParamClause |
           _: Member.ParamClauseGroup =>
         tree.parent match {
-          case Some(p) => defDefReturnType(p)
+          case Some(p) => defDefReturnTypeImpl(p)
           case _ => None
         }
       case _ => None
     }
+  def defDefReturnType(tree: Tree): Option[Type] =
+    defDefReturnTypeImpl(tree).filter(!_.pos.isEmpty)
+
   val DefDefReturnTypeLeft =
     new FormatToken.ExtractFromMeta(x => defDefReturnType(x.leftOwner))
   val DefDefReturnTypeRight =


### PR DESCRIPTION
Historically, the parser returns `Type.Name("Unit")` for declarations or definitions using the procedure syntax (i.e., no explicit `: type`).

However, that tree occupies no tokens and hence needs to be ignored.