### PR TITLE
Router: fix bp.defnsite=oneline inconsistency bug

### DIFF
--- a/scalafmt-tests/src/test/resources/scalajs/Class.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Class.stat
@@ -42,8 +42,7 @@ class Response(content: BodyInit = null, init: ResponseInit = null)
 class Promise[+A](
     executor: js.Function2[js.Function1[A | Thenable[A], _], js.Function1[scala.Any, _], _])
 >>>
-class Promise[+A](
-    executor: js.Function2[js.Function1[A | Thenable[A], _],
+class Promise[+A](executor: js.Function2[js.Function1[A | Thenable[A], _],
         js.Function1[scala.Any, _], _])
 <<< #270
 object a {

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -238,8 +238,8 @@ object a {
 >>>
 object a {
   object b {
-    def applyDynamicNamed(name: String)(
-        fields: (String, Any)*): Object with Dynamic = sys.error("stub")
+    def applyDynamicNamed(name: String)(fields: (String,
+            Any)*): Object with Dynamic = sys.error("stub")
   }
 }
 <<< weird breaking #252, oneline


### PR DESCRIPTION
The code was applying a single-line constraint after a no-break split when we had multiple arguments OR NON-oneline formatting.

Instead, we should we applying this when we had multiple arguments AND oneline formatting, since single-line is the requirement of oneline.

This inconsistency was leading to non-idempotent formatting at times.