### PR TITLE
Scalafmt: remove special case of shebang prefix

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -82,19 +82,6 @@ object Scalafmt {
     )
   }
 
-  private[scalafmt] def splitCodePrefix(input: String): (String, String) =
-    if (!input.startsWith("#!")) ("", input)
-    else {
-      val beforeNL = input.indexOf(UnixLineEnding, 2)
-      if (beforeNL < 0) (input + UnixLineEnding, "")
-      else {
-        val afterNL = beforeNL + UnixLineEnding.length
-        val hasBlank = input.startsWith(UnixLineEnding, afterNL)
-        val idx = if (hasBlank) afterNL + UnixLineEnding.length else afterNL
-        (input.substring(0, idx), input.substring(idx))
-      }
-    }
-
   private def formatCodeWithStyle(
       code: String,
       style: ScalafmtConfig,
@@ -102,11 +89,10 @@ object Scalafmt {
       filename: String,
   ): Formatted.Result = {
     val isWin = code.contains(WinLineEnding)
-    val (prefix, unixCode) = splitCodePrefix(
-      if (isWin) code.replaceAll(WinLineEnding, UnixLineEnding) else code,
-    )
+    val unixCode =
+      if (isWin) code.replaceAll(WinLineEnding, UnixLineEnding) else code
     val res = doFormat(unixCode, style, filename, range).map { x =>
-      val s = if (prefix.isEmpty && x.isEmpty) UnixLineEnding else prefix + x
+      val s = if (x.isEmpty) UnixLineEnding else x
       val asWin = style.lineEndings == LineEndings.windows ||
         (isWin && style.lineEndings == LineEndings.preserve)
       if (asWin) s.replaceAll(UnixLineEnding, WinLineEnding) else s

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -74,6 +74,7 @@ class Router(formatOps: FormatOps) {
       case FormatToken(_, _: T.EOF, _) => Seq(
           Split(Newline, 0), // End files with trailing newline
         )
+      case FormatToken(_: T.Shebang, _, _) => Seq(Split(Newline2x(ft), 0))
       case FormatToken(start: T.Interpolation.Start, _, m) =>
         val end = matching(start)
         val okNewlines = style.newlines.inInterpolation

--- a/scalafmt-tests/src/test/scala/org/scalafmt/util/FormatAssertions.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/util/FormatAssertions.scala
@@ -35,8 +35,7 @@ trait FormatAssertions {
       obtained: String,
   )(implicit ev: Parse[T], dialect: Dialect): Unit = {
     import scala.meta._
-    def toInput(code: String) = Scalafmt
-      .toInput(Scalafmt.splitCodePrefix(code)._2, filename)
+    def toInput(code: String) = Scalafmt.toInput(code, filename)
     toInput(original).parse[T] match {
       case Parsed.Error(pos, message, _) =>
         val msgWithPos = pos.formatMessage("error", message)


### PR DESCRIPTION
Now that the parser supports shebang tokens, there's no need to handle this as a special case anymore.