### PR TITLE
YML: Add java21 to the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11' ]
+        java: [ '11', '21' ]
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Now that scalameta supports jdk21, and scalafmt uses mdoc-parser, let's start validating the formatter with jdk21 in pre-commit checks.