### PR TITLE
FormatOps: set indent correctly for enclosed body

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1904,7 +1904,13 @@ class FormatOps(
         style: ScalafmtConfig
     ): Split =
       asInfixApp(body).fold {
-        val expire = tokens.nextNonCommentSameLine(tokens.getLast(body)).left
+        val lastFt = tokens.getLast(body)
+        val right = nextNonComment(ft).right
+        val rpOpt = if (right.is[T.LeftParen]) matchingOpt(right) else None
+        val expireFt = rpOpt.fold(lastFt) { rp =>
+          if (rp.end >= lastFt.left.end) tokens.before(rp) else lastFt
+        }
+        val expire = tokens.nextNonCommentSameLine(expireFt).left
         nlSplit.withIndent(Num(style.indent.main), expire, ExpiresOn.After)
       }(app => InfixSplits.withNLIndent(nlSplit)(app, ft))
 

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1342,11 +1342,11 @@ object A {
   def test =
     (
       foo,
-  )
+    )
   def test =
     (
       foo,
-  )
+    )
   def test =
     (
       Option(""),
@@ -1373,11 +1373,11 @@ object A {
   def test =
     (
       foo,
-  )
+    )
   def test =
     (
       foo,
-  )
+    )
   def test =
     (
       Option(""),
@@ -1404,11 +1404,11 @@ object A {
   def test =
     (
       foo,
-  )
+    )
   def test =
     (
       foo,
-  )
+    )
   def test =
     (
       Option(""),


### PR DESCRIPTION
Follow on to #3743.