### PR TITLE
FormatOps: add all arguments to `argumentStarts`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -84,13 +84,13 @@ class FormatOps(
     queue += topSourceTree :: Nil
     while (queue.nonEmpty) queue.remove(0).foreach { tree =>
       tree match {
-        case _: Lit.Unit | _: Member.SyntaxValuesClause =>
-        case t: Term.Param =>
+        case _: Lit.Unit | _: Term.ArgClause | _: Term.ParamClause =>
+        case t: Member.SyntaxValuesClause => t.values.foreach(add)
+        case t: Term.Param => // includes Term.ParamClause
           add(t)
           t.mods.foreach(addOptional)
           addOptional(t.name)
-        case t: Term => add(t)
-        case t: Pat.Extract => t.argClause.values.foreach(add)
+        case t: Term => add(t) // includes Term.ArgClause
         case _ =>
       }
       queue += tree.children

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1423,8 +1423,10 @@ class Router(formatOps: FormatOps) {
             }
             def optFT = nextCommaOrParen.fold(lastFT) { cp =>
               if (cp.right.is[T.Comma]) if (oneline) cp else lastFT
-              else if (!cp.right.is[T.RightParen]) lastFT
-              else if (!style.newlines.avoidInResultType) lastFT
+              else if (
+                !style.newlines.avoidInResultType ||
+                style.newlines.sometimesBeforeColonInMethodReturnType
+              ) lastFT
               else {
                 val nft = findToken(next(cp), next) { x =>
                   x.right match {

--- a/scalafmt-tests/src/test/resources/scalajs/Class.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Class.stat
@@ -43,8 +43,8 @@ class Promise[+A](
     executor: js.Function2[js.Function1[A | Thenable[A], _], js.Function1[scala.Any, _], _])
 >>>
 class Promise[+A](
-    executor: js.Function2[js.Function1[A | Thenable[A], _], js.Function1[
-            scala.Any, _], _])
+    executor: js.Function2[js.Function1[A | Thenable[A], _],
+        js.Function1[scala.Any, _], _])
 <<< #270
 object a {
 private class Encoder extends CharsetEncoder(

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -423,13 +423,13 @@ object a {
    }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   override private[util] def newNode(key: K, hash: Int, value: V,
--      previous: HashMap.Node[K, V],
-+      previous: HashMap.Node[K,
-+        V],
-       next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+object a {
+  override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V])
+      : HashMap.Node[K, V] = {
+    new NullRejectingHashMap.Node(key, hash, value, previous, next)
+  }
+}
 <<< oneline def with keep, cfg+!dangle
 preset = default
 newlines.source = keep
@@ -444,13 +444,13 @@ object a {
    }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   override private[util] def newNode(key: K, hash: Int, value: V,
--      previous: HashMap.Node[K, V],
-+      previous: HashMap.Node[K,
-+        V],
-       next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+object a {
+  override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V])
+      : HashMap.Node[K, V] = {
+    new NullRejectingHashMap.Node(key, hash, value, previous, next)
+  }
+}
 <<< oneline def with keep, !cfg+dangle
 preset = default
 newlines.source = keep
@@ -465,13 +465,13 @@ object a {
    }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   override private[util] def newNode(key: K, hash: Int, value: V,
--      previous: HashMap.Node[K, V],
-+      previous: HashMap.Node[K,
-+        V],
-       next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+object a {
+  override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V])
+      : HashMap.Node[K, V] = {
+    new NullRejectingHashMap.Node(key, hash, value, previous, next)
+  }
+}
 <<< oneline def with keep, !cfg+!dangle
 preset = default
 newlines.source = keep
@@ -486,13 +486,13 @@ object a {
    }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   override private[util] def newNode(key: K, hash: Int, value: V,
--      previous: HashMap.Node[K, V],
-+      previous: HashMap.Node[K,
-+        V],
-       next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+object a {
+  override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V])
+      : HashMap.Node[K, V] = {
+    new NullRejectingHashMap.Node(key, hash, value, previous, next)
+  }
+}
 <<< last comma right on maxColumn boundary, oneline
 preset = default
 maxColumn = 78
@@ -509,9 +509,8 @@ object a {
 }
 >>>
 object a {
-  implicit def toFunction12[
-      VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam, R](
-      f: js.Function12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam,
+  implicit def toFunction12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam,
+      R](f: js.Function12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam,
         R]): scala.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,
     T12, R] =
     (x1, x12) => f(x1, x12)

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -242,13 +242,61 @@ object a {
         fields: (String, Any)*): Object with Dynamic = sys.error("stub")
   }
 }
