### PR TITLE
RedundantBraces: fix "moving" braces around func

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -49,6 +49,10 @@ case class FormatToken(left: Token, right: Token, meta: FormatToken.Meta) {
   /** A format token is uniquely identified by its left token.
     */
   override def hashCode(): Int = hash(left).##
+
+  private[scalafmt] def withIdx(idx: Int): FormatToken =
+    copy(meta = meta.copy(idx = idx))
+
 }
 
 object FormatToken {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -39,10 +39,11 @@ class FormatTokens(leftTok2tok: Map[TokenHash, Int])(
     if (idx >= arr.length) arr.last
     else {
       val ft = arr(idx)
-      if (isBefore) {
-        if (ft.left.start <= tok.start) ft else at(idx - 1)
+      if (ft.left eq tok) ft
+      else if (isBefore) {
+        if (ft.left.start < tok.start) ft else at(idx - 1)
       } else {
-        if (ft.left.start >= tok.start) ft else at(idx + 1)
+        if (ft.left.start > tok.start) ft else at(idx + 1)
       }
     }
   }


### PR DESCRIPTION
Previously, we'd handle the case of `foo(x => { ... })` by:

1. replacing the `(` with a `{`
2. "pretending" to replace the `{` with a `(`
3. upon encountering the `}` for a fake `(`, removing the `(` and changing on the owner of the `}`
4. then removing the `)`

Instead, let's modify steps 2, 3 and 4 as follows:

2. remove `{`
3. remove `}`
4. replace the closing `)` with a `}` moving it to the position of the `}` in step 3, along with token ownership.