### PR TITLE
FormatOps: fix leading infix before fewer braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -508,7 +508,9 @@ class FormatOps(
           val mod = getMod(ft)
           val modOrNoSplit =
             if (mod != Space || isBeforeOp || useSpace) mod else NoSplit
-          Seq(InfixSplits.withNLIndent(Split(modOrNoSplit, 0))(app, ft))
+          val split = Split(modOrNoSplit, 0)
+          if (isBeforeOp && isFewerBracesRhs(app.arg)) Seq(split)
+          else Seq(InfixSplits.withNLIndent(split)(app, ft))
         }
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -1083,6 +1083,17 @@ object TreeOps {
       case _ => false
     })
 
+  @tailrec
+  def isFewerBracesRhs(
+      tree: Tree
+  )(implicit dialect: Dialect, ftoks: FormatTokens): Boolean =
+    !ftoks.isEnclosedInMatching(tree) && (tree match {
+      case t: Term.Apply => isFewerBraces(t)
+      case t: Term.ApplyInfix => isFewerBracesRhs(t.lhs)
+      case Term.ArgClause(arg :: Nil, _) => isFewerBracesRhs(arg)
+      case _ => false
+    })
+
   def isParentAnApply(t: Tree): Boolean =
     t.parent.exists(_.is[Term.Apply])
 

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces.stat
@@ -2271,16 +2271,15 @@ object a:
       x + 3
    }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-         x + 2
--          + mtd3 { x =>
--             x + 1
--             x + 2
--             x + 3
--          }
-+     + mtd3 { x =>
-+        x + 1
-+        x + 2
-+        x + 3
-+     }
+object a:
+   mtd1 { x =>
+     x + 1
+   }
+   + mtd2: x =>
+      x + 1
+      x + 2
+   + mtd3 { x =>
+      x + 1
+      x + 2
+      x + 3
+   }

--- a/scalafmt-tests/src/test/resources/scala3/FewerBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/FewerBraces_keep.stat
@@ -2248,16 +2248,15 @@ object a:
       x + 3
    }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-         x + 2
--          + mtd3 { x =>
--             x + 1
--             x + 2
--             x + 3
--          }
-+     + mtd3 { x =>
-+        x + 1
-+        x + 2
-+        x + 3
-+     }
+object a:
+   mtd1 { x =>
+     x + 1
+   }
+   + mtd2: x =>
+      x + 1
+      x + 2
+   + mtd3 { x =>
+      x + 1
+      x + 2
+      x + 3
+   }


### PR DESCRIPTION
Specifically, just like after fewer braces, we shouldn't indent leading infix before fewer braces either. Helps with #3812.