### PR TITLE
FormatWriter: accumulate align shift correctly

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -948,9 +948,11 @@ Apart from a few special cases, the way alignment works is as follows:
   - both owners belong to the same "statement container"; this is determined
     internally and usually selects the nearest containing block, template,
     match, argument or parameter group.
-- if two tokens match:
-  - if there's a space before them, they themselves will be aligned on the right
-  - if there's a space after them, the next tokens will be aligned on the left
+- for each token that has matches in the surrounding lines:
+  - we'll determine the amount of extra space needed to be added _before_
+    that token, to align it _on the right_ with matching tokens
+  - however, if there was no space before the token, that extra space will be
+    added to the next space on its line, aligning subsequent token _on the left_.
 
 Align has several nested fields, which you can customize. However, it comes with
 four possible presets: none, some, more, & most.

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -2037,3 +2037,37 @@ object ScalaFormatRecreator extends App {
 object ScalaFormatRecreator extends App {
   private var s: String = _
 }
+<<< #3614 spaces.inParentheses
+spaces.inParentheses = true
+align.tokens."+" = [ { code = ":" }, { code = "(" }, { code = ")" }, { code = "=" } ]
+===
+object a {
+  def meeethod1(pram1: AnyRef): Any = ???
+  def methd2(paaaaaram2: Any): Any = ???
+  def meth3(param333333: Any): Any = ???
+  def md4(param4: Any): Any = ???
+}
+>>>
+object a {
+  def meeethod1( pram1:       AnyRef ): Any = ???
+  def methd2(    paaaaaram2:  Any    ): Any = ???
+  def meth3(     param333333: Any    ): Any = ???
+  def md4(       param4:      Any    ): Any = ???
+}
+<<< #3614 !spaces.inParentheses
+spaces.inParentheses = false
+align.tokens."+" = [ { code = ":" }, { code = "(" }, { code = ")" }, { code = "=" } ]
+===
+object a {
+  def meeethod1(pram1: AnyRef): Any = ???
+  def methd2(paaaaaram2: Any): Any = ???
+  def meth3(param333333: Any): Any = ???
+  def md4(param4: Any): Any = ???
+}
+>>>
+object a {
+  def meeethod1(pram1:       AnyRef): Any = ???
+  def methd2(paaaaaram2:  Any): Any = ???
+  def meth3(param333333: Any): Any = ???
+  def md4(param4:      Any): Any = ???
+}

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -2067,7 +2067,7 @@ object a {
 >>>
 object a {
   def meeethod1(pram1:       AnyRef): Any = ???
-  def methd2(paaaaaram2:  Any): Any = ???
-  def meth3(param333333: Any): Any = ???
-  def md4(param4:      Any): Any = ???
+  def methd2(paaaaaram2:     Any):    Any = ???
+  def meth3(param333333:     Any):    Any = ???
+  def md4(param4:            Any):    Any = ???
 }

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -201,8 +201,11 @@ trait HasTests extends FormatAssertions {
     val builder = mutable.ArrayBuilder.make[FormatOutput]
     debug.locations.foreach { entry =>
       val token = entry.curr.formatToken
+      implicit val sb = new StringBuilder()
+      sb.append(token.left.syntax)
+      entry.formatWhitespace(0)
       builder += FormatOutput(
-        token.left.syntax + entry.getWhitespace(0),
+        sb.result(),
         Option(debug.formatTokenExplored).fold(-1)(_(token.meta.idx))
       )
     }


### PR DESCRIPTION
Alignment logic accumulates alignment shift for matching lines, with the assumption that the extra space will definitely be added.

However, we don't add extra spaces to no-split cases, instead attempting to delay them until the next token... but if the next token is also a no-split, then the extra alignment space is lost, leading to incorrect formatting.

One such example is `(` which typically has no spaces before or after.

Helps with #3614.