### PR TITLE
FormatWriter: fix top-level identification logic

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1578,8 +1578,8 @@ class FormatWriter(formatOps: FormatOps) {
               setTopStats(t, stats)
               super.apply(stats) // skip ref
             }
-          case _ =>
-            super.apply(tree)
+          case t: Stat.WithTemplate => apply(t.templ)
+          case _ => // everything else is not "top-level"
         }
       }
 

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -660,3 +660,55 @@ object a {
       d: D,
       implicit val e: E) {}
 }
+<<< #3800
+newlines.topLevelBodyMinStatements = 1
+newlines.topLevelBodyIfMinStatements = [before]
+===
+class DummyTest extends AnyWordSpecLike {
+  private class Scope {
+    val x = 1
+  }
+
+  "Test" should {
+    "example 1" in new Scope {
+      val x = 1
+    }
+
+    class Scope2 {
+      val x = 1
+    }
+
+    "example 2" in {
+      class Scope3 {
+        val x = 1
+      }
+    }
+  }
+}
+>>>
+class DummyTest extends AnyWordSpecLike {
+
+  private class Scope {
+
+    val x = 1
+  }
+
+  "Test" should {
+    "example 1" in new Scope {
+
+      val x = 1
+    }
+
+    class Scope2 {
+
+      val x = 1
+    }
+
+    "example 2" in {
+      class Scope3 {
+
+        val x = 1
+      }
+    }
+  }
+}

--- a/scalafmt-tests/src/test/resources/default/Class.stat
+++ b/scalafmt-tests/src/test/resources/default/Class.stat
@@ -695,18 +695,15 @@ class DummyTest extends AnyWordSpecLike {
 
   "Test" should {
     "example 1" in new Scope {
-
       val x = 1
     }
 
     class Scope2 {
-
       val x = 1
     }
 
     "example 2" in {
       class Scope3 {
-
         val x = 1
       }
     }


### PR DESCRIPTION
Previously, exclusion of Term.Block was accidentally removed. Let's now be even more explicit and recurse into templated trees only. Fixes #3800.