### PR TITLE
Router: Align binpack.{call,defn}Site behaviour

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4792,6 +4792,7 @@ object Example2 {
 
 This group of parameters controls binpacking of an argument list if _all_ arguments are
 considered to be literals.
+These parameters take precedence over [forcing of config style](#forcing-config-style).
 
 The following parameters affect this behaviour:
 
@@ -4919,65 +4920,65 @@ object A {
 }
 ```
 
-### `binPack.defnSite`
+### `binPack.xxxSite`
 
-Controls binpacking around method/type definition sites (and was called
-`unsafeDefnSite` up until v3.8.1). The following parameter values are supported
+Controls binpacking around method/type definition sites (`binPack.defnSite`) or
+method call sites (`binPack.callSite`) (both were called
+`unsafeXxxSite` up until v3.8.1). The following parameter values are supported
 since v3.0.0:
 
 - `Never` disables the functionality (also takes `false`)
 - `Always` enables the functionality (also takes `true`)
 - `Oneline` ensures multiline arguments are not binpacked
 
-When not disabled, this parameter has complex interactions with
+When not disabled, these parameters have complex interactions with
 [`newline.source`](#newlinessource),
-[config-style formatting](#newlines-config-style-formatting) and
-[`danglingParentheses.defnSite`](#danglingparenthesesdefnsite).
+[`newlines.configStyleXxxSite.prefer`](#newlinesconfigstylexxxsiteprefer)
+(aka `cfgStyle` below) and
+[`danglingParentheses.xxxSite`](#newlines-danglingparentheses) (aka `dangle`).
+Keep in mind that when [config-style is forced](#forcing-config-style),
+it takes precedence over options described below.
 
-- `newlines.source=classic/keep`
-  - open break is preserved for `keep`, matches close break for `classic`
-  - when `config-style` is enabled: close break is preserved,
-    `danglingParentheses.defnSite` is ignored
-  - when `config-style` is disabled: `danglingParentheses.defnSite`
-    dictates close break
-- `newlines.source=fold/unfold`
-  - open break matches close break for `fold`, dangles for `unfold`
-  - `danglingParentheses.defnSite` dictates close break
-  - `config-style` is ignored
-
-### `binPack.callSite`
-
-Controls binpacking around method call sites (and was called `unsafeCallSite` up
-until v3.8.1). It takes the same values as [`binPack.defnSite`](#binpackdefnsite),
-and similarly has cross-parameter interactions:
-
-- interaction with `config-style` parameters:
-  - when [config-style is forced](#forcing-config-style), it takes precedence
-    over binpacking
-  - for `newlines.source=classic`, behaviour depends on
-    [config-style](#newlinesconfigstylexxxsiteprefer):
-    - if enabled, config style is used if
-      - it is [detected](#newlinesconfigstylexxxsiteprefer), or
-      - configured to use [scala.js style](#presetscalajs)
-    - otherwise, uses binpacking
-  - for other values of [`newlines.source`](#newlinessource),
-    binpacking takes precedence
-- interaction with [`danglingParentheses.callSite`](#danglingparenthesescallsite)
-  - `newlines.source=classic`: please see above
-  - `newlines.source=keep`
-    - open break is preserved
-    - when both [config-style](#newlinesconfigstylexxxsiteprefer) and
-      [`danglingParentheses.callSite`](#danglingparenthesescallsite) are disabled,
-      close break is "tucked"
-    - otherwise, close break matches open break
-  - `newlines.source=fold/unfold`
-    - when [`danglingParentheses.callSite`](#danglingparenthesescallsite) is enabled,
-      open break matches close break, and close is always dangling for `unfold`,
-      and only when [config-style is forced](#forcing-config-style) for `fold`
-    - otherwise, open is always dangling,
-      and close is dangling only when both
-      [`newlines.configStyleXxxSite.prefer=true`](#newlinesconfigstylexxxsiteprefer)
-      and [config-style is forced](#forcing-config-style)
+- `newlines.source=classic`
+  - `cfgStyle=T`, `dangle=T`:
+    use cfg-style if both parens had breaks, otherwise binpack without breaks
+    - before v3.8.2, this formatting was used for `callSite` with `dangle=F` as well
+  - `cfgStyle=T`, `dangle=F`:
+    ([scala.js](#presetscalajs))
+    use cfg-style if close paren had a break; otherwise, binpack without breaks
+  - `cfgStyle=F`, `dangle=T`:
+    binpack; if both parens had breaks, keep; otherwise, use no breaks
+    - before v3.8.2, this formatting was used for `defnSite` with
+      `cfgStyle=T` and any `dangle`
+  - `cfgStyle=F`, `dangle=F`:
+    binpack without breaks
+    - before v3.8.2, this formatting was used for `callSite` with
+      `cfgStyle=F` and any `dangle`, and for `defnSite` with
+      `cfgStyle=F` and `dangle=F`
+- `newlines.source=keep`
+  - `cfgStyle=T`, `dangle=T`:
+    use cfg-style if open paren had a break; otherwise, binpack and preserve both breaks
+  - `cfgStyle=T`, `dangle=F`:
+    ([scala.js](#presetscalajs))
+    use cfg-style if close paren had a break; otherwise, binpack without breaks
+  - `cfgStyle=F`, `dangle=T`:
+    binpack; if open paren had a break, force both breaks; otherwise, preserve both
+  - `cfgStyle=F`, `dangle=F`:
+    binpack; preserve both breaks
+- `newlines.source=fold`: if single line is not possible:
+  - `cfgStyle=T`, `dangle=T`:
+    binpack with both breaks
+  - `cfgStyle=T`, `dangle=F`:
+    binpack with dangling open and tucked close
+  - `cfgStyle=F`, `dangle=T`:
+    binpack with tucked open and dangling close
+    - if [`binPack.indentCallSiteOnce`](#binpackindentcallsiteonce) is set,
+      we will not force dangling as it might lead to consecutive lines
+      with a closing parenthesis at the same indentation level
+  - `cfgStyle=F`, `dangle=F`:
+    binpack without breaks
+- `newlines.source=unfold`: if single line is not possible:
+  - open dangles, close break matches `dangle`, `cfgStyle` is ignored
 
 > Please also see [callSite indentation parameters](#indent-for-binpackcallsite).
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ConfigStyle.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ConfigStyle.scala
@@ -1,9 +1,0 @@
-package org.scalafmt.internal
-
-sealed abstract class ConfigStyle
-
-object ConfigStyle {
-  case object None extends ConfigStyle
-  case object Source extends ConfigStyle
-  case object Forced extends ConfigStyle
-}

--- a/scalafmt-tests/src/test/resources/binPack/LiteralList.stat
+++ b/scalafmt-tests/src/test/resources/binPack/LiteralList.stat
@@ -193,7 +193,8 @@ private val lengthByLeading: Array[Int] = Array(
   // 11110uuu
   4, 4, 4, 4, 4, 4, 4, 4,
   // > 11110111
-  -1, -1, -1, -1, -1, -1, -1, -1)
+  -1, -1, -1, -1, -1, -1, -1, -1
+)
 <<< native 2, !dangle
 danglingParentheses.preset = false
 ===

--- a/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
+++ b/scalafmt-tests/src/test/resources/binPack/ParentConstructors.stat
@@ -63,7 +63,8 @@ object a {
 >>>
 object a {
   case class TopLevelExportInfo(moduleID: String, jsName: String)(
-      val pos: Position) extends ExportInfo
+      val pos: Position
+  ) extends ExportInfo
 }
 <<< #2633 keep with class, !dangle
 maxColumn = 70

--- a/scalafmt-tests/src/test/resources/binPack/TermNameList.stat
+++ b/scalafmt-tests/src/test/resources/binPack/TermNameList.stat
@@ -71,7 +71,8 @@ somethingVeryLong(
     baz(
       qux // c1
     )
-  })
+  }
+)
 <<< unsafeCallSite forced newline, cfg + !dangle
 maxColumn = 20
 binPack.unsafeCallSite = true
@@ -103,7 +104,8 @@ somethingVeryLong(bar{baz(
 >>>
 somethingVeryLong(
   bar {
-    baz(qux // c1
+    baz(
+      qux // c1
     )
   }
 )

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1714,13 +1714,13 @@ object a {
 }
 >>>
 object a {
-  val cls =
-    Select(Select(Select(Select(Select(Select(Ident(nme.ROOTPKG), nme.scala_),
-                                       scalajs),
-                                js),
-                         nme.annotation, x, y, z),
-                  internal_, a, b, c),
-           wasPublicBeforeTyperXxx)
+  val cls = Select(
+    Select(
+      Select(
+        Select(Select(Select(Ident(nme.ROOTPKG), nme.scala_), scalajs), js),
+        nme.annotation, x, y, z),
+      internal_, a, b, c),
+    wasPublicBeforeTyperXxx)
 }
 <<< #2633 with binPack always
 maxColumn = 70
@@ -1746,8 +1746,7 @@ object a {
       .getAnnotation(JSNameAnnotation).fold {
         sym.addAnnotation(JSNameAnnotation,
                           Literal(Constant(jsInterop.defaultJSNameOf(
-                                             symForName
-                                           ))))
+                                             symForName))))
       } { annot =>
         sym.addAnnotation(annot)
       }
@@ -1776,8 +1775,8 @@ object a {
     symForName
       .getAnnotation(JSNameAnnotation).fold {
         sym.addAnnotation(JSNameAnnotation,
-                          Literal(Constant(jsInterop
-                            .defaultJSNameOf(symForName))))
+                          Literal(Constant(
+                            jsInterop.defaultJSNameOf(symForName))))
       } { annot =>
         sym.addAnnotation(annot)
       }

--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -436,9 +436,8 @@ def props[M[_[_]], F[_]: Async, I: KeyDecoder, State, Event: PersistentEncoder: 
 object a {
   def deploy[M[_[_]]: FunctorK, F[_], State, Event: PersistentEncoder: PersistentDecoder,
              K: KeyEncoder: KeyDecoder] = ???
-  def props[
-      M[_[_]], F[_]: Async, I: KeyDecoder, State, Event: PersistentEncoder: PersistentDecoder]() =
-    ???
+  def props[M[_[_]], F[_]: Async, I: KeyDecoder, State,
+            Event: PersistentEncoder: PersistentDecoder]() = ???
 }
 <<< #2739 bracketDefnSite = oneline, !danglingParentheses
 maxColumn = 100
@@ -472,9 +471,8 @@ def props[M[_[_]], F[_]: Async, I: KeyDecoder, State, Event: PersistentEncoder: 
 object a {
   def deploy[M[_[_]]: FunctorK, F[_], State, Event: PersistentEncoder: PersistentDecoder,
              K: KeyEncoder: KeyDecoder] = ???
-  def props[
-      M[_[_]], F[_]: Async, I: KeyDecoder, State, Event: PersistentEncoder: PersistentDecoder]() =
-    ???
+  def props[M[_[_]], F[_]: Async, I: KeyDecoder, State,
+            Event: PersistentEncoder: PersistentDecoder]() = ???
 }
 <<< #2739 bracketDefnSite = always, !danglingParentheses
 maxColumn = 100

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2875,7 +2875,8 @@ object a {
 object a {
   val foo = bar.map(x =>
     x.copy(
-      baz = Option.when(false)(x.qux))
+      baz = Option.when(false)(x.qux)
+    )
   )
 }
 <<< binPack with named parameter values, configStyleArguments + !danglingParentheses
@@ -3049,8 +3050,10 @@ object a {
           Some(0), Some(1), foo = Some("bar")),
         Qux("", 1, "par1", "2018-01-01", "2018-12-31", "2018-01-01", "2018-02-01", None, None, 1000,
           Some(0), Some(1), foo = Some("bar")),
-        Qux("", 1, "par1", "2018-01-01", "2018-12-31", "2018-01-01", "2018-02-01", None, None, 1000,
-          Some(0), Some(1), foo = Some("bar"))
+        Qux(
+          "", 1, "par1", "2018-01-01", "2018-12-31", "2018-01-01", "2018-02-01", None, None, 1000,
+          Some(0), Some(1), foo = Some("bar")
+        )
       )
     )
   )
@@ -3080,12 +3083,13 @@ object a {
 }
 >>>
 object a {
-  private val audience3 =
-    apiAudience(3, "b_name", Sams, Inid, "2", "created-by-user2", "updated-by-user2").copy(
-      updatedAt = nowDate.minusDays(15),
-      audienceSizeOnsite = Some(3333),
-      audienceSizeOffsite = Some(1)
-    )
+  private val audience3 = apiAudience(
+    3, "b_name", Sams, Inid, "2", "created-by-user2", "updated-by-user2"
+  ).copy(
+    updatedAt = nowDate.minusDays(15),
+    audienceSizeOnsite = Some(3333),
+    audienceSizeOffsite = Some(1)
+  )
   private val audience3 =
     apiAudience(3, "b_name", Sams, Inid, "2", "created-by-user2", "updated-by-user2").copy(
       updatedAt = nowDate.minusDays(15),
@@ -3122,10 +3126,10 @@ object a {
 }
 >>>
 object a {
-  protected def foo[U](
-      bar: String,
-      baz: Seq[String] = Seq.empty
-  )(f: HttpResponse => U): U = qux
+  protected def foo[U](bar: String,
+      baz: Seq[String] = Seq.empty)(
+      f: HttpResponse => U
+  ): U = qux
 }
 <<< binPack indent expiresOn=Before when !dangle, configStyleArguments
 binPack.preset = true
@@ -5047,8 +5051,11 @@ object a {
 }
 >>>
 object a {
-  def foo(bb: BB, cc: CC, dd: DD = DDD.ddd): Bar[
-    Baz] = {
+  def foo(
+      bb: BB,
+      cc: CC,
+      dd: DD = DDD.ddd
+  ): Bar[Baz] = {
     // c
     qux
   }
@@ -5070,8 +5077,7 @@ object a {
 >>>
 object a {
   def foo(bb: BB, cc: CC, dd: DD = DDD.ddd): Bar[
-    Baz
-  ] = {
+    Baz] = {
     // c
     qux
   }
@@ -5088,8 +5094,9 @@ object a {
 }
 >>>
 object a {
-  def foo(dd: DD[AA[BB], CC] =
-        DDD.ddd): Bar[Baz] = {
+  def foo(
+      dd: DD[AA[BB], CC] = DDD.ddd
+  ): Bar[Baz] = {
     // c
     qux
   }
@@ -7743,7 +7750,9 @@ object Main {
 >>>
 object Main {
   def foo1(
-      x1: X, x2: X, xs: X*
+      x1: X,
+      x2: X,
+      xs: X*
   ): Set[Int]
   def foo1(x1: X, x2: X,
       xs: X*): Set[Int]
@@ -7752,12 +7761,18 @@ object Main {
   def foo1(x1: X, x2: X,
       xs: X*): Set[Int]
   def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
   def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with !configStyle, danglingParentheses
@@ -7787,8 +7802,9 @@ object Main {
 }
 >>>
 object Main {
-  val bar1 = foo1(10000,
-    10001, 10002 + 0)
+  val bar1 = foo1(
+    10000, 10001, 10002 + 0
+  )
   val bar1 = foo1(10000,
     10001, 10002 + 0)
   val bar1 = foo1(10000,
@@ -7831,23 +7847,19 @@ object Main {
   def foo1(
       x1: X, x2: X, xs: X*
   ): Set[Int]
-  def foo1(
-      x1: X, x2: X, xs: X*
-  ): Set[Int]
-  def foo1(
-      x1: X, x2: X, xs: X*
-  ): Set[Int]
-  def foo1(
-      x1: X, x2: X, xs: X*
-  ): Set[Int]
+  def foo1(x1: X, x2: X,
+      xs: X*): Set[Int]
+  def foo1(x1: X, x2: X,
+      xs: X*): Set[Int]
+  def foo1(x1: X, x2: X,
+      xs: X*): Set[Int]
   def foo2(
       x1: X, x2: X, x3: X,
       x4: X, xs: X*
   ): Set[Int]
-  def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
-  ): Set[Int]
+  def foo3(x1: X, x2: X,
+      x3: X, x4: X, xs: X*)
+      : Set[Int]
 }
 <<< binPack.callSite with configStyle, !danglingParentheses
 newlines.configStyleCallSite.prefer = true
@@ -7935,22 +7947,32 @@ object Main {
 >>>
 object Main {
   def foo1(
-      x1: X, x2: X, xs: X*
+      x1: X,
+      x2: X,
+      xs: X*
   ): Set[Int]
   def foo1(
-      x1: X, x2: X, xs: X*
+      x1: X,
+      x2: X,
+      xs: X*
   ): Set[Int]
   def foo1(x1: X, x2: X,
       xs: X*): Set[Int]
   def foo1(x1: X, x2: X,
       xs: X*): Set[Int]
   def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
   def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with !configStyle, !danglingParentheses

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2622,12 +2622,13 @@ object a {
 >>>
 object a {
   test("foo") {
-    a.b(c, d) shouldBe E(
-      Seq(F(1, "v1"), F(2, "v2")),
-      G(Some(Seq(h, i)),
-        Some(Seq(j, k)), a.b, c.d,
-        e.f.g, h.i.j)
-    ).foo
+    a.b(c, d) shouldBe
+      E(Seq(F(1, "v1"), F(2, "v2")),
+        G(Some(Seq(h, i)),
+          Some(Seq(j, k)), a.b, c.d,
+          e.f.g, h.i.j
+        )
+      ).foo
   }
 }
 <<< binpack call, oneline
@@ -2647,7 +2648,8 @@ object a {
       E(Seq(F(1, "v1"), F(2, "v2")),
         G(Some(Seq(h, i)),
           Some(Seq(j, k)), a.b, c.d,
-          e.f.g, h.i.j)
+          e.f.g, h.i.j
+        )
       ).foo
   }
 }
@@ -2716,8 +2718,9 @@ object a {
 >>>
 object a {
   val foo = bar.map(x =>
-    x.copy(baz = Option
-      .when(false)(x.qux))
+    x.copy(
+      baz = Option.when(false)(x.qux)
+    )
   )
 }
 <<< binPack with named parameter values, !danglingParentheses
@@ -2796,9 +2799,8 @@ object a {
 }
 >>>
 object a {
-  foo(bar.baz(Seq(Qux(
-    "", 1, "par1", "2018-01-01", "2018-12-31", "2018-01-01", "2018-02-01", None, None, 1000,
-    Some(0), Some(1), foo = Some("bar")
+  foo(bar.baz(Seq(Qux("", 1, "par1", "2018-01-01", "2018-12-31", "2018-01-01", "2018-02-01", None,
+    None, 1000, Some(0), Some(1), foo = Some("bar")
   ))))
 }
 <<< binPack.literals, danglingParentheses, avoid fold
@@ -2839,8 +2841,7 @@ object a {
 }
 >>>
 object a {
-  protected def foo[U](
-      bar: String,
+  protected def foo[U](bar: String,
       baz: Seq[String] = Seq.empty
   )(f: HttpResponse => U): U = qux
 }
@@ -4849,12 +4850,17 @@ object a {
 }
 >>>
 object a {
-  binder.bind("f", params) shouldBe Some(Left(
-    s"Cannot parse parameter f as DummyEnum, $wrongValue is not a member of Enum (dummy-value)"
-  ))
+  binder.bind("f", params) shouldBe Some(
+    Left(
+      s"Cannot parse parameter f as DummyEnum, $wrongValue is not a member of Enum (dummy-value)"
+    )
+  )
 
-  when(audienceService.publish(any[Tenant], any[Int])).thenReturn(Success[NonEmptyList[String],
-    ApiAudience](apiAudience.copy(status = AudienceStatus.Pending.name)))
+  when(audienceService.publish(any[Tenant], any[Int])).thenReturn(
+    Success[NonEmptyList[String], ApiAudience](
+      apiAudience.copy(status = AudienceStatus.Pending.name)
+    )
+  )
 }
 <<< binPack.callSite = Oneline, nested with one arg, several options
 maxColumn = 100
@@ -4881,21 +4887,26 @@ object a {
 >>>
 object a {
   when(
-    service.list(ApiAudienceFilter(tenants = Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
-      Order.default)
+    service.list(
+      ApiAudienceFilter(tenants = Contains(Seq(ATenant))), Page(0, Page.maxPageLimit), Order.default
+    )
   ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
   when(
-    service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant)), Page(0, Page.maxPageLimit),
-      Order.default)
+    service.list(
+      ApiAudienceFilter(tenants), Contains(Seq(ATenant)), Page(0, Page.maxPageLimit), Order.default
+    )
   ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
-  when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
-    Order.default).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
+  when(
+    service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
+    Order.default
+  ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
-  when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
-    Order.default, PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
-    .thenReturn(None)
+  when(
+    service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
+    Order.default, PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10))
+  ).thenReturn(None)
 }
 <<< binPack.callSite = always, nested with one arg
 maxColumn = 100
@@ -4915,13 +4926,17 @@ object a {
 }
 >>>
 object a {
-  binder.bind("f", params) shouldBe Some(Left(
+  binder.bind("f", params) shouldBe Some(
+    Left(
       s"Cannot parse parameter f as DummyEnum, $wrongValue is not a member of Enum (dummy-value)"
-    ))
+    )
+  )
 
-  when(audienceService.publish(any[Tenant], any[Int]))
-    .thenReturn(Success[NonEmptyList[String], ApiAudience](apiAudience
-          .copy(status = AudienceStatus.Pending.name)))
+  when(audienceService.publish(any[Tenant], any[Int])).thenReturn(
+    Success[NonEmptyList[String], ApiAudience](
+      apiAudience.copy(status = AudienceStatus.Pending.name)
+    )
+  )
 }
 <<< binPack.callSite = always, nested with one arg, several options
 maxColumn = 100
@@ -4947,20 +4962,27 @@ object a {
 }
 >>>
 object a {
-  when(service.list(ApiAudienceFilter(tenants = Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
-      Order.default))
-    .thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
+  when(
+    service.list(
+      ApiAudienceFilter(tenants = Contains(Seq(ATenant))), Page(0, Page.maxPageLimit), Order.default
+    )
+  ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
-  when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant)), Page(0, Page.maxPageLimit),
-      Order.default))
-    .thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
+  when(
+    service.list(
+      ApiAudienceFilter(tenants), Contains(Seq(ATenant)), Page(0, Page.maxPageLimit), Order.default
+    )
+  ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
-  when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
-    Order.default).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
+  when(
+    service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
+    Order.default
+  ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
-  when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
-    Order.default, PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
-    .thenReturn(None)
+  when(
+    service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))), Page(0, Page.maxPageLimit),
+    Order.default, PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10))
+  ).thenReturn(None)
 }
 <<< #2821 default
 assembly / assemblyMergeStrategy := {
@@ -6921,8 +6943,10 @@ object a {
 object a {
   assert(
     t21 ==
-      (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-        20, 21)
+      (
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        20, 21
+      )
   )
 }
 <<< SM 7.4.0: 44
@@ -7141,6 +7165,9 @@ maxColumn = 30
 runner.optimizer.callSite { minSpan = 20, minCount = 5 }
 ===
 object Main {
+  val bar0 = foo0(
+    1, 2, 3 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -7160,14 +7187,19 @@ object Main {
 }
 >>>
 object Main {
-  val bar1 = foo1(10000,
-    10001, 10002 + 0)
-  val bar1 = foo1(10000,
-    10001, 10002 + 0)
-  val bar1 = foo1(10000,
-    10001, 10002 + 0)
-  val bar1 = foo1(10000,
-    10001, 10002 + 0)
+  val bar0 = foo0(1, 2, 3 + 0)
+  val bar1 = foo1(
+    10000, 10001, 10002 + 0
+  )
+  val bar1 = foo1(
+    10000, 10001, 10002 + 0
+  )
+  val bar1 = foo1(
+    10000, 10001, 10002 + 0
+  )
+  val bar1 = foo1(
+    10000, 10001, 10002 + 0
+  )
   val bar2 = foo2(
     0,
     1,
@@ -7225,12 +7257,18 @@ object Main {
       x1: X, x2: X, xs: X*
   ): Set[Int]
   def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
   def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with !configStyle, danglingParentheses
@@ -7241,6 +7279,9 @@ maxColumn = 30
 runner.optimizer.callSite { minSpan = 20, minCount = 5 }
 ===
 object Main {
+  val bar0 = foo0(
+    1, 2, 3 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -7260,17 +7301,21 @@ object Main {
 }
 >>>
 object Main {
+  val bar0 = foo0(1, 2, 3 + 0)
   val bar1 = foo1(10000,
-    10001, 10002 + 0)
+    10001, 10002 + 0
+  )
   val bar1 = foo1(10000,
-    10001, 10002 + 0)
+    10001, 10002 + 0
+  )
   val bar1 = foo1(10000,
-    10001, 10002 + 0)
+    10001, 10002 + 0
+  )
   val bar1 = foo1(10000,
-    10001, 10002 + 0)
-  val bar2 = foo2(
-    0, 1, 2, 3, 4, 5, 6, 7, 8,
-    9, 10 + 0
+    10001, 10002 + 0
+  )
+  val bar2 = foo2(0, 1, 2, 3,
+    4, 5, 6, 7, 8, 9, 10 + 0
   )
 }
 <<< binPack.defnSite with !configStyle, danglingParentheses
@@ -7303,25 +7348,23 @@ object Main {
 }
 >>>
 object Main {
-  def foo1(
-      x1: X, x2: X, xs: X*
+  def foo1(x1: X, x2: X,
+      xs: X*
   ): Set[Int]
-  def foo1(
-      x1: X, x2: X, xs: X*
+  def foo1(x1: X, x2: X,
+      xs: X*
   ): Set[Int]
-  def foo1(
-      x1: X, x2: X, xs: X*
+  def foo1(x1: X, x2: X,
+      xs: X*
   ): Set[Int]
-  def foo1(
-      x1: X, x2: X, xs: X*
+  def foo1(x1: X, x2: X,
+      xs: X*
   ): Set[Int]
-  def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+  def foo2(x1: X, x2: X,
+      x3: X, x4: X, xs: X*
   ): Set[Int]
-  def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+  def foo3(x1: X, x2: X,
+      x3: X, x4: X, xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with configStyle, !danglingParentheses
@@ -7332,6 +7375,9 @@ maxColumn = 30
 runner.optimizer.callSite { minSpan = 20, minCount = 5 }
 ===
 object Main {
+  val bar0 = foo0(
+    1, 2, 3 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -7351,6 +7397,7 @@ object Main {
 }
 >>>
 object Main {
+  val bar0 = foo0(1, 2, 3 + 0)
   val bar1 = foo1(
     10000, 10001, 10002 + 0)
   val bar1 = foo1(
@@ -7403,21 +7450,31 @@ object Main {
 }
 >>>
 object Main {
-  def foo1(x1: X, x2: X,
-      xs: X*): Set[Int]
-  def foo1(x1: X, x2: X,
-      xs: X*): Set[Int]
-  def foo1(x1: X, x2: X,
-      xs: X*): Set[Int]
-  def foo1(x1: X, x2: X,
-      xs: X*): Set[Int]
+  def foo1(
+      x1: X, x2: X, xs: X*)
+      : Set[Int]
+  def foo1(
+      x1: X, x2: X, xs: X*)
+      : Set[Int]
+  def foo1(
+      x1: X, x2: X, xs: X*)
+      : Set[Int]
+  def foo1(
+      x1: X, x2: X, xs: X*)
+      : Set[Int]
   def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
   def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with !configStyle, !danglingParentheses
@@ -7428,6 +7485,9 @@ maxColumn = 30
 runner.optimizer.callSite { minSpan = 20, minCount = 5 }
 ===
 object Main {
+  val bar0 = foo0(
+    1, 2, 3 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -7447,17 +7507,17 @@ object Main {
 }
 >>>
 object Main {
-  val bar1 = foo1(
-    10000, 10001, 10002 + 0)
-  val bar1 = foo1(
-    10000, 10001, 10002 + 0)
-  val bar1 = foo1(
-    10000, 10001, 10002 + 0)
-  val bar1 = foo1(
-    10000, 10001, 10002 + 0)
-  val bar2 = foo2(
-    0, 1, 2, 3, 4, 5, 6, 7, 8,
-    9, 10 + 0)
+  val bar0 = foo0(1, 2, 3 + 0)
+  val bar1 = foo1(10000,
+    10001, 10002 + 0)
+  val bar1 = foo1(10000,
+    10001, 10002 + 0)
+  val bar1 = foo1(10000,
+    10001, 10002 + 0)
+  val bar1 = foo1(10000,
+    10001, 10002 + 0)
+  val bar2 = foo2(0, 1, 2, 3,
+    4, 5, 6, 7, 8, 9, 10 + 0)
 }
 <<< binPack.defnSite with !configStyle, !danglingParentheses
 newlines.configStyleDefnSite.prefer = false

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2875,7 +2875,8 @@ object a {
 object a {
   val foo = bar.map(x =>
     x.copy(baz =
-      Option.when(false)(x.qux))
+      Option.when(false)(x.qux)
+    )
   )
 }
 <<< binPack with named parameter values, !danglingParentheses
@@ -2894,7 +2895,8 @@ object a {
 object a {
   val foo = bar.map(x =>
     x.copy(baz =
-      Option.when(false)(x.qux)))
+      Option.when(false)(x.qux)
+    ))
 }
 <<< literalsIncludeSimpleExpr with named parameter values, danglingParentheses
 binPack.literalsIncludeSimpleExpr = true
@@ -3002,10 +3004,8 @@ object a {
 }
 >>>
 object a {
-  protected def foo[U](
-      bar: String,
-      baz: Seq[String] = Seq.empty
-  )(
+  protected def foo[U](bar: String,
+      baz: Seq[String] = Seq.empty)(
       f: HttpResponse => U
   ): U = qux
 }
@@ -5116,17 +5116,19 @@ object a {
 object a {
   when(
     service.list(ApiAudienceFilter(tenants = Contains(Seq(ATenant))),
-      Page(0, Page.maxPageLimit), Order.default)
+      Page(0, Page.maxPageLimit), Order.default
+    )
   ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
   when(
     service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant)),
-      Page(0, Page.maxPageLimit), Order.default)
+      Page(0, Page.maxPageLimit), Order.default
+    )
   ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
   when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))),
-    Page(0, Page.maxPageLimit), Order.default).thenReturn(
-    PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
+    Page(0, Page.maxPageLimit), Order.default
+  ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
   when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))),
     Page(0, Page.maxPageLimit), Order.default,
@@ -5170,7 +5172,8 @@ object a {
 
   when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))),
     Page(0, Page.maxPageLimit), Order.default).thenReturn(
-    PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
+    PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10))
+  )
 
   when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))),
     Page(0, Page.maxPageLimit), Order.default,
@@ -5228,16 +5231,16 @@ object a {
 >>>
 object a {
   when(service.list(ApiAudienceFilter(tenants = Contains(Seq(ATenant))),
-      Page(0, Page.maxPageLimit), Order.default)).thenReturn(PageResult(Seq(audience,
-        audience.copy(id = 2)), PageInfo(50, 0, 10)))
+      Page(0, Page.maxPageLimit), Order.default
+    )).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
   when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant)),
-      Page(0, Page.maxPageLimit), Order.default)).thenReturn(PageResult(Seq(audience,
-        audience.copy(id = 2)), PageInfo(50, 0, 10)))
+      Page(0, Page.maxPageLimit), Order.default
+    )).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
   when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))),
-    Page(0, Page.maxPageLimit), Order.default).thenReturn(PageResult(Seq(audience,
-        audience.copy(id = 2)), PageInfo(50, 0, 10)))
+    Page(0, Page.maxPageLimit), Order.default
+  ).thenReturn(PageResult(Seq(audience, audience.copy(id = 2)), PageInfo(50, 0, 10)))
 
   when(service.list(ApiAudienceFilter(tenants), Contains(Seq(ATenant))),
     Page(0, Page.maxPageLimit), Order.default,
@@ -7579,15 +7582,19 @@ object Main {
 object Main {
   val bar1 = foo1(
     10000,
-    10001, 10002 + 0
+    10001,
+    10002 + 0
   )
   val bar1 = foo1(10000,
     10001, 10002 + 0)
   val bar1 = foo1(10000,
-    10001, 10002 + 0)
+    10001, 10002 + 0
+  )
   val bar1 = foo1(
     10000,
-    10001, 10002 + 0)
+    10001,
+    10002 + 0
+  )
   val bar2 = foo2(
     0,
     1,
@@ -7634,22 +7641,32 @@ object Main {
 object Main {
   def foo1(
       x1: X,
-      x2: X, xs: X*
+      x2: X,
+      xs: X*
   ): Set[Int]
   def foo1(x1: X,
-      x2: X, xs: X*): Set[Int]
+      x2: X, xs: X*
+  ): Set[Int]
   def foo1(
       x1: X,
-      x2: X, xs: X*): Set[Int]
+      x2: X,
+      xs: X*
+  ): Set[Int]
   def foo1(x1: X,
       x2: X, xs: X*): Set[Int]
   def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
   def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with !configStyle, danglingParentheses
@@ -7686,7 +7703,8 @@ object Main {
   val bar1 = foo1(10000,
     10001, 10002 + 0)
   val bar1 = foo1(10000,
-    10001, 10002 + 0)
+    10001, 10002 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -7731,18 +7749,15 @@ object Main {
       x1: X,
       x2: X, xs: X*
   ): Set[Int]
-  def foo1(
-      x1: X,
+  def foo1(x1: X,
       x2: X, xs: X*
   ): Set[Int]
   def foo1(
       x1: X,
       x2: X, xs: X*
   ): Set[Int]
-  def foo1(
-      x1: X,
-      x2: X, xs: X*
-  ): Set[Int]
+  def foo1(x1: X,
+      x2: X, xs: X*): Set[Int]
   def foo2(
       x1: X, x2: X, x3: X,
       x4: X, xs: X*
@@ -7781,16 +7796,17 @@ object Main {
 object Main {
   val bar1 = foo1(
     10000,
-    10001, 10002 + 0
+    10001,
+    10002 + 0
   )
   val bar1 = foo1(10000,
     10001, 10002 + 0)
   val bar1 = foo1(
     10000,
-    10001, 10002 + 0
+    10001,
+    10002 + 0
   )
-  val bar1 = foo1(
-    10000,
+  val bar1 = foo1(10000,
     10001, 10002 + 0)
   val bar2 = foo2(
     0,
@@ -7838,24 +7854,31 @@ object Main {
 object Main {
   def foo1(
       x1: X,
-      x2: X, xs: X*
+      x2: X,
+      xs: X*
   ): Set[Int]
   def foo1(
       x1: X,
-      x2: X, xs: X*
+      x2: X,
+      xs: X*
   ): Set[Int]
-  def foo1(
-      x1: X,
+  def foo1(x1: X,
       x2: X, xs: X*): Set[Int]
   def foo1(x1: X,
       x2: X, xs: X*): Set[Int]
   def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
   def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with !configStyle, !danglingParentheses
@@ -7887,11 +7910,13 @@ object Main {
 object Main {
   val bar1 = foo1(
     10000,
-    10001, 10002 + 0)
+    10001, 10002 + 0
+  )
   val bar1 = foo1(10000,
     10001, 10002 + 0)
   val bar1 = foo1(10000,
-    10001, 10002 + 0)
+    10001, 10002 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0)
@@ -7932,9 +7957,11 @@ object Main {
 object Main {
   def foo1(
       x1: X,
-      x2: X, xs: X*): Set[Int]
+      x2: X, xs: X*
+  ): Set[Int]
   def foo1(x1: X,
-      x2: X, xs: X*): Set[Int]
+      x2: X, xs: X*
+  ): Set[Int]
   def foo1(
       x1: X,
       x2: X, xs: X*): Set[Int]
@@ -7942,7 +7969,8 @@ object Main {
       x2: X, xs: X*): Set[Int]
   def foo2(
       x1: X, x2: X, x3: X,
-      x4: X, xs: X*): Set[Int]
+      x4: X, xs: X*
+  ): Set[Int]
   def foo3(
       x1: X, x2: X, x3: X,
       x4: X, xs: X*): Set[Int]

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -7718,6 +7718,9 @@ maxColumn = 30
 runner.optimizer.callSite { minSpan = 20, minCount = 5 }
 ===
 object Main {
+  val bar0 = foo0(
+    1, 2, 3 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -7737,6 +7740,7 @@ object Main {
 }
 >>>
 object Main {
+  val bar0 = foo0(1, 2, 3 + 0)
   val bar1 = foo1(
     10000, 10001, 10002 + 0
   )
@@ -7806,12 +7810,18 @@ object Main {
       x1: X, x2: X, xs: X*
   ): Set[Int]
   def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
   def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with !configStyle, danglingParentheses
@@ -7822,6 +7832,9 @@ maxColumn = 30
 runner.optimizer.callSite { minSpan = 20, minCount = 5 }
 ===
 object Main {
+  val bar0 = foo0(
+    1, 2, 3 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -7841,6 +7854,7 @@ object Main {
 }
 >>>
 object Main {
+  val bar0 = foo0(1, 2, 3 + 0)
   val bar1 = foo1(
     10000, 10001, 10002 + 0
   )
@@ -7917,6 +7931,9 @@ maxColumn = 30
 runner.optimizer.callSite { minSpan = 20, minCount = 5 }
 ===
 object Main {
+  val bar0 = foo0(
+    1, 2, 3 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -7936,6 +7953,7 @@ object Main {
 }
 >>>
 object Main {
+  val bar0 = foo0(1, 2, 3 + 0)
   val bar1 = foo1(
     10000, 10001, 10002 + 0)
   val bar1 = foo1(
@@ -8001,12 +8019,18 @@ object Main {
       x1: X, x2: X, xs: X*)
       : Set[Int]
   def foo2(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
   def foo3(
-      x1: X, x2: X, x3: X,
-      x4: X, xs: X*
+      x1: X,
+      x2: X,
+      x3: X,
+      x4: X,
+      xs: X*
   ): Set[Int]
 }
 <<< binPack.callSite with !configStyle, !danglingParentheses
@@ -8017,6 +8041,9 @@ maxColumn = 30
 runner.optimizer.callSite { minSpan = 20, minCount = 5 }
 ===
 object Main {
+  val bar0 = foo0(
+    1, 2, 3 + 0
+  )
   val bar1 = foo1(
     10000,
     10001, 10002 + 0
@@ -8036,6 +8063,7 @@ object Main {
 }
 >>>
 object Main {
+  val bar0 = foo0(1, 2, 3 + 0)
   val bar1 = foo1(
     10000, 10001, 10002 + 0)
   val bar1 = foo1(

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -201,8 +201,8 @@ object a {
 }
 >>>
 object a {
-  new SimpleMethodName(validateSimpleEncodedName(name, 0, len,
-      openAngleBracketOK = false))
+  new SimpleMethodName(
+      validateSimpleEncodedName(name, 0, len, openAngleBracketOK = false))
 }
 <<< #2079 avoid nested indent, always; 2
 binPack.preset = true
@@ -229,8 +229,8 @@ object a {
 }
 >>>
 object a {
-  new SimpleMethodName(new SimpleMethodName(validateSimpleEncodedName(name, 0,
-      len, openAngleBracketOK = false)))
+  new SimpleMethodName(new SimpleMethodName(
+      validateSimpleEncodedName(name, 0, len, openAngleBracketOK = false)))
 }
 <<< #2079 avoid nested indent, always; 3
 binPack.preset = true
@@ -269,8 +269,7 @@ object a {
       new SimpleMethodName(new SimpleMethodName(validateSimpleEncodedName(name,
           0, len, openAngleBracketOK = false))),
       new SimpleMethodName(new SimpleMethodName(validateSimpleEncodedName(name,
-          0, len, openAngleBracketOK = false)))
-  )
+          0, len, openAngleBracketOK = false))))
 }
 <<< #2079 avoid nested indent, always; 4
 binPack.preset = true
@@ -285,8 +284,7 @@ object a {
 object a {
   new SimpleMethodName(
       new SimpleMethodName(new SimpleMethodName(validateSimpleEncodedName(name,
-                  0, len, openAngleBracketOK = false)))
-  ).foo
+                  0, len, openAngleBracketOK = false)))).foo
 }
 <<< #2079 avoid nested indent, oneline; 4
 binPack.preset = true
@@ -300,8 +298,8 @@ object a {
 >>>
 object a {
   new SimpleMethodName(
-      new SimpleMethodName(new SimpleMethodName(validateSimpleEncodedName(name,
-          0, len, openAngleBracketOK = false)))
+      new SimpleMethodName(new SimpleMethodName(
+          validateSimpleEncodedName(name, 0, len, openAngleBracketOK = false)))
   ).foo
 }
 <<< binpack=oneline, nested, inner with multiple args
@@ -436,8 +434,7 @@ object a {
 object a {
   val call = js.JSFunctionApply(
       js.Select(js.This()(classType), className, fFieldIdent)(jstpe.AnyType),
-      actualParams
-  )
+      actualParams)
 }
 <<< binpack=always, no break after opening, apply
 maxColumn = 80
@@ -451,8 +448,9 @@ object a {
 }
 >>>
 object a {
-  val call = js.JSFunctionApply(js.Select(js.This()(classType), className,
-          fFieldIdent)(jstpe.AnyType), actualParams)
+  val call =
+    js.JSFunctionApply(js.Select(js.This()(classType), className, fFieldIdent)(
+            jstpe.AnyType), actualParams)
 }
 <<< binpack=oneline, no break after opening, extract
 maxColumn = 80
@@ -516,8 +514,7 @@ optDef.getOrElse {
   abort(
       foo &&
       bar,
-      baz
-  )
+      baz)
   abort(
       foo &&
       bar,
@@ -525,8 +522,7 @@ optDef.getOrElse {
       bar,
       foo && // c
       bar,
-      baz
-  )
+      baz)
 }
 <<< binpack with non-top-level-only infix, afterInfix=many
 maxColumn = 16
@@ -551,8 +547,7 @@ foo.bar {
   abort(
       foo &&
       bar,
-      baz
-  )
+      baz)
   abort(
       foo &&
       bar,
@@ -560,8 +555,7 @@ foo.bar {
       bar,
       foo && // c
       bar,
-      baz
-  )
+      baz)
 }
 <<< binpack with non-top-level-only infix, afterInfix=keep, indent once
 indentOperator.topLevelOnly = false
@@ -773,8 +767,7 @@ optDef.getOrElse {
   abort(
       fooFoo &&
       barBar,
-      bazBaz
-  )
+      bazBaz)
 }
 <<< binpack with non-top-level-only infix, fold
 maxColumn = 20
@@ -790,8 +783,9 @@ optDef.getOrElse {
 }
 >>>
 optDef.getOrElse {
-  abort(fooFoo &&
-    barBar)
+  abort(
+      fooFoo &&
+      barBar)
   abort(
       fooFoo &&
       barBar,
@@ -820,14 +814,16 @@ object a {
 }
 >>>
 object a {
-  Seq(foo +
-    bar)
+  Seq(
+    foo +
+      bar)
   Seq(
     foo +
       bar,
     foo +
       bar)
-  Seq(foo &&
+  Seq(
+    foo &&
     bar)
   Seq(
     foo &&
@@ -901,16 +897,14 @@ object a {
     foo +
       bar,
     foo +
-      bar
-  )
+      bar)
   Seq(foo &&
     bar)
   Seq(
     foo &&
     bar,
     foo &&
-    bar
-  )
+    bar)
 }
 <<< binpack with infix rhs in parens, 1 arg
 maxColumn = 20
@@ -924,8 +918,7 @@ object a {
 >>>
 object a {
   val a = foo bar (
-    baz = qux
-  )
+    baz = qux)
 }
 <<< binpack with infix rhs in parens, 2 args
 maxColumn = 25

--- a/scalafmt-tests/src/test/resources/scalajs/Class.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Class.stat
@@ -43,8 +43,8 @@ class Promise[+A](
     executor: js.Function2[js.Function1[A | Thenable[A], _], js.Function1[scala.Any, _], _])
 >>>
 class Promise[+A](
-    executor: js.Function2[js.Function1[A | Thenable[A],
-            _], js.Function1[scala.Any, _], _])
+    executor: js.Function2[js.Function1[A | Thenable[A], _], js.Function1[
+            scala.Any, _], _])
 <<< #270
 object a {
 private class Encoder extends CharsetEncoder(

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -266,24 +266,19 @@ implicit def toFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
     js.Array[JSStackTraceElem], js.Array[JSStackTraceElem]]] = js.native
 >>>
 def sourceMapper: js.UndefOr[js.Function1[ // scalastyle:ignore
-    js.Array[JSStackTraceElem],
-    js.Array[JSStackTraceElem]
-]] = js.native
+    js.Array[JSStackTraceElem], js.Array[JSStackTraceElem]]] = js.native
 <<< comment inside middle of type parameter #264 3
    def sourceMapper: js.UndefOr[ // scalastyle:ignore
     js.Array[JSStackTraceElem], js.Array[JSStackTraceElem]] = js.native
 >>>
 def sourceMapper: js.UndefOr[ // scalastyle:ignore
-    js.Array[JSStackTraceElem],
-    js.Array[JSStackTraceElem]
-] = js.native
+    js.Array[JSStackTraceElem], js.Array[JSStackTraceElem]] = js.native
 <<< comment inside middle of type parameter #264 4
    def sourceMapper: js.UndefOr[js.Array[ // scalastyle:ignore
     JSStackTraceElem], js.Array[JSStackTraceElem]] = js.native
 >>>
 def sourceMapper: js.UndefOr[js.Array[ // scalastyle:ignore
-        JSStackTraceElem
-    ], js.Array[JSStackTraceElem]] = js.native
+        JSStackTraceElem], js.Array[JSStackTraceElem]] = js.native
 <<< align by =>;Case #268
    def unwrapJavaScriptException(th: Throwable): Any = th match {
      case js.JavaScriptException(e) => e

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -358,10 +358,12 @@ import foo.{
   a, b,
 }
 class foo(
-    a: String, b: String,
+    a: String,
+    b: String,
 ) {
   def method(
-      a: String, b: String,
+      a: String,
+      b: String,
   ) = ???
   method(
     a,

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysComments.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasAlwaysComments.stat
@@ -363,13 +363,16 @@ import foo.{
   a, b, /* c1 */ /* c2 */
 }
 class foo(
-    a: String, b: String, /* c1 */ /* c2 */
+    a: String,
+    b: String, /* c1 */ /* c2 */
 ) {
   def method(
-      a: String, b: String, /* c1 */ /* c2 */
+      a: String,
+      b: String, /* c1 */ /* c2 */
   ) = ???
   method(
-    a, b, /* c1 */ /* c2 */
+    a,
+    b, /* c1 */ /* c2 */
   )
 }
 <<< #2755 two, no comma, no fold, binPack, !cfgStyle

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultiple.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultiple.stat
@@ -343,10 +343,12 @@ import foo.{
   a, b,
 }
 class foo(
-    a: String, b: String,
+    a: String,
+    b: String,
 ) {
   def method(
-      a: String, b: String,
+      a: String,
+      b: String,
   ) = ???
   method(
     a,

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleComments.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasMultipleComments.stat
@@ -347,13 +347,16 @@ import foo.{
   a, b, /* c1 */ /* c2 */
 }
 class foo(
-    a: String, b: String, /* c1 */ /* c2 */
+    a: String,
+    b: String, /* c1 */ /* c2 */
 ) {
   def method(
-      a: String, b: String, /* c1 */ /* c2 */
+      a: String,
+      b: String, /* c1 */ /* c2 */
   ) = ???
   method(
-    a, b, /* c1 */ /* c2 */
+    a,
+    b, /* c1 */ /* c2 */
   )
 }
 <<< #2755 two, no comma, no fold, binPack, !cfgStyle

--- a/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
+++ b/scalafmt-tests/src/test/resources/trailing-commas/trailingCommasPreserve.stat
@@ -60,7 +60,8 @@ def a(b: Int,
 )
 >>>
 def a(
-    b: Int, c: Int,
+    b: Int,
+    c: Int,
 )
 <<< keep, do not fold, binpack, !cfgStyle
 binPack.preset = true
@@ -108,7 +109,9 @@ def a(b: Int, c: Int,
  /* comment */ )
 >>>
 def a(
-    b: Int, c: Int, /* comment */
+    b: Int,
+    c: Int,
+    /* comment */
 )
 <<< keep, do not fold, with comment after break, binpack, !cfgStyle
 maxColumn = 40
@@ -182,7 +185,8 @@ def a(b: Int,
 )
 >>>
 def a(
-    b: Int, c: Int,
+    b: Int,
+    c: Int,
 )
 <<< keep, do not fold, with spaces, binpack, !cfgStyle
 binPack.preset = true
@@ -234,7 +238,9 @@ def a(b: Int, c: Int,
  /* comment */ )
 >>>
 def a(
-    b: Int, c: Int, /* comment */
+    b: Int,
+    c: Int,
+    /* comment */
 )
 <<< keep, do not fold, with spaces and comment after break, binpack, !cfgStyle
 spaces.inParentheses = true

--- a/scalafmt-tests/src/test/resources/unit/Comment.stat
+++ b/scalafmt-tests/src/test/resources/unit/Comment.stat
@@ -913,7 +913,7 @@ object a:
     baz /* comment1
      * comment2
      * comment3 */
-<<< trailing-wrapped comments with fold, binpack(lots) and dangling
+<<< trailing-wrapped comments with fold, binpack(lots) and dangling 1
 maxColumn = 100
 indent.callSite = 2
 align.preset = none
@@ -966,11 +966,13 @@ object a {
       user_id: String, dept_id: Option[Int], catg_grp_id: Option[Int], // for store only
       catg_id: Option[Int], subcatg_id: Option[Int], brand_id: Option[Int], order_date: String,
       item_id: Long
-  ) = SalesUserActivity(user_id, dept_id, catg_grp_id, catg_id, subcatg_id, brand_id,
-    Some(dummyBrand), 1f, 1f, item_id, tenant, inid, catalog, channel,
-    order_date.split("-")(0).toInt, order_date.split("-")(1).toInt, "v1", order_date)
+  ) = SalesUserActivity(
+    user_id, dept_id, catg_grp_id, catg_id, subcatg_id, brand_id, Some(dummyBrand), 1f, 1f, item_id,
+    tenant, inid, catalog, channel, order_date.split("-")(0).toInt, order_date.split("-")(1).toInt,
+    "v1", order_date
+  )
 }
-<<< trailing-wrapped comments with fold, binpack(lots) and dangling
+<<< trailing-wrapped comments with fold, binpack(lots) and dangling 2
 maxColumn = 100
 indent.callSite = 2
 align.preset = none
@@ -996,8 +998,9 @@ object a {
 object a {
   private val impressionUniqueMetricsData = Seq(
     // out of range
-    ImpUnique("2018-01-02", 102, Some("444"), Some(1), Some(2), Some(1), None, None, 2018, 1,
-      ver) /* aggimp3 */
+    ImpUnique(
+      "2018-01-02", 102, Some("444"), Some(1), Some(2), Some(1), None, None, 2018, 1, ver
+    ) /* aggimp3 */
   )
 }
 <<< trailing-wrapped comments with fold, binpack=oneline
@@ -1020,7 +1023,8 @@ object a {
 object a {
   private val foo = Seq(
     // out of range
-    Bar("2018-01-02", 1,
+    Bar(
+      "2018-01-02", 1,
       ver) /* baz */
   )
 }


### PR DESCRIPTION
Also, modify it so that it matches configuration parameters better. In most cases, it will either preserve formatting (which tests may not show as they operate on non-formatted code) or can easily be configured to match existing formatting.

This change partially restores some of formatting changes introduced in recent commits, by making their results more consistent with new logic.

Fixes #3954.