### PR TITLE
Router: add NL split in select chain for src=keep

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1700,7 +1700,12 @@ class Router(formatOps: FormatOps) {
 
           case _ if left.is[T.Comment] => Seq(Split(Space.orNL(t.noBreak), 0))
 
-          case Newlines.keep => Seq(Split(NoSplit.orNL(t.noBreak), 0))
+          case Newlines.keep =>
+            if (t.noBreak) Seq(
+              Split(NoSplit, 0),
+              Split(Newline, Constants.ExceedColumnPenalty * 3),
+            )
+            else Seq(Split(Newline, 0))
 
           case Newlines.unfold =>
             val nlCost = if (nlOnly) 0 else 1

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -945,9 +945,8 @@ object a {
 }
 >>>
 object a {
-  (intercept[java.lang.IllegalStateException] {
-    in.readObject
-  }).getMessage should ===(
+  (intercept[java.lang.IllegalStateException] { in.readObject })
+    .getMessage should ===(
     "Trying to deserialize a serialized ActorRef without an ActorSystem in scope." +
       " Use 'akka.serialization.Serialization.currentSystem.withValue(system) { ... }'")
 }
@@ -2073,9 +2072,8 @@ object a {
 }
 >>>
 object a {
-  plugins(
-    service.pluginType
-  ) += service.pluginName -> service
+  plugins(service.pluginType) += service
+    .pluginName -> service
 }
 <<< 8.7
 maxColumn = 80
@@ -2803,7 +2801,10 @@ object a {
   test("foo") {
     a.b(c, d) shouldBe
       E(Seq(F(1, "v1"), F(2, "v2")),
-        G(Some(Seq(h, i)), Some(Seq(j, k)), a.b, c.d, e.f.g, h.i.j)).foo
+        G(Some(Seq(h, i)),
+          Some(Seq(j, k)), a.b, c.d,
+          e.f.g, h.i.j))
+        .foo
   }
 }
 <<< binpack call, oneline, with syntaxNL, single arg
@@ -3551,9 +3552,8 @@ pubSubMessage match {
   case message: UploadMessage => {
     val services = makeUploadServices()
 
-    UploadSubscriber(
-      services
-    ).processEff(message)
+    UploadSubscriber(services)
+      .processEff(message)
   }
   case message: IngestionMessage => (
       IngestionSubscriber.defaultServices

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -1062,11 +1062,13 @@ object a {
   }
 }
 >>>
-BestFirstSearch:289 Failed to format
-UNABLE TO FORMAT,
-tok=)∙.: RightParen [139..140) [] Dot [140..141)
-toks.length=43
-deepestYet.length=30
-policies=List(REL?:[Router:1449](NB:[Router:1449]@141d,???,NoPolicy), REL?:[Router:1449](NB:[Router:1449]@141d,???,NoPolicy), REL?:[Router:1449](NB:[Router:1449]@141d,???,NoPolicy), NB:[Router:221]@165d, NB:[Router:221]@167d)
-nextSplits=List(NoSplit:[Router:1703](cost=0, indents=[], NoPolicy))
-splitsAfterPolicy=Decision()∙.: RightParen [139..140) [] Dot [140..141),List())
+object a {
+  def createResetButton(): JQuery = {
+    jQuery("<input>",
+      js.Dynamic.literal(
+        `type` = "button",
+        value = "Reset"
+      ))
+      .click(() => reset())
+  }
+}

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -1045,3 +1045,28 @@ object a {
       })(
       OptimizerHints.empty, Unversioned)
 }
+<<< oneline with keep and select after
+preset = default
+maxColumn = 80
+newlines.source = keep
+binPack.preset = oneline
+danglingParentheses.preset = false
+newlines.configStyleCallSite.prefer = true
+newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
+===
+object a {
+  def createResetButton(): JQuery = {
+    jQuery("<input>", js.Dynamic.literal(
+        `type` = "button", value = "Reset"
+    )).click(() => reset())
+  }
+}
+>>>
+BestFirstSearch:289 Failed to format
+UNABLE TO FORMAT,
+tok=)∙.: RightParen [139..140) [] Dot [140..141)
+toks.length=43
+deepestYet.length=30
+policies=List(REL?:[Router:1449](NB:[Router:1449]@141d,???,NoPolicy), REL?:[Router:1449](NB:[Router:1449]@141d,???,NoPolicy), REL?:[Router:1449](NB:[Router:1449]@141d,???,NoPolicy), NB:[Router:221]@165d, NB:[Router:221]@167d)
+nextSplits=List(NoSplit:[Router:1703](cost=0, indents=[], NoPolicy))
+splitsAfterPolicy=Decision()∙.: RightParen [139..140) [] Dot [140..141),List())


### PR DESCRIPTION
With binpack.callSite=oneline, we are assuming that we can always break before a select dot; for source=keep, it wasn't true so let's fix it. However, penalize this newline split so that it's only used sparingly.

