### PR TITLE
FormatTokensRewrite: token map expects left token

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -41,9 +41,9 @@ class FormatTokens(leftTok2tok: Map[TokenHash, Int])(
       val ft = arr(idx)
       if (ft.left eq tok) ft
       else if (isBefore) {
-        if (ft.left.start < tok.start) ft else at(idx - 1)
+        if (ft.left.start <= tok.start) ft else at(idx - 1)
       } else {
-        if (ft.left.start > tok.start) ft else at(idx + 1)
+        if (ft.left.start >= tok.start) ft else at(idx + 1)
       }
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -58,9 +58,9 @@ class FormatTokensRewrite(
         tokenMap += FormatTokens.thash(rtOld) -> dstidx
       copySlice(idx)
       def append(): Unit = {
-        if (rtOld ne ft.right) mapOld(appended)
         appended += 1
         result += ft
+        if (rtOld ne ft.right) mapOld(appended)
       }
       def remove(dstidx: Int): Unit = {
         mapOld(dstidx)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -155,8 +155,8 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
         // move right to the end of the function
         val rType = new ReplacementType.RemoveAndResurrect(pft.meta.idx - 1)
         left -> replaceToken("}", rtype = rType) {
-          // create a different token so that any child tree wouldn't own it
-          new Token.RightBrace(rb.input, rb.dialect, rb.start)
+          // create a shifted token so that any child tree wouldn't own it
+          new Token.RightBrace(rb.input, rb.dialect, rb.start + 1)
         }
       } else null // don't know how to Replace
     case _ => null


### PR DESCRIPTION
Hence, point right token to next index instead. Helps with #3812.