### PR TITLE
RedundantParens: don't rewrite `Init`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -102,6 +102,7 @@ class RedundantParens(implicit val ftoks: FormatTokens)
 
     case _: Term.AnonymousFunction | _: Term.Param => false
     case _: Type.FunctionType => false
+    case _: Init => false
 
     case t: Member.ArgClause => okToReplaceArgClause(t)
     case Term.ParamClause(t :: Nil, _) => tree.parent.exists {

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1542,3 +1542,14 @@ object a {
   (!'\r').toByte
   (~'\f').toByte
 }
+<<< #4122
+runner.dialect = scala3
+===
+new (Const[String, *] ~> ([a] =>> IO[Const[Int, a]])) {
+}
+>>>
+test does not parse: [dialect scala3] `=>` expected but `=>>` found
+new Const[String, *] ~> ([a] =>> IO[Const[Int, a]]) {}
+                             ^
+====== full result: ======
+new Const[String, *] ~> ([a] =>> IO[Const[Int, a]]) {}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -1548,8 +1548,4 @@ runner.dialect = scala3
 new (Const[String, *] ~> ([a] =>> IO[Const[Int, a]])) {
 }
 >>>
-test does not parse: [dialect scala3] `=>` expected but `=>>` found
-new Const[String, *] ~> ([a] =>> IO[Const[Int, a]]) {}
-                             ^
-====== full result: ======
-new Const[String, *] ~> ([a] =>> IO[Const[Int, a]]) {}
+new (Const[String, *] ~> ([a] =>> IO[Const[Int, a]])) {}


### PR DESCRIPTION
Fixes #4122.