### PR TITLE
RedundantBraces: claim left brace inside parens

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -233,7 +233,13 @@ object FormatTokensRewrite {
         ft: FormatToken,
         style: ScalafmtConfig
     ): Replacement =
-      Replacement(this, ft, ReplacementType.Remove, style)
+      removeToken(Nil)
+
+    protected final def removeToken(claim: Iterable[Int] = Nil)(implicit
+        ft: FormatToken,
+        style: ScalafmtConfig
+    ): Replacement =
+      Replacement(this, ft, ReplacementType.Remove, style, claim)
 
     protected final def replaceToken(
         text: String,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -128,8 +128,13 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       case ta @ Term.ArgClause(arg :: Nil, _)
           if !ta.parent.exists(_.is[Init]) =>
         getOpeningParen(ta).map { lp =>
-          val ko = lp.ne(rt) || getBlockNestedPartialFunction(arg).isEmpty
-          if (ko) null else removeToken
+          if (lp.ne(rt) || getBlockNestedPartialFunction(arg).isEmpty) null
+          else
+            ftoks.nextNonCommentAfter(ft) match {
+              case FormatToken(_, _: Token.LeftBrace, lbm) =>
+                removeToken(claim = lbm.idx :: Nil)
+              case _ => null
+            }
         }
       case _ => None
     }


### PR DESCRIPTION
Since the code aims to remove the parens assuming the next brace is not mutated by another rule, let's explicitly stake claim to that brace. Helps with #3812.