### PR TITLE
Split: block optimal token with non-zero cost

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -760,7 +760,8 @@ class FormatOps(
                 if (breakMany) TokenRanges.empty
                 else insideBracesBlock(nextFT, expire, true)
               Split(ModExt(newStmtMod.getOrElse(spaceMod)), cost)
-                .withSingleLine(expire, exclude)
+                .withSingleLineNoOptimal(expire, exclude)
+                .withOptimalToken(expire, ignore = cost != 0)
           }
         }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -933,7 +933,7 @@ class Router(formatOps: FormatOps) {
             Seq(
               Split(Newline, nestedPenalty + Constants.ExceedColumnPenalty)
                 .withPolicy(newlinePolicy).withIndent(indent, close, Before),
-              Split(NoSplit, nestedPenalty).withSingleLine(breakToken)
+              Split(NoSplit, nestedPenalty).withSingleLineNoOptimal(breakToken)
                 .andPolicy(newlinePolicy & newlineAfterAssignDecision),
             )
           }
@@ -1276,7 +1276,7 @@ class Router(formatOps: FormatOps) {
           else NewlineT(alt = if (singleLineOnly) Some(NoSplit) else None)
         val nlSplit = Split(nlMod, bracketPenalty * (if (oneline) 4 else 2))
           .withIndent(indent)
-          .withSingleLineOpt(if (singleLineOnly) Some(close) else None)
+          .withSingleLineNoOptimal(close, ignore = !singleLineOnly)
           .andPolicy(nlPolicy & penalizeNewlinesPolicy, singleLineOnly)
           .andPolicyOpt(singleArgAsInfix.map(InfixSplits(_, ft).nlPolicy))
         Seq(noSplit, nlSplit)


### PR DESCRIPTION
The BestFirstSearch algorithm doesn't allow this anyway.