### PR TITLE
FormatOps: getMustDangleForTrailingCommas(Token)

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2852,11 +2852,6 @@ class FormatOps(
       case _ => false
     }
 
-  def getMustDangleForTrailingCommas(close: T)(implicit
-      style: ScalafmtConfig
-  ): Boolean =
-    getMustDangleForTrailingCommas(tokens.justBefore(close))
-
   def getMustDangleForTrailingCommas(getCloseFt: => FormatToken)(implicit
       style: ScalafmtConfig
   ): Boolean =


### PR DESCRIPTION
Remove this method and create a reusable FormatToken at invocation site.