### PR TITLE
Router: break on `(lambda` to keep trailing comma

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -865,7 +865,10 @@ class Router(formatOps: FormatOps) {
           if (!style.danglingParentheses.callSite) None
           else Some(decideNewlinesOnlyBeforeClose(close))
         val noSplitMod =
-          if (style.newlines.alwaysBeforeCurlyLambdaParams) null
+          if (
+            style.newlines.alwaysBeforeCurlyLambdaParams ||
+            getMustDangleForTrailingCommas(tokens.justBefore(close))
+          ) null
           else getNoSplit(formatToken, true)
 
         def multilineSpaceSplit(implicit fileLine: FileLine): Split = {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1505,13 +1505,12 @@ object a {
 >>>
 Idempotency violated
 => Diff (- obtained, + expected)
- object a {
--  mtd1(x => x + 1) + mtd2(x => x + 1 x +2)
-+  mtd1(x => x + 1) + mtd2(x =>
-+    x + 1
-+    x + 2,
-+  )
- }
+   ) + mtd2(
+-    x => x + 1 x +2,
++    x =>
++      x + 1
++      x + 2,
+   )
 <<< rewrite with trailing commas: func in parens and braces, allowFolding
 rewrite.rules = [RedundantBraces, RedundantParens]
 rewrite.trailingCommas.style = keep

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces.stat
@@ -1975,17 +1975,21 @@ foo
   )
 >>>
 foo
-  .mtd1(x => x + 1)
-  .mtd2(x =>
-     x + 1
-     x + 2
-  ,
+  .mtd1(
+    x => x + 1,
   )
-  .mtd3(x =>
-     x + 1
-     x + 2
-     x + 3
-  ,
+  .mtd2(
+    x =>
+       x + 1
+       x + 2
+    ,
+  )
+  .mtd3(
+    x =>
+       x + 1
+       x + 2
+       x + 3
+    ,
   )
 <<< rewrite to fewer braces: func in parens, infix after
 rewrite.rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces_fold.stat
@@ -1729,13 +1729,17 @@ foo
     },
   )
 >>>
-foo.mtd1(x => x + 1).mtd2(x =>
-   x + 1
-   x + 2,
-).mtd3(x =>
-   x + 1
-   x + 2
-   x + 3,
+foo.mtd1(
+  x => x + 1,
+).mtd2(
+  x =>
+     x + 1
+     x + 2,
+).mtd3(
+  x =>
+     x + 1
+     x + 2
+     x + 3,
 )
 <<< rewrite to fewer braces: func in parens, infix after
 rewrite.rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces_keep.stat
@@ -1948,19 +1948,22 @@ foo
   )
 >>>
 foo
-  .mtd1(x =>
-    x + 1,
+  .mtd1(
+    x =>
+      x + 1,
   )
-  .mtd2(x =>
-     x + 1
-     x + 2
-  ,
+  .mtd2(
+    x =>
+       x + 1
+       x + 2
+    ,
   )
-  .mtd3(x =>
-     x + 1
-     x + 2
-     x + 3
-  ,
+  .mtd3(
+    x =>
+       x + 1
+       x + 2
+       x + 3
+    ,
   )
 <<< rewrite to fewer braces: func in parens, infix after
 rewrite.rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces_unfold.stat
@@ -1964,15 +1964,19 @@ foo
   )
 >>>
 foo
-  .mtd1(x => x + 1)
-  .mtd2(x =>
-     x + 1
-     x + 2,
+  .mtd1(
+    x => x + 1,
   )
-  .mtd3(x =>
-     x + 1
-     x + 2
-     x + 3,
+  .mtd2(
+    x =>
+       x + 1
+       x + 2,
+  )
+  .mtd3(
+    x =>
+       x + 1
+       x + 2
+       x + 3,
   )
 <<< rewrite to fewer braces: func in parens, infix after
 rewrite.rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
@@ -397,9 +397,11 @@ foo.mtd(
     },
   )
 >>>
-foo.mtd(x => {
-  x + 1
-})
+foo.mtd(
+  x => {
+    x + 1
+  },
+)
 <<< partial func in parens, !allowFolding
 rewrite.trailingCommas.allowFolding = false
 ===
@@ -430,9 +432,11 @@ object a {
 }
 >>>
 object a {
-  foo.mtd(bar(x => {
-    x + 1
-  }))
+  foo.mtd(bar(
+      x => {
+      x + 1
+    },
+    ))
   foo.mtd(
     bar(x => {
       x + 1
@@ -445,21 +449,24 @@ binPack.indentCallSiteOnce = true
 rewrite.trailingCommas.allowFolding = false
 ===
 object a {
-    foo.mtd(bar(x => {
-          x + 1
-        },
-      ))
-    foo.mtd(bar(x => {
-          x + 1
-        }
-      ),
-    )
+  foo.mtd(bar(
+      x => {
+      x + 1
+    },
+    ))
+  foo.mtd(
+    bar(x => {
+      x + 1
+    }),
+  )
 }
 >>>
 object a {
-  foo.mtd(bar(x => {
-    x + 1
-  }))
+  foo.mtd(bar(
+      x => {
+      x + 1
+    },
+    ))
   foo.mtd(
     bar(x => {
       x + 1


### PR DESCRIPTION
Other cases already implement this. Helps with #3812.