### PR TITLE
PreferCurlyFors: don't rewrite semicolon only

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/PreferCurlyFors.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/PreferCurlyFors.stat
@@ -140,7 +140,18 @@ object O {
     c = pos.split("->")
   } yield ()
 }
-<<< #2695 generator and multiple guards
+<<< #2695 generator and multiple guards, braces but semicolons
+object O {
+  for { a <- b; if c; if d } yield ()
+}
+>>>
+object O {
+  for {
+    a <- b if c
+    if d
+  } yield ()
+}
+<<< #2695 generator and multiple guards, parens and semicolons
 object O {
   for (a <- b; if c; if d) yield ()
 }


### PR DESCRIPTION
If we are not rewriting parentheses, we shouldn't remove semicolons as they are required. Exclude the `if` guards, however, as they can come without a newline or semicolon.