### PR TITLE
TokenOps: backquoted tokens don't "end" in symbol

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -126,7 +126,7 @@ object TokenOps {
     }
 
   def endsWithSymbolIdent(tok: Token): Boolean = tok match {
-    case Ident(name) => !name.last.isLetterOrDigit
+    case Ident(name) => !name.last.isLetterOrDigit && !tok.isBackquoted
     case _ => false
   }
 

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -326,3 +326,11 @@ object a {
       ord: Ordering[T]
   ): Seq[T]
 }
+<<< #4106
+trait Test {
+  def `x_`: String
+}
+>>>
+trait Test {
+  def `x_` : String
+}

--- a/scalafmt-tests/src/test/resources/default/DefDef.stat
+++ b/scalafmt-tests/src/test/resources/default/DefDef.stat
@@ -332,5 +332,5 @@ trait Test {
 }
 >>>
 trait Test {
-  def `x_` : String
+  def `x_`: String
 }


### PR DESCRIPTION
Fixed #4106.