### PR TITLE
FormatWriter: fix end marker handling

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -98,7 +98,15 @@ object FormatToken {
   ) {
     lazy val firstNL = text.indexOf('\n')
     @inline def hasNL: Boolean = firstNL >= 0
-    def countNL: Int = if (hasNL) text.count(_ == '\n') else 0
+    def countNL: Int = {
+      var cnt = 0
+      var idx = firstNL
+      while (idx >= 0) {
+        cnt += 1
+        idx = text.indexOf('\n', idx + 1)
+      }
+      cnt
+    }
   }
 
   class ExtractFromMeta[A](f: FormatToken.Meta => Option[A]) {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -2513,14 +2513,12 @@ object a:
    def foo() =
       require(bar)
       bar
-   end foo
 
    /** c
      */
    def foo() =
       require(bar)
       bar
-   end foo
 <<< #3731 exclude leading multiline comment, body + comment length
 rewrite.scala3.insertEndMarkerMinLines = 5
 rewrite.scala3.removeEndMarkerMaxLines = 4

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -2428,6 +2428,128 @@ def update(tpf: Float): Unit =
        scene.updateLogicalState(tpf)
      )
    end while
+<<< #3731 exclude leading multiline comment, one shorter
+rewrite.scala3.insertEndMarkerMinLines = 2
+rewrite.scala3.removeEndMarkerMaxLines = 1
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, body length
+rewrite.scala3.insertEndMarkerMinLines = 3
+rewrite.scala3.removeEndMarkerMaxLines = 2
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, one longer
+rewrite.scala3.insertEndMarkerMinLines = 4
+rewrite.scala3.removeEndMarkerMaxLines = 3
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, body + comment length
+rewrite.scala3.insertEndMarkerMinLines = 5
+rewrite.scala3.removeEndMarkerMaxLines = 4
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
 <<< TryWithHandler: newline after catch
 object a {
   def foo = try

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -2295,6 +2295,128 @@ def update(tpf: Float): Unit =
    end while
    while (true) scene.updateLogicalState(tpf, scene.updateLogicalState(tpf))
    end while
+<<< #3731 exclude leading multiline comment, one shorter
+rewrite.scala3.insertEndMarkerMinLines = 2
+rewrite.scala3.removeEndMarkerMaxLines = 1
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, body length
+rewrite.scala3.insertEndMarkerMinLines = 3
+rewrite.scala3.removeEndMarkerMaxLines = 2
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, one longer
+rewrite.scala3.insertEndMarkerMinLines = 4
+rewrite.scala3.removeEndMarkerMaxLines = 3
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, body + comment length
+rewrite.scala3.insertEndMarkerMinLines = 5
+rewrite.scala3.removeEndMarkerMaxLines = 4
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
 <<< TryWithHandler: newline after catch
 object a {
   def foo = try

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -2380,14 +2380,12 @@ object a:
    def foo() =
       require(bar)
       bar
-   end foo
 
    /** c
      */
    def foo() =
       require(bar)
       bar
-   end foo
 <<< #3731 exclude leading multiline comment, body + comment length
 rewrite.scala3.insertEndMarkerMinLines = 5
 rewrite.scala3.removeEndMarkerMaxLines = 4

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2435,6 +2435,128 @@ def update(tpf: Float): Unit =
      scene.updateLogicalState(tpf)
    )
    end while
+<<< #3731 exclude leading multiline comment, one shorter
+rewrite.scala3.insertEndMarkerMinLines = 2
+rewrite.scala3.removeEndMarkerMaxLines = 1
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, body length
+rewrite.scala3.insertEndMarkerMinLines = 3
+rewrite.scala3.removeEndMarkerMaxLines = 2
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, one longer
+rewrite.scala3.insertEndMarkerMinLines = 4
+rewrite.scala3.removeEndMarkerMaxLines = 3
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, body + comment length
+rewrite.scala3.insertEndMarkerMinLines = 5
+rewrite.scala3.removeEndMarkerMaxLines = 4
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
 <<< TryWithHandler: newline after catch
 object a {
   def foo = try

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2520,14 +2520,12 @@ object a:
    def foo() =
       require(bar)
       bar
-   end foo
 
    /** c
      */
    def foo() =
       require(bar)
       bar
-   end foo
 <<< #3731 exclude leading multiline comment, body + comment length
 rewrite.scala3.insertEndMarkerMinLines = 5
 rewrite.scala3.removeEndMarkerMaxLines = 4

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2540,6 +2540,128 @@ def update(tpf: Float): Unit =
    while (true)
      scene.updateLogicalState(tpf, scene.updateLogicalState(tpf))
    end while
+<<< #3731 exclude leading multiline comment, one shorter
+rewrite.scala3.insertEndMarkerMinLines = 2
+rewrite.scala3.removeEndMarkerMaxLines = 1
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, body length
+rewrite.scala3.insertEndMarkerMinLines = 3
+rewrite.scala3.removeEndMarkerMaxLines = 2
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, one longer
+rewrite.scala3.insertEndMarkerMinLines = 4
+rewrite.scala3.removeEndMarkerMaxLines = 3
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+   end foo
+<<< #3731 exclude leading multiline comment, body + comment length
+rewrite.scala3.insertEndMarkerMinLines = 5
+rewrite.scala3.removeEndMarkerMaxLines = 4
+===
+object a:
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  /**
+     * c */
+  def foo() =
+    require(bar)
+    bar
+  end foo
+>>>
+object a:
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
+
+   /** c
+     */
+   def foo() =
+      require(bar)
+      bar
 <<< TryWithHandler: newline after catch
 object a {
   def foo = try

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2625,14 +2625,12 @@ object a:
    def foo() =
       require(bar)
       bar
-   end foo
 
    /** c
      */
    def foo() =
       require(bar)
       bar
-   end foo
 <<< #3731 exclude leading multiline comment, body + comment length
 rewrite.scala3.insertEndMarkerMinLines = 5
 rewrite.scala3.removeEndMarkerMaxLines = 4


### PR DESCRIPTION
The current issue is that the span is computed using `leftLineId` of the token just before and the token at the end. However, `leftLineId` refers to the beginning of the token, thus multiline comments are incorrectly accounted.

Instead, use the token at the beginning of the span and increase by 1. Fixes #3731.