### PR TITLE
Router: move up rule for def/val `=`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -214,6 +214,14 @@ class Router(formatOps: FormatOps) {
             OptionalBraces(splits),
           ) if dialect.allowSignificantIndentation => splits
 
+      case FormatToken(_: T.Equals, _, DefValAssignLeft(rhs)) =>
+        maybeGetInfixSplitsBeforeLhs(ft) {
+          getSplitsDefValEquals(ft, rhs) {
+            if (leftOwner.is[Tree.WithParamClauses]) getSplitsDefEquals(ft, rhs)
+            else getSplitsValEquals(ft, rhs)(getSplitsValEqualsClassic(ft, rhs))
+          }
+        }
+
       // { ... } Blocks
       case FormatToken(open: T.LeftBrace, right, m) =>
         val close = matching(open)
@@ -743,15 +751,9 @@ class Router(formatOps: FormatOps) {
             delayedBreakPolicyBefore(expire)(forceNewlineBeforeExtends)
           }
         Seq(Split(Space, 0).withPolicy(policy))
+
       // DefDef
       case FormatToken(_: T.KwDef, _: T.Ident, _) => Seq(Split(Space, 0))
-      case FormatToken(_: T.Equals, _, DefValAssignLeft(rhs)) =>
-        maybeGetInfixSplitsBeforeLhs(ft) {
-          getSplitsDefValEquals(ft, rhs) {
-            if (leftOwner.is[Tree.WithParamClauses]) getSplitsDefEquals(ft, rhs)
-            else getSplitsValEquals(ft, rhs)(getSplitsValEqualsClassic(ft, rhs))
-          }
-        }
 
       // Parameter opening for one parameter group. This format works
       // on the WHOLE defnSite (via policies)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5381,3 +5381,26 @@ object a:
    if b1 then if b2 then x else y
    else if b2 then p
    else q
+<<< block with trailing comment
+maxColumn = 80
+===
+object a:
+  private def allInheritedOverriddenSymbols(sym: Symbol)(using Context): List[Symbol] =
+    if (!sym.owner.isClass) Nil
+    else sym.allOverriddenSymbols.toList.filter(_ != NoSymbol) //TODO: could also be `sym.owner.allOverrid..`
+    //else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+    ): List[Symbol] =
+-     if (!sym.owner.isClass) Nil
+-     else
+-       sym.allOverriddenSymbols.toList.filter(
+-         _ != NoSymbol
+-       ) // TODO: could also be `sym.owner.allOverrid..`
++   if (!sym.owner.isClass) Nil
++   else
++     sym.allOverriddenSymbols.toList.filter(
++       _ != NoSymbol
++     ) // TODO: could also be `sym.owner.allOverrid..`
+    // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5390,17 +5390,13 @@ object a:
     else sym.allOverriddenSymbols.toList.filter(_ != NoSymbol) //TODO: could also be `sym.owner.allOverrid..`
     //else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-    ): List[Symbol] =
--     if (!sym.owner.isClass) Nil
--     else
--       sym.allOverriddenSymbols.toList.filter(
--         _ != NoSymbol
--       ) // TODO: could also be `sym.owner.allOverrid..`
-+   if (!sym.owner.isClass) Nil
-+   else
-+     sym.allOverriddenSymbols.toList.filter(
-+       _ != NoSymbol
-+     ) // TODO: could also be `sym.owner.allOverrid..`
-    // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+object a:
+   private def allInheritedOverriddenSymbols(sym: Symbol)(using
+       Context
+   ): List[Symbol] =
+     if (!sym.owner.isClass) Nil
+     else
+       sym.allOverriddenSymbols.toList.filter(
+         _ != NoSymbol
+       ) // TODO: could also be `sym.owner.allOverrid..`
+     // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5152,21 +5152,12 @@ object a:
     else sym.allOverriddenSymbols.toList.filter(_ != NoSymbol) //TODO: could also be `sym.owner.allOverrid..`
     //else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a:
--   private def allInheritedOverriddenSymbols(
--       sym: Symbol
--   )(using Context): List[Symbol] =
--     if (!sym.owner.isClass) Nil
--     else
--       sym.allOverriddenSymbols.toList
--         .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
-+   private def allInheritedOverriddenSymbols(sym: Symbol)(using
-+       Context
-+   ): List[Symbol] =
-+   if (!sym.owner.isClass) Nil
-+   else
-+     sym.allOverriddenSymbols.toList
-+       .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
-    // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+object a:
+   private def allInheritedOverriddenSymbols(
+       sym: Symbol
+   )(using Context): List[Symbol] =
+     if (!sym.owner.isClass) Nil
+     else
+       sym.allOverriddenSymbols.toList
+         .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
+     // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5143,3 +5143,30 @@ object a:
 >>>
 object a:
    if b1 then if b2 then x else y else if b2 then p else q
