### PR TITLE
Config-style: separate control for call/defn sites

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2306,14 +2306,14 @@ newlines.implicitParamListModifierForce = [before,after]
 def format(code: String, age: Int)(implicit ev: Parser, c: Context): String
 ```
 
-#### Implicit with `optIn.configStyleArguments`
+#### Implicit with `newlines.configStyleDefnSite.prefer`
 
 While config-style normally requires a newline after the opening parenthesis,
 postponing that break until after the `implicit` keyword is allowed if other
 parameters require keeping this keyword attached to the opening brace.
 
 Therefore, any of the parameters described in this section will take precedence
-even when `optIn.configStyleArguments = true` is used.
+even when `newlines.configStyleDefnSite.prefer = true` is used.
 
 ### `newlines.afterInfix`
 
@@ -2787,10 +2787,12 @@ It normally involves a newline after the opening parenthesis (or after the
 As part of the formatting output, arguments are output one per line (but this is
 not used in determining whether the source uses config-style formatting).
 
-While this parameter is not technically under the `newlines` section, it
-logically belongs there.
+### `newlines.configStyleXxxSite.prefer`
 
-### `optIn.configStyleArguments`
+`CallSite` applies to argument clauses method calls, while `DefnSite` to
+parameter clauses in method or class definitions.
+In v3.8.2 replaced a single parameter `optIn.configStyleArguments` and
+falls back to its value (which is enabled by default).
 
 If true, applies config-style formatting:
 
@@ -2799,12 +2801,8 @@ If true, applies config-style formatting:
 
 Please note that other parameters might also force config-style (see below).
 
-```scala mdoc:defaults
-optIn.configStyleArguments
-```
-
 ```scala mdoc:scalafmt
