### PR TITLE
RedundantBraces: ignore block under Term.Xml

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -244,6 +244,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
           case Some(f: Term.FunctionTerm)
               if okToReplaceFunctionInSingleArgApply(f) => removeToken
           case Some(_: Term.Interpolate) => handleInterpolation
+          case Some(_: Term.Xml) => null
           case _ => if (processBlock(t)) removeToken else null
         }
       case _: Term.Interpolate => handleInterpolation

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
@@ -100,3 +100,9 @@ object Test {
 object Test {
   s"${foo}_${bar}"
 }
+<<< #3891 braces within xml
+<testcase id={ id }/>
+>>>
+org.scalafmt.util.FormatException: org.scalafmt.Error$PreciseIncomplete: ...: error: Unable to format file due to bug in scalafmt
+<testcase id={ id }/>
+             ^

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
@@ -103,6 +103,4 @@ object Test {
 <<< #3891 braces within xml
 <testcase id={ id }/>
 >>>
-org.scalafmt.util.FormatException: org.scalafmt.Error$PreciseIncomplete: ...: error: Unable to format file due to bug in scalafmt
-<testcase id={ id }/>
-             ^
+<testcase id={id}/>


### PR DESCRIPTION
Fixes #3891.