### PR TITLE
TreeOps: relax when trailing comma paren possible

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -480,16 +480,14 @@ class FormatWriter(formatOps: FormatOps) {
           getClosedDelimWithNewline(expectedNewline).isDefined
         }
 
-        def getClosedDelimWithNewline(
-            expectedNewline: Boolean
-        ): Option[FormatToken] = {
+        def getClosedDelimWithNewline(whenNL: Boolean): Option[FormatToken] = {
           @tailrec
           def iter(
               floc: FormatLocation,
               hadNL: Boolean
           ): Option[FormatToken] = {
             val isNL = floc.hasBreakAfter
-            if (isNL && !expectedNewline) None
+            if (isNL && !whenNL) None
             else {
               val ft = floc.formatToken
               def gotNL = hadNL || isNL
@@ -499,8 +497,8 @@ class FormatWriter(formatOps: FormatOps) {
                   if (idx == locations.length) None
                   else iter(locations(idx), gotNL)
                 case _ =>
-                  val ok = gotNL == expectedNewline &&
-                    TreeOps.rightIsCloseDelimForTrailingComma(tok.left, ft)
+                  val ok = gotNL == whenNL && TreeOps
+                    .rightIsCloseDelimForTrailingComma(tok.left, ft, whenNL)
                   if (ok) Some(ft) else None
               }
             }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -844,11 +844,12 @@ object TreeOps {
   // try to add them in the TrainingCommas.always branch.
   def rightIsCloseDelimForTrailingComma(
       left: Token,
-      ft: FormatToken
+      ft: FormatToken,
+      whenNL: Boolean = true
   )(implicit style: ScalafmtConfig): Boolean = {
     def owner = ft.meta.rightOwner
     def isArgOrParamClauseSite(tree: Tree) =
-      isArgClauseSite(tree) || isParamClauseSite(tree)
+      !whenNL || isArgClauseSite(tree) || isParamClauseSite(tree)
     // skip empty parens/braces/brackets
     ft.right match {
       case _: Token.RightBrace =>

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
@@ -367,20 +367,12 @@ val x = (
 val x = ( "a", 
 )
 >>>
-test does not parse: [dialect scala213] illegal start of simple expression
-val x = ("a", )
-              ^
-====== full result: ======
-val x = ("a", )
+val x = ("a")
 <<< #3663 enclosed lambda
 val x = ( x => x + 1,
 )
 >>>
-test does not parse: [dialect scala213] illegal start of simple expression
-val x = (x => x + 1, )
-                     ^
-====== full result: ======
-val x = (x => x + 1, )
+val x = (x => x + 1)
 <<< #3663 enclosed lambda 1
 val x = (
  x => x + 1,


### PR DESCRIPTION
Follow-on for #3743.