-optIn.configStyleArguments = true
+newlines.configStyleDefnSite.prefer = true
 maxColumn=45
 ---
 object a {
@@ -4870,7 +4868,7 @@ and similarly has cross-parameter interactions:
   - when [config-style is forced](#forcing-config-style), it takes precedence
     over binpacking
   - for `newlines.source=classic`, behaviour depends on
-    [config-style](#optinconfigstylearguments):
+    [config-style](#newlinesconfigstylexxxsiteprefer):
     - if enabled: used if [detected](#newlines-config-style-formatting), otherwise binpacked
     - if disabled with both [`danglingParentheses.callSite`](#danglingparenthesescallsite)
       enabled and closing parenthesis following a break: forces config-style, as described in
@@ -4882,7 +4880,7 @@ and similarly has cross-parameter interactions:
   - `newlines.source=classic`: please see above
   - `newlines.source=keep`
     - open break is preserved
-    - when both [config-style](#optinconfigstylearguments) and
+    - when both [config-style](#newlinesconfigstylexxxsiteprefer) and
       [`danglingParentheses.callSite`](#danglingparenthesescallsite) are disabled,
       close break is "tucked"
     - otherwise, close break matches open break
@@ -4892,7 +4890,7 @@ and similarly has cross-parameter interactions:
       and only when [config-style is forced](#forcing-config-style) for `fold`
     - otherwise, open is always dangling,
       and close is dangling only when both
-      [`optIn.configStyleArguments=true`](#optinconfigstylearguments)
+      [`newlines.configStyleXxxSite.prefer=true`](#newlinesconfigstylexxxsiteprefer)
       and [config-style is forced](#forcing-config-style)
 
 > Please also see [callSite indentation parameters](#indent-for-binpackcallsite).

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -217,6 +217,8 @@ case class Newlines(
     inInterpolation: InInterpolation = InInterpolation.allow,
     ignoreInSyntax: Boolean = true,
     avoidAfterYield: Boolean = true,
+    configStyleCallSite: Option[ConfigStyleElement] = None,
+    configStyleDefnSite: Option[ConfigStyleElement] = None,
 ) {
   if (
     implicitParamListModifierForce.nonEmpty &&
@@ -537,6 +539,19 @@ object Newlines {
       case (_, conf) => SourceHints.codec.read(None, conf)
           .map(BeforeOpenParen.apply)
     }
+  }
+
+  /** Clauses where there is a newline after opening `(`` and newline before
+    * closing `)`. If true, preserves the newlines and keeps one line per
+    * argument.
+    */
+  case class ConfigStyleElement(prefer: Boolean = true)
+  private[config] object ConfigStyleElement {
+    private val default = ConfigStyleElement()
+    implicit val surface: Surface[ConfigStyleElement] = generic
+      .deriveSurface[ConfigStyleElement]
+    implicit val codec: ConfCodecEx[ConfigStyleElement] = generic
+      .deriveCodecEx(default).noTypos
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/OptIn.scala
@@ -100,7 +100,12 @@ import metaconfig.generic.Surface
   *   }}}
   */
 case class OptIn(
-    configStyleArguments: Boolean = true,
+    @annotation.DeprecatedName(
+      "configStyleArguments",
+      "Use `newlines.configStyleCallSite` instead",
+      "3.8.2",
+    )
+    private[config] val configStyleArguments: Boolean = true,
     breaksInsideChains: Boolean = false,
     breakChainOnFirstMethodDot: Boolean = true,
     encloseClassicChains: Boolean = false,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -277,6 +277,16 @@ case class ScalafmtConfig(
   def getFewerBraces(): Indents.FewerBraces =
     if (indent.getSignificant < 2) Indents.FewerBraces.never
     else indent.fewerBraces
+
+  private def getOptInConfigStyle: Newlines.ConfigStyleElement = Newlines
+    .ConfigStyleElement(prefer = optIn.configStyleArguments)
+
+  lazy val configStyleCallSite: Newlines.ConfigStyleElement = newlines
+    .configStyleCallSite.getOrElse(getOptInConfigStyle)
+
+  lazy val configStyleDefnSite: Newlines.ConfigStyleElement = newlines
+    .configStyleDefnSite.getOrElse(getOptInConfigStyle)
+
 }
 
 object ScalafmtConfig {
@@ -363,12 +373,12 @@ object ScalafmtConfig {
       implicit val errors = new mutable.ArrayBuffer[String]
       if (newlines.sourceIgnored) {
         newlines.beforeOpenParenCallSite.fold(addIfDirect(
-          optIn.configStyleArguments && align.openParenCallSite,
-          "optIn.configStyleArguments && align.openParenCallSite && !newlines.beforeOpenParenCallSite",
+          configStyleCallSite.prefer && align.openParenCallSite,
+          "newlines.configStyleCallSite && align.openParenCallSite && !newlines.beforeOpenParenCallSite",
         ))(x => addIfDirect(x.src eq Newlines.keep, "newlines.beforeOpenParenCallSite.src = keep"))
         newlines.beforeOpenParenDefnSite.fold(addIfDirect(
-          optIn.configStyleArguments && align.openParenDefnSite,
-          "optIn.configStyleArguments && align.openParenDefnSite && !newlines.beforeOpenParenDefnSite",
+          configStyleDefnSite.prefer && align.openParenDefnSite,
+          "newlines.configStyleDefnSite && align.openParenDefnSite && !newlines.beforeOpenParenDefnSite",
         ))(x => addIfDirect(x.src eq Newlines.keep, "newlines.beforeOpenParenDefnSite.src = keep"))
         def mustIgnoreSourceSplit(what: sourcecode.Text[Option[Newlines.IgnoreSourceSplit]]) = what.value
           .foreach(x => addIfDirect(!x.ignoreSourceSplit, s"${what.source}=$x"))

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -7603,8 +7603,8 @@ object a {
       " try {x.add(y, null);} catch(e) {if (typeof(e) == 'object' && typeof(e.number) == 'number' && (e.number & 0xFFFF) == 5){ x.add(y,x.options.length); } } "
   }
 }
-<<< binPack.callSite with configStyleArguments, danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.callSite with configStyle, danglingParentheses
+newlines.configStyleCallSite.prefer = true
 danglingParentheses.callSite = true
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7655,8 +7655,8 @@ object Main {
     10 + 0
   )
 }
-<<< binPack.defnSite with configStyleArguments, danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.defnSite with configStyle, danglingParentheses
+newlines.configStyleDefnSite.prefer = true
 danglingParentheses.defnSite = true
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7702,8 +7702,8 @@ object Main {
       x3: X, x4: X, xs: X*)
       : Set[Int]
 }
-<<< binPack.callSite with !configStyleArguments, danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.callSite with !configStyle, danglingParentheses
+newlines.configStyleCallSite.prefer = false
 danglingParentheses.callSite = true
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7746,8 +7746,8 @@ object Main {
   val bar2 = foo2(0, 1, 2, 3,
     4, 5, 6, 7, 8, 9, 10 + 0)
 }
-<<< binPack.defnSite with !configStyleArguments, danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.defnSite with !configStyle, danglingParentheses
+newlines.configStyleDefnSite.prefer = false
 danglingParentheses.defnSite = true
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7797,8 +7797,8 @@ object Main {
       x4: X, xs: X*
   ): Set[Int]
 }
-<<< binPack.callSite with configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.callSite with configStyle, !danglingParentheses
+newlines.configStyleCallSite.prefer = true
 danglingParentheses.callSite = false
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7849,8 +7849,8 @@ object Main {
     10 + 0
   )
 }
-<<< binPack.defnSite with configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.defnSite with configStyle, !danglingParentheses
+newlines.configStyleDefnSite.prefer = true
 danglingParentheses.defnSite = false
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7896,8 +7896,8 @@ object Main {
       x3: X, x4: X, xs: X*)
       : Set[Int]
 }
-<<< binPack.callSite with !configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.callSite with !configStyle, !danglingParentheses
+newlines.configStyleCallSite.prefer = false
 danglingParentheses.callSite = false
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7934,8 +7934,8 @@ object Main {
   val bar2 = foo2(0, 1, 2, 3,
     4, 5, 6, 7, 8, 9, 10 + 0)
 }
-<<< binPack.defnSite with !configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.defnSite with !configStyle, !danglingParentheses
+newlines.configStyleDefnSite.prefer = false
 danglingParentheses.defnSite = false
 binPack.unsafeDefnSite = always
 maxColumn = 30

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -7133,8 +7133,8 @@ object a {
       " try {x.add(y, null);} catch(e) {if (typeof(e) == 'object' && typeof(e.number) == 'number' && (e.number & 0xFFFF) == 5){ x.add(y,x.options.length); } } "
   }
 }
-<<< binPack.callSite with configStyleArguments, danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.callSite with configStyle, danglingParentheses
+newlines.configStyleCallSite.prefer = true
 danglingParentheses.callSite = true
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7182,8 +7182,8 @@ object Main {
     10 + 0
   )
 }
-<<< binPack.defnSite with configStyleArguments, danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.defnSite with configStyle, danglingParentheses
+newlines.configStyleDefnSite.prefer = true
 danglingParentheses.defnSite = true
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7233,8 +7233,8 @@ object Main {
       x4: X, xs: X*
   ): Set[Int]
 }
-<<< binPack.callSite with !configStyleArguments, danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.callSite with !configStyle, danglingParentheses
+newlines.configStyleCallSite.prefer = false
 danglingParentheses.callSite = true
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7273,8 +7273,8 @@ object Main {
     9, 10 + 0
   )
 }
-<<< binPack.defnSite with !configStyleArguments, danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.defnSite with !configStyle, danglingParentheses
+newlines.configStyleDefnSite.prefer = false
 danglingParentheses.defnSite = true
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7324,8 +7324,8 @@ object Main {
       x4: X, xs: X*
   ): Set[Int]
 }
-<<< binPack.callSite with configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.callSite with configStyle, !danglingParentheses
+newlines.configStyleCallSite.prefer = true
 danglingParentheses.callSite = false
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7373,8 +7373,8 @@ object Main {
     10 + 0
   )
 }
-<<< binPack.defnSite with configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.defnSite with configStyle, !danglingParentheses
+newlines.configStyleDefnSite.prefer = true
 danglingParentheses.defnSite = false
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7418,8 +7418,8 @@ object Main {
       x3: X, x4: X, xs: X*)
       : Set[Int]
 }
-<<< binPack.callSite with !configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.callSite with !configStyle, !danglingParentheses
+newlines.configStyleCallSite.prefer = false
 danglingParentheses.callSite = false
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7457,8 +7457,8 @@ object Main {
     0, 1, 2, 3, 4, 5, 6, 7, 8,
     9, 10 + 0)
 }
-<<< binPack.defnSite with !configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.defnSite with !configStyle, !danglingParentheses
+newlines.configStyleDefnSite.prefer = false
 danglingParentheses.defnSite = false
 binPack.unsafeDefnSite = always
 maxColumn = 30

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -7546,8 +7546,8 @@ object a {
       " try {x.add(y, null);} catch(e) {if (typeof(e) == 'object' && typeof(e.number) == 'number' && (e.number & 0xFFFF) == 5){ x.add(y,x.options.length); } } "
   }
 }
-<<< binPack.callSite with configStyleArguments, danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.callSite with configStyle, danglingParentheses
+newlines.configStyleCallSite.prefer = true
 danglingParentheses.callSite = true
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7598,8 +7598,8 @@ object Main {
     10 + 0
   )
 }
-<<< binPack.defnSite with configStyleArguments, danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.defnSite with configStyle, danglingParentheses
+newlines.configStyleDefnSite.prefer = true
 danglingParentheses.defnSite = true
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7647,8 +7647,8 @@ object Main {
       x1: X, x2: X, x3: X,
       x4: X, xs: X*): Set[Int]
 }
