### PR TITLE
Router: extend single line for bp.defnsite=oneline

### DIFF
--- a/scalafmt-tests/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/src/test/resources/default/TypeArguments.stat
@@ -453,9 +453,8 @@ def props[M[_[_]], F[_]: Async, I: KeyDecoder, State, Event: PersistentEncoder: 
 object a {
   def deploy[M[_[_]]: FunctorK, F[_], State, Event: PersistentEncoder: PersistentDecoder,
              K: KeyEncoder: KeyDecoder] = ???
-  def props[
-      M[_[_]], F[_]: Async, I: KeyDecoder, State, Event: PersistentEncoder: PersistentDecoder]() =
-    ???
+  def props[M[_[_]], F[_]: Async, I: KeyDecoder, State,
+            Event: PersistentEncoder: PersistentDecoder]() = ???
 }
 <<< #2739 bracketDefnSite = always, danglingParentheses
 maxColumn = 100

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -5050,11 +5050,9 @@ object a {
 }
 >>>
 object a {
-  def foo(
-      bb: BB,
-      cc: CC,
-      dd: DD = DDD.ddd
-  ): Bar[Baz] = {
+  def foo(bb: BB, cc: CC, dd: DD = DDD.ddd): Bar[
+    Baz
+  ] = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -509,8 +509,8 @@ object a {
 }
 >>>
 object a {
-  implicit def toFunction12[
-      VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam, R](
+  implicit def toFunction12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam,
+      R](
       f: js.Function12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam, R])
       : scala.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
         R] =
@@ -530,8 +530,7 @@ object a {
 }
 >>>
 object a {
-  def setTimeout(
-      handler: js.Function0[Any], interval: Double): SetTimeoutHandle =
+  def setTimeout(handler: js.Function0[Any], interval: Double): SetTimeoutHandle =
     js.native
 }
 <<< break at maxColumn, with overflow enabled 2


### PR DESCRIPTION
Include comma and any attached comments after it.