### PR TITLE
Router: src=keep force NL only for matching `else`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2220,7 +2220,11 @@ class FormatOps(
           style: ScalafmtConfig,
       ): Option[OptionalBracesRegion] = ft.meta.leftOwner match {
         case t: Term.If => (t.elsep match {
-            case _: Term.If => None
+            case _: Term.If
+                if !style.newlines.keepBreak(
+                  if (ft eq nft) ft.hasBreak
+                  else ft.left.pos.startLine != nft.right.pos.startLine,
+                ) => None
             case x if !isTreeSingleExpr(x) => Some(true)
             case b @ Term.Block(List(_: Term.If))
                 if (matchingOpt(nft.right) match {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5370,3 +5370,14 @@ object a:
 object a:
    for (a <- b)
       val x = 3 / 0
+<<< #4104
+object a:
+  if b1 then
+    if b2 then x else y
+  else
+    if b2 then p else q
+>>>
+object a:
+   if b1 then if b2 then x else y
+   else if b2 then p
+   else q

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5134,3 +5134,12 @@ object a:
 object a:
    for (a <- b)
       val x = 3 / 0
+<<< #4104
+object a:
+  if b1 then
+    if b2 then x else y
+  else
+    if b2 then p else q
+>>>
+object a:
+   if b1 then if b2 then x else y else if b2 then p else q

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -701,10 +701,11 @@ object a:
      if a then
         if aa then
            if bb then if cc then ccc
-        else if bb then
-           if cc then ccc
-           else ddd
-        else eee
+        else
+           if bb then
+              if cc then ccc
+              else ddd
+           else eee
      else if aa then aaa else bbb
 <<< nested if-else single
 object a:
@@ -724,9 +725,10 @@ object a:
         if aa then
            aaa
            // c1
-     else if aa then
-        aaa
-        // c1
+     else
+        if aa then
+           aaa
+           // c1
 <<< #2448
 object Foo:
   def bar = process(arg match
@@ -5415,4 +5417,5 @@ object a:
 object a:
    if b1 then
       if b2 then x else y
-   else if b2 then p else q
+   else
+      if b2 then p else q

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -705,8 +705,7 @@ object a:
            if cc then ccc
            else ddd
         else eee
-     else if aa then aaa
-     else bbb
+     else if aa then aaa else bbb
 <<< nested if-else single
 object a:
   val a =
@@ -918,8 +917,7 @@ private def mtd: Res =
 >>>
 private def mtd: Res =
   if foo then fooBody
-  else if bar then barBody
-  else bazBody
+  else if bar then barBody else bazBody
 <<< rewrite with given-with
 rewrite.scala3.removeOptionalBraces = oldSyntaxToo
 ===
@@ -5417,5 +5415,4 @@ object a:
 object a:
    if b1 then
       if b2 then x else y
-   else if b2 then p
-   else q
+   else if b2 then p else q

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5407,3 +5407,15 @@ object a:
 object a:
    for (a <- b)
       val x = 3 / 0
+<<< #4104
+object a:
+  if b1 then
+    if b2 then x else y
+  else
+    if b2 then p else q
+>>>
+object a:
+   if b1 then
+      if b2 then x else y
+   else if b2 then p
+   else q

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -5540,3 +5540,20 @@ object a:
 object a:
    for (a <- b)
       val x = 3 / 0
+<<< #4104
+object a:
+  if b1 then
+    if b2 then x else y
+  else
+    if b2 then p else q
+>>>
+object a:
+   if b1 then
+      if b2 then
+         x
+      else
+         y
+   else if b2 then
+      p
+   else
+      q


### PR DESCRIPTION
Previously, and still for other values of `newlines.source`, we force breaks over the entire `else` chain. Also, in FormatOps, treat `else<NL>` as opt-braces. Fixes #4104.