### PR TITLE
TokenClasses: don't use classifiers

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -931,11 +931,11 @@ class FormatOps(
 
   def functionExpire(function: Term.FunctionTerm): (T, ExpiresOn) = {
     def dropWS(rtoks: Seq[T]): Seq[T] =
-      rtoks.dropWhile(_.is[Whitespace])
+      rtoks.dropWhile(_.is[T.Whitespace])
     def orElse(rtoks: Seq[T]) = {
       val last = rtoks.head
       if (last.is[T.RightParen] && matchingOpt(last).contains(rtoks.last))
-        rtoks.tail.find(!_.is[Whitespace]).get -> ExpiresOn.After
+        rtoks.tail.find(!_.is[T.Whitespace]).get -> ExpiresOn.After
       else
         last -> ExpiresOn.After
     }
@@ -1012,7 +1012,7 @@ class FormatOps(
   def opensConfigStyleImplicitParamList(
       formatToken: FormatToken
   )(implicit style: ScalafmtConfig): Boolean =
-    formatToken.right.is[soft.ImplicitOrUsing] &&
+    soft.ImplicitOrUsing.unapply(formatToken.right) &&
       style.newlines.notBeforeImplicitParamListModifier &&
       hasImplicitParamList(formatToken.meta.rightOwner)
 
@@ -1332,7 +1332,7 @@ class FormatOps(
       val nlSplit = Split(Newline, 1, policy = policy).withIndent(firstIndent)
       Seq(slbSplit, noSplit.andPolicy(noSlbPolicy), nlSplit)
     } else {
-      val rightIsImplicit = r.is[soft.ImplicitOrUsing]
+      val rightIsImplicit = soft.ImplicitOrUsing.unapply(r)
       val implicitNL = rightIsImplicit &&
         style.newlines.forceBeforeImplicitParamListModifier
       val implicitParams = if (rightIsImplicit) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -314,7 +314,7 @@ object FormatTokens {
     val tokCnt = arr.length
     while (tokIdx < tokCnt)
       arr(tokIdx) match {
-        case Whitespace() => tokIdx += 1
+        case _: Token.Whitespace => tokIdx += 1
         case right =>
           process(right)
           tokIdx += 1

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -10,7 +10,6 @@ import org.scalafmt.internal.FormatToken
 import org.scalafmt.internal.FormatTokens
 import org.scalafmt.util.StyleMap
 import org.scalafmt.util.TokenOps
-import org.scalafmt.util.Whitespace
 
 class FormatTokensRewrite(
     ftoks: FormatTokens,
@@ -169,7 +168,7 @@ class FormatTokensRewrite(
 
         case _ if ft.meta.formatOff =>
 
-        case Whitespace() =>
+        case _: T.Whitespace =>
 
         case _ => applyRules
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
@@ -396,7 +396,7 @@ object Imports extends RewriteFactory {
           if (hadLf) Some(true) else { hadLf = true; None }
         case t: Token.Comment if TokenOps.isSingleLineIfComment(t) =>
           slc.prepend(t); hadLf = false; None
-        case Whitespace() => None
+        case _: Token.Whitespace => None
         case _ => if (!hadLf && slc.nonEmpty) slc.remove(0); Some(false)
       }
       slc.result()
@@ -407,7 +407,7 @@ object Imports extends RewriteFactory {
         case _: Token.LF => Some(false)
         case t: Token.Comment if TokenOps.isSingleLineIfComment(t) =>
           Some(true)
-        case Whitespace() | _: Token.Comma => None
+        case _: Token.Whitespace | _: Token.Comma => None
         case _ => Some(false)
       }
   }
@@ -451,7 +451,7 @@ object Imports extends RewriteFactory {
             val nextOff = off - 1
             ctx.tokens(nextOff) match {
               case t: Token.LF => t.input.text.substring(t.end, nonWs.start)
-              case Whitespace() => iter(nextOff, nonWs)
+              case _: Token.Whitespace => iter(nextOff, nonWs)
               case t => iter(nextOff, t)
             }
           }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -42,7 +42,7 @@ object LoggerOps {
 
   def cleanup(token: Token): String =
     token match {
-      case Literal() | Interpolation.Part(_) =>
+      case Token.Literal() | Interpolation.Part(_) =>
         escape(token.syntax).stripPrefix("\"").stripSuffix("\"")
       case _ => token.syntax.replace("\n", "")
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenClasses.scala
@@ -1,121 +1,41 @@
 package org.scalafmt.util
 
 import scala.meta.Dialect
-import scala.meta.internal.classifiers.classifier
 import scala.meta.internal.parsers.SoftKeywords
 import scala.meta.tokens.Token
 import scala.meta.tokens.Token._
 
-@classifier
-trait Keyword
-object Keyword {
-  def unapply(token: Token): Boolean = {
-    token.is[KwAbstract] || token.is[KwCase] || token.is[KwCatch] ||
-    token.is[KwClass] || token.is[KwDef] || token.is[KwDo] ||
-    token.is[KwElse] || token.is[KwEnum] || token.is[KwExport] ||
-    token.is[KwExtends] || token.is[KwFalse] || token.is[KwFinal] ||
-    token.is[KwFinally] || token.is[KwFor] || token.is[KwForsome] ||
-    token.is[KwGiven] || token.is[KwIf] || token.is[KwImplicit] ||
-    token.is[KwImport] || token.is[KwLazy] || token.is[KwMatch] ||
-    token.is[KwMacro] || token.is[KwNew] || token.is[KwNull] ||
-    token.is[KwObject] || token.is[KwOverride] || token.is[KwPackage] ||
-    token.is[KwPrivate] || token.is[KwProtected] || token.is[KwReturn] ||
-    token.is[KwSealed] || token.is[KwSuper] || token.is[KwThis] ||
-    token.is[KwThen] ||
-    token.is[KwThrow] || token.is[KwTrait] || token.is[KwTrue] ||
-    token.is[KwTry] || token.is[KwType] || token.is[KwVal] ||
-    token.is[KwVar] || token.is[KwWhile] || token.is[KwWith] ||
-    token.is[KwYield]
+object Reserved {
+  def unapply(token: Token): Boolean = token match {
+    case _: Keyword | _: KwFalse | _: KwNull | _: KwTrue => true
+    case _ => false
   }
 }
 
-@classifier
-trait Delim
-object Delim {
-  def unapply(token: Token): Boolean = {
-    token.is[Hash] || token.is[Colon] || token.is[Viewbound] ||
-    token.is[LeftArrow] || token.is[Subtype] || token.is[Equals] ||
-    token.is[RightArrow] || token.is[Supertype] || token.is[At] ||
-    token.is[Underscore] || token.is[LeftParen] || token.is[RightParen] ||
-    token.is[Comma] || token.is[Dot] || token.is[Semicolon] ||
-    token.is[LeftBracket] || token.is[RightBracket] || token.is[LeftBrace] ||
-    token.is[RightBrace] || token.is[ContextArrow] || token.is[TypeLambdaArrow]
-  }
-}
-
-@classifier
-trait Modifier
-object Modifier {
-  def unapply(token: Token): Boolean = {
-    token.is[KwAbstract] || token.is[KwFinal] || token.is[KwSealed] ||
-    token.is[KwImplicit] || token.is[KwLazy] || token.is[KwPrivate] ||
-    token.is[KwProtected] || token.is[KwOverride]
-  }
-}
-
-@classifier
-trait Literal
-object Literal {
-  def unapply(token: Token): Boolean = {
-    token.is[Constant.Int] || token.is[Constant.Long] ||
-    token.is[Constant.Float] || token.is[Constant.Double] ||
-    token.is[Constant.Char] || token.is[Constant.Symbol] ||
-    token.is[Constant.String] || token.is[KwNull] || token.is[KwTrue] ||
-    token.is[KwFalse]
-  }
-}
-
-@classifier
-trait Whitespace
-object Whitespace {
-  def unapply(token: Token): Boolean = {
-    token.is[Space] || token.is[Tab] || token.is[CR] || token.is[LF] ||
-    token.is[FF]
-  }
-}
-
-@classifier
-trait Trivia
-object Trivia {
-  def unapply(token: Token): Boolean = {
-    token.is[Whitespace] || token.is[Comment]
-  }
-}
-
-@classifier
-trait LeftParenOrBracket
 object LeftParenOrBracket {
   def unapply(tok: Token): Boolean =
     tok.is[LeftParen] || tok.is[LeftBracket]
 }
 
-@classifier
-trait RightParenOrBracket
 object RightParenOrBracket {
   def unapply(tok: Token): Boolean =
     tok.is[RightParen] || tok.is[RightBracket]
 }
 
-@classifier
-trait LeftParenOrBrace
 object LeftParenOrBrace {
   def unapply(tok: Token): Boolean = tok.is[LeftParen] || tok.is[LeftBrace]
 }
 
 class SoftKeywordClasses(dialect: Dialect) extends SoftKeywords(dialect) {
-  @classifier
-  trait ImplicitOrUsing
   object ImplicitOrUsing {
     def unapply(tok: Token): Boolean = {
-      tok.is[KwImplicit] || tok.is[KwUsing]
+      tok.is[KwImplicit] || KwUsing.unapply(tok)
     }
   }
 
-  @classifier
-  trait ExtendsOrDerives
   object ExtendsOrDerives {
     def unapply(tok: Token): Boolean = {
-      tok.is[KwExtends] || tok.is[KwDerives]
+      tok.is[KwExtends] || KwDerives.unapply(tok)
     }
   }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -126,6 +126,6 @@ class TokenTraverser(tokens: Tokens, input: Input) {
 object TokenTraverser {
 
   private def isTrivialPred(token: Token): Option[Boolean] =
-    if (token.is[Trivia]) None else Some(true)
+    if (token.is[Token.Trivia]) None else Some(true)
 
 }


### PR DESCRIPTION
Scalameta is gradually phasing out macros, so let's stop using custom classifiers.

Also, let's switch to using standard scalameta token branches instead of custom ones defined within scalafmt:
- Trivia -> Token.Trivia
- Whitespace -> Token.Whitespace
- Delim -> Token.Symbolic
- Literal -> Token.Literal
- rename Keyword as Reserved and represent it as Token.Keyword and false/true/null
- remove Modifier since it's covered by Reserved and used only once, where Reserved applies already