### PR TITLE
ScalafmtConfig: use Sbt dialect for .sbt files

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -4,6 +4,7 @@ import java.nio.file.Path
 
 import metaconfig.Configured
 import scala.meta.Input
+import scala.meta.dialects
 import scala.meta.parsers.ParseException
 import scala.util.Failure
 import scala.util.Success
@@ -12,6 +13,7 @@ import scala.util.Try
 import org.scalafmt.Error.PreciseIncomplete
 import org.scalafmt.config.FormatEvent.CreateFormatOps
 import org.scalafmt.config.LineEndings
+import org.scalafmt.config.NamedDialect
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.BestFirstSearch
 import org.scalafmt.internal.FormatOps
@@ -65,7 +67,11 @@ object Scalafmt {
   ): Formatted.Result = {
     def getStyleByFile(style: ScalafmtConfig) = {
       val isSbt = FileOps.isSbt(filename)
-      if (isSbt) style.forSbt else style
+      if (isSbt) {
+        val sbtStyle = style.forSbt
+        if (sbtStyle.dialect ne baseStyle.dialect) sbtStyle
+        else sbtStyle.withDialect(NamedDialect(dialects.Sbt))
+      } else style
     }
     val styleTry =
       if (filename == defaultFilename) Success(baseStyle)

--- a/scalafmt-tests/src/test/resources/scala3/Issues.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Issues.stat
@@ -114,5 +114,6 @@ lazy val versions = new {
   val cats = "2.10.0"
 }
 >>> build.sbt
-lazy val versions = new:
+lazy val versions = new {
   val cats = "2.10.0"
+}

--- a/scalafmt-tests/src/test/resources/scala3/Issues.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Issues.stat
@@ -97,3 +97,22 @@ def g =
     val a = param + 2
     a
   }
+<<< #3787 with custom dialect via fileOverride
+rewrite.scala3.removeOptionalBraces = true
+fileOverride { ".sbt" { runner.dialect = scala3 } }
+===
+lazy val versions = new {
+  val cats = "2.10.0"
+}
+>>> build.sbt
+lazy val versions = new:
+  val cats = "2.10.0"
+<<< #3787 without fileOverride and default dialect
+rewrite.scala3.removeOptionalBraces = true
+===
+lazy val versions = new {
+  val cats = "2.10.0"
+}
+>>> build.sbt
+lazy val versions = new:
+  val cats = "2.10.0"


### PR DESCRIPTION
Apply this default unless another dialect, different from the primary one, was explicitly specified through `fileOverride`. Fixes #3787.