### PR TITLE
[PoC] Extract convert import wildcard to start as independent rewrite

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -7,6 +7,7 @@ import metaconfig._
 case class RewriteScala3Settings(
     convertToNewSyntax: Boolean = false,
     removeOptionalBraces: RemoveOptionalBraces = RemoveOptionalBraces.no,
+    convertImportWildcardsToStar: Boolean = false,
     countEndMarkerLines: RewriteScala3Settings.EndMarkerLines =
       RewriteScala3Settings.EndMarkerLines.all,
     removeEndMarkerMaxLines: Int = 0,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ConvertImportWildcardToStar.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ConvertImportWildcardToStar.scala
@@ -1,0 +1,53 @@
+package org.scalafmt.rewrite
+
+import scala.meta.Importee
+import scala.meta.tokens.Token
+
+import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.internal.FormatToken
+import org.scalafmt.internal.FormatTokens
+
+object ConvertImportWildcardToStar extends FormatTokensRewrite.RuleFactory {
+
+  override def enabled(implicit style: ScalafmtConfig): Boolean =
+    style.rewrite.scala3.convertToNewSyntax || style.rewrite.scala3.convertImportWildcardsToStar
+
+  override def create(ftoks: FormatTokens): FormatTokensRewrite.Rule =
+    new ConvertImportWildcardToStar(ftoks)
+
+}
+
+private class ConvertImportWildcardToStar(ftoks: FormatTokens)
+    extends FormatTokensRewrite.Rule {
+
+  import FormatTokensRewrite._
+
+  @inline
+  private def dialect(implicit style: ScalafmtConfig) = style.dialect
+
+  override def enabled(implicit style: ScalafmtConfig): Boolean =
+    ConvertImportWildcardToStar.enabled
+
+  override def onToken(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Option[FormatTokensRewrite.Replacement] = Option {
+    ft.right match {
+      case _: Token.Underscore =>
+        ft.meta.rightOwner match {
+          case _: Importee.Wildcard if dialect.allowStarWildcardImport =>
+            replaceTokenIdent("*", ft.right)
+          case _ => null
+        }
+      case _ => null
+    }
+  }
+
+  override def onRight(
+      left: FormatTokensRewrite.Replacement,
+      hasFormatOff: Boolean
+  )(implicit ft: FormatToken, style: ScalafmtConfig): Option[
+    (FormatTokensRewrite.Replacement, FormatTokensRewrite.Replacement)
+  ] = None
+
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ConvertToNewScala3Syntax.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ConvertToNewScala3Syntax.scala
@@ -65,8 +65,6 @@ private class ConvertToNewScala3Syntax(ftoks: FormatTokens)
 
       case _: Token.Underscore =>
         ft.meta.rightOwner match {
-          case _: Importee.Wildcard if dialect.allowStarWildcardImport =>
-            replaceTokenIdent("*", ft.right)
           case t: Type.Wildcard
               if dialect.allowQuestionMarkAsTypeWildcard &&
                 t.parent.exists(_.is[Type.ArgClause]) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -201,6 +201,7 @@ object FormatTokensRewrite {
   private val factories = Seq(
     RemoveScala3OptionalBraces,
     ConvertToNewScala3Syntax,
+    ConvertImportWildcardToStar,
     RemoveEmptyDocstrings,
     RewriteTrailingCommas
   )


### PR DESCRIPTION
I would like to know if such change has a chance to be added.
The scenario in which such functionality is needed is when I want to rewrite underscores in imports to stars, but leave possibility to use both old and new syntax for `if` control syntax.
Currently when I set:
- `rewrite.scala3.convertToNewSyntax = true` and `allowStarWildcardImport = true` and `allowSignificantIndentation = true` all old `if` syntax is rewritten to new one
- `rewrite.scala3.convertToNewSyntax = true` and `allowStarWildcardImport = true` and `allowSignificantIndentation = false` it fails on places where new syntax of `if` is used.

Let me know what do you think and what further changes are needed to add this functionality.