### PR TITLE
PolicyOps: use `newlines.ignoreInSyntax`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2576,6 +2576,44 @@ newlines.inInterpolation
 - `avoid`: attemps to avoid breaks within the spliced code, regardless of line overflow
 - `oneline`: formats the splice on a single line, or breaks after `${` if overflows
 
+### `newlines.ignoreInSyntax`
+
+The formatter frequently chooses between adding a newline and continuing the
+same line but either prohibiting or heavily discouraging subsequent newlines
+_between_ tokens, to fit the rest of the expression on the same line.
+
+However, in many cases and, for historical reasons, intentionally, newlines
+_within_ tokens have been frequently ignored, leading to "single-line" blocks
+which actually span multiple lines.
+
+This boolean parameter now allows controlling whether to ignore newlines found
+in syntax of strings or other possibly multi-line tokens when newlines are
+otherwise prohibited or undesirable (such as for single-line formatting).
+
+```scala mdoc:defaults
+newlines.ignoreInSyntax
+```
+
+> Since v3.7.13. Prior to that, this behaviour was always enabled.
+
+```scala mdoc:scalafmt
+newlines.ignoreInSyntax = true
+---
+// ignores newline in string, pretends everything fits on one line
+println(s"""${1}
+    """.stripMargin
+)
+```
+
+```scala mdoc:scalafmt
+newlines.ignoreInSyntax = false
+---
+// detects newline in string, forces proper multi-line formatting
+println(s"""${1}
+    """.stripMargin
+)
+```
+
 ### `optIn.annotationNewlines`
 
 This boolean parameter controls newlines after annotations.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -202,6 +202,7 @@ case class Newlines(
     afterInfixMaxCountPerFile: Int = 500,
     avoidForSimpleOverflow: Seq[AvoidForSimpleOverflow] = Seq.empty,
     inInterpolation: InInterpolation = InInterpolation.allow,
+    ignoreInSyntax: Boolean = true,
     avoidAfterYield: Boolean = true
 ) {
   if (

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1687,7 +1687,7 @@ class FormatOps(
         nlSplitFunc: Int => Split,
         isKeep: Boolean,
         spaceIndents: Seq[Indent] = Seq.empty
-    ): Seq[Split] = {
+    )(implicit style: ScalafmtConfig): Seq[Split] = {
       def bheadFT = tokens.getHead(body)
       val blastFT = tokens.getLastNonTrivial(body)
       val blast = blastFT.left
@@ -1788,14 +1788,14 @@ class FormatOps(
         nlSplitFunc: Int => Split,
         isKeep: Boolean,
         spaceIndents: Seq[Indent]
-    ): Seq[Split] =
+    )(implicit style: ScalafmtConfig): Seq[Split] =
       if (body.tokens.isEmpty) Seq(Split(Space, 0))
       else foldedNonEmptyNonComment(body, nlSplitFunc, isKeep, spaceIndents)
 
     private def unfoldedSpaceNonEmptyNonComment(
         body: Tree,
         slbOnly: Boolean
-    ): Split = {
+    )(implicit style: ScalafmtConfig): Split = {
       val expire = nextNonCommentSameLine(tokens.getLastNonTrivial(body)).left
       def slbSplit(end: T)(implicit fileLine: FileLine) =
         Split(Space, 0).withSingleLine(end, noSyntaxNL = true)
@@ -1816,7 +1816,7 @@ class FormatOps(
         nlSplitFunc: Int => Split,
         spaceIndents: Seq[Indent],
         slbOnly: Boolean
-    ): Seq[Split] =
+    )(implicit style: ScalafmtConfig): Seq[Split] =
       if (body.tokens.isEmpty) Seq(Split(Space, 0).withIndents(spaceIndents))
       else {
         val spaceSplit = unfoldedSpaceNonEmptyNonComment(body, slbOnly)
@@ -1848,7 +1848,7 @@ class FormatOps(
         body: Tree,
         isKeep: Boolean,
         spaceIndents: Seq[Indent] = Seq.empty
-    )(nlSplitFunc: Int => Split): Seq[Split] =
+    )(nlSplitFunc: Int => Split)(implicit style: ScalafmtConfig): Seq[Split] =
       checkComment(ft, nlSplitFunc) { _ =>
         foldedNonComment(body, nlSplitFunc, isKeep, spaceIndents)
       }
@@ -1857,7 +1857,7 @@ class FormatOps(
         ft: FormatToken,
         body: Tree,
         spaceIndents: Seq[Indent] = Seq.empty
-    )(nlSplitFunc: Int => Split): Seq[Split] =
+    )(nlSplitFunc: Int => Split)(implicit style: ScalafmtConfig): Seq[Split] =
       checkComment(ft, nlSplitFunc) { _ =>
         unfoldedNonComment(body, nlSplitFunc, spaceIndents, true)
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -2,6 +2,7 @@ package org.scalafmt.internal
 
 import scala.meta.tokens.Token
 
+import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.Policy.NoPolicy
 import org.scalafmt.util.PolicyOps
 import org.scalameta.FileLine
@@ -142,7 +143,7 @@ case class Split(
       noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false,
       rank: Int = 0
-  )(implicit fileLine: FileLine): Split =
+  )(implicit fileLine: FileLine, style: ScalafmtConfig): Split =
     withSingleLineAndOptimal(
       expire,
       expire,
@@ -158,7 +159,7 @@ case class Split(
       noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false,
       rank: Int = 0
-  )(implicit fileLine: FileLine): Split =
+  )(implicit fileLine: FileLine, style: ScalafmtConfig): Split =
     expire.fold(this)(
       withSingleLine(_, exclude, noSyntaxNL, killOnFail, rank)
     )
@@ -170,7 +171,7 @@ case class Split(
       noSyntaxNL: Boolean = false,
       killOnFail: Boolean = false,
       rank: Int = 0
-  )(implicit fileLine: FileLine): Split =
+  )(implicit fileLine: FileLine, style: ScalafmtConfig): Split =
     withOptimalToken(optimal, killOnFail)
       .withSingleLineNoOptimal(expire, exclude, noSyntaxNL, rank)
 
