### PR TITLE
Router: extend optimal token to include comment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2524,9 +2524,7 @@ class Router(formatOps: FormatOps) {
       case _: Term.ForYield => twoBranches
       // we force newlines in try/catch/finally
       case _: Term.Try | _: Term.TryWithHandler => Split.ignored
-      case t: Term.Apply if t.argClause.nonEmpty =>
-        baseSpaceSplit.withOptimalToken(optimalWithComment)
-      case _ => baseSpaceSplit.withOptimalToken(optimal)
+      case _ => baseSpaceSplit.withOptimalToken(optimalWithComment)
     }
     Seq(
       spaceSplit,

--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -820,8 +820,8 @@ override final def next(): To =
 override final def next(): To =
   if (hasNext) {
     val ret = _next
-    _next =
-      null.asInstanceOf[To] // Mark as consumed aaaaaaaaaaaaaaaaaa(nice to the GC, don't leak the last returned value)
+    _next = null
+      .asInstanceOf[To] // Mark as consumed aaaaaaaaaaaaaaaaaa(nice to the GC, don't leak the last returned value)
     _hasNext = false // Mark as consumed (we need to look for the next value)
     ret
   } else throw new java.util.NoSuchElementException("next")

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -153,12 +153,25 @@ object a {
 object a {
   system.log.warning("Replicator points to dead letters: Make sure the cluster node is not terminated and has the proper role!")
 }
-<<< #1505 2
+<<< #1505 2.1 break, can fit within maxColumn
 newlines.avoidForSimpleOverflow = [toolong]
 ===
 object a {
   intercept[TestException] {
     val ct = Thread.currentThread() // Ensure that the thunk is executed in the tests thread
+  }
+}
+>>>
+object a {
+  intercept[TestException] {
+    val ct = Thread.currentThread() // Ensure that the thunk is executed in the tests thread
+  }
+}
+<<< #1505 2.2 don't break, overflows anyway
+newlines.avoidForSimpleOverflow = [toolong]
+===
+object a {
+  intercept[TestException] {
     val ct =
       Thread.currentThread() // Ensure that the thunk is executed in the tests thread
   }
@@ -166,12 +179,11 @@ object a {
 >>>
 object a {
   intercept[TestException] {
-    val ct = Thread.currentThread() // Ensure that the thunk is executed in the tests thread
     val ct =
       Thread.currentThread() // Ensure that the thunk is executed in the tests thread
   }
 }
-<<< #1505 2.1
+<<< #1505 2.3 break, can fit within maxColumn
 maxColumn = 90
 newlines.avoidForSimpleOverflow = [toolong]
 ===
@@ -191,7 +203,7 @@ object a {
       Thread.currentThread() // Ensure that the thunk is executed in the tests thread
   }
 }
-<<< #1505 2.2 [#2633]
+<<< #1505 2.4 [#2633] ok to overflow for single-line comment, despite no-overflow solution
 maxColumn = 90
 newlines.avoidForSimpleOverflow = [slc]
 ===
@@ -210,7 +222,7 @@ object a {
       Thread.currentThread() // Ensure that the thunk is executed in the tests thread
   }
 }
-<<< #1505 3
+<<< #1505 3 break, can fit within maxColumn
 newlines.avoidForSimpleOverflow = [toolong]
 ===
 object a {

--- a/scalafmt-tests/src/test/resources/default/String.stat
+++ b/scalafmt-tests/src/test/resources/default/String.stat
@@ -164,7 +164,8 @@ object a {
 >>>
 object a {
   intercept[TestException] {
-    val ct = Thread.currentThread() // Ensure that the thunk is executed in the tests thread
+    val ct = Thread
+      .currentThread() // Ensure that the thunk is executed in the tests thread
   }
 }
 <<< #1505 2.2 don't break, overflows anyway
@@ -233,7 +234,8 @@ object a {
 >>>
 object a {
   intercept[TestException] {
-    val ct = Thread.currentThread() // Ensure that the thunk is executed in the tests thread
+    val ct = Thread
+      .currentThread() // Ensure that the thunk is executed in the tests thread
   }
 }
 <<< #1505 4

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1939,6 +1939,23 @@ end f
 
 /** Some doc comment */
 def g = f("Foo")
+<<< oveflow infix assignment with trailing single-line comment
+maxColumn = 26
+===
+object a:
+  def foo =
+     bar = baz + baz(qux) // c1
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+    def foo =
+-     bar = baz + baz(
+-       qux
+-     ) // c1
++     bar =
++       baz + baz(
++         qux
++       ) // c1
 <<< #2561 no forced dangle in tuples
 maxColumn = 40
 newlines {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1946,16 +1946,11 @@ object a:
   def foo =
      bar = baz + baz(qux) // c1
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-    def foo =
--     bar = baz + baz(
--       qux
--     ) // c1
-+     bar =
-+       baz + baz(
-+         qux
-+       ) // c1
+object a:
+   def foo =
+     bar = baz + baz(
+       qux
+     ) // c1
 <<< #2561 no forced dangle in tuples
 maxColumn = 40
 newlines {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1856,6 +1856,16 @@ end f
 
 /** Some doc comment */
 def g = f("Foo")
+<<< oveflow infix assignment with trailing single-line comment
+maxColumn = 26
+===
+object a:
+  def foo =
+     bar = baz + baz(qux) // c1
+>>>
+object a:
+   def foo = bar = baz +
+     baz(qux) // c1
 <<< #2561 no forced dangle in tuples
 maxColumn = 40
 newlines {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1976,6 +1976,18 @@ end f
 
 /** Some doc comment */
 def g = f("Foo")
+<<< oveflow infix assignment with trailing single-line comment
+maxColumn = 26
+===
+object a:
+  def foo =
+     bar = baz + baz(qux) // c1
+>>>
+object a:
+   def foo =
+     bar = baz + baz(
+       qux
+     ) // c1
 <<< #2561 no forced dangle in tuples
 newlines {
   beforeOpenParenDefnSite = source

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -2083,6 +2083,18 @@ end f
 
 /** Some doc comment */
 def g = f("Foo")
+<<< oveflow infix assignment with trailing single-line comment
+maxColumn = 26
+===
+object a:
+  def foo =
+     bar = baz + baz(qux) // c1
+>>>
+object a:
+   def foo =
+     bar =
+       baz +
+         baz(qux) // c1
 <<< #2561 no forced dangle in tuples
 newlines {
   beforeOpenParenDefnSite = source


### PR DESCRIPTION
Fixes non-idempotence and incorrect handling of avoidForSimpleOverflow containing only `tooLong` (which applies only when there's no possible alternative which doesn't overflow). Helps with #4133.