### PR TITLE
Policy: add a Split parameter to `unexpired()`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -10,10 +10,11 @@ class PolicySummary(val policies: Seq[Policy]) extends AnyVal {
   @inline
   def noDequeue = policies.exists(_.noDequeue)
 
-  def combine(other: Policy, ft: FormatToken): PolicySummary =
-    if (ft.right.is[Token.EOF]) PolicySummary.empty
+  def combine(split: Split, nextft: FormatToken): PolicySummary =
+    if (nextft.right.is[Token.EOF]) PolicySummary.empty
     else new PolicySummary(
-      (other +: policies).flatMap(_.unexpiredOpt(ft)).sortBy(_.rank),
+      (split.policy +: policies).flatMap(_.unexpiredOpt(split, nextft))
+        .sortBy(_.rank),
     )
 
   def execute(decision: Decision, debug: Boolean = false): Decision = policies

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -81,7 +81,7 @@ final case class State(
       .getColumns(tok, nextIndent, startColumn)
 
     val nextTok = tokens.next(tok)
-    val nextPolicy: PolicySummary = policy.combine(nextSplit.policy, nextTok)
+    val nextPolicy: PolicySummary = policy.combine(nextSplit, nextTok)
 
     def noOverflowPenalties = (math.max(0, delayedPenalty), 0) // fits inside column
 


### PR DESCRIPTION
Also, emphasize that the `FormatToken` parameter is for the token after the split, not at the split.