### PR TITLE
Router: fix fold bug after semicolon

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -527,16 +527,11 @@ class Router(formatOps: FormatOps) {
           }
         }
       // New statement
-      case FormatToken(_: T.Semicolon, _, StartsStatementRight(stmt))
-          if newlines == 0 =>
-        val spaceSplit =
-          if (style.newlines.source eq Newlines.unfold) Split.ignored
-          else {
-            val expire = getLastToken(stmt)
+      case FormatToken(_: T.Semicolon, _, StartsStatementRight(stmt)) => Seq(
+          if (style.newlines.okSpaceForSource(newlines)) {
+            val expire = endOfSingleLineBlock(tokens.getLast(stmt))
             Split(Space, 0).withSingleLine(expire)
-          }
-        Seq(
-          spaceSplit,
+          } else Split.ignored,
           // For some reason, this newline cannot cost 1.
           Split(Newline2x(formatToken), 0),
         )

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -7735,3 +7735,22 @@ object Main {
       x3: X, x4: X, xs: X*)
       : Set[Int]
 }
+<<< two statements separated by semicolon
+foo match {
+  case a =>
+    bara;
+    baza
+  case b => barb;
+    bazb
+  case c => barc; bazc
+}
+>>>
+foo match {
+  case a =>
+    bara;
+    baza
+  case b =>
+    barb;
+    bazb
+  case c => barc; bazc
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -833,8 +833,7 @@ object a {
     wrap(result ⇒
       actorOf(Props(new OuterActor(actorOf(Props(
         promiseIntercept({
-          throw new IllegalStateException("Ur state be b0rked");
-          new InnerActor
+          throw new IllegalStateException("Ur state be b0rked"); new InnerActor
         })(result)))))))
   }).getMessage should ===("Ur state be b0rked")
 }
@@ -1620,8 +1619,8 @@ object a {
 >>>
 object a {
   for (
-    i <- 0 until n;
-    j <- 0 until n if i + j == v
+    i <- 0 until n; j <- 0 until n
+    if i + j == v
   ) yield (i, j)
 }
 <<< 7.1.2: enumerator and guard short, for long, parens
@@ -7396,11 +7395,7 @@ foo match {
 }
 >>>
 foo match {
-  case a =>
-    bara;
-    baza
-  case b =>
-    barb;
-    bazb
+  case a => bara; baza
+  case b => barb; bazb
   case c => barc; bazc
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -7385,3 +7385,22 @@ object Main {
       x3: X, x4: X, xs: X*)
       : Set[Int]
 }
+<<< two statements separated by semicolon
+foo match {
+  case a =>
+    bara;
+    baza
+  case b => barb;
+    bazb
+  case c => barc; bazc
+}
+>>>
+foo match {
+  case a =>
+    bara;
+    baza
+  case b =>
+    barb;
+    bazb
+  case c => barc; bazc
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -7729,3 +7729,22 @@ object Main {
       x1: X, x2: X, x3: X,
       x4: X, xs: X*): Set[Int]
 }
+<<< two statements separated by semicolon
+foo match {
+  case a =>
+    bara;
+    baza
+  case b => barb;
+    bazb
+  case c => barc; bazc
+}
+>>>
+foo match {
+  case a =>
+    bara;
+    baza
+  case b =>
+    barb;
+    bazb
+  case c => barc; bazc
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -7965,3 +7965,24 @@ object Main {
       x1: X, x2: X, x3: X,
       x4: X, xs: X*): Set[Int]
 }
+<<< two statements separated by semicolon
+foo match {
+  case a =>
+    bara;
+    baza
+  case b => barb;
+    bazb
+  case c => barc; bazc
+}
+>>>
+foo match {
+  case a =>
+    bara;
+    baza
+  case b =>
+    barb;
+    bazb
+  case c =>
+    barc;
+    bazc
+}


### PR DESCRIPTION
We used two separate rules depending on whether there had been a break, which is prohibited for either fold or unfold, and in case of fold, the two rules were inconsistent.