### PR TITLE
Router: no space after `=>` if empty body

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2102,7 +2102,15 @@ class FormatOps(
       ): Option[OptionalBracesRegion] = ft.meta.leftOwner match {
         case t @ Term.Try(_, catchp, _) => Some(new OptionalBracesRegion {
             def owner = Some(t)
-            def splits = getSplitsForStats(ft, nft, catchp)
+            def splits = {
+              val nlOnly = catchp match {
+                case Nil => false
+                // to avoid next expression being interpreted as body
+                case head :: Nil => isEmptyTree(head.body) && t.finallyp.isEmpty
+                case _ => true
+              }
+              getSplitsForStats(ft, nft, catchp, nlOnly = nlOnly)
+            }
             def rightBrace = seqLast(catchp)
           })
         case _ => None

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -511,7 +511,10 @@ class Router(formatOps: FormatOps) {
           else if (ft.right.is[T.KwCase]) Seq(nlSplit(ft)(0))
           else if (hasBreak() && !beforeMultiline.ignoreSourceSplit)
             Seq(nlSplit(ft)(0))
-          else if (bodyIsEmpty) Seq(baseSplit, nlSplit(ft)(1))
+          else if (bodyIsEmpty)
+            if (rt.isAny[T.RightBrace, T.Semicolon])
+              Seq(baseSplit, nlSplit(ft)(1))
+            else Seq(nlSplit(ft)(0))
           else if (beforeMultiline eq Newlines.unfold)
             if (style.newlines.source ne Newlines.unfold) withSlbSplit
             else Seq(nlSplit(ft)(0))

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5375,7 +5375,8 @@ object a:
 object a:
    try
       val x = 3 / 0
-   catch case e: Throwable =>
+   catch
+      case e: Throwable =>
 <<< #3653 try-finally
 object a:
   try
@@ -5446,15 +5447,12 @@ object a:
 
   val qux = quux
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-    try baz
--   catch
--      case ex: Baz =>
--        val qux = quux
-+   catch case ex: Baz =>
-+
-+   val qux = quux
+object a:
+   try baz
+   catch
+      case ex: Baz =>
+
+   val qux = quux
 <<< braceless catch, single inline case, non-empty non-indented body
 object a:
   try baz

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5437,3 +5437,43 @@ object a:
          _ != NoSymbol
        ) // TODO: could also be `sym.owner.allOverrid..`
      // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+<<< braceless catch, single multi-line case, empty body
+object a:
+  try
+    baz
+  catch
+    case ex: Baz =>
+
+  val qux = quux
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+    try baz
+-   catch
+-      case ex: Baz =>
+-        val qux = quux
++   catch case ex: Baz =>
++
++   val qux = quux
+<<< braceless catch, single inline case, non-empty non-indented body
+object a:
+  try baz
+  catch case ex: Baz =>
+
+  val qux = quux
+>>>
+object a:
+   try baz
+   catch
+      case ex: Baz =>
+        val qux = quux
+<<< braceless match, empty body
+object a:
+  foo match
+    case bar =>
+  val qux = quux
+>>>
+object a:
+   foo match
+      case bar =>
+   val qux = quux

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5139,7 +5139,8 @@ object a:
 object a:
    try
       val x = 3 / 0
-   catch case e: Throwable =>
+   catch
+      case e: Throwable =>
 <<< #3653 try-finally
 object a:
   try
@@ -5209,7 +5210,10 @@ object a:
 >>>
 object a:
    try baz
-   catch case ex: Baz => val qux = quux
+   catch
+      case ex: Baz =>
+
+   val qux = quux
 <<< braceless catch, single inline case, non-empty non-indented body
 object a:
   try baz

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5198,3 +5198,35 @@ object a:
        sym.allOverriddenSymbols.toList
          .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
      // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+<<< braceless catch, single multi-line case, empty body
+object a:
+  try
+    baz
+  catch
+    case ex: Baz =>
+
+  val qux = quux
+>>>
+object a:
+   try baz
+   catch case ex: Baz => val qux = quux
+<<< braceless catch, single inline case, non-empty non-indented body
+object a:
+  try baz
+  catch case ex: Baz =>
+
+  val qux = quux
+>>>
+object a:
+   try baz
+   catch case ex: Baz => val qux = quux
+<<< braceless match, empty body
+object a:
+  foo match
+    case bar =>
+  val qux = quux
+>>>
+object a:
+   foo match
+      case bar =>
+   val qux = quux

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5476,3 +5476,41 @@ object a:
          _ != NoSymbol
        ) // TODO: could also be `sym.owner.allOverrid..`
      // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+<<< braceless catch, single multi-line case, empty body
+object a:
+  try
+    baz
+  catch
+    case ex: Baz =>
+
+  val qux = quux
+>>>
+object a:
+   try
+      baz
+   catch
+      case ex: Baz =>
+
+   val qux = quux
+<<< braceless catch, single inline case, non-empty non-indented body
+object a:
+  try baz
+  catch case ex: Baz =>
+
+  val qux = quux
+>>>
+object a:
+   try baz
+   catch
+      case ex: Baz =>
+        val qux = quux
+<<< braceless match, empty body
+object a:
+  foo match
+    case bar =>
+  val qux = quux
+>>>
+object a:
+   foo match
+      case bar =>
+   val qux = quux

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -5616,3 +5616,42 @@ object a:
          .toList
          .filter(_ != NoSymbol) // TODO: could also be `sym.owner.allOverrid..`
      // else sym.owner.ancestors map (sym overriddenSymbol _) filter (_ != NoSymbol)
+<<< braceless catch, single multi-line case, empty body
+object a:
+  try
+    baz
+  catch
+    case ex: Baz =>
+
+  val qux = quux
+>>>
+object a:
+   try
+      baz
+   catch
+      case ex: Baz =>
+
+   val qux = quux
+<<< braceless catch, single inline case, non-empty non-indented body
+object a:
+  try baz
+  catch case ex: Baz =>
+
+  val qux = quux
+>>>
+object a:
+   try
+      baz
+   catch
+      case ex: Baz =>
+        val qux = quux
+<<< braceless match, empty body
+object a:
+  foo match
+    case bar =>
+  val qux = quux
+>>>
+object a:
+   foo match
+      case bar =>
+   val qux = quux


### PR DESCRIPTION
Also, make sure a lone catch case is formatted as multi-line (i.e., has a break between `catch` and `case`), or else the next expression at the same indent level will be interpreted as the body. Helps with #4133.
