### PR TITLE
Router: fix handling of binpack=oneline

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2805,8 +2805,7 @@ object a {
       E(Seq(F(1, "v1"), F(2, "v2")),
         G(Some(Seq(h, i)),
           Some(Seq(j, k)), a.b, c.d,
-          e.f.g, h.i.j)
-      ).foo
+          e.f.g, h.i.j)).foo
   }
 }
 <<< binpack call, oneline, with syntaxNL, single arg

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2805,8 +2805,7 @@ object a {
       E(Seq(F(1, "v1"), F(2, "v2")),
         G(Some(Seq(h, i)),
           Some(Seq(j, k)), a.b, c.d,
-          e.f.g, h.i.j)
-      ).foo
+          e.f.g, h.i.j)).foo
   }
 }
 <<< binpack call, oneline, with syntaxNL, single arg

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -991,3 +991,42 @@ object a {
     }
   }
 }
+<<< nested with oneline
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleCallSite.prefer = true
+===
+object a {
+  js.MethodDef(flags, methodIdent, originalName, jsParams, resultType, Some {
+             genApplyMethod(genLoadModule(moduleClass), m, jsParams.map(_.ref))
+           })(OptimizerHints.empty, Unversioned)
+}
+>>>
+BestFirstSearch:290 Failed to format
+UNABLE TO FORMAT,
+tok=}∙): RightBrace [180..181) [] RightParen [181..182)
+toks.length=48
+deepestYet.length=38
+policies=List(NB:[Router:1460]@182d, NB:[Router:1460]@182d, [FormatOps:2660]@182d, NB:[Router:232]@219d)
+nextSplits=List(NoSplit:[Router:2360](cost=0, indents=[], NoPolicy))
+splitsAfterPolicy=Decision(}∙): RightBrace [180..181) [] RightParen [181..182),List())
+<<< nested with oneline, keep
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleCallSite.prefer = true
+===
+object a {
+  js.MethodDef(flags, methodIdent, originalName, jsParams, resultType, Some {
+             genApplyMethod(genLoadModule(moduleClass), m, jsParams.map(_.ref))
+           })(OptimizerHints.empty, Unversioned)
+}
+>>>
+BestFirstSearch:290 Failed to format
+UNABLE TO FORMAT,
+tok=}∙): RightBrace [180..181) [] RightParen [181..182)
+toks.length=48
+deepestYet.length=38
+policies=List(NB:[Router:1460]@182d, NB:[Router:1460]@182d, [FormatOps:2660]@182d, NB:[Router:232]@219d)
+nextSplits=List(NoSplit:[Router:2360](cost=0, indents=[], NoPolicy))
+splitsAfterPolicy=Decision(}∙): RightBrace [180..181) [] RightParen [181..182),List())

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -359,7 +359,9 @@ object a {
   foo match {
     case Apply(appMeth,
             Apply(wrapRefArrayMeth,
-                StripCast(arg @ ArrayValue(elemtpt, elems)) :: Nil) :: classTagEvidence :: Nil)
+                StripCast(
+                    arg @ ArrayValue(elemtpt, elems)
+                ) :: Nil) :: classTagEvidence :: Nil)
         if WrapArray.isClassTagBasedWrapArrayMethod(wrapRefArrayMeth.symbol) &&
           appMeth.symbol == ArrayModule_genericApply =>
       bar
@@ -403,7 +405,9 @@ object a {
 object a {
   Apply(appMeth,
       Apply(wrapRefArrayMeth,
-          StripCast(ArrayValue(elemtpt, elems)) :: Nil) :: classTagEvidence :: Nil)
+          StripCast(
+              ArrayValue(elemtpt, elems)
+          ) :: Nil) :: classTagEvidence :: Nil)
 }
 <<< binpack=always, with infix
 maxColumn = 80
@@ -1002,14 +1006,13 @@ object a {
            })(OptimizerHints.empty, Unversioned)
 }
 >>>
-BestFirstSearch:290 Failed to format
-UNABLE TO FORMAT,
-tok=}∙): RightBrace [180..181) [] RightParen [181..182)
-toks.length=48
-deepestYet.length=38
-policies=List(NB:[Router:1460]@182d, NB:[Router:1460]@182d, [FormatOps:2660]@182d, NB:[Router:232]@219d)
-nextSplits=List(NoSplit:[Router:2360](cost=0, indents=[], NoPolicy))
-splitsAfterPolicy=Decision(}∙): RightBrace [180..181) [] RightParen [181..182),List())
+object a {
+  js.MethodDef(flags, methodIdent, originalName, jsParams, resultType,
+      Some {
+        genApplyMethod(genLoadModule(moduleClass), m, jsParams.map(_.ref))
+      })(
+      OptimizerHints.empty, Unversioned)
+}
 <<< nested with oneline, keep
 newlines.source = keep
 binPack.preset = oneline
@@ -1022,11 +1025,10 @@ object a {
            })(OptimizerHints.empty, Unversioned)
 }
 >>>
-BestFirstSearch:290 Failed to format
-UNABLE TO FORMAT,
-tok=}∙): RightBrace [180..181) [] RightParen [181..182)
-toks.length=48
-deepestYet.length=38
-policies=List(NB:[Router:1460]@182d, NB:[Router:1460]@182d, [FormatOps:2660]@182d, NB:[Router:232]@219d)
-nextSplits=List(NoSplit:[Router:2360](cost=0, indents=[], NoPolicy))
-splitsAfterPolicy=Decision(}∙): RightBrace [180..181) [] RightParen [181..182),List())
+object a {
+  js.MethodDef(flags, methodIdent, originalName, jsParams, resultType,
+      Some {
+        genApplyMethod(genLoadModule(moduleClass), m, jsParams.map(_.ref))
+      })(
+      OptimizerHints.empty, Unversioned)
+}


### PR DESCRIPTION
We can't force a newline before closing parenthesis because the policies for intervening splits might actually disable that, and for scala.js it would also require forcing a newline after the opening parenthesis.