### PR TITLE
FormatTokensRewrite: sort rule factories

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -17,6 +17,8 @@ object RemoveScala3OptionalBraces extends FormatTokensRewrite.RuleFactory {
   override def create(implicit ftoks: FormatTokens): FormatTokensRewrite.Rule =
     new RemoveScala3OptionalBraces
 
+  override def priority: Int = 1
+
 }
 
 private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)


### PR DESCRIPTION
Specifically, make sure that remove-optional-braces comes after redundant-braces and redundant-parens.