### PR TITLE
Scalafmt: move line ending choice to FormatWriter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5319,9 +5319,7 @@ takes the following values:
 - `windows`: uses CRLF (`U+000D U+000A`)
 - `preserve`: if an input file _contains_ CRLF anywhere, use CRLF for every line; otherwise, LF
 
-```scala mdoc:defaults
-lineEndings
-```
+By default, this parameter is assumed to be set to `unix`.
 
 ### `rewriteTokens`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -119,7 +119,7 @@ case class ScalafmtConfig(
     align: Align = Align(),
     spaces: Spaces = Spaces(),
     literals: Literals = Literals(),
-    lineEndings: LineEndings = LineEndings.unix,
+    lineEndings: Option[LineEndings] = None,
     rewriteTokens: Map[String, String] = Map.empty[String, String],
     rewrite: RewriteSettings = RewriteSettings.default,
     indentOperator: IndentOperator = IndentOperator(),
@@ -174,6 +174,9 @@ case class ScalafmtConfig(
     dialect,
     NamedDialect.getName(dialect).getOrElse("unknown dialect"),
   )
+
+  def withLineEndings(value: LineEndings): ScalafmtConfig =
+    copy(lineEndings = Option(value))
 
   private lazy val forMain: ScalafmtConfig =
     if (project.layout.isEmpty) forTest

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatToken.scala
@@ -57,6 +57,12 @@ case class FormatToken(left: Token, right: Token, meta: FormatToken.Meta) {
   @inline
   def hasBreakOrEOF: Boolean = hasBreak || right.is[Token.EOF]
 
+  def hasCRLF: Boolean = between.exists {
+    case _: Token.CRLF => true
+    case t: Token.MultiNL => t.tokens.exists(_.is[Token.CRLF])
+    case _ => false
+  }
+
   /** A format token is uniquely identified by its left token.
     */
   override def hashCode(): Int = hash(left).##

--- a/scalafmt-tests/src/test/scala/org/scalafmt/EmptyFileTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/EmptyFileTest.scala
@@ -1,5 +1,8 @@
 package org.scalafmt
 
+import org.scalafmt.config.LineEndings
+import org.scalafmt.config.ScalafmtConfig
+
 import scala.meta.internal.prettyprinters.DoubleQuotes
 
 import java.lang.System.lineSeparator
@@ -8,16 +11,32 @@ import munit.FunSuite
 
 class EmptyFileTest extends FunSuite {
 
+  private val cfgWithLineEndingsCRLF = ScalafmtConfig.default
+    .withLineEndings(LineEndings.windows)
+  private val cfgWithLineEndingsKeep = ScalafmtConfig.default
+    .withLineEndings(LineEndings.preserve)
+
   Seq(
-    ("", "\n"),
-    ("  \n  \n  ", "\n"),
-    ("  \r\n  \r\n  ", "\n"),
-    (lineSeparator(), "\n"),
-    (s"   $lineSeparator  ", "\n"),
-  ).foreach { case (original, expected) =>
+    ("", "\n", "\r\n", "\n"),
+    ("  \n  \n  ", "\n", "\r\n", "\n"),
+    ("  \r\n  \r\n  ", "\n", "\r\n", "\r\n"),
+    (lineSeparator(), "\n", "\r\n", lineSeparator()),
+    (s"   $lineSeparator  ", "\n", "\r\n", lineSeparator()),
+  ).foreach { case (original, expectedUnix, expectedCrlf, expectedKeep) =>
+    defineTest(original, expectedUnix, ScalafmtConfig.default, "unix")
+    defineTest(original, expectedCrlf, cfgWithLineEndingsCRLF, "crlf")
+    defineTest(original, expectedKeep, cfgWithLineEndingsKeep, "keep")
+  }
+
+  private def defineTest(
+      original: String,
+      expected: String,
+      cfg: ScalafmtConfig,
+      label: String,
+  ): Unit = {
     val expectedQuoted = DoubleQuotes(expected)
-    test(s"empty tree formats to newline: ${DoubleQuotes(original)} -> $expectedQuoted") {
-      val obtained = Scalafmt.format(original).get
+    test(s"empty tree formats to newline [$label]: ${DoubleQuotes(original)} -> $expectedQuoted") {
+      val obtained = Scalafmt.format(original, cfg).get
       if (obtained != expected) fail(
         s"values are not equal: ${DoubleQuotes(obtained)} != $expectedQuoted",
       )

--- a/scalafmt-tests/src/test/scala/org/scalafmt/LineEndingsTest.scala
+++ b/scalafmt-tests/src/test/scala/org/scalafmt/LineEndingsTest.scala
@@ -11,7 +11,7 @@ class LineEndingsTest extends FunSuite {
     val original = "@ Singleton\r\nobject a {\r\nval y = 2\r\n}"
     val expected = "@Singleton\r\nobject a {\r\n  val y = 2\r\n}\r\n"
     val obtained = Scalafmt
-      .format(original, ScalafmtConfig.default.copy(lineEndings = preserve)).get
+      .format(original, ScalafmtConfig.default.withLineEndings(preserve)).get
     assertNoDiff(obtained, expected)
   }
 
@@ -19,7 +19,7 @@ class LineEndingsTest extends FunSuite {
     val original = "@ Singleton\nobject a {\nval y = 2\n}"
     val expected = "@Singleton\nobject a {\n  val y = 2\n}\n"
     val obtained = Scalafmt
-      .format(original, ScalafmtConfig.default.copy(lineEndings = preserve)).get
+      .format(original, ScalafmtConfig.default.withLineEndings(preserve)).get
     assertNoDiff(obtained, expected)
   }
 
@@ -27,7 +27,7 @@ class LineEndingsTest extends FunSuite {
     val original = "@ Singleton\r\nobject a {\r\nval y = 2\r\n}"
     val expected = "@Singleton\r\nobject a {\r\n  val y = 2\r\n}\r\n"
     val obtained = Scalafmt
-      .format(original, ScalafmtConfig.default.copy(lineEndings = windows)).get
+      .format(original, ScalafmtConfig.default.withLineEndings(windows)).get
     assertNoDiff(obtained, expected)
   }
 
@@ -35,7 +35,7 @@ class LineEndingsTest extends FunSuite {
     val original = "@ Singleton\nobject a {\nval y = 2\n}"
     val expected = "@Singleton\r\nobject a {\r\n  val y = 2\r\n}\r\n"
     val obtained = Scalafmt
-      .format(original, ScalafmtConfig.default.copy(lineEndings = windows)).get
+      .format(original, ScalafmtConfig.default.withLineEndings(windows)).get
     assertNoDiff(obtained, expected)
   }
 
@@ -43,7 +43,7 @@ class LineEndingsTest extends FunSuite {
     val original = "@ Singleton\r\nobject a {\r\nval y = 2\r\n}"
     val expected = "@Singleton\nobject a {\n  val y = 2\n}\n"
     val obtained = Scalafmt
-      .format(original, ScalafmtConfig.default.copy(lineEndings = unix)).get
+      .format(original, ScalafmtConfig.default.withLineEndings(unix)).get
     assertNoDiff(obtained, expected)
   }
 
@@ -51,7 +51,7 @@ class LineEndingsTest extends FunSuite {
     val original = "@ Singleton\nobject a {\nval y = 2\n}"
     val expected = "@Singleton\nobject a {\n  val y = 2\n}\n"
     val obtained = Scalafmt
-      .format(original, ScalafmtConfig.default.copy(lineEndings = unix)).get
+      .format(original, ScalafmtConfig.default.withLineEndings(unix)).get
     assertNoDiff(obtained, expected)
   }
 }


### PR DESCRIPTION
Now that the parser supports both line ending types in input directly, we can generate the right output rather than do a post-conversion.