+<<< block with trailing comment
+maxColumn = 80
+===
+object a:
+  private def allInheritedOverriddenSymbols(sym: Symbol)(using Context): List[Symbol] =
+    if (!sym.owner.isClass) Nil
+    else sym.allOverriddenSymbols.toList.filter(_ != NoSymbol) //TODO: could also be `sym.owner.allOverrid..`
+    //else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a:
+-   private def allInheritedOverriddenSymbols(
+-       sym: Symbol
+-   )(using Context): List[Symbol] =
+-     if (!sym.owner.isClass) Nil
+-     else
+-       sym.allOverriddenSymbols.toList
+-         .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
++   private def allInheritedOverriddenSymbols(sym: Symbol)(using
++       Context
++   ): List[Symbol] =
++   if (!sym.owner.isClass) Nil
++   else
++     sym.allOverriddenSymbols.toList
++       .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
+    // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5419,3 +5419,26 @@ object a:
       if b2 then x else y
    else
       if b2 then p else q
+<<< block with trailing comment
+maxColumn = 80
+===
+object a:
+  private def allInheritedOverriddenSymbols(sym: Symbol)(using Context): List[Symbol] =
+    if (!sym.owner.isClass) Nil
+    else sym.allOverriddenSymbols.toList.filter(_ != NoSymbol) //TODO: could also be `sym.owner.allOverrid..`
+    //else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+    ): List[Symbol] =
+-     if (!sym.owner.isClass) Nil
+-     else
+-       sym.allOverriddenSymbols.toList.filter(
+-         _ != NoSymbol
+-       ) // TODO: could also be `sym.owner.allOverrid..`
++   if (!sym.owner.isClass) Nil
++   else
++     sym.allOverriddenSymbols.toList.filter(
++       _ != NoSymbol
++     ) // TODO: could also be `sym.owner.allOverrid..`
+    // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5428,17 +5428,13 @@ object a:
     else sym.allOverriddenSymbols.toList.filter(_ != NoSymbol) //TODO: could also be `sym.owner.allOverrid..`
     //else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-    ): List[Symbol] =
--     if (!sym.owner.isClass) Nil
--     else
--       sym.allOverriddenSymbols.toList.filter(
--         _ != NoSymbol
--       ) // TODO: could also be `sym.owner.allOverrid..`
-+   if (!sym.owner.isClass) Nil
-+   else
-+     sym.allOverriddenSymbols.toList.filter(
-+       _ != NoSymbol
-+     ) // TODO: could also be `sym.owner.allOverrid..`
-    // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+object a:
+   private def allInheritedOverriddenSymbols(sym: Symbol)(using
+       Context
+   ): List[Symbol] =
+     if (!sym.owner.isClass) Nil
+     else
+       sym.allOverriddenSymbols.toList.filter(
+         _ != NoSymbol
+       ) // TODO: could also be `sym.owner.allOverrid..`
+     // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -5566,27 +5566,15 @@ object a:
     else sym.allOverriddenSymbols.toList.filter(_ != NoSymbol) //TODO: could also be `sym.owner.allOverrid..`
     //else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a:
--   private def allInheritedOverriddenSymbols(
--       sym: Symbol
--   )(using Context): List[Symbol] =
--     if (!sym.owner.isClass)
--       Nil
--     else
--       sym
--         .allOverriddenSymbols
--         .toList
--         .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
-+   private def allInheritedOverriddenSymbols(sym: Symbol)(using
-+       Context
-+   ): List[Symbol] =
-+   if (!sym.owner.isClass)
-+     Nil
-+   else
-+     sym
-+       .allOverriddenSymbols
-+       .toList
-+       .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
-    // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+object a:
+   private def allInheritedOverriddenSymbols(
+       sym: Symbol
+   )(using Context): List[Symbol] =
+     if (!sym.owner.isClass)
+       Nil
+     else
+       sym
+         .allOverriddenSymbols
+         .toList
+         .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
+     // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -5557,3 +5557,36 @@ object a:
       p
    else
       q
+<<< block with trailing comment
+maxColumn = 80
+===
+object a:
+  private def allInheritedOverriddenSymbols(sym: Symbol)(using Context): List[Symbol] =
+    if (!sym.owner.isClass) Nil
+    else sym.allOverriddenSymbols.toList.filter(_ != NoSymbol) //TODO: could also be `sym.owner.allOverrid..`
+    //else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a:
+-   private def allInheritedOverriddenSymbols(
+-       sym: Symbol
+-   )(using Context): List[Symbol] =
+-     if (!sym.owner.isClass)
+-       Nil
+-     else
+-       sym
+-         .allOverriddenSymbols
+-         .toList
+-         .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
++   private def allInheritedOverriddenSymbols(sym: Symbol)(using
++       Context
++   ): List[Symbol] =
++   if (!sym.owner.isClass)
++     Nil
++   else
++     sym
++       .allOverriddenSymbols
++       .toList
++       .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
+    // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)


### PR DESCRIPTION
Also, skip cur token when searching for next `=`.
