### PR TITLE
Scalafmt: use .forSbt for .sbt files only

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -65,8 +65,7 @@ object Scalafmt {
       filename: String = defaultFilename
   ): Formatted.Result = {
     def getStyleByFile(style: ScalafmtConfig) = {
-      val isSbt = FileOps.isAmmonite(filename) || FileOps.isSbt(filename) ||
-        FileOps.isMarkdown(filename)
+      val isSbt = FileOps.isSbt(filename)
       if (isSbt) style.forSbt else style
     }
     val styleTry =


### PR DESCRIPTION
Ammonite and/or markdown were really just looking to enable the top-level terms flag in the dialect, which has already been enabled for all files anyway.

Helps with #3787.