### PR TITLE
FormatOps: use src=keep to open break for scala.js

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4958,6 +4958,11 @@ When not disabled, these parameters have complex interactions with
 Keep in mind that when [config-style is forced](#forcing-config-style),
 it takes precedence over options described below.
 
+The code that is being binpacked might also yield an additional force over
+the selection of breaks, such as when dealing with multiline arguments
+(they behave differently under `Oneline` setting, or depending on
+[alignment](#alignopenparencallsite)).
+
 - `newlines.source=classic`
   - `cfgStyle=T`, `dangle=T`:
     use cfg-style if both parens had breaks, otherwise binpack without breaks
@@ -4974,16 +4979,16 @@ it takes precedence over options described below.
     - before v3.8.2, this formatting was used for `callSite` with
       `cfgStyle=F` and any `dangle`, and for `defnSite` with
       `cfgStyle=F` and `dangle=F`
-- `newlines.source=keep`
+- `newlines.source=keep`: always preserve break after open paren
   - `cfgStyle=T`, `dangle=T`:
-    use cfg-style if open paren had a break; otherwise, binpack and preserve both breaks
+    use cfg-style if open paren had a break; otherwise, binpack and keep close break
   - `cfgStyle=T`, `dangle=F`:
     ([scala.js](#presetscalajs))
-    use cfg-style if close paren had a break; otherwise, binpack without breaks
+    use cfg-style if close paren had a break; otherwise, binpack and keep close break
   - `cfgStyle=F`, `dangle=T`:
-    binpack; if open paren had a break, force both breaks; otherwise, preserve both
+    binpack; force close break if open paren had a break; otherwise, preserve it
   - `cfgStyle=F`, `dangle=F`:
-    binpack; preserve both breaks
+    binpack; preserve close break
 - `newlines.source=fold`: if single line is not possible:
   - `cfgStyle=T`, `dangle=T`:
     binpack with both breaks

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2655,14 +2655,17 @@ class FormatOps(
             case Newlines.keep => openBreak
             case _ => false
           }) || isRightCommentWithBreak(ftAfterOpen)
-        val nlBothIncludingCfg = !sourceIgnored && closeBreak && {
-          scalaJsStyle || nlOpenExcludingCfg ||
-          preserveConfigStyle(ftAfterOpen, true)
+        val nlBothIncludingCfg = !sourceIgnored && {
+          val nlBothExcludingCfg =
+            if (!shouldDangle) scalaJsStyle && closeBreak
+            else nlOpenExcludingCfg && !style.newlines.keepBreak(!closeBreak)
+          nlBothExcludingCfg ||
+          closeBreak && preserveConfigStyle(ftAfterOpen, true)
         }
         // close on open NL; doesn't cover case with no break after open
         val nlClose = nlBothIncludingCfg || dangleForTrailingCommas ||
           shouldDangle || style.newlines.keepBreak(closeBreak)
-        if (!nlClose) (nlOpenExcludingCfg && !scalaJsStyle, NlClosedOnOpen.No)
+        if (!nlClose) (nlOpenExcludingCfg, NlClosedOnOpen.No)
         else {
           val cfg = !literalArgList && configStyleSource
           val dangle = if (cfg) NlClosedOnOpen.Cfg else NlClosedOnOpen.Yes

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -7805,7 +7805,8 @@ object Main {
     10001,
     10002 + 0
   )
-  val bar1 = foo1(10000,
+  val bar1 = foo1(
+    10000,
     10001, 10002 + 0)
   val bar2 = foo2(
     0,
@@ -7861,7 +7862,8 @@ object Main {
       x2: X,
       xs: X*
   ): Set[Int]
-  def foo1(x1: X,
+  def foo1(
+      x1: X,
       x2: X, xs: X*): Set[Int]
   def foo1(x1: X,
       x2: X, xs: X*): Set[Int]

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -509,10 +509,11 @@ object a {
 }
 >>>
 object a {
-  implicit def toFunction12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam,
-      R](f: js.Function12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam,
-        R]): scala.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,
-    T12, R] =
+  implicit def toFunction12[
+      VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam, R](
+      f: js.Function12[VeryVeryVeryVeryVeryVeryVeryVeryVeryLongTypeParam, R])
+      : scala.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+        R] =
     (x1, x12) => f(x1, x12)
 }
 <<< break at maxColumn, with overflow enabled 1
@@ -528,13 +529,11 @@ object a {
   def setTimeout(handler: js.Function0[Any], interval: Double): SetTimeoutHandle = js.native
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a {
--  def setTimeout(handler: js.Function0[Any], interval: Double): SetTimeoutHandle =
-+  def setTimeout(
-+      handler: js.Function0[Any], interval: Double): SetTimeoutHandle =
-     js.native
+object a {
+  def setTimeout(
+      handler: js.Function0[Any], interval: Double): SetTimeoutHandle =
+    js.native
+}
 <<< break at maxColumn, with overflow enabled 2
 preset = default
 maxColumn = 80
@@ -550,11 +549,10 @@ object a {
   }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a {
--  def getArrayUnderlyingTypedArrayClassRef(elemTypeRef: NonArrayTypeRef)(
--      implicit tracking: GlobalRefTracking,
-+  def getArrayUnderlyingTypedArrayClassRef(
-+      elemTypeRef: NonArrayTypeRef)(implicit tracking: GlobalRefTracking,
-       pos: Position): Option[WithGlobals[VarRef]] = {
+object a {
+  def getArrayUnderlyingTypedArrayClassRef(
+      elemTypeRef: NonArrayTypeRef)(implicit tracking: GlobalRefTracking,
+      pos: Position): Option[WithGlobals[VarRef]] = {
+    // foo
+  }
+}

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -515,3 +515,46 @@ object a {
     T12, R] =
     (x1, x12) => f(x1, x12)
 }
+<<< break at maxColumn, with overflow enabled 1
+preset = default
+maxColumn = 80
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleDefnSite.prefer = true
+newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
+===
+object a {
+  def setTimeout(handler: js.Function0[Any], interval: Double): SetTimeoutHandle = js.native
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a {
+-  def setTimeout(handler: js.Function0[Any], interval: Double): SetTimeoutHandle =
++  def setTimeout(
++      handler: js.Function0[Any], interval: Double): SetTimeoutHandle =
+     js.native
+<<< break at maxColumn, with overflow enabled 2
+preset = default
+maxColumn = 80
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleDefnSite.prefer = true
+# newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
+===
+object a {
+  def getArrayUnderlyingTypedArrayClassRef(elemTypeRef: NonArrayTypeRef)(implicit tracking: GlobalRefTracking, pos: Position): Option[WithGlobals[VarRef]] = {
+    // foo
+  }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a {
+-  def getArrayUnderlyingTypedArrayClassRef(elemTypeRef: NonArrayTypeRef)(
+-      implicit tracking: GlobalRefTracking,
++  def getArrayUnderlyingTypedArrayClassRef(
++      elemTypeRef: NonArrayTypeRef)(implicit tracking: GlobalRefTracking,
+       pos: Position): Option[WithGlobals[VarRef]] = {


### PR DESCRIPTION
Otherwise, it was leading to widespread non-idempotency problems.