@@ -179,7 +180,7 @@ case class Split(
       exclude: => TokenRanges = TokenRanges.empty,
       noSyntaxNL: Boolean = false,
       rank: Int = 0
-  )(implicit fileLine: FileLine): Split =
+  )(implicit fileLine: FileLine, style: ScalafmtConfig): Split =
     withPolicy(
       SingleLineBlock(expire, exclude, noSyntaxNL = noSyntaxNL, rank = rank)
     )

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -625,7 +625,8 @@ println("""|
   |""".stripMargin
 )
 >>>
-println("""|
-           |A very long string
-           |with multiple lines
-           |""".stripMargin)
+println(
+    """|
+       |A very long string
+       |with multiple lines
+       |""".stripMargin)

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -599,3 +599,33 @@ val s = raw"""${
                  else "else"
                  end if
                }"""
+<<< #3608 ignoreInSyntax
+maxColumn = 30
+assumeStandardLibraryStripMargin = true
+newlines.ignoreInSyntax = true
+===
+println("""|
+  |A very long string
+  |with multiple lines
+  |""".stripMargin
+)
+>>>
+println("""|
+           |A very long string
+           |with multiple lines
+           |""".stripMargin)
+<<< #3608 !ignoreInSyntax
+maxColumn = 30
+assumeStandardLibraryStripMargin = true
+newlines.ignoreInSyntax = false
+===
+println("""|
+  |A very long string
+  |with multiple lines
+  |""".stripMargin
+)
+>>>
+println("""|
+           |A very long string
+           |with multiple lines
+           |""".stripMargin)

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -314,6 +314,18 @@ final class MyClass {
   println(s"""${1}
     """.stripMargin)
 }
+<<< #2025 3 !ignoreInSyntax
+newlines.ignoreInSyntax = false
+===
+final class MyClass {
+    println(s"""${1}
+    """.stripMargin)
+}
+>>>
+final class MyClass {
+  println(s"""${1}
+    """.stripMargin)
+}
 <<< #3090 string without margin
 maxColumn = 100
 optIn.breaksInsideChains = true

--- a/scalafmt-tests/src/test/resources/test/StripMargin.stat
+++ b/scalafmt-tests/src/test/resources/test/StripMargin.stat
@@ -323,8 +323,10 @@ final class MyClass {
 }
 >>>
 final class MyClass {
-  println(s"""${1}
-    """.stripMargin)
+  println(
+    s"""${1}
+    """.stripMargin
+  )
 }
 <<< #3090 string without margin
 maxColumn = 100


### PR DESCRIPTION
Specifically, for PenalizeAllNewlines and SingleLineBlock policies. Fixes #3608.