### PR TITLE
FormatOps: outindent after fewer braces in infix

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -485,7 +485,8 @@ class FormatOps(
             case x => !isEnclosedInParens(x)
           })
         val afterInfix = style.breakAfterInfix(t)
-        if (afterInfix ne Newlines.AfterInfix.keep) {
+        if (isBeforeOp && endsWithFewerBraces(app.lhs)) Seq(Split(Newline, 0))
+        else if (afterInfix ne Newlines.AfterInfix.keep) {
           if (isBeforeOp) Seq(Split(Space, 0))
           else {
             val spaceMod = Space(useSpace)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -1019,4 +1019,16 @@ object TreeOps {
   def isFewerBraces(tree: Term.Apply)(implicit dialect: Dialect): Boolean =
     dialect.allowFewerBraces && tree.argClause.tokens.head.is[Colon]
 
+  @tailrec
+  def endsWithFewerBraces(tree: Tree)(implicit dialect: Dialect): Boolean =
+    tree match {
+      case t: Term.Apply => isFewerBraces(t)
+      case t: Term.ApplyInfix =>
+        t.argClause.values match {
+          case arg :: Nil => endsWithFewerBraces(arg)
+          case _ => false
+        }
+      case _ => false
+    }
+
 }

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces.stat
@@ -1,0 +1,1794 @@
+indent.significant = 3
+<<< #3720 fewerBraces = never ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+        ++
+          bar:
+            argbar
+          ++
+          baz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = never || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+        ++ bar:
+          argbar
+        ++ baz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = never || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = never ++ selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+      ++
+        bar:
+          argbar
+        .sbar
+        ++
+        baz:
+          argbaz
+        .sbaz
+        ++
+        qux
+<<< #3720 fewerBraces = never || selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+<<< #3720 fewerBraces = never || selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+<<< #3720 fewerBraces = never ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++
+          bar.sbar:
+            argbar
+          ++
+          baz.sbaz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = never || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++ bar.sbar:
+          argbar
+        ++ baz.sbaz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = never || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = never ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2
+      ++
+        bar
+          .sbar1:
+            argbar
+          .sbar2
+        ++
+        baz
+          .sbaz1:
+            argbaz
+          .sbaz2
+        ++
+        qux
+<<< #3720 fewerBraces = never || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2
+    ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2
+    ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++ bar
+      .sbar1:
+        argbar
+      .sbar2 ++ baz
+      .sbaz1:
+        argbaz
+      .sbaz2 ++ qux
+<<< #3720 fewerBraces = never || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 || bar
+      .sbar1:
+        argbar
+      .sbar2 || baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = never ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+        ++
+          baz:
+            arg
+          ++
+          qux
+<<< #3720 fewerBraces = never || short, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+        ++ baz:
+          arg
+        ++ qux
+<<< #3720 fewerBraces = never || short, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+<<< #3720 fewerBraces = always ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      ++
+        bar:
+            argbar
+        ++
+        baz:
+            argbaz
+        ++
+        qux
+<<< #3720 fewerBraces = always || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+    ||
+    bar:
+        argbar
+    ||
+    baz:
+        argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+        argfoo
+          ++ bar:
+              argbar
+          ++ baz:
+              argbaz
+          ++ qux
+<<< #3720 fewerBraces = always || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+    || bar:
+        argbar
+    || baz:
+        argbaz
+    || qux
+<<< #3720 fewerBraces = always ++ selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo
+      ++
+        bar:
+            argbar
+          .sbar
+        ++
+        baz:
+            argbaz
+          .sbaz
+        ++
+        qux
+<<< #3720 fewerBraces = always || selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo
+    ||
+    bar:
+        argbar
+      .sbar
+    ||
+    baz:
+        argbaz
+      .sbaz
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ++ bar:
+        argbar
+      .sbar ++ baz:
+        argbaz
+      .sbaz ++ qux
+<<< #3720 fewerBraces = always || selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo || bar:
+        argbar
+      .sbar || baz:
+        argbaz
+      .sbaz || qux
+<<< #3720 fewerBraces = always ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+      ++
+        bar.sbar:
+            argbar
+        ++
+        baz.sbaz:
+            argbaz
+        ++
+        qux
+<<< #3720 fewerBraces = always || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+    ||
+    bar.sbar:
+        argbar
+    ||
+    baz.sbaz:
+        argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+          ++ bar.sbar:
+              argbar
+          ++ baz.sbaz:
+              argbaz
+          ++ qux
+<<< #3720 fewerBraces = always || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+    || bar.sbar:
+        argbar
+    || baz.sbaz:
+        argbaz
+    || qux
+<<< #3720 fewerBraces = always ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2
+      ++
+        bar
+          .sbar1:
+            argbar
+          .sbar2
+        ++
+        baz
+          .sbaz1:
+            argbaz
+          .sbaz2
+        ++
+        qux
+<<< #3720 fewerBraces = always || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2
+    ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2
+    ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++ bar
+      .sbar1:
+        argbar
+      .sbar2 ++ baz
+      .sbaz1:
+        argbaz
+      .sbaz2 ++ qux
+<<< #3720 fewerBraces = always || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 || bar
+      .sbar1:
+        argbar
+      .sbar2 || baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = always ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+        arg
+      ++
+        baz:
+            arg
+        ++
+        qux
+<<< #3720 fewerBraces = always || short, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+        arg
+    ||
+    baz:
+        arg
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+        arg
+          ++ baz:
+              arg
+          ++ qux
+<<< #3720 fewerBraces = always || short, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+        arg
+    || baz:
+        arg
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+        ++
+          bar:
+            argbar
+          ++
+          baz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = beforeSelect || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+        ++ bar:
+          argbar
+        ++ baz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = beforeSelect || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects after, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo
+      ++
+        bar:
+            argbar
+          .sbar
+        ++
+        baz:
+            argbaz
+          .sbaz
+        ++
+        qux
+<<< #3720 fewerBraces = beforeSelect || selects after, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo
+    ||
+    bar:
+        argbar
+      .sbar
+    ||
+    baz:
+        argbaz
+      .sbaz
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ selects after, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ++ bar:
+        argbar
+      .sbar ++ baz:
+        argbaz
+      .sbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects after, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo || bar:
+        argbar
+      .sbar || baz:
+        argbaz
+      .sbaz || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++
+          bar.sbar:
+            argbar
+          ++
+          baz.sbaz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = beforeSelect || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++ bar.sbar:
+          argbar
+        ++ baz.sbaz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2
+      ++
+        bar
+          .sbar1:
+            argbar
+          .sbar2
+        ++
+        baz
+          .sbaz1:
+            argbaz
+          .sbaz2
+        ++
+        qux
+<<< #3720 fewerBraces = beforeSelect || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2
+    ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2
+    ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++ bar
+      .sbar1:
+        argbar
+      .sbar2 ++ baz
+      .sbaz1:
+        argbaz
+      .sbaz2 ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 || bar
+      .sbar1:
+        argbar
+      .sbar2 || baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects mixed, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++
+          bar:
+            argbar
+          ++
+          baz.sbaz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = beforeSelect || selects mixed, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ selects mixed, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++ bar:
+          argbar
+        ++ baz.sbaz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects mixed, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+        ++
+          baz:
+            arg
+          ++
+          qux
+<<< #3720 fewerBraces = beforeSelect || short, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+        ++ baz:
+          arg
+        ++ qux
+<<< #3720 fewerBraces = beforeSelect || short, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces.stat
@@ -17,19 +17,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
       argfoo
-        ++
-          bar:
-            argbar
-          ++
-          baz:
-            argbaz
-          ++
-          qux
+    ++
+      bar:
+        argbar
+      ++
+      baz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = never || no selects, newlines
 indent.significant = 2
 indent.fewerBraces = never
@@ -75,16 +74,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
       argfoo
-        ++ bar:
-          argbar
-        ++ baz:
-          argbaz
-        ++ qux
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = never || no selects, spaces
 indent.significant = 2
 indent.fewerBraces = never
@@ -247,19 +245,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++
-          bar.sbar:
-            argbar
-          ++
-          baz.sbaz:
-            argbaz
-          ++
-          qux
+    ++
+      bar.sbar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = never || selects before, newlines
 indent.significant = 2
 indent.fewerBraces = never
@@ -305,16 +302,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++ bar.sbar:
-          argbar
-        ++ baz.sbaz:
-          argbaz
-        ++ qux
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = never || selects before, spaces
 indent.significant = 2
 indent.fewerBraces = never
@@ -486,16 +482,15 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
       arg
-        ++
-          baz:
-            arg
-          ++
-          qux
+    ++
+      baz:
+        arg
+      ++
+      qux
 <<< #3720 fewerBraces = never || short, newlines
 indent.significant = 2
 indent.fewerBraces = never
@@ -533,14 +528,13 @@ object a:
       arg
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
       arg
-        ++ baz:
-          arg
-        ++ qux
+    ++ baz:
+      arg
+    ++ qux
 <<< #3720 fewerBraces = never || short, spaces
 indent.significant = 2
 indent.fewerBraces = never
@@ -583,14 +577,14 @@ object a:
   def mtd =
     foo:
         argfoo
+    ++
+      bar:
+          argbar
       ++
-        bar:
-            argbar
-        ++
-        baz:
-            argbaz
-        ++
-        qux
+      baz:
+          argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = always || no selects, newlines
 indent.significant = 2
 indent.fewerBraces = always
@@ -636,16 +630,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
         argfoo
-          ++ bar:
-              argbar
-          ++ baz:
-              argbaz
-          ++ qux
+    ++ bar:
+        argbar
+    ++ baz:
+        argbaz
+    ++ qux
 <<< #3720 fewerBraces = always || no selects, spaces
 indent.significant = 2
 indent.fewerBraces = always
@@ -812,14 +805,14 @@ object a:
   def mtd =
     foo.sfoo:
         argfoo
+    ++
+      bar.sbar:
+          argbar
       ++
-        bar.sbar:
-            argbar
-        ++
-        baz.sbaz:
-            argbaz
-        ++
-        qux
+      baz.sbaz:
+          argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = always || selects before, newlines
 indent.significant = 2
 indent.fewerBraces = always
@@ -865,16 +858,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
         argfoo
-          ++ bar.sbar:
-              argbar
-          ++ baz.sbaz:
-              argbaz
-          ++ qux
+    ++ bar.sbar:
+        argbar
+    ++ baz.sbaz:
+        argbaz
+    ++ qux
 <<< #3720 fewerBraces = always || selects before, spaces
 indent.significant = 2
 indent.fewerBraces = always
@@ -1050,11 +1042,11 @@ object a:
   def mtd =
     foo.bar:
         arg
+    ++
+      baz:
+          arg
       ++
-        baz:
-            arg
-        ++
-        qux
+      qux
 <<< #3720 fewerBraces = always || short, newlines
 indent.significant = 2
 indent.fewerBraces = always
@@ -1092,14 +1084,13 @@ object a:
       arg
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
         arg
-          ++ baz:
-              arg
-          ++ qux
+    ++ baz:
+        arg
+    ++ qux
 <<< #3720 fewerBraces = always || short, spaces
 indent.significant = 2
 indent.fewerBraces = always
@@ -1138,19 +1129,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
       argfoo
-        ++
-          bar:
-            argbar
-          ++
-          baz:
-            argbaz
-          ++
-          qux
+    ++
+      bar:
+        argbar
+      ++
+      baz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = beforeSelect || no selects, newlines
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1196,16 +1186,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
       argfoo
-        ++ bar:
-          argbar
-        ++ baz:
-          argbaz
-        ++ qux
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = beforeSelect || no selects, spaces
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1368,19 +1357,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++
-          bar.sbar:
-            argbar
-          ++
-          baz.sbaz:
-            argbaz
-          ++
-          qux
+    ++
+      bar.sbar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = beforeSelect || selects before, newlines
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1426,16 +1414,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++ bar.sbar:
-          argbar
-        ++ baz.sbaz:
-          argbaz
-        ++ qux
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = beforeSelect || selects before, spaces
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1610,19 +1597,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++
-          bar:
-            argbar
-          ++
-          baz.sbaz:
-            argbaz
-          ++
-          qux
+    ++
+      bar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = beforeSelect || selects mixed, newlines
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1668,16 +1654,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++ bar:
-          argbar
-        ++ baz.sbaz:
-          argbaz
-        ++ qux
+    ++ bar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = beforeSelect || selects mixed, spaces
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1717,16 +1702,15 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
       arg
-        ++
-          baz:
-            arg
-          ++
-          qux
+    ++
+      baz:
+        arg
+      ++
+      qux
 <<< #3720 fewerBraces = beforeSelect || short, newlines
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1764,14 +1748,13 @@ object a:
       arg
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
       arg
-        ++ baz:
-          arg
-        ++ qux
+    ++ baz:
+      arg
+    ++ qux
 <<< #3720 fewerBraces = beforeSelect || short, spaces
 indent.significant = 2
 indent.fewerBraces = beforeSelect

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces_fold.stat
@@ -1,0 +1,1552 @@
+indent.significant = 3
+newlines.source = fold
+<<< #3720 fewerBraces = never ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  ++ bar:
+    argbar
+  ++ baz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = never || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  || bar:
+    argbar
+  || baz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = never ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  ++ bar:
+    argbar
+  ++ baz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = never || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  || bar:
+    argbar
+  || baz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = never ++ selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  .sfoo ++ bar:
+    argbar
+  .sbar ++ baz:
+    argbaz
+  .sbaz ++ qux
+<<< #3720 fewerBraces = never || selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  .sfoo || bar:
+    argbar
+  .sbar || baz:
+    argbaz
+  .sbaz || qux
+<<< #3720 fewerBraces = never ++ selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  .sfoo ++ bar:
+    argbar
+  .sbar ++ baz:
+    argbaz
+  .sbaz ++ qux
+<<< #3720 fewerBraces = never || selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  .sfoo || bar:
+    argbar
+  .sbar || baz:
+    argbaz
+  .sbaz || qux
+<<< #3720 fewerBraces = never ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  ++ bar.sbar:
+    argbar
+  ++ baz.sbaz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = never || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  || bar.sbar:
+    argbar
+  || baz.sbaz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = never ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  ++ bar.sbar:
+    argbar
+  ++ baz.sbaz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = never || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  || bar.sbar:
+    argbar
+  || baz.sbaz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = never ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+    argfoo
+  .sfoo2 ++ bar.sbar1:
+    argbar
+  .sbar2 ++ baz.sbaz1:
+    argbaz
+  .sbaz2 ++ qux
+<<< #3720 fewerBraces = never || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+    argfoo
+  .sfoo2 || bar.sbar1:
+    argbar
+  .sbar2 || baz.sbaz1:
+    argbaz
+  .sbaz2 || qux
+<<< #3720 fewerBraces = never ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+    argfoo
+  .sfoo2 ++ bar.sbar1:
+    argbar
+  .sbar2 ++ baz.sbaz1:
+    argbaz
+  .sbaz2 ++ qux
+<<< #3720 fewerBraces = never || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+    argfoo
+  .sfoo2 || bar.sbar1:
+    argbar
+  .sbar2 || baz.sbaz1:
+    argbaz
+  .sbaz2 || qux
+<<< #3720 fewerBraces = never ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.bar:
+    arg
+  ++ baz:
+    arg
+  ++ qux
+<<< #3720 fewerBraces = never || short, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.bar:
+    arg
+  || baz:
+    arg
+  || qux
+<<< #3720 fewerBraces = never ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+object a:
+  def mtd = foo.bar:
+    arg
+  ++ baz:
+    arg
+  ++ qux
+<<< #3720 fewerBraces = never || short, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd = foo.bar:
+    arg
+  || baz:
+    arg
+  || qux
+<<< #3720 fewerBraces = always ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+  ++ bar:
+      argbar
+  ++ baz:
+      argbaz
+  ++ qux
+<<< #3720 fewerBraces = always || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+  || bar:
+      argbar
+  || baz:
+      argbaz
+  || qux
+<<< #3720 fewerBraces = always ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+  ++ bar:
+      argbar
+  ++ baz:
+      argbaz
+  ++ qux
+<<< #3720 fewerBraces = always || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+  || bar:
+      argbar
+  || baz:
+      argbaz
+  || qux
+<<< #3720 fewerBraces = always ++ selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+<<< #3720 fewerBraces = always || selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+<<< #3720 fewerBraces = always ++ selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+<<< #3720 fewerBraces = always || selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+<<< #3720 fewerBraces = always ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+      argfoo
+  ++ bar.sbar:
+      argbar
+  ++ baz.sbaz:
+      argbaz
+  ++ qux
+<<< #3720 fewerBraces = always || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+      argfoo
+  || bar.sbar:
+      argbar
+  || baz.sbaz:
+      argbaz
+  || qux
+<<< #3720 fewerBraces = always ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+      argfoo
+  ++ bar.sbar:
+      argbar
+  ++ baz.sbaz:
+      argbaz
+  ++ qux
+<<< #3720 fewerBraces = always || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+      argfoo
+  || bar.sbar:
+      argbar
+  || baz.sbaz:
+      argbaz
+  || qux
+<<< #3720 fewerBraces = always ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+<<< #3720 fewerBraces = always || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+<<< #3720 fewerBraces = always ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+<<< #3720 fewerBraces = always || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+<<< #3720 fewerBraces = always ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.bar:
+      arg
+  ++ baz:
+      arg
+  ++ qux
+<<< #3720 fewerBraces = always || short, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.bar:
+      arg
+  || baz:
+      arg
+  || qux
+<<< #3720 fewerBraces = always ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+object a:
+  def mtd = foo.bar:
+      arg
+  ++ baz:
+      arg
+  ++ qux
+<<< #3720 fewerBraces = always || short, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd = foo.bar:
+      arg
+  || baz:
+      arg
+  || qux
+<<< #3720 fewerBraces = beforeSelect ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  ++ bar:
+    argbar
+  ++ baz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = beforeSelect || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  || bar:
+    argbar
+  || baz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = beforeSelect ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  ++ bar:
+    argbar
+  ++ baz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = beforeSelect || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd = foo:
+    argfoo
+  || bar:
+    argbar
+  || baz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects after, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects after, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects after, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects after, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd = foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  ++ bar.sbar:
+    argbar
+  ++ baz.sbaz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  || bar.sbar:
+    argbar
+  || baz.sbaz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  ++ bar.sbar:
+    argbar
+  ++ baz.sbaz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  || bar.sbar:
+    argbar
+  || baz.sbaz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd = foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects mixed, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  ++ bar:
+    argbar
+  ++ baz.sbaz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects mixed, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  || bar:
+    argbar
+  || baz.sbaz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects mixed, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  ++ bar:
+    argbar
+  ++ baz.sbaz:
+    argbaz
+  ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects mixed, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd = foo.sfoo:
+    argfoo
+  || bar:
+    argbar
+  || baz.sbaz:
+    argbaz
+  || qux
+<<< #3720 fewerBraces = beforeSelect ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+object a:
+  def mtd = foo.bar:
+    arg
+  ++ baz:
+    arg
+  ++ qux
+<<< #3720 fewerBraces = beforeSelect || short, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd = foo.bar:
+    arg
+  || baz:
+    arg
+  || qux
+<<< #3720 fewerBraces = beforeSelect ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+object a:
+  def mtd = foo.bar:
+    arg
+  ++ baz:
+    arg
+  ++ qux
+<<< #3720 fewerBraces = beforeSelect || short, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd = foo.bar:
+    arg
+  || baz:
+    arg
+  || qux

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces_keep.stat
@@ -1,0 +1,1759 @@
+indent.significant = 3
+newlines.source = keep
+<<< #3720 fewerBraces = never ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+        ++
+          bar:
+            argbar
+          ++
+          baz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = never || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+        ++ bar:
+          argbar
+        ++ baz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = never || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = never ++ selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+      ++
+        bar:
+          argbar
+        .sbar
+        ++
+        baz:
+          argbaz
+        .sbaz
+        ++
+        qux
+<<< #3720 fewerBraces = never || selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+<<< #3720 fewerBraces = never || selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+<<< #3720 fewerBraces = never ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++
+          bar.sbar:
+            argbar
+          ++
+          baz.sbaz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = never || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++ bar.sbar:
+          argbar
+        ++ baz.sbaz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = never || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = never ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+      ++
+        bar.sbar1:
+          argbar
+        .sbar2
+        ++
+        baz.sbaz1:
+          argbaz
+        .sbaz2
+        ++
+        qux
+<<< #3720 fewerBraces = never || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+<<< #3720 fewerBraces = never || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+<<< #3720 fewerBraces = never ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+        ++
+          baz:
+            arg
+          ++
+          qux
+<<< #3720 fewerBraces = never || short, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+<<< #3720 fewerBraces = never ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+        ++ baz:
+          arg
+        ++ qux
+<<< #3720 fewerBraces = never || short, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+<<< #3720 fewerBraces = always ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      ++
+        bar:
+            argbar
+        ++
+        baz:
+            argbaz
+        ++
+        qux
+<<< #3720 fewerBraces = always || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+    ||
+    bar:
+        argbar
+    ||
+    baz:
+        argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+        argfoo
+          ++ bar:
+              argbar
+          ++ baz:
+              argbaz
+          ++ qux
+<<< #3720 fewerBraces = always || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+    || bar:
+        argbar
+    || baz:
+        argbaz
+    || qux
+<<< #3720 fewerBraces = always ++ selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo
+      ++
+        bar:
+            argbar
+          .sbar
+        ++
+        baz:
+            argbaz
+          .sbaz
+        ++
+        qux
+<<< #3720 fewerBraces = always || selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo
+    ||
+    bar:
+        argbar
+      .sbar
+    ||
+    baz:
+        argbaz
+      .sbaz
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ++ bar:
+        argbar
+      .sbar ++ baz:
+        argbaz
+      .sbaz ++ qux
+<<< #3720 fewerBraces = always || selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo || bar:
+        argbar
+      .sbar || baz:
+        argbaz
+      .sbaz || qux
+<<< #3720 fewerBraces = always ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+      ++
+        bar.sbar:
+            argbar
+        ++
+        baz.sbaz:
+            argbaz
+        ++
+        qux
+<<< #3720 fewerBraces = always || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+    ||
+    bar.sbar:
+        argbar
+    ||
+    baz.sbaz:
+        argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+          ++ bar.sbar:
+              argbar
+          ++ baz.sbaz:
+              argbaz
+          ++ qux
+<<< #3720 fewerBraces = always || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+    || bar.sbar:
+        argbar
+    || baz.sbaz:
+        argbaz
+    || qux
+<<< #3720 fewerBraces = always ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+        argfoo
+      .sfoo2
+      ++
+        bar.sbar1:
+            argbar
+          .sbar2
+        ++
+        baz.sbaz1:
+            argbaz
+          .sbaz2
+        ++
+        qux
+<<< #3720 fewerBraces = always || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+        argfoo
+      .sfoo2
+    ||
+    bar.sbar1:
+        argbar
+      .sbar2
+    ||
+    baz.sbaz1:
+        argbaz
+      .sbaz2
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+        argfoo
+      .sfoo2 ++ bar.sbar1:
+        argbar
+      .sbar2 ++ baz.sbaz1:
+        argbaz
+      .sbaz2 ++ qux
+<<< #3720 fewerBraces = always || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+        argfoo
+      .sfoo2 || bar.sbar1:
+        argbar
+      .sbar2 || baz.sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = always ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+        arg
+      ++
+        baz:
+            arg
+        ++
+        qux
+<<< #3720 fewerBraces = always || short, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+        arg
+    ||
+    baz:
+        arg
+    ||
+    qux
+<<< #3720 fewerBraces = always ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+        arg
+          ++ baz:
+              arg
+          ++ qux
+<<< #3720 fewerBraces = always || short, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+        arg
+    || baz:
+        arg
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+        ++
+          bar:
+            argbar
+          ++
+          baz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = beforeSelect || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+        ++ bar:
+          argbar
+        ++ baz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = beforeSelect || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects after, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo
+      ++
+        bar:
+            argbar
+          .sbar
+        ++
+        baz:
+            argbaz
+          .sbaz
+        ++
+        qux
+<<< #3720 fewerBraces = beforeSelect || selects after, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo
+    ||
+    bar:
+        argbar
+      .sbar
+    ||
+    baz:
+        argbaz
+      .sbaz
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ selects after, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ++ bar:
+        argbar
+      .sbar ++ baz:
+        argbaz
+      .sbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects after, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo || bar:
+        argbar
+      .sbar || baz:
+        argbaz
+      .sbaz || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++
+          bar.sbar:
+            argbar
+          ++
+          baz.sbaz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = beforeSelect || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++ bar.sbar:
+          argbar
+        ++ baz.sbaz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+        argfoo
+      .sfoo2
+      ++
+        bar.sbar1:
+            argbar
+          .sbar2
+        ++
+        baz.sbaz1:
+            argbaz
+          .sbaz2
+        ++
+        qux
+<<< #3720 fewerBraces = beforeSelect || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+        argfoo
+      .sfoo2
+    ||
+    bar.sbar1:
+        argbar
+      .sbar2
+    ||
+    baz.sbaz1:
+        argbaz
+      .sbaz2
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+        argfoo
+      .sfoo2 ++ bar.sbar1:
+        argbar
+      .sbar2 ++ baz.sbaz1:
+        argbaz
+      .sbaz2 ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo1:
+        argfoo
+      .sfoo2 || bar.sbar1:
+        argbar
+      .sbar2 || baz.sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects mixed, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++
+          bar:
+            argbar
+          ++
+          baz.sbaz:
+            argbaz
+          ++
+          qux
+<<< #3720 fewerBraces = beforeSelect || selects mixed, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ selects mixed, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+        ++ bar:
+          argbar
+        ++ baz.sbaz:
+          argbaz
+        ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects mixed, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+        ++
+          baz:
+            arg
+          ++
+          qux
+<<< #3720 fewerBraces = beforeSelect || short, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+<<< #3720 fewerBraces = beforeSelect ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+        ++ baz:
+          arg
+        ++ qux
+<<< #3720 fewerBraces = beforeSelect || short, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces_keep.stat
@@ -18,19 +18,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
       argfoo
-        ++
-          bar:
-            argbar
-          ++
-          baz:
-            argbaz
-          ++
-          qux
+    ++
+      bar:
+        argbar
+      ++
+      baz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = never || no selects, newlines
 indent.significant = 2
 indent.fewerBraces = never
@@ -76,16 +75,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
       argfoo
-        ++ bar:
-          argbar
-        ++ baz:
-          argbaz
-        ++ qux
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = never || no selects, spaces
 indent.significant = 2
 indent.fewerBraces = never
@@ -248,19 +246,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++
-          bar.sbar:
-            argbar
-          ++
-          baz.sbaz:
-            argbaz
-          ++
-          qux
+    ++
+      bar.sbar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = never || selects before, newlines
 indent.significant = 2
 indent.fewerBraces = never
@@ -306,16 +303,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++ bar.sbar:
-          argbar
-        ++ baz.sbaz:
-          argbaz
-        ++ qux
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = never || selects before, spaces
 indent.significant = 2
 indent.fewerBraces = never
@@ -475,16 +471,15 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
       arg
-        ++
-          baz:
-            arg
-          ++
-          qux
+    ++
+      baz:
+        arg
+      ++
+      qux
 <<< #3720 fewerBraces = never || short, newlines
 indent.significant = 2
 indent.fewerBraces = never
@@ -522,14 +517,13 @@ object a:
       arg
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
       arg
-        ++ baz:
-          arg
-        ++ qux
+    ++ baz:
+      arg
+    ++ qux
 <<< #3720 fewerBraces = never || short, spaces
 indent.significant = 2
 indent.fewerBraces = never
@@ -572,14 +566,14 @@ object a:
   def mtd =
     foo:
         argfoo
+    ++
+      bar:
+          argbar
       ++
-        bar:
-            argbar
-        ++
-        baz:
-            argbaz
-        ++
-        qux
+      baz:
+          argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = always || no selects, newlines
 indent.significant = 2
 indent.fewerBraces = always
@@ -625,16 +619,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
         argfoo
-          ++ bar:
-              argbar
-          ++ baz:
-              argbaz
-          ++ qux
+    ++ bar:
+        argbar
+    ++ baz:
+        argbaz
+    ++ qux
 <<< #3720 fewerBraces = always || no selects, spaces
 indent.significant = 2
 indent.fewerBraces = always
@@ -801,14 +794,14 @@ object a:
   def mtd =
     foo.sfoo:
         argfoo
+    ++
+      bar.sbar:
+          argbar
       ++
-        bar.sbar:
-            argbar
-        ++
-        baz.sbaz:
-            argbaz
-        ++
-        qux
+      baz.sbaz:
+          argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = always || selects before, newlines
 indent.significant = 2
 indent.fewerBraces = always
@@ -854,16 +847,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
         argfoo
-          ++ bar.sbar:
-              argbar
-          ++ baz.sbaz:
-              argbaz
-          ++ qux
+    ++ bar.sbar:
+        argbar
+    ++ baz.sbaz:
+        argbaz
+    ++ qux
 <<< #3720 fewerBraces = always || selects before, spaces
 indent.significant = 2
 indent.fewerBraces = always
@@ -1027,11 +1019,11 @@ object a:
   def mtd =
     foo.bar:
         arg
+    ++
+      baz:
+          arg
       ++
-        baz:
-            arg
-        ++
-        qux
+      qux
 <<< #3720 fewerBraces = always || short, newlines
 indent.significant = 2
 indent.fewerBraces = always
@@ -1069,14 +1061,13 @@ object a:
       arg
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
         arg
-          ++ baz:
-              arg
-          ++ qux
+    ++ baz:
+        arg
+    ++ qux
 <<< #3720 fewerBraces = always || short, spaces
 indent.significant = 2
 indent.fewerBraces = always
@@ -1115,19 +1106,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
       argfoo
-        ++
-          bar:
-            argbar
-          ++
-          baz:
-            argbaz
-          ++
-          qux
+    ++
+      bar:
+        argbar
+      ++
+      baz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = beforeSelect || no selects, newlines
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1173,16 +1163,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo:
       argfoo
-        ++ bar:
-          argbar
-        ++ baz:
-          argbaz
-        ++ qux
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = beforeSelect || no selects, spaces
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1345,19 +1334,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++
-          bar.sbar:
-            argbar
-          ++
-          baz.sbaz:
-            argbaz
-          ++
-          qux
+    ++
+      bar.sbar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = beforeSelect || selects before, newlines
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1403,16 +1391,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++ bar.sbar:
-          argbar
-        ++ baz.sbaz:
-          argbaz
-        ++ qux
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = beforeSelect || selects before, spaces
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1575,19 +1562,18 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++
-          bar:
-            argbar
-          ++
-          baz.sbaz:
-            argbaz
-          ++
-          qux
+    ++
+      bar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz
+      ++
+      qux
 <<< #3720 fewerBraces = beforeSelect || selects mixed, newlines
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1633,16 +1619,15 @@ object a:
       argbaz
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.sfoo:
       argfoo
-        ++ bar:
-          argbar
-        ++ baz.sbaz:
-          argbaz
-        ++ qux
+    ++ bar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
 <<< #3720 fewerBraces = beforeSelect || selects mixed, spaces
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1682,16 +1667,15 @@ object a:
     ++
     qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
       arg
-        ++
-          baz:
-            arg
-          ++
-          qux
+    ++
+      baz:
+        arg
+      ++
+      qux
 <<< #3720 fewerBraces = beforeSelect || short, newlines
 indent.significant = 2
 indent.fewerBraces = beforeSelect
@@ -1729,14 +1713,13 @@ object a:
       arg
     ++ qux
 >>>
-Idempotency violated
 object a:
   def mtd =
     foo.bar:
       arg
-        ++ baz:
-          arg
-        ++ qux
+    ++ baz:
+      arg
+    ++ qux
 <<< #3720 fewerBraces = beforeSelect || short, spaces
 indent.significant = 2
 indent.fewerBraces = beforeSelect

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces_unfold.stat
@@ -1,0 +1,1768 @@
+indent.significant = 3
+newlines.source = unfold
+<<< #3720 fewerBraces = never ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+      bar:
+        argbar
+      ++
+      baz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = never || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = never ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+      bar:
+        argbar
+      ++
+      baz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = never || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = never ++ selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++
+      bar:
+        argbar
+      .sbar ++
+      baz:
+        argbaz
+      .sbaz ++ qux
+<<< #3720 fewerBraces = never || selects, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ||
+    bar:
+      argbar
+    .sbar ||
+    baz:
+      argbaz
+    .sbaz || qux
+<<< #3720 fewerBraces = never ++ selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++
+      bar:
+        argbar
+      .sbar ++
+      baz:
+        argbaz
+      .sbaz ++ qux
+<<< #3720 fewerBraces = never || selects, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ||
+    bar:
+      argbar
+    .sbar ||
+    baz:
+      argbaz
+    .sbaz || qux
+<<< #3720 fewerBraces = never ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+      bar.sbar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = never || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = never ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+      bar.sbar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = never || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = never ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++
+      bar
+        .sbar1:
+          argbar
+        .sbar2 ++
+      baz
+        .sbaz1:
+          argbaz
+        .sbaz2 ++ qux
+<<< #3720 fewerBraces = never || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2 ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = never ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++
+      bar
+        .sbar1:
+          argbar
+        .sbar2 ++
+      baz
+        .sbaz1:
+          argbaz
+        .sbaz2 ++ qux
+<<< #3720 fewerBraces = never || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2 ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = never ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+      baz:
+        arg ++ qux
+<<< #3720 fewerBraces = never || short, newlines
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    || qux
+<<< #3720 fewerBraces = never ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+      baz:
+        arg ++ qux
+<<< #3720 fewerBraces = never || short, spaces
+indent.significant = 2
+indent.fewerBraces = never
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    || qux
+<<< #3720 fewerBraces = always ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+        argfoo
+    ++
+      bar:
+          argbar
+      ++
+      baz:
+          argbaz ++ qux
+<<< #3720 fewerBraces = always || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+    ||
+    bar:
+        argbar
+    ||
+    baz:
+        argbaz
+    || qux
+<<< #3720 fewerBraces = always ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+        argfoo
+    ++
+      bar:
+          argbar
+      ++
+      baz:
+          argbaz ++ qux
+<<< #3720 fewerBraces = always || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+    ||
+    bar:
+        argbar
+    ||
+    baz:
+        argbaz
+    || qux
+<<< #3720 fewerBraces = always ++ selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ++
+      bar:
+          argbar
+        .sbar ++
+      baz:
+          argbaz
+        .sbaz ++ qux
+<<< #3720 fewerBraces = always || selects, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ||
+    bar:
+        argbar
+      .sbar ||
+    baz:
+        argbaz
+      .sbaz || qux
+<<< #3720 fewerBraces = always ++ selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ++
+      bar:
+          argbar
+        .sbar ++
+      baz:
+          argbaz
+        .sbaz ++ qux
+<<< #3720 fewerBraces = always || selects, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ||
+    bar:
+        argbar
+      .sbar ||
+    baz:
+        argbaz
+      .sbaz || qux
+<<< #3720 fewerBraces = always ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+    ++
+      bar.sbar:
+          argbar
+      ++
+      baz.sbaz:
+          argbaz ++ qux
+<<< #3720 fewerBraces = always || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+    ||
+    bar.sbar:
+        argbar
+    ||
+    baz.sbaz:
+        argbaz
+    || qux
+<<< #3720 fewerBraces = always ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+    ++
+      bar.sbar:
+          argbar
+      ++
+      baz.sbaz:
+          argbaz ++ qux
+<<< #3720 fewerBraces = always || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+        argfoo
+    ||
+    bar.sbar:
+        argbar
+    ||
+    baz.sbaz:
+        argbaz
+    || qux
+<<< #3720 fewerBraces = always ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++
+      bar
+        .sbar1:
+          argbar
+        .sbar2 ++
+      baz
+        .sbaz1:
+          argbaz
+        .sbaz2 ++ qux
+<<< #3720 fewerBraces = always || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2 ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = always ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++
+      bar
+        .sbar1:
+          argbar
+        .sbar2 ++
+      baz
+        .sbaz1:
+          argbaz
+        .sbaz2 ++ qux
+<<< #3720 fewerBraces = always || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2 ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = always ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+        arg
+    ++
+      baz:
+          arg ++ qux
+<<< #3720 fewerBraces = always || short, newlines
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+        arg
+    ||
+    baz:
+        arg
+    || qux
+<<< #3720 fewerBraces = always ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+        arg
+    ++
+      baz:
+          arg ++ qux
+<<< #3720 fewerBraces = always || short, spaces
+indent.significant = 2
+indent.fewerBraces = always
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+        arg
+    ||
+    baz:
+        arg
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ no selects, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+      bar:
+        argbar
+      ++
+      baz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || no selects, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ no selects, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ++
+      bar:
+        argbar
+      ++
+      baz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || no selects, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    || bar:
+      argbar
+    || baz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects after, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ++
+    bar:
+      argbar
+    .sbar
+    ++
+    baz:
+      argbaz
+    .sbaz
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ++
+      bar:
+          argbar
+        .sbar ++
+      baz:
+          argbaz
+        .sbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects after, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo
+    ||
+    bar:
+      argbar
+    .sbar
+    ||
+    baz:
+      argbaz
+    .sbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ||
+    bar:
+        argbar
+      .sbar ||
+    baz:
+        argbaz
+      .sbaz || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects after, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo ++ bar:
+      argbar
+    .sbar ++ baz:
+      argbaz
+    .sbaz ++ qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ++
+      bar:
+          argbar
+        .sbar ++
+      baz:
+          argbaz
+        .sbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects after, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo:
+      argfoo
+    .sfoo || bar:
+      argbar
+    .sbar || baz:
+      argbaz
+    .sbaz || qux
+>>>
+object a:
+  def mtd =
+    foo:
+        argfoo
+      .sfoo ||
+    bar:
+        argbar
+      .sbar ||
+    baz:
+        argbaz
+      .sbaz || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects before, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar.sbar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+      bar.sbar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects before, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects before, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar.sbar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+      bar.sbar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects before, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar.sbar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar.sbar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects both, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ++
+    bar.sbar1:
+      argbar
+    .sbar2
+    ++
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ++
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++
+      bar
+        .sbar1:
+          argbar
+        .sbar2 ++
+      baz
+        .sbaz1:
+          argbaz
+        .sbaz2 ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects both, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2
+    ||
+    bar.sbar1:
+      argbar
+    .sbar2
+    ||
+    baz.sbaz1:
+      argbaz
+    .sbaz2
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2 ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects both, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 ++ bar.sbar1:
+      argbar
+    .sbar2 ++ baz.sbaz1:
+      argbaz
+    .sbaz2 ++ qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ++
+      bar
+        .sbar1:
+          argbar
+        .sbar2 ++
+      baz
+        .sbaz1:
+          argbaz
+        .sbaz2 ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects both, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo1:
+      argfoo
+    .sfoo2 || bar.sbar1:
+      argbar
+    .sbar2 || baz.sbaz1:
+      argbaz
+    .sbaz2 || qux
+>>>
+object a:
+  def mtd =
+    foo
+      .sfoo1:
+        argfoo
+      .sfoo2 ||
+    bar
+      .sbar1:
+        argbar
+      .sbar2 ||
+    baz
+      .sbaz1:
+        argbaz
+      .sbaz2 || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects mixed, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+    bar:
+      argbar
+    ++
+    baz.sbaz:
+      argbaz
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+      bar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects mixed, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ selects mixed, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++ bar:
+      argbar
+    ++ baz.sbaz:
+      argbaz
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ++
+      bar:
+        argbar
+      ++
+      baz.sbaz:
+        argbaz ++ qux
+<<< #3720 fewerBraces = beforeSelect || selects mixed, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    || bar:
+      argbar
+    || baz.sbaz:
+      argbaz
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.sfoo:
+      argfoo
+    ||
+    bar:
+      argbar
+    ||
+    baz.sbaz:
+      argbaz
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ short, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+    baz:
+      arg
+    ++
+    qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+      baz:
+        arg ++ qux
+<<< #3720 fewerBraces = beforeSelect || short, newlines
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    ||
+    qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    || qux
+<<< #3720 fewerBraces = beforeSelect ++ short, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++ baz:
+      arg
+    ++ qux
+>>>
+Idempotency violated
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ++
+      baz:
+        arg ++ qux
+<<< #3720 fewerBraces = beforeSelect || short, spaces
+indent.significant = 2
+indent.fewerBraces = beforeSelect
+indentOperator.exemptScope = all
+===
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    || baz:
+      arg
+    || qux
+>>>
+object a:
+  def mtd =
+    foo.bar:
+      arg
+    ||
+    baz:
+      arg
+    || qux


### PR DESCRIPTION
When a fewer braces call is used before an infix operator, that operator may not be indented as it will otherwise be interpreted as part of the fewer-braces argument.

This fix leaves a few cases (notably, many for newlines.source=unfold) still broken, but that requires a change to the parser which will be released in the new version of scalameta.

Helps with #3720.