### PR TITLE
Changed example line limit to agree with Intellij default and industr…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ Here is an example `.scalafmt.conf`:
 
 ```scala config
 align.preset = more    // For pretty alignment.
-maxColumn = 100 // For my wide 30" display.
+maxColumn = 120 // For my wide 30" display.
 ```
 
 ## Most popular


### PR DESCRIPTION
The reason why 120 has long been the ubiquitously accepted convention is because Intellij IDE has been the longest ubiquitously accepted IDE for Scala, which came prior to scalafmt and which picks a default of 120 characters.

There are roughly 170 OS repositories that use 120 given by this approximate search: https://github.com/search?q=maxColumn+%3D+120&type=commits

Then about 33 for length 100 https://github.com/search?q=maxColumn+%3D+100&type=commits

