### PR TITLE
Changed example `maxColumn` to 120, which is more Scala conventional

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ Here is an example `.scalafmt.conf`:
 
 ```scala config
 align.preset = more    // For pretty alignment.
-maxColumn = 100 // For my wide 30" display.
+maxColumn = 120 // For my wide 30" display.
 ```
 
 ## Most popular


### PR DESCRIPTION
Intellij default has always been 120.  A quick search also says about 170 OS repos use 120, only 30 use 100.