-<<< toFunction8 #255
+<<< weird breaking #252, oneline
+binPack.preset = oneline
+===
+object a {
+  object b {
+        def applyDynamicNamed(name: String)(fields: (String, Any)*): Object with Dynamic = sys.error("stub")
+  }
+}
+>>>
+object a {
+  object b {
+    def applyDynamicNamed(name: String)(fields: (String,
+            Any)*): Object with Dynamic = sys.error("stub")
+  }
+}
+<<< toFunction8 #255 avoidInResultType, sometimesBeforeColonInMethodReturnType
+newlines.avoidInResultType = true
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+  implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R]): scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3, x4, x5, x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
+>>>
+implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](
+    f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R])
+    : scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3, x4, x5,
+    x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
+<<< toFunction8 #255 avoidInResultType, !sometimesBeforeColonInMethodReturnType
+newlines.avoidInResultType = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
   implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R]): scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3, x4, x5, x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
 >>>
 implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](
     f: Function8[T1, T2, T3, T4, T5, T6, T7, T8,
         R]): scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3,
     x4, x5, x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
+<<< toFunction8 #255 !avoidInResultType, sometimesBeforeColonInMethodReturnType
+newlines.avoidInResultType = false
+newlines.sometimesBeforeColonInMethodReturnType = true
+===
+  implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R]): scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3, x4, x5, x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
+>>>
+implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](
+    f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R])
+    : scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3, x4, x5,
+    x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
+<<< toFunction8 #255 !avoidInResultType, !sometimesBeforeColonInMethodReturnType
+newlines.avoidInResultType = false
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+  implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R]): scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3, x4, x5, x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
+>>>
+implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](
+    f: Function8[T1, T2, T3, T4, T5, T6, T7, T8, R]): scala.Function8[T1, T2,
+    T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3, x4, x5, x6, x7, x8) =>
+  f(x1, x2, x3, x4, x5, x6, x7, x8)
 <<< toFunction22 #255
   implicit def toFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](f: Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]): scala.Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22)
 >>>
@@ -360,4 +408,111 @@ object a {
     if (flags.isPrivate)
       print("private::")
   }
+}
+<<< oneline def with keep, cfg+dangle
+preset = default
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = true
+newlines.configStyleDefnSite.prefer = true
+===
+object a {
+   override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+     new NullRejectingHashMap.Node(key, hash, value, previous, next)
+   }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   override private[util] def newNode(key: K, hash: Int, value: V,
+-      previous: HashMap.Node[K, V],
++      previous: HashMap.Node[K,
++        V],
+       next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+<<< oneline def with keep, cfg+!dangle
+preset = default
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleDefnSite.prefer = true
+===
+object a {
+   override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+     new NullRejectingHashMap.Node(key, hash, value, previous, next)
+   }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   override private[util] def newNode(key: K, hash: Int, value: V,
+-      previous: HashMap.Node[K, V],
++      previous: HashMap.Node[K,
++        V],
+       next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+<<< oneline def with keep, !cfg+dangle
+preset = default
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = true
+newlines.configStyleDefnSite.prefer = false
+===
+object a {
+   override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+     new NullRejectingHashMap.Node(key, hash, value, previous, next)
+   }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   override private[util] def newNode(key: K, hash: Int, value: V,
+-      previous: HashMap.Node[K, V],
++      previous: HashMap.Node[K,
++        V],
+       next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+<<< oneline def with keep, !cfg+!dangle
+preset = default
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleDefnSite.prefer = false
+===
+object a {
+   override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+     new NullRejectingHashMap.Node(key, hash, value, previous, next)
+   }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   override private[util] def newNode(key: K, hash: Int, value: V,
+-      previous: HashMap.Node[K, V],
++      previous: HashMap.Node[K,
++        V],
+       next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+<<< last comma right on maxColumn boundary, oneline
+preset = default
+maxColumn = 78
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleDefnSite.prefer = true
+===
+object a {
+  implicit def toFunction12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam, R](
+    f: js.Function12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam, R])
+    : scala.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] =
+      (x1, x12) => f(x1, x12)
+}
+>>>
+object a {
+  implicit def toFunction12[
+      VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam, R](
+      f: js.Function12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam,
+        R]): scala.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,
+    T12, R] =
+    (x1, x12) => f(x1, x12)
 }


### PR DESCRIPTION
This now allows us to handle bracketed arguments.