### PR TITLE
FormatOps: can't look at breaks for fold/unfold

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -167,7 +167,7 @@ class FormatOps(
       case _: T.RightParen if start.left.is[T.LeftParen] => None
       case c: T.Comment if start.noBreak && tokens.isBreakAfterRight(start) =>
         Some(c)
-      case _ if start.noBreak && isInfix => None
+      case _ if !style.newlines.formatInfix && start.noBreak && isInfix => None
       case _ => Some(start.left)
     }
 

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -167,6 +167,44 @@ object a {
     SizeUtils.calculate(segments, "user")
   } should have message """Cannot resolve column name "user" among (segment_id);"""
 }
+<<< 1.c.1: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< 1.c.2: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+       have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< 1.c.3: block followed by an infix, overflowing if no break
+newlines.afterInfix = keep
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy
+       { SizeUtils.calculate(segments, "user") } should
+       have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
+}
 <<< 1.d: if-else, no curlies
 if (a)
 println("bbb") else if (b) b else

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -155,6 +155,45 @@ object a {
   } should have message
     """Cannot resolve column name "user" among (segment_id);"""
 }
+<<< 1.c.1: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message
+    """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< 1.c.2: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+       have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< 1.c.3: block followed by an infix, overflowing if no break
+newlines.afterInfix = keep
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy
+       { SizeUtils.calculate(segments, "user") } should
+       have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
+}
 <<< 1.d: if-else, no curlies
 if (a)
 println("bbb")

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -150,10 +150,8 @@ object a {
 }
 >>>
 object a {
-  the[Exception] thrownBy {
-    SizeUtils.calculate(segments, "user")
-  } should have message
-    """Cannot resolve column name "user" among (segment_id);"""
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
 }
 <<< 1.c.1: block followed by an infix, overflowing if no break
 maxColumn = 80
@@ -163,10 +161,8 @@ object a {
 }
 >>>
 object a {
-  the[Exception] thrownBy {
-    SizeUtils.calculate(segments, "user")
-  } should have message
-    """Cannot resolve column name "user" among (segment_id);"""
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
 }
 <<< 1.c.2: block followed by an infix, overflowing if no break
 maxColumn = 80

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -167,6 +167,44 @@ object a {
     SizeUtils.calculate(segments, "user")
   } should have message """Cannot resolve column name "user" among (segment_id);"""
 }
+<<< 1.c.1: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< 1.c.2: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+       have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< 1.c.3: block followed by an infix, overflowing if no break
+newlines.afterInfix = keep
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy
+       { SizeUtils.calculate(segments, "user") } should
+       have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
+}
 <<< 1.d: if-else, no curlies
 if (a)
 println("bbb") else if (b) b else

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -182,6 +182,49 @@ object a {
   } should have message
     """Cannot resolve column name "user" among (segment_id);"""
 }
+<<< 1.c.1: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message
+    """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< 1.c.2: block followed by an infix, overflowing if no break
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy { SizeUtils.calculate(segments, "user") } should
+       have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should have message
+    """Cannot resolve column name "user" among (segment_id);"""
+}
+<<< 1.c.3: block followed by an infix, overflowing if no break
+newlines.afterInfix = keep
+maxColumn = 80
+===
+object a {
+    the[Exception] thrownBy
+       { SizeUtils.calculate(segments, "user") } should
+       have message """Cannot resolve column name "user" among (segment_id);"""
+}
+>>>
+object a {
+  the[Exception] thrownBy {
+    SizeUtils.calculate(segments, "user")
+  } should
+    have message """Cannot resolve column name "user" among (segment_id);"""
+}
 <<< 1.d: if-else, no curlies
 if (a)
 println("bbb") else if (b) b else c

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1706,11 +1706,11 @@ object a {
     } tag (ScalafmtTagPack: _*)
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-       session: FormatSession
--  ) = Def.task(session.checkTrackedSources(sources, dirs)) tag
--    (ScalafmtTagPack: _*)
-+  ) =
-+    Def.task(session.checkTrackedSources(sources, dirs)) tag (ScalafmtTagPack: _*)
- }
+object a {
+  private def scalafmtCheckTask(
+      sources: Seq[File],
+      dirs: Seq[File],
+      session: FormatSession
+  ) = Def.task(session.checkTrackedSources(sources, dirs)) tag
+    (ScalafmtTagPack: _*)
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1691,3 +1691,26 @@ foo.mtd({
     }
   },
 )
+<<< with infix (from sbt-scalafmt plugin)
+maxColumn = 80
+newlines.source = fold
+===
+object a {
+  private def scalafmtCheckTask(
+      sources: Seq[File],
+      dirs: Seq[File],
+      session: FormatSession
+  ) =
+    Def.task {
+      session.checkTrackedSources(sources, dirs)
+    } tag (ScalafmtTagPack: _*)
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+       session: FormatSession
+-  ) = Def.task(session.checkTrackedSources(sources, dirs)) tag
+-    (ScalafmtTagPack: _*)
++  ) =
++    Def.task(session.checkTrackedSources(sources, dirs)) tag (ScalafmtTagPack: _*)
+ }


### PR DESCRIPTION
The tests added were either non-idempotent or showed a bug in `fold` formatting which produces different output depending on breaks in input (which is contrary to what `fold` is supposed to do).