### PR TITLE
Router: fix extensions with/out optional braces

### DIFF
--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -2104,15 +2104,15 @@ maxColumn = 40
 extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
-  def getAll: Boolean = a
+   def getAll: Boolean = a
 <<< #2725 no newline after extension parameter long, no optional braces
 maxColumn = 40
 runner.dialectOverride.allowSignificantIndentation = false
 ===
 extension (a: All) def getAll: Boolean = a
 >>>
-extension (a: All)
-  def getAll: Boolean = a
+extension (a: All) def getAll: Boolean =
+  a
 <<< #2740
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -2105,6 +2105,14 @@ extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
   def getAll: Boolean = a
+<<< #2725 no newline after extension parameter long, no optional braces
+maxColumn = 40
+runner.dialectOverride.allowSignificantIndentation = false
+===
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a
 <<< #2740
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -2024,15 +2024,15 @@ maxColumn = 40
 extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
-  def getAll: Boolean = a
+   def getAll: Boolean = a
 <<< #2725 no newline after extension parameter long, no optional braces
 maxColumn = 40
 runner.dialectOverride.allowSignificantIndentation = false
 ===
 extension (a: All) def getAll: Boolean = a
 >>>
-extension (a: All)
-  def getAll: Boolean = a
+extension (a: All) def getAll: Boolean =
+  a
 <<< #2740
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -2025,6 +2025,14 @@ extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
   def getAll: Boolean = a
+<<< #2725 no newline after extension parameter long, no optional braces
+maxColumn = 40
+runner.dialectOverride.allowSignificantIndentation = false
+===
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a
 <<< #2740
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2133,7 +2133,7 @@ extension (a: All)
   def getAll: Boolean = a
 >>>
 extension (a: All)
-  def getAll: Boolean = a
+   def getAll: Boolean = a
 <<< #2725 newline after extension parameter short
 extension (a: All) def getAll: Boolean = a
 >>>
@@ -2144,15 +2144,15 @@ maxColumn = 40
 extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
-  def getAll: Boolean = a
+   def getAll: Boolean = a
 <<< #2725 no newline after extension parameter long, no optional braces
 maxColumn = 40
 runner.dialectOverride.allowSignificantIndentation = false
 ===
 extension (a: All) def getAll: Boolean = a
 >>>
-extension (a: All)
-  def getAll: Boolean = a
+extension (a: All) def getAll: Boolean =
+  a
 <<< #2740
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -2145,6 +2145,14 @@ extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
   def getAll: Boolean = a
+<<< #2725 no newline after extension parameter long, no optional braces
+maxColumn = 40
+runner.dialectOverride.allowSignificantIndentation = false
+===
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a
 <<< #2740
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2251,27 +2251,27 @@ extension (a: All)
   def getAll: Boolean = a
 >>>
 extension (a: All)
-  def getAll: Boolean = a
+   def getAll: Boolean = a
 <<< #2725 newline after extension parameter short
 extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
-  def getAll: Boolean = a
+   def getAll: Boolean = a
 <<< #2725 newline after extension parameter long
 maxColumn = 40
 ===
 extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
-  def getAll: Boolean = a
+   def getAll: Boolean = a
 <<< #2725 no newline after extension parameter long, no optional braces
 maxColumn = 40
 runner.dialectOverride.allowSignificantIndentation = false
 ===
 extension (a: All) def getAll: Boolean = a
 >>>
-extension (a: All)
-  def getAll: Boolean = a
+extension (a: All) def getAll: Boolean =
+  a
 <<< #2740
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 1

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2264,6 +2264,14 @@ extension (a: All) def getAll: Boolean = a
 >>>
 extension (a: All)
   def getAll: Boolean = a
+<<< #2725 no newline after extension parameter long, no optional braces
+maxColumn = 40
+runner.dialectOverride.allowSignificantIndentation = false
+===
+extension (a: All) def getAll: Boolean = a
+>>>
+extension (a: All)
+  def getAll: Boolean = a
 <<< #2740
 runner.parser = source
 rewrite.scala3.insertEndMarkerMinLines = 1


### PR DESCRIPTION
When optional braces are not enabled, there may not be a newline at all.

When optional braces are enabled, a newline after extension declaration must come with a significant indentation.