### PR TITLE
FormatOps: prefer ConfigStyle.Force over Source

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -900,16 +900,16 @@ class FormatOps(
   def couldUseConfigStyle(
       ft: FormatToken,
       beforeCloseFt: => FormatToken,
-      allowForce: => Boolean = true,
+      allowForce: Boolean = true,
   )(implicit style: ScalafmtConfig): ConfigStyle = {
     def opensImplicit =
       (next(ft).hasBreak ||
         style.newlines.forceAfterImplicitParamListModifier) &&
         opensConfigStyleImplicitParamList(ft)
-    val opensConfigStyle = !style.newlines.sourceIgnored && // classic
+    def opensConfigStyle = !style.newlines.sourceIgnored && // classic
       (ft.hasBreak || opensImplicit) && beforeCloseFt.hasBreak
-    if (opensConfigStyle) ConfigStyle.Source
-    else if (allowForce && forceConfigStyle(hash(ft.left))) ConfigStyle.Forced
+    if (allowForce && forceConfigStyle(hash(ft.left))) ConfigStyle.Forced
+    else if (opensConfigStyle) ConfigStyle.Source
     else ConfigStyle.None
   }
 


### PR DESCRIPTION
Since we changed this method to return the type of config style rather than a simple boolean, we used this type to make other format choices. However, Force should always take precedence as it doesn't depend on the formatting choices in the original code.