### PR TITLE
FormatOps: in folded ctrl body, use `adjustedBody`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1510,13 +1510,13 @@ class FormatOps(
           val callPolicy = CallSite.getFoldedPolicy(lia.lhs)
           // lia is enclosed in parens if and only if lia == ia (== body)
           if (callPolicy.nonEmpty) getPolicySplits(0, callPolicy)
-          else if (isBodyEnclosedAsBlock(body))
+          else if (isBodyEnclosedAsBlock(ia))
             if (isKeep) getPolicySplits(0, Policy.NoPolicy)
             else getSplits(getSlbSplit(getLastToken(lia.lhs)))
           else getSplits(getSlbSplit(getLastToken(lia.op)))
-        case _ =>
-          val callPolicy = CallSite.getFoldedPolicy(body)
-          val nlCost = body match {
+        case b =>
+          val callPolicy = CallSite.getFoldedPolicy(b)
+          val nlCost = b match {
             case Member.Apply(_, ac)
                 if styleMap.at(getHead(ac)).binPack.callSiteFor(ac).isOneline =>
               3

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1766,16 +1766,16 @@ object a {
   }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-       nest: Int,
--  ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
--    .takeWhile(_.minBreaks <= numBreaks).find { x =>
--      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
-+  ): Option[NumBlanks] =
-+    topStatBlankLinesSorted.iterator.takeWhile(_.minBreaks <= numBreaks).find {
-+      x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
-     }.flatMap(_.blanks)
+object a {
+  def getTopStatBlankLines(
+      prefix: String,
+      numBreaks: Int,
+      nest: Int,
+  ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
+    .takeWhile(_.minBreaks <= numBreaks).find { x =>
+      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
+    }.flatMap(_.blanks)
+}
 <<< fold ctrl body with redundant braces, !trailing commas
 maxColumn = 80
 newlines.source = fold
@@ -1794,13 +1794,13 @@ object a {
   }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-       nest: Int
--  ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
--    .takeWhile(_.minBreaks <= numBreaks).find { x =>
--      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
-+  ): Option[NumBlanks] =
-+    topStatBlankLinesSorted.iterator.takeWhile(_.minBreaks <= numBreaks).find {
-+      x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
-     }.flatMap(_.blanks)
+object a {
+  def getTopStatBlankLines(
+      prefix: String,
+      numBreaks: Int,
+      nest: Int
+  ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
+    .takeWhile(_.minBreaks <= numBreaks).find { x =>
+      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
+    }.flatMap(_.blanks)
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1748,3 +1748,59 @@ class WutAppSpringCfg extends SomeOtherStuff {}
   )
 )
 class WutAppSpringCfg extends SomeOtherStuff {}
+<<< fold ctrl body with redundant braces, trailing commas
+maxColumn = 80
+newlines.source = fold
+rewrite.redundantBraces.maxLines = 100
+rewrite.trailingCommas.style = always
+===
+object a {
+  def getTopStatBlankLines(
+      prefix: String,
+      numBreaks: Int,
+      nest: Int,
+  ): Option[NumBlanks] = {
+    topStatBlankLinesSorted.iterator.takeWhile(_.minBreaks <= numBreaks).find {
+      x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
+    }.flatMap(_.blanks)
+  }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+       nest: Int,
+-  ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
+-    .takeWhile(_.minBreaks <= numBreaks).find { x =>
+-      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
++  ): Option[NumBlanks] =
++    topStatBlankLinesSorted.iterator.takeWhile(_.minBreaks <= numBreaks).find {
++      x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
+     }.flatMap(_.blanks)
+<<< fold ctrl body with redundant braces, !trailing commas
+maxColumn = 80
+newlines.source = fold
+rewrite.redundantBraces.maxLines = 100
+rewrite.trailingCommas.style = never
+===
+object a {
+  def getTopStatBlankLines(
+      prefix: String,
+      numBreaks: Int,
+      nest: Int,
+  ): Option[NumBlanks] = {
+    topStatBlankLinesSorted.iterator.takeWhile(_.minBreaks <= numBreaks).find {
+      x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
+    }.flatMap(_.blanks)
+  }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+       nest: Int
+-  ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
+-    .takeWhile(_.minBreaks <= numBreaks).find { x =>
+-      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
++  ): Option[NumBlanks] =
++    topStatBlankLinesSorted.iterator.takeWhile(_.minBreaks <= numBreaks).find {
++      x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
+     }.flatMap(_.blanks)


### PR DESCRIPTION
It is already checked for any removed braces, while the original `body` is not and hence could lead to non-idempotent formatting.