### PR TITLE
FormatTokensRewrite: claim current token as well

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -253,6 +253,7 @@ object FormatTokensRewrite {
     )(implicit ft: FormatToken, style: ScalafmtConfig): Boolean =
       rule.enabled && (rule.onToken match {
         case Some(repl) =>
+          claimed.getOrElseUpdate(ft.meta.idx, rule)
           repl.claim.foreach { claimed.getOrElseUpdate(_, rule) }
           tokens.append(repl)
           true


### PR DESCRIPTION
That way, a rule could check whether any previous token had been handled by another rule.