### PR TITLE
Exclude "of" from default AvoidInfix configuration (used in ScalaTest)

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
@@ -37,6 +37,7 @@ object Pattern {
       "in",
       "ignore",
       "be",
+      "of",
       "taggedAs",
       "thrownBy",
       "synchronized",

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix.stat
@@ -71,9 +71,19 @@ a banana walked have ordered a martini
 >>>
 (a.banana(walked) have ordered).a(martini)
 <<< more scalatest
-cp should not contain (jar3.getPath())
+class SomeScalaTest {
+  behavior of "XYZ"
+  it should "pass" in {
+    cp should not contain (jar3.getPath())
+  }
+}
 >>>
-cp should not contain (jar3.getPath())
+class SomeScalaTest {
+  behavior of "XYZ"
+  it should "pass" in {
+    cp should not contain (jar3.getPath())
+  }
+}
 <<< in lambda !allowInfixPlaceholderArg
 rewrite.allowInfixPlaceholderArg = false
 rewrite.neverInfix {

--- a/scalafmt-tests/src/test/resources/rewrite/AvoidInfix2.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/AvoidInfix2.stat
@@ -15,21 +15,13 @@ lst :+ foo
 >>>
 // format: off
 lst :+ foo
-<<< default scalatest
-behavior of "..." {
-  a shouldBe b
-}
+<<< default AvoidInfix configuration
+a multiply b
 >>>
-behavior.of("..." {
-  a shouldBe b
-})
-<<< default scalatest with appended excludeFilters
-rewrite.neverInfix.excludeFilters."+" = [ "of" ]
+a.multiply(b)
+<<< default AvoidInfix configuration with appended excludeFilters
+rewrite.neverInfix.excludeFilters."+" = [ "multiply" ]
 ===
-behavior of "..." {
-  a shouldBe b
-}
+a multiply b
 >>>
-behavior of "..." {
-  a shouldBe b
-}
+a multiply b


### PR DESCRIPTION
Fixes #3699

It also:
 - makes the `more ScalaTest` formatting test a bit more realistic
 - uses some arbitrary infix call in excludeFilters list append test