### PR TITLE
InputMethod: check for empty diff

### DIFF
--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -26,8 +26,12 @@ sealed abstract class InputMethod {
     else if (codeChanged)
       options.writeMode match {
         case WriteMode.Test =>
-          val diff = InputMethod.unifiedDiff(path.toString, original, formatted)
-          throw MisformattedFile(path, diff)
+          val pathStr = path.toString
+          val diff = InputMethod.unifiedDiff(pathStr, original, formatted)
+          val msg =
+            if (diff.nonEmpty) diff
+            else s"--- +$pathStr\n    => modified line endings only"
+          throw MisformattedFile(path, msg)
         case WriteMode.Override => overwrite(formatted, options)
         case WriteMode.List => list(options)
         case _ =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -150,7 +150,7 @@ object Scalafmt {
       file: String,
       range: Set[Range] = Set.empty
   ): Try[String] =
-    if (code.matches("\\s*")) Try("")
+    if (code.matches("\\s*")) Success("")
     else {
       val runner = style.runner
       val codeToInput: String => Input = toInput(_, file)


### PR DESCRIPTION
difflib could return an empty string when the only difference is in the line endings of the strings being compared, which currently leads to a "silent" error (because the empty diff is output).

Instead, let's explicitly clarify that that is what happened.

Fixes #3675.