### PR TITLE
RedundantParens: don't rewrite unary within select

### DIFF
--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1472,3 +1472,80 @@ a match {
 a match {
   case _: (A | B) | _: (C & D) =>
 }
+<<< #4116 1 val
+object a {
+  (~validByte).toByte
+  (+validByte).toByte
+  (-validByte).toByte
+}
+>>>
+object a {
+  ~validByte.toByte
+  +validByte.toByte
+  -validByte.toByte
+}
+<<< #4116 2 int literal
+object a {
+  (~1).toByte
+  (+1).toByte
+  (-1).toByte
+}
+>>>
+object a {
+  ~1.toByte
+  +1.toByte
+  -1.toByte
+}
+<<< #4116 3 bool literal
+object a {
+  (false).toByte
+  (!true).toByte
+  (~true).toByte
+}
+>>>
+object a {
+  false.toByte
+  !true.toByte
+  ~true.toByte
+}
+<<< #4116 3.1 !!bool literal
+object a {
+  (!(!true))
+  (!(!true)).toByte
+}
+>>>
+test does not parse: [dialect scala213] `;` expected but `true` found
+object a {
+  ! !true
+     ^
+  ! !true.toByte
+}
+====== full result: ======
+object a {
+  ! !true
+  ! !true.toByte
+}
+<<< #4116 4 string literal
+object a {
+  ("foo").toByte
+  (!"bar").toByte
+  (~"baz").toByte
+}
+>>>
+object a {
+  "foo".toByte
+  !"bar".toByte
+  ~"baz".toByte
+}
+<<< #4116 5 char literal
+object a {
+  ('\n').toByte
+  (!'\r').toByte
+  (~'\f').toByte
+}
+>>>
+object a {
+  '\n'.toByte
+  !'\r'.toByte
+  ~'\f'.toByte
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1480,9 +1480,9 @@ object a {
 }
 >>>
 object a {
-  ~validByte.toByte
-  +validByte.toByte
-  -validByte.toByte
+  (~validByte).toByte
+  (+validByte).toByte
+  (-validByte).toByte
 }
 <<< #4116 2 int literal
 object a {
@@ -1492,9 +1492,9 @@ object a {
 }
 >>>
 object a {
-  ~1.toByte
-  +1.toByte
-  -1.toByte
+  (~1).toByte
+  (+1).toByte
+  (-1).toByte
 }
 <<< #4116 3 bool literal
 object a {
@@ -1505,8 +1505,8 @@ object a {
 >>>
 object a {
   false.toByte
-  !true.toByte
-  ~true.toByte
+  (!true).toByte
+  (~true).toByte
 }
 <<< #4116 3.1 !!bool literal
 object a {
@@ -1514,16 +1514,9 @@ object a {
   (!(!true)).toByte
 }
 >>>
-test does not parse: [dialect scala213] `;` expected but `true` found
 object a {
-  ! !true
-     ^
-  ! !true.toByte
-}
-====== full result: ======
-object a {
-  ! !true
-  ! !true.toByte
+  !(!true)
+  (!(!true)).toByte
 }
 <<< #4116 4 string literal
 object a {
@@ -1534,8 +1527,8 @@ object a {
 >>>
 object a {
   "foo".toByte
-  !"bar".toByte
-  ~"baz".toByte
+  (!"bar").toByte
+  (~"baz").toByte
 }
 <<< #4116 5 char literal
 object a {
@@ -1546,6 +1539,6 @@ object a {
 >>>
 object a {
   '\n'.toByte
-  !'\r'.toByte
-  ~'\f'.toByte
+  (!'\r').toByte
+  (~'\f').toByte
 }


### PR DESCRIPTION
In reality, it's unclear why ApplyUnary extends Term.Ref, but since Term.Select does, too, let's introduce a special-case handling for it. Fixes #4116.