### PR TITLE
Router: use built-to FormatToken.toString

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2395,7 +2395,7 @@ class Router(formatOps: FormatOps) {
         Seq(Split(mod, 0))
       case FormatToken(_: T.Symbolic, _, _) => Seq(Split(Space, 0))
       case tok =>
-        logger.debug("MISSING CASE:\n" + log(tok))
+        logger.debug(s"MISSING CASE: $tok")
         Seq() // No solution available, partially format tree.
     }
   }


### PR DESCRIPTION
In the usually unreachable default case, let's use the built-in toString method rather than the more verbpse (but harder to read) LoggerOps.log2. Inspired by #3891.