### PR TITLE
FormatTokensRewrite: ScalafmtConfig in Replacement

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -220,29 +220,33 @@ object FormatTokensRewrite {
         style: ScalafmtConfig
     ): Option[(Replacement, Replacement)]
 
-    protected final def removeToken(implicit ft: FormatToken): Replacement =
-      new Replacement(this, ft, ReplacementType.Remove)
+    protected final def removeToken(implicit
+        ft: FormatToken,
+        style: ScalafmtConfig
+    ): Replacement =
+      Replacement(this, ft, ReplacementType.Remove, style)
 
     protected final def replaceToken(
         text: String,
         owner: Option[Tree] = None,
         claim: Iterable[Int] = Nil
-    )(tok: T)(implicit ft: FormatToken): Replacement = {
+    )(tok: T)(implicit ft: FormatToken, style: ScalafmtConfig): Replacement = {
       val mOld = ft.meta.right
       val mNew = mOld.copy(text = text, owner = owner.getOrElse(mOld.owner))
       val ftNew = ft.copy(right = tok, meta = ft.meta.copy(right = mNew))
-      new Replacement(this, ftNew, ReplacementType.Replace, claim)
+      Replacement(this, ftNew, ReplacementType.Replace, style, claim)
     }
 
     protected final def replaceTokenBy(
         text: String,
         owner: Option[Tree] = None,
         claim: Iterable[Int] = Nil
-    )(f: T => T)(implicit ft: FormatToken): Replacement =
+    )(f: T => T)(implicit ft: FormatToken, style: ScalafmtConfig): Replacement =
       replaceToken(text, owner, claim)(f(ft.right))
 
     protected final def replaceTokenIdent(text: String, t: T)(implicit
-        ft: FormatToken
+        ft: FormatToken,
+        style: ScalafmtConfig
     ): Replacement = replaceToken(text)(
       new T.Ident(t.input, t.dialect, t.start, t.start + text.length, text)
     )
@@ -317,12 +321,13 @@ object FormatTokensRewrite {
       rules.find(tag.runtimeClass.isInstance).map(_.asInstanceOf[A])
   }
 
-  private[rewrite] class Replacement(
-      val rule: Rule,
-      val ft: FormatToken,
-      val how: ReplacementType,
+  private[rewrite] case class Replacement(
+      rule: Rule,
+      ft: FormatToken,
+      how: ReplacementType,
+      style: ScalafmtConfig,
       // list of FormatToken indices, with the claimed token on the **right**
-      val claim: Iterable[Int] = Nil
+      claim: Iterable[Int] = Nil
   )
 
   private[rewrite] sealed trait ReplacementType

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -94,12 +94,18 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
   }
 
   // we might not keep it but will hint to onRight
-  private def replaceWithLeftParen(implicit ft: FormatToken): Replacement =
+  private def replaceWithLeftParen(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Replacement =
     replaceTokenBy("(") { x =>
       new Token.LeftParen(x.input, x.dialect, x.start)
     }
 
-  private def replaceWithEquals(implicit ft: FormatToken): Replacement =
+  private def replaceWithEquals(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): Replacement =
     replaceTokenBy("=") { x =>
       new Token.Equals(x.input, x.dialect, x.start)
     }
@@ -140,9 +146,10 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
     lpFunction.orElse(lpPartialFunction).orNull
   }
 
-  private def onRightParen(
-      left: Replacement
-  )(implicit ft: FormatToken): (Replacement, Replacement) =
+  private def onRightParen(left: Replacement)(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): (Replacement, Replacement) =
     (left, removeToken)
 
   private def onLeftBrace(implicit
@@ -199,9 +206,10 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
     }
   }
 
-  private def onRightBrace(
-      left: Replacement
-  )(implicit ft: FormatToken): (Replacement, Replacement) =
+  private def onRightBrace(left: Replacement)(implicit
+      ft: FormatToken,
+      style: ScalafmtConfig
+  ): (Replacement, Replacement) =
     left.ft match {
       case lft @ FormatToken(_, _: Token.LeftParen, _)
           if left.how eq ReplacementType.Replace =>
@@ -209,7 +217,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
           // shifted right
           new Token.RightBrace(rt.input, rt.dialect, rt.start + 1)
         }
-        (removeToken(lft), right)
+        (removeToken(lft, style), right)
       case _ => (left, removeToken)
     }
 


### PR DESCRIPTION
We will need it to check configuration of the left token when processing the right token via a different rule. Helps with #3812.