### PR TITLE
ScalafmtReflect: lazily load obsolete class

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Config.scala
@@ -1,0 +1,4 @@
+package org.scalafmt.config
+
+// this class is used in older versions of scalafmt-dynamic, keep it here
+object Config {}

--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -18,7 +18,7 @@ case class ScalafmtReflect(
   private val formattedCls = loadClass("org.scalafmt.Formatted")
   private val scalaSetCls = loadClass("scala.collection.immutable.Set")
   private val optionCls = loadClass("scala.Option")
-  private val configCls = loadClass("org.scalafmt.config.Config")
+  private lazy val configCls = loadClass("org.scalafmt.config.Config")
   private val scalafmtCls = loadClass("org.scalafmt.Scalafmt")
 
   private val parseExceptionCls =

--- a/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -171,6 +171,7 @@ class DynamicSuite extends FunSuite {
   }
 
   private val testedVersions = Seq(
+    latest,
     "3.1.2",
     "2.7.5",
     "2.5.3",


### PR DESCRIPTION
Also, restore that same class in the repository so older versions of the dynamic ScalafmtReflect will continue functioning even if they won't be using the class. Helps with #3689.