### PR TITLE
RedundantBraces: don't remove empty blocks

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -349,14 +349,13 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       ft: FormatToken,
       session: Session,
       style: ScalafmtConfig,
-  ): Boolean =
-    (b.tokens.headOption.contains(ft.right) &&
-      b.tokens.last.is[Token.RightBrace] && okToRemoveBlock(b)) &&
-      (b.parent match {
-        case Some(p: Term.ArgClause) => p.parent.exists(checkValidInfixParent)
-        case Some(p) => checkValidInfixParent(p)
-        case _ => true
-      })
+  ): Boolean = b.stats.nonEmpty && b.tokens.headOption.contains(ft.right) &&
+    b.tokens.last.is[Token.RightBrace] && okToRemoveBlock(b) &&
+    (b.parent match {
+      case Some(p: Term.ArgClause) => p.parent.exists(checkValidInfixParent)
+      case Some(p) => checkValidInfixParent(p)
+      case _ => true
+    })
 
   private def checkValidInfixParent(
       p: Tree,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -246,6 +246,10 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
           case Some(_: Term.Interpolate) => handleInterpolation
           case Some(_: Term.Xml) => null
           case Some(_: Term.Annotate) => null
+          case Some(p: Case) =>
+            val ok = settings.generalExpressions &&
+              ((p.body eq t) || shouldRemoveSingleStatBlock(t))
+            if (ok) removeToken else null
           case _ => if (processBlock(t)) removeToken else null
         }
       case _: Term.Interpolate => handleInterpolation
@@ -380,11 +384,6 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       b: Term.Block,
   )(implicit style: ScalafmtConfig, session: Session): Boolean = b.parent
     .exists {
-
-      case p: Case => settings.generalExpressions && {
-          (p.body eq b) || shouldRemoveSingleStatBlock(b)
-        }
-
       case t: Term.ArgClause if isParentAnApply(t) =>
         // Example: as.map { _.toString }
         // Leave this alone for now.

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1888,3 +1888,24 @@ object a {
     ()
   finally {}
 }
+<<< don't remove inner-block braces if outer-block become optional
+runner.dialect = scala3
+rewrite.scala3 {
+  insertEndMarkerMinLines = 5
+  removeOptionalBraces = yes
+}
+===
+object a:
+  override def didSave(params: DidSaveTextDocumentParams): Unit = {
+    /*thisServer.synchronized*/ {}
+  }
+>>>
+test does not parse: [dialect scala3] illegal start of simple expression
+object a:
+  override def didSave(params: DidSaveTextDocumentParams): Unit =
+    /*thisServer.synchronized*/
+                               ^
+====== full result: ======
+object a:
+  override def didSave(params: DidSaveTextDocumentParams): Unit =
+    /*thisServer.synchronized*/

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1900,12 +1900,6 @@ object a:
     /*thisServer.synchronized*/ {}
   }
 >>>
-test does not parse: [dialect scala3] illegal start of simple expression
 object a:
   override def didSave(params: DidSaveTextDocumentParams): Unit =
-    /*thisServer.synchronized*/
-                               ^
-====== full result: ======
-object a:
-  override def didSave(params: DidSaveTextDocumentParams): Unit =
-    /*thisServer.synchronized*/
+    /*thisServer.synchronized*/ {}


### PR DESCRIPTION
There are only limited contexts where it is OK (`case` being one, but it is handled elsewhere). Helps with #4133.