### PR TITLE
Router: fix bp.callsite=oneline penalty bug

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1231,7 +1231,8 @@ class Router(formatOps: FormatOps) {
                   penalizeNewlinesPolicy
                 else {
                   val slbEnd = nextCommaOneline.getOrElse(close)
-                  SingleLineBlock(slbEnd, noSyntaxNL = true)
+                  SingleLineBlock(slbEnd, noSyntaxNL = true) |
+                    penalizeNewlinesPolicy
                 }
               }
             val indentPolicy =

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -5130,8 +5130,9 @@ object a {
 }
 >>>
 object a {
-  def foo(dd: DD[AA[BB],
-        CC] = DDD.ddd): Bar[Baz] = {
+  def foo(
+      dd: DD[AA[BB], CC] = DDD.ddd
+  ): Bar[Baz] = {
     // c
     qux
   }
@@ -5173,8 +5174,8 @@ object a {
 }
 >>>
 object a {
-  def foo(dd: DD[AA[BB],
-            CC] = DDDD.dddd) = {
+  def foo(dd: DD[AA[BB], CC] =
+            DDDD.dddd) = {
     // c
     qux
   }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -2644,13 +2644,13 @@ object a {
 >>>
 object a {
   test("foo") {
-    a.b(c, d) shouldBe
-      E(Seq(F(1, "v1"), F(2, "v2")),
-        G(Some(Seq(h, i)),
-          Some(Seq(j, k)), a.b, c.d,
-          e.f.g, h.i.j
-        )
-      ).foo
+    a.b(c, d) shouldBe E(
+      Seq(F(1, "v1"), F(2, "v2")),
+      G(Some(Seq(h, i)),
+        Some(Seq(j, k)), a.b, c.d,
+        e.f.g, h.i.j
+      )
+    ).foo
   }
 }
 <<< binpack call, oneline, with syntaxNL, single arg

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -935,9 +935,8 @@ object a {
 }
 >>>
 object a {
-  val a =
-    foo bar (baz = qux,
-      bar = qux)
+  val a = foo bar (
+    baz = qux, bar = qux)
 }
 <<< binpack with infix rhs in parens, 2 args, bp=always
 maxColumn = 25

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -924,7 +924,7 @@ object a {
   val a = foo bar (
     baz = qux)
 }
-<<< binpack with infix rhs in parens, 2 args
+<<< binpack with infix rhs in parens, 2 args, bp=oneline
 maxColumn = 25
 binPack.unsafeCallSite = oneline
 indentOperator.topLevelOnly = false
@@ -938,6 +938,20 @@ object a {
   val a =
     foo bar (baz = qux,
       bar = qux)
+}
+<<< binpack with infix rhs in parens, 2 args, bp=always
+maxColumn = 25
+binPack.unsafeCallSite = always
+indentOperator.topLevelOnly = false
+indent.callSite = 2
+===
+object a {
+  val a = foo bar (baz = qux, bar = qux)
+}
+>>>
+object a {
+  val a = foo bar (
+    baz = qux, bar = qux)
 }
 <<< binpack with infix match rhs in parens
 maxColumn = 25

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -529,13 +529,16 @@ object a {
   implicit def fromFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](f: scala.Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]): js.Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = (x1: T1, x2: T2, x3: T3, x4: T4, x5: T5, x6: T6, x7: T7, x8: T8, x9: T9, x10: T10, x11: T11, x12: T12, x13: T13, x14: T14, x15: T15, x16: T16, x17: T17) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17)
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   implicit def fromFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
--      T13, T14, T15, T16, T17, R](f: scala.Function17[T1, T2, T3, T4, T5, T6,
--        T7,
-+      T13, T14, T15, T16, T17, R](f: scala.Function17[T1, T2, T3, T4, T5, T6, T7,
-         T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]): js.Function17[T1,
+object a {
+  implicit def fromFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+      T13, T14, T15, T16, T17, R](
+      f: scala.Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+        T13, T14, T15, T16, T17, R]): js.Function17[T1, T2, T3, T4, T5, T6, T7,
+    T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = (x1: T1, x2: T2,
+      x3: T3, x4: T4, x5: T5, x6: T6, x7: T7, x8: T8, x9: T9, x10: T10,
+      x11: T11, x12: T12, x13: T13, x14: T14, x15: T15, x16: T16, x17: T17) =>
+    f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17)
+}
 <<< break at maxColumn, with overflow enabled 1
 preset = default
 maxColumn = 80

--- a/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/DefDef.stat
@@ -516,6 +516,26 @@ object a {
         R] =
     (x1, x12) => f(x1, x12)
 }
+<<< one of the commas right on maxColumn boundary, oneline
+preset = default
+maxColumn = 80
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleDefnSite.prefer = true
+newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
+===
+object a {
+  implicit def fromFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](f: scala.Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]): js.Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = (x1: T1, x2: T2, x3: T3, x4: T4, x5: T5, x6: T6, x7: T7, x8: T8, x9: T9, x10: T10, x11: T11, x12: T12, x13: T13, x14: T14, x15: T15, x16: T16, x17: T17) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17)
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   implicit def fromFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+-      T13, T14, T15, T16, T17, R](f: scala.Function17[T1, T2, T3, T4, T5, T6,
+-        T7,
++      T13, T14, T15, T16, T17, R](f: scala.Function17[T1, T2, T3, T4, T5, T6, T7,
+         T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]): js.Function17[T1,
 <<< break at maxColumn, with overflow enabled 1
 preset = default
 maxColumn = 80


### PR DESCRIPTION
For NoSplit, we intend to penalize all newlines up to the closing paren of the argument clause, but we failed to add this policy for oneline, possibly because it was forcing a single line - but to the first comma, not the closing paren.