-<<< binPack.callSite with !configStyleArguments, danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.callSite with !configStyle, danglingParentheses
+newlines.configStyleCallSite.prefer = false
 danglingParentheses.callSite = true
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7692,8 +7692,8 @@ object Main {
     4, 5, 6, 7, 8, 9, 10 + 0
   )
 }
-<<< binPack.defnSite with !configStyleArguments, danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.defnSite with !configStyle, danglingParentheses
+newlines.configStyleDefnSite.prefer = false
 danglingParentheses.defnSite = true
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7747,8 +7747,8 @@ object Main {
       x4: X, xs: X*
   ): Set[Int]
 }
-<<< binPack.callSite with configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.callSite with configStyle, !danglingParentheses
+newlines.configStyleCallSite.prefer = true
 danglingParentheses.callSite = false
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7799,8 +7799,8 @@ object Main {
     10 + 0
   )
 }
-<<< binPack.defnSite with configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.defnSite with configStyle, !danglingParentheses
+newlines.configStyleDefnSite.prefer = true
 danglingParentheses.defnSite = false
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7848,8 +7848,8 @@ object Main {
       x1: X, x2: X, x3: X,
       x4: X, xs: X*): Set[Int]
 }
-<<< binPack.callSite with !configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.callSite with !configStyle, !danglingParentheses
+newlines.configStyleCallSite.prefer = false
 danglingParentheses.callSite = false
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7890,8 +7890,8 @@ object Main {
     1, 2, 3,
     4, 5, 6, 7, 8, 9, 10 + 0)
 }
