### PR TITLE
bugfix: Show exception from path matcher correctly

### DIFF
--- a/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -286,6 +286,37 @@ class DynamicSuite extends FunSuite {
     )
   }
 
+  check("regex-error") { f =>
+    f.setConfig(s"""|version = "$nightly"
+      |runner.dialect = "scala212"
+      |project.excludeFilters = [
+      |    ".*foo("
+      |]
+      |""".stripMargin)
+    val err = f.assertThrows[ScalafmtDynamicError.ConfigParseError]().getMessage
+    assertNoDiff(
+      err.takeRight(120),
+      """|Invalid config: Illegal regex in configuration: .*foo(
+        |reason: Unclosed group near index 6
+        |.*foo(
+        |""".stripMargin
+    )
+  }
+
+  check("path-error") { f =>
+    f.setConfig(s"""|version = "$nightly"
+      |runner.dialect = "scala212"
+      |project.excludePaths = [
+      |    "foo.scala"
+      |]
+      |""".stripMargin)
+    val err = f.assertThrows[ScalafmtDynamicError.ConfigParseError]().getMessage
+    assertNoDiff(
+      err.takeRight(120),
+      "Invalid config: Illegal pattern in configuration: foo.scala"
+    )
+  }
+
   check("config-cache") { f =>
     f.setVersion(latest, "scala211")
     f.assertFormat()


### PR DESCRIPTION
Previously, we would just get a stack trace:
```
Exception in thread "main" java.lang.IllegalArgumentException
	at sun.nio.fs.UnixFileSystem.getPathMatcher(UnixFileSystem.java:286)
	at org.scalafmt.config.ProjectFiles$FileMatcher$Nio.<init>(ProjectFiles.scala:74)
	at org.scalafmt.config.ProjectFiles$FileMatcher$.$anonfun$nio$1(ProjectFiles.scala:70)
	at scala.collection.immutable.List.map(List.scala:250)
	at scala.collection.immutable.List.map(List.scala:79)
	at org.scalafmt.config.ProjectFiles$FileMatcher$.create(ProjectFiles.scala:69)
	at org.scalafmt.config.ProjectFiles$FileMatcher$.nio(ProjectFiles.scala:70)
	at org.scalafmt.config.ProjectFiles$FileMatcher$.apply(ProjectFiles.scala:64)
	at org.scalafmt.cli.ScalafmtCoreRunner$.$anonfun$run$2(ScalafmtCoreRunner.scala:27)
	at metaconfig.Configured$ConfiguredImplicit.fold(Configured.scala:111)
	at org.scalafmt.cli.ScalafmtCoreRunner$.run(ScalafmtCoreRunner.scala:23)
	at org.scalafmt.cli.Cli$.runWithRunner(Cli.scala:140)
	at org.scalafmt.cli.Cli$.run(Cli.scala:91)
	at org.scalafmt.cli.Cli$.mainWithOptions(Cli.scala:61)
	at org.scalafmt.cli.Cli$.main(Cli.scala:43)
	at org.scalafmt.cli.Cli.main(Cli.scala)
```

Reported in https://github.com/VirtusLab/scala-cli/issues/2415