### PR TITLE
RemoveScala3OptionalBraces: allow leading infix op

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -76,7 +76,9 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
         case t: Term.Name =>
           t.parent.exists {
             case p: Term.Select => p.name eq t // select without `.`
-            case p: Term.ApplyInfix => p.op eq t
+            case p: Term.ApplyInfix if p.op eq t =>
+              !style.dialect.allowInfixOperatorAfterNL ||
+              !t.tokens.head.isSymbolicInfixOperator
             case _ => false
           }
         case _ => false

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5211,10 +5211,10 @@ object a:
    withEval.so(evalComment so { c =>
      s"($c) "
    }) +
-     this.match {
-       case MateAdvice(seq, _, _, _) => seq.desc
-       case CpAdvice(judgment, _, _) => judgment.toString
-     } + "."
+     this.match
+        case MateAdvice(seq, _, _, _) => seq.desc
+        case CpAdvice(judgment, _, _) => judgment.toString
+     + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -4981,10 +4981,10 @@ object a {
 }
 >>>
 object a:
-   withEval.so(evalComment so { c => s"($c) " }) + this.match {
-     case MateAdvice(seq, _, _, _) => seq.desc
-     case CpAdvice(judgment, _, _) => judgment.toString
-   } + "."
+   withEval.so(evalComment so { c => s"($c) " }) + this.match
+      case MateAdvice(seq, _, _, _) => seq.desc
+      case CpAdvice(judgment, _, _) => judgment.toString
+   + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5246,10 +5246,10 @@ object a:
    withEval.so(evalComment so { c =>
      s"($c) "
    }) +
-     this.match {
-       case MateAdvice(seq, _, _, _) => seq.desc
-       case CpAdvice(judgment, _, _) => judgment.toString
-     } + "."
+     this.match
+        case MateAdvice(seq, _, _, _) => seq.desc
+        case CpAdvice(judgment, _, _) => judgment.toString
+     + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -5373,12 +5373,12 @@ object a:
        s"($c) "
      }
    ) +
-     this.match {
-       case MateAdvice(seq, _, _, _) =>
-         seq.desc
-       case CpAdvice(judgment, _, _) =>
-         judgment.toString
-     } + "."
+     this.match
+        case MateAdvice(seq, _, _, _) =>
+          seq.desc
+        case CpAdvice(judgment, _, _) =>
+          judgment.toString
+     + "."
 <<< match as infix lhs, with rewrite
 rewrite.scala3.removeOptionalBraces = yes
 ===


### PR DESCRIPTION
Previously, we didn't allow it as the scalameta library didn't provide a way to check when it was actually possible. Helps with #3812.