### PR TITLE
Router: fix bp.callsite=oneline post-comma policy

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -2803,9 +2803,7 @@ object a {
   test("foo") {
     a.b(c, d) shouldBe
       E(Seq(F(1, "v1"), F(2, "v2")),
-        G(Some(Seq(h, i)),
-          Some(Seq(j, k)), a.b, c.d,
-          e.f.g, h.i.j)).foo
+        G(Some(Seq(h, i)), Some(Seq(j, k)), a.b, c.d, e.f.g, h.i.j)).foo
   }
 }
 <<< binpack call, oneline, with syntaxNL, single arg

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -2803,9 +2803,7 @@ object a {
   test("foo") {
     a.b(c, d) shouldBe
       E(Seq(F(1, "v1"), F(2, "v2")),
-        G(Some(Seq(h, i)),
-          Some(Seq(j, k)), a.b, c.d,
-          e.f.g, h.i.j)).foo
+        G(Some(Seq(h, i)), Some(Seq(j, k)), a.b, c.d, e.f.g, h.i.j)).foo
   }
 }
 <<< binpack call, oneline, with syntaxNL, single arg


### PR DESCRIPTION
First, the subsequent break we should force is before a Dot which comes from a Select, not a Comma.

Second, we should cancel forcing of that break if there's another break which is output after the argument and before the dot or parenthesis.