### PR TITLE
Config-style: control over forcing vs optimization

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2821,12 +2821,16 @@ object a {
 
 ### Forcing config style
 
-When `optIn.configStyleArguments` is enabled and
+When `newlines.configStyleXxxSite.forceIfOptimized` is enabled and
 [call-site clause optimization](#route-search-optimizations-call-site-clause)
 is applicable to a clause, the formatter will force config-style formatting.
 
+By default, takes the same value as
+[`newlines.configStyleXxxSite.prefer`](#newlinesconfigstylexxxsiteprefer).
+
 ```scala mdoc:scalafmt
-optIn.configStyleArguments = true
+newlines.configStyleCallSite.forceIfOptimized = true
+newlines.configStyleDefnSite.forceIfOptimized = false
 runner.optimizer.forceConfigStyleMinSpan = 5
 runner.optimizer.forceConfigStyleMinArgCount = 2
 maxColumn = 60

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -545,7 +545,13 @@ object Newlines {
     * closing `)`. If true, preserves the newlines and keeps one line per
     * argument.
     */
-  case class ConfigStyleElement(prefer: Boolean = true)
+  case class ConfigStyleElement(
+      prefer: Boolean = true,
+      private val forceIfOptimized: Option[Boolean] = None,
+  ) {
+    @inline
+    def getForceIfOptimized: Boolean = forceIfOptimized.getOrElse(prefer)
+  }
   private[config] object ConfigStyleElement {
     private val default = ConfigStyleElement()
     implicit val surface: Surface[ConfigStyleElement] = generic

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -871,7 +871,7 @@ class FormatOps(
 
   def mustForceConfigStyle(ft: FormatToken)(implicit
       cfg: Newlines.ConfigStyleElement,
-  ): Boolean = cfg.prefer && forceConfigStyle(ft.meta.idx)
+  ): Boolean = cfg.getForceIfOptimized && forceConfigStyle(ft.meta.idx)
 
   def preserveConfigStyle(
       ft: FormatToken,


### PR DESCRIPTION
Currently, the `runner.optimizer` parameters always force config-style formatting when `newlines.configStyle.xxxSite.prefer` is true, even though they were intended primarily to affect the route search.

On the other hand, there could be cases when a user wouldn't enable the `newlines.configStyle.xxxSite.prefer` flag for regular operation (for instance, it makes no sense for `newlines.source=fold/unfold`) but would still be interested in forcing config-style.

Therefore, let's add the sibling `xxxSite.forceConfigStyleIfOptimized` flag to decide when to force.

Helps with #3954.