### PR TITLE
TreeOps: rename, improve `endsWithFewerBraces`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -486,7 +486,7 @@ class FormatOps(
             case x => !isEnclosedInParens(x)
           })
         val afterInfix = style.breakAfterInfix(t)
-        if (isBeforeOp && endsWithFewerBraces(app.lhs)) Seq(Split(Newline, 0))
+        if (isBeforeOp && isFewerBracesLhs(app.lhs)) Seq(Split(Newline, 0))
         else if (afterInfix ne Newlines.AfterInfix.keep) {
           if (isBeforeOp) Seq(Split(Space, 0))
           else {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -1073,18 +1073,15 @@ object TreeOps {
     dialect.allowFewerBraces && ftoks.getHead(tree.argClause).left.is[Colon]
 
   @tailrec
-  def endsWithFewerBraces(
+  def isFewerBracesLhs(
       tree: Tree
   )(implicit dialect: Dialect, ftoks: FormatTokens): Boolean =
-    tree match {
+    !ftoks.isEnclosedInMatching(tree) && (tree match {
       case t: Term.Apply => isFewerBraces(t)
-      case t: Term.ApplyInfix =>
-        t.argClause.values match {
-          case arg :: Nil => endsWithFewerBraces(arg)
-          case _ => false
-        }
+      case t: Term.ApplyInfix => isFewerBracesLhs(t.argClause)
+      case Term.ArgClause(arg :: Nil, _) => isFewerBracesLhs(arg)
       case _ => false
-    }
+    })
 
   def isParentAnApply(t: Tree): Boolean =
     t.parent.exists(_.is[Term.Apply])


### PR DESCRIPTION
Exclude expressions enclosed in braces or parens. Helps with #3812.