### PR TITLE
RewriteScala3Settings: expand RemoveOptionalBraces

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3100,7 +3100,7 @@ def f() = {
 > formatter might need to be run twice.
 >
 > This rule cannot be used with `rewrite.scala3.insertEndMarkerMinLines` or
-> `rewrite.scala3.removeOptionalBraces == oldSyntaxToo`.
+> `rewrite.scala3.removeOptionalBraces.oldSyntaxToo == true`.
 
 This rewrite in essence provides the opposite of what `RedundantBraces` achieves,
 and somewhat similar to Scala3's end marker rewrite rules.
@@ -3678,16 +3678,33 @@ NB: You could control these rules individually by
 
 ### `rewrite.scala3.removeOptionalBraces`
 
-If this flag is enabled,
+If this section is enabled,
 [optional braces](https://dotty.epfl.ch/docs/reference/other-new-features/indentation.html)
 will be removed and significant indentation applied.
 
-The flag takes the following values:
+```scala mdoc:defaults
+rewrite.scala3.removeOptionalBraces
+```
 
-- `no`: disabled
-- `yes`: applies to expressions using the new control syntax (or
-  `rewrite.scala3.convertToNewSyntax` is set)
-- `oldSyntaxToo`: applies also to expressions using deprecated syntax
+The section contains the following settings (available since v3.8.1):
+
+- `enabled`:
+  - if `false`, disables any rewriting, regardless of other
+    flags in this section
+  - if `true`, enables rewriting
+    - applies to expressions using the new control syntax
+      (or those which would rewritten to new syntax if
+      `rewrite.scala3.convertToNewSyntax` is set)
+    - other flags below might extend rewrites to other cases
+- `oldSyntaxToo`
+  - if `true`, applies also to expressions using deprecated syntax
+
+Prior to v3.8.1, `rewrite.scala3.removeOptionalBraces` was a flag which
+took three possible values (with their equivalent current settings shown):
+
+- `no`: `enabled = false`
+- `yes`: `enabled = true`
+- `oldSyntaxToo`: `enabled = true` and `oldSyntaxToo = true`
 
 ### `rewrite.scala3.insertEndMarkerMinLines`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -11,7 +11,6 @@ import scala.meta.Type
 import scala.util.Try
 
 import metaconfig._
-import org.scalafmt.config.RewriteScala3Settings._
 import org.scalafmt.rewrite.FormatTokensRewrite
 import org.scalafmt.rewrite.RedundantBraces
 import org.scalafmt.sysops.AbsoluteFile
@@ -453,7 +452,7 @@ object ScalafmtConfig {
       if (rewrite.scala3.insertEndMarkerMinLines != 0)
         addIf(rewrite.scala3.removeEndMarkerMaxLines >= rewrite.scala3.insertEndMarkerMinLines)
       addIf(rewrite.insertBraces.minLines != 0 && rewrite.scala3.insertEndMarkerMinLines != 0)
-      addIf(rewrite.insertBraces.minLines != 0 && rewrite.scala3.removeOptionalBraces == RemoveOptionalBraces.oldSyntaxToo)
+      addIf(rewrite.insertBraces.minLines != 0 && rewrite.scala3.removeOptionalBraces.oldSyntaxToo)
       if (rewrite.insertBraces.minLines != 0 && rewrite.rules.contains(RedundantBraces))
         addIf(rewrite.insertBraces.minLines < rewrite.redundantBraces.maxBreaks)
       addIf(align.beforeOpenParenDefnSite && !align.closeParenSite)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -3,7 +3,6 @@ package org.scalafmt.rewrite
 import scala.meta._
 import scala.meta.tokens.Token
 
-import org.scalafmt.config.RewriteScala3Settings
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.FormatToken
 import org.scalafmt.internal.FormatTokens
@@ -13,8 +12,7 @@ object RemoveScala3OptionalBraces extends FormatTokensRewrite.RuleFactory {
 
   override def enabled(implicit style: ScalafmtConfig): Boolean =
     style.dialect.allowSignificantIndentation &&
-      style.rewrite.scala3.removeOptionalBraces
-        .ne(RewriteScala3Settings.RemoveOptionalBraces.no)
+      style.rewrite.scala3.removeOptionalBraces.enabled
 
   override def create(implicit ftoks: FormatTokens): FormatTokensRewrite.Rule =
     new RemoveScala3OptionalBraces
@@ -28,8 +26,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
 
   private def allowOldSyntax(implicit style: ScalafmtConfig): Boolean =
     ConvertToNewScala3Syntax.enabled ||
-      style.rewrite.scala3.removeOptionalBraces
-        .eq(RewriteScala3Settings.RemoveOptionalBraces.oldSyntaxToo)
+      style.rewrite.scala3.removeOptionalBraces.oldSyntaxToo
 
   override def enabled(implicit style: ScalafmtConfig): Boolean =
     RemoveScala3OptionalBraces.enabled


### PR DESCRIPTION
Let's turn it into a class, with separate setting fields, rather than a single enum. Helps with #3812.