### PR TITLE
Router: fix `annotationNewlines=false`

### DIFF
--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -1361,8 +1361,7 @@ object WrapperToHaveStatTestCaseParserWorking {
 >>>
 object WrapperToHaveStatTestCaseParserWorking {
   @annot
-  @deprecated
-  class B(
+  @deprecated class B(
       @annot @deprecated private implicit val x: Int
   ) extends A {
     @annot override def foo = 1

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -1256,8 +1256,7 @@ object WrapperToHaveStatTestCaseParserWorking {
 }
 >>>
 object WrapperToHaveStatTestCaseParserWorking {
-  @annot @deprecated
-  class B(
+  @annot @deprecated class B(
       @annot @deprecated
       private implicit val x: Int
   ) extends A {

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -1343,8 +1343,7 @@ object WrapperToHaveStatTestCaseParserWorking {
 }
 >>>
 object WrapperToHaveStatTestCaseParserWorking {
-  @annot @deprecated
-  class B(
+  @annot @deprecated class B(
       @annot @deprecated private implicit val x: Int
   ) extends A {
     @annot override def foo = 1
@@ -1358,8 +1357,7 @@ object WrapperToHaveStatTestCaseParserWorking {
 
     // in case of annotations with params located in many lines
     // let's live with changed lines of params
-    @annot
-    @annot2(
+    @annot @annot2(
       value =
         "foo",
       someInt = 5


### PR DESCRIPTION
It was incorrectly forcing a newline in some cases.