### PR TITLE
Router: fix scala.js style for binPack.callSite

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4878,25 +4878,25 @@ and similarly has cross-parameter interactions:
 - interaction with `config-style` parameters:
   - when [config-style is forced](#forcing-config-style), it takes precedence
     over binpacking
-  - for `newlines.source=classic`, formatting is mandated by the
-    [scala.js](https://github.com/scala-js/scala-js/pull/4522#issuecomment-879168123)
-    coding style, determined by the position of the closing parenthesis; "tucked"
-    parenthesis enables binpacking, while "dangling" one forces config-style
+  - for `newlines.source=classic`, behaviour depends on
+    [config-style](#optinconfigstylearguments):
+    - if enabled: used if [detected](#newlines-config-style-formatting), otherwise binpacked
+    - if disabled with both [`danglingParentheses.callSite`](#danglingparenthesescallsite)
+      enabled and closing parenthesis following a break: forces config-style, as described in
+      [scala.js](https://github.com/scala-js/scala-js/pull/4522#issuecomment-879168123)
+    - otherwise, uses binpacking
   - for other values of [`newlines.source`](#newlinessource),
     binpacking takes precedence
-- interaction with [`danglingParentheses.callSite``](#danglingparenthesescallsite)
-  - `newlines.source=classic`
-    - `danglingParentheses.callSite` is ignored
-    - when `config-style` is enabled: open break is preserved, close break
-      matches open break
-    - otherwise: both open and close are "tucked"
+- interaction with [`danglingParentheses.callSite`](#danglingparenthesescallsite)
+  - `newlines.source=classic`: please see above
   - `newlines.source=keep`
     - open break is preserved
-    - when both `config-style` and `danglingParentheses.callSite` are disabled,
+    - when both [config-style](#optinconfigstylearguments) and
+      [`danglingParentheses.callSite`](#danglingparenthesescallsite) are disabled,
       close break is "tucked"
     - otherwise, close break matches open break
   - `newlines.source=fold/unfold`
-    - when `danglingParentheses.callSite` is enabled,
+    - when [`danglingParentheses.callSite`](#danglingparenthesescallsite) is enabled,
       open break matches close break, and close is always dangling for `unfold`,
       and only when [config-style is forced](#forcing-config-style) for `fold`
     - otherwise, open is always dangling,

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2801,10 +2801,7 @@ object a {
   test("foo") {
     a.b(c, d) shouldBe
       E(Seq(F(1, "v1"), F(2, "v2")),
-        G(Some(Seq(h, i)),
-          Some(Seq(j, k)), a.b, c.d,
-          e.f.g, h.i.j)
-      ).foo
+        G(Some(Seq(h, i)), Some(Seq(j, k)), a.b, c.d, e.f.g, h.i.j)).foo
   }
 }
 <<< binpack call, oneline, with syntaxNL, single arg
@@ -7667,12 +7664,18 @@ object Main {
 }
 >>>
 object Main {
+  val bar1 = foo1(
+    10000,
+    10001,
+    10002 + 0
+  )
   val bar1 = foo1(10000,
     10001, 10002 + 0)
-  val bar1 = foo1(10000,
-    10001, 10002 + 0)
-  val bar1 = foo1(10000,
-    10001, 10002 + 0)
+  val bar1 = foo1(
+    10000,
+    10001,
+    10002 + 0
+  )
   val bar1 = foo1(10000,
     10001, 10002 + 0)
   val bar2 = foo2(0, 1, 2, 3,


### PR DESCRIPTION
Previously, how we handle `binpack.callSite=true` depended only on `optIn.configStyleArguments`, and `danglingParentheses.callSite` was ignored completely.

Also, the declared `scala.js` style, which purported to depend on the existence of a break before closing parenthesis, wasn't properly done.

Both opening and closing parentheses were output tucked in all cases but one, when both of them were dangling in the input (and the choice of whether to dangle or tuck depended solely on `configStyleArguments`).

Now let's introduce a small modification, so that we can express more formatting alternatives, and fix `scala.js` style.

Specifically, associate the two variants above with dangling parentheses in the disabled state.

When it's enabled, determine whether to tuck or dangle on break before closing parenthesis. Also, apply config style when that parenthesis is dangling and `configStyleArguments` is disabled (because in the enabled state, it requires both parentheses to be dangling to be triggered).