### PR TITLE
FormatOps: fix `functionExpire` when rewritten

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -944,8 +944,8 @@ class FormatOps(
 
     def getRToks = dropWS(function.tokens.reverse)
     function.parent match {
-      case Some(b @ Term.Block(_ :: Nil)) =>
-        getLastToken(b) -> ExpiresOn.Before
+      case Some(p @ Term.Block(_ :: Nil)) =>
+        p.tokens.last -> ExpiresOn.Before
       case Some(Case(_, _, `function`)) =>
         orElse(dropComment(getRToks))
       case _ =>


### PR DESCRIPTION
Also, now it can be used in Router after `=>`.