-<<< binPack.defnSite with !configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.defnSite with !configStyle, !danglingParentheses
+newlines.configStyleDefnSite.prefer = false
 danglingParentheses.defnSite = false
 binPack.unsafeDefnSite = always
 maxColumn = 30

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -7710,8 +7710,8 @@ object a {
           " try {x.add(y, null);} catch(e) {if (typeof(e) == 'object' && typeof(e.number) == 'number' && (e.number & 0xFFFF) == 5){ x.add(y,x.options.length); } } "
       }
 }
-<<< binPack.callSite with configStyleArguments, danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.callSite with configStyle, danglingParentheses
+newlines.configStyleCallSite.prefer = true
 danglingParentheses.callSite = true
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7763,8 +7763,8 @@ object Main {
     10 + 0
   )
 }
-<<< binPack.defnSite with configStyleArguments, danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.defnSite with configStyle, danglingParentheses
+newlines.configStyleDefnSite.prefer = true
 danglingParentheses.defnSite = true
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7814,8 +7814,8 @@ object Main {
       x4: X, xs: X*
   ): Set[Int]
 }
-<<< binPack.callSite with !configStyleArguments, danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.callSite with !configStyle, danglingParentheses
+newlines.configStyleCallSite.prefer = false
 danglingParentheses.callSite = true
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7858,8 +7858,8 @@ object Main {
     9, 10 + 0
   )
 }
-<<< binPack.defnSite with !configStyleArguments, danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.defnSite with !configStyle, danglingParentheses
+newlines.configStyleDefnSite.prefer = false
 danglingParentheses.defnSite = true
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -7909,8 +7909,8 @@ object Main {
       x4: X, xs: X*
   ): Set[Int]
 }
-<<< binPack.callSite with configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.callSite with configStyle, !danglingParentheses
+newlines.configStyleCallSite.prefer = true
 danglingParentheses.callSite = false
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -7958,8 +7958,8 @@ object Main {
     10 + 0
   )
 }
-<<< binPack.defnSite with configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = true
+<<< binPack.defnSite with configStyle, !danglingParentheses
+newlines.configStyleDefnSite.prefer = true
 danglingParentheses.defnSite = false
 binPack.unsafeDefnSite = always
 maxColumn = 30
@@ -8007,8 +8007,8 @@ object Main {
       x1: X, x2: X, x3: X,
       x4: X, xs: X*): Set[Int]
 }
-<<< binPack.callSite with !configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.callSite with !configStyle, !danglingParentheses
+newlines.configStyleCallSite.prefer = false
 danglingParentheses.callSite = false
 binPack.unsafeCallSite = always
 maxColumn = 30
@@ -8046,8 +8046,8 @@ object Main {
     0, 1, 2, 3, 4, 5, 6, 7, 8,
     9, 10 + 0)
 }
-<<< binPack.defnSite with !configStyleArguments, !danglingParentheses
-optIn.configStyleArguments = false
+<<< binPack.defnSite with !configStyle, !danglingParentheses
+newlines.configStyleDefnSite.prefer = false
 danglingParentheses.defnSite = false
 binPack.unsafeDefnSite = always
 maxColumn = 30


### PR DESCRIPTION
Currently, the `optIn.configStyleArguments` parameter applies both to call-site as well as defn-site clauses.

Instead, let's move it to `newlines.configStyle.xxxSite` and separate the two.

Helps with #3954.