### PR TITLE
`:` could be from the single term in ArgClause

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -454,8 +454,16 @@ class Router(formatOps: FormatOps) {
           if (isEmptyFunctionBody(leftOwner) && !right.is[T.Comment]) 0
           else if (leftOwner.is[Template]) 0 // { applied the indent
           else
-            leftOwner.parent match {
-              case Some(ArgClauseParent(p: Term.Apply)) if isFewerBraces(p) =>
+            (leftOwner.parent match {
+              case Some(ac: Term.ArgClause) => ac.parent
+              case Some(x: Term) =>
+                x.parent.flatMap {
+                  case ac: Term.ArgClause => ac.parent
+                  case _ => None
+                }
+              case _ => None
+            }) match {
+              case Some(p: Term.Apply) if isFewerBraces(p) =>
                 style.indent.getSignificant
               case _ => style.indent.main
             }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -86,7 +86,3 @@ object ParamClauseParent {
     case p => p
   }
 }
-
-object ArgClauseParent {
-  def unapply(t: Member.ArgClause): Option[Tree] = t.parent
-}


### PR DESCRIPTION
For instance, Term.Block or Term.PartialFunction.