### PR TITLE
ScalafmtOptimizer: rename forceConfigStyleOnOffset

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,7 +210,7 @@ top-level.
       sometimesBeforeColonInMethodReturnType = false
     }
     runner.optimizer {
-      forceConfigStyleOnOffset = 500
+      forceConfigStyleMinSpan = 500
       forceConfigStyleMinArgCount = 5
     }
 ```
@@ -2810,19 +2810,20 @@ Controls parameters which trigger forced config-style formatting. All conditions
 must be satisfied in order for this rule to apply.
 
 ```scala mdoc:defaults
-runner.optimizer.forceConfigStyleOnOffset
+runner.optimizer.forceConfigStyleMinSpan
 runner.optimizer.forceConfigStyleMinArgCount
 ```
 
-- `runner.optimizer.forceConfigStyleOnOffset`: applies to method calls; if
+- `runner.optimizer.forceConfigStyleMinSpan`: applies to method calls; if
   positive, specifies the minimum character distance between the matching
-  parentheses, excluding any whitespace
+  parentheses, excluding any whitespace (prior to v3.8.1, this parameter
+  was called `forceConfigStyleOnOffset`)
 - `runner.optimizer.forceConfigStyleMinArgCount` applies to method calls;
   specifies the minimum number of arguments
 
 ```scala mdoc:scalafmt
 optIn.configStyleArguments = true
-runner.optimizer.forceConfigStyleOnOffset = 5
+runner.optimizer.forceConfigStyleMinSpan = 5
 runner.optimizer.forceConfigStyleMinArgCount = 2
 maxColumn = 60
 ---

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -364,7 +364,7 @@ object ScalafmtConfig {
     default.runner.copy(
       optimizer = default.runner.optimizer.copy(
         // The tests were not written in this style
-        forceConfigStyleOnOffset = 500,
+        forceConfigStyleMinSpan = 500,
         forceConfigStyleMinArgCount = 5
       )
     )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtOptimizer.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtOptimizer.scala
@@ -46,13 +46,13 @@ import metaconfig._
   *
   * By starting a new search queue, we can perform aggressive optimizations
   * inside optimizations zones.
-  * @param forceConfigStyleOnOffset
+  * @param forceConfigStyleMinSpan
   *   If negative number, does nothing. If n >= 0, then scalafmt will force
   *   "config style" on Term.Apply nodes IF it has more than
   *   [[forceConfigStyleMinArgCount]] arguments AND the non-whitespace byte
   *   offset between the opening parens and closing parens is greater than
-  *   [[forceConfigStyleOnOffset]]. By forcing config style on such
-  *   applications, the search space is greatly reduced.
+  *   [[forceConfigStyleMinSpan]]. By forcing config style on such applications,
+  *   the search space is greatly reduced.
   */
 case class ScalafmtOptimizer(
     dequeueOnNewStatements: Boolean = true,
@@ -64,7 +64,8 @@ case class ScalafmtOptimizer(
     disableOptimizationsInsideSensitiveAreas: Boolean = true,
     pruneSlowStates: Boolean = true,
     recurseOnBlocks: Boolean = true,
-    forceConfigStyleOnOffset: Int = 150,
+    @annotation.ExtraName("forceConfigStyleOnOffset")
+    forceConfigStyleMinSpan: Int = 150,
     forceConfigStyleMinArgCount: Int = 2
 )
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1135,7 +1135,7 @@ class FormatOps(
   }
 
   def getForceConfigStyle: (Set[TokenHash], Set[TokenHash]) = {
-    val maxDistance = runner.optimizer.forceConfigStyleOnOffset
+    val maxDistance = runner.optimizer.forceConfigStyleMinSpan
     if (maxDistance < 0)
       (Set.empty, Set.empty)
     else {

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1,7 +1,7 @@
 align.preset = none
 maxColumn = 40
 # newlines.source = classic
-runner.optimizer.forceConfigStyleOnOffset = 50
+runner.optimizer.forceConfigStyleMinSpan = 50
 binPack.parentConstructors = OnelineIfPrimaryOneline
 <<< 1.1: block, if-else, line too long
 if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2,7 +2,7 @@ align.preset = none
 maxColumn = 40
 newlines.source = fold
 newlines.afterCurlyLambda = squash
-runner.optimizer.forceConfigStyleOnOffset = 50
+runner.optimizer.forceConfigStyleMinSpan = 50
 <<< 1.1: block, if-else, line too long
 if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}
 >>>

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1,7 +1,7 @@
 align.preset = none
 maxColumn = 40
 newlines.source = keep
-runner.optimizer.forceConfigStyleOnOffset = 50
+runner.optimizer.forceConfigStyleMinSpan = 50
 binPack.parentConstructors = OnelineIfPrimaryOneline
 <<< 1.1: block, if-else, line too long
 if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -1,7 +1,7 @@
 align.preset = none
 maxColumn = 40
 newlines.source = unfold
-runner.optimizer.forceConfigStyleOnOffset = 50
+runner.optimizer.forceConfigStyleMinSpan = 50
 binPack.parentConstructors = OnelineIfPrimaryOneline
 <<< 1.1: block, if-else, line too long
 if (true) {      println(aaaaaaaaaaaaaaaaaaaaaaaaaa)}


### PR DESCRIPTION
Use `MinSpan` instead, for consistency with similar `fewerBracesXxxSpan` parameters under `rewrite.scala3.removeOptionalBraces`.