### PR TITLE
Router: restore Shebang token handling

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -74,6 +74,7 @@ class Router(formatOps: FormatOps) {
       // End files with trailing newline
       case FormatToken(_, _: T.EOF, _) => Seq(Split(Newline, 0))
       case FormatToken(_: T.BOF, _, _) => Seq(Split(NoSplit, 0))
+      case FormatToken(_: T.Shebang, _, _) => Seq(Split(Newline2x(ft), 0))
       case FormatToken(start: T.Interpolation.Start, _, m) =>
         val end = matching(start)
         val okNewlines = style.newlines.inInterpolation


### PR DESCRIPTION
It was accidentally removed in #4096, was handled by an annotation rule.