### PR TITLE
Token.LF: replace all references with Token.AtEOL

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -74,7 +74,7 @@ object FormatToken {
   def hasBlankLine(newlines: Int): Boolean = newlines > 1
 
   @inline
-  def isNL(token: Token): Boolean = token.is[Token.LF]
+  def isNL(token: Token): Boolean = token.is[Token.AtEOL]
 
   /** @param between
     *   The whitespace tokens between left and right.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
@@ -386,7 +386,7 @@ object Imports extends RewriteFactory {
       var hadLf = false
       val slc = new ListBuffer[Token]
       ctx.tokenTraverser.findAtOrBefore(ctx.getIndex(tok) - 1) {
-        case _: Token.LF => if (hadLf) Some(true) else { hadLf = true; None }
+        case _: Token.AtEOL => if (hadLf) Some(true) else { hadLf = true; None }
         case t: Token.Comment if TokenOps.isSingleLineIfComment(t) =>
           slc.prepend(t); hadLf = false; None
         case _: Token.Whitespace => None
@@ -397,7 +397,7 @@ object Imports extends RewriteFactory {
 
     protected final def getCommentAfter(tok: Token): Option[Token] = ctx
       .tokenTraverser.findAtOrAfter(ctx.getIndex(tok) + 1) {
-        case _: Token.LF => Some(false)
+        case _: Token.AtEOL => Some(false)
         case t: Token.Comment if TokenOps.isSingleLineIfComment(t) => Some(true)
         case _: Token.Whitespace | _: Token.Comma => None
         case _ => Some(false)
@@ -440,7 +440,7 @@ object Imports extends RewriteFactory {
           else {
             val nextOff = off - 1
             ctx.tokens(nextOff) match {
-              case t: Token.LF => t.input.text.substring(t.end, nonWs.start)
+              case t: Token.AtEOL => t.input.text.substring(t.end, nonWs.start)
               case _: Token.Whitespace => iter(nextOff, nonWs)
               case t => iter(nextOff, t)
             }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -54,17 +54,18 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
 
   def onlyWhitespaceBefore(index: Int): Boolean = tokenTraverser
     .findAtOrBefore(index - 1) {
-      case _: T.LF | _: T.BOF => Some(true)
+      case _: T.AtEOL | _: T.BOF => Some(true)
       case _: T.Whitespace => None
       case _ => Some(false)
     }.isDefined
 
   def findNonWhitespaceWith(
       f: (Token => Option[Boolean]) => Option[Token],
-  ): Option[(Token, Option[T.LF])] = {
-    var lf: Option[T.LF] = None
+  ): Option[(Token, Option[T.AtEOL])] = {
+    var lf: Option[T.AtEOL] = None
     val nonWs = f {
-      case t: T.LF => if (lf.nonEmpty) Some(false) else { lf = Some(t); None }
+      case t: T.AtEOL =>
+        if (lf.nonEmpty) Some(false) else { lf = Some(t); None }
       case _: T.Whitespace => None
       case _ => Some(true)
     }
@@ -75,8 +76,8 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
   def removeLFToAvoidEmptyLine(beg: Int, end: Int)(implicit
       builder: Rewrite.PatchBuilder,
   ): Unit = if (onlyWhitespaceBefore(beg)) tokenTraverser.findAtOrAfter(end + 1) {
-    case _: T.LF => Some(true)
-    case _: T.Whitespace => None
+    case _: T.EOL => Some(true)
+    case _: T.HSpace => None
     case _ => Some(false)
   }.map(TokenPatch.Remove).foreach(builder += _)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -68,7 +68,7 @@ object TokenOps {
 
   @inline
   def withNoIndent(ft: FormatToken): Boolean = ft.between.lastOption
-    .exists(_.is[LF])
+    .exists(_.is[AtEOL])
 
   @inline
   def rhsIsCommentedOut(ft: FormatToken): Boolean = ft.right.is[Comment] &&

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -24,7 +24,7 @@ class TokenTraverser(tokens: Tokens, input: Input) {
       realTokens.headOption.foreach {
         // shebang in .sc files
         case t: Token.Ident if t.value.startsWith("#!") =>
-          realTokens.takeWhile(!_.is[Token.LF]).foreach {
+          realTokens.takeWhile(!_.is[Token.AtEOL]).foreach {
             excluded += TokenOps.hash(_)
           }
         case _ =>


### PR DESCRIPTION
This will allow us to support CRLF and any multi-newline sequences such as LFLF.