### PR TITLE
Remove use of deprecated PlatformTokenizerCache

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -8,7 +8,6 @@ import org.scalafmt.{Formatted, Scalafmt, Versions}
 import org.scalafmt.config.{ProjectFiles, ScalafmtConfig}
 import org.scalafmt.CompatCollections.ParConverters._
 
-import scala.meta.internal.tokenizers.PlatformTokenizerCache
 import scala.meta.parsers.ParseException
 import scala.meta.tokenizers.TokenizeException
 
@@ -36,7 +35,6 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
           val code = handleFile(inputMethod, options, scalafmtConf)
           exitCode.getAndUpdate(ExitCode.merge(code, _))
           if (options.check && !code.isOk) Breaks.break
-          PlatformTokenizerCache.megaCache.clear()
           termDisplay.taskProgress(termDisplayMessage)
         }
       }

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
@@ -10,7 +10,6 @@ import org.scalafmt.interfaces.Scalafmt
 import org.scalafmt.interfaces.ScalafmtSession
 import org.scalafmt.sysops.FileOps
 
-import scala.meta.internal.tokenizers.PlatformTokenizerCache
 import util.control.Breaks._
 
 object ScalafmtDynamicRunner extends ScalafmtRunner {
@@ -53,7 +52,6 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
             reporter.error(e.file, e)
             if (options.check) break
         }
-        PlatformTokenizerCache.megaCache.clear()
         termDisplay.taskProgress(termDisplayMessage)
       }
     }

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -122,7 +122,10 @@ case class ScalafmtReflect(
         case _ =>
           formatMethod.invoke(null, code, config.target, emptyRange)
       }
-      clearTokenizerCache()
+      if (version < ScalafmtVersion(2, 3, 0))
+        moduleInstance("scala.meta.internal.tokenizers.PlatformTokenizerCache$")
+          .invoke("megaCache")
+          .invoke("clear")
       formattedGet.invoke(formatted).asInstanceOf[String]
     }.recoverWith {
       case ReflectionException(e)
@@ -166,13 +169,6 @@ case class ScalafmtReflect(
           end.invokeAs[Int]("column")
         )
     }
-  }
-
-  private def clearTokenizerCache(): Unit = {
-    val cache = moduleInstance(
-      "scala.meta.internal.tokenizers.PlatformTokenizerCache$"
-    )
-    cache.invoke("megaCache").invoke("clear")
   }
 
   private def moduleInstance(fqn: String): Object = {


### PR DESCRIPTION
It was deprecated in scalameta 4.3.0, used since 2.3.0-RC2.