### PR TITLE
Router: no space around `{` to be changed to `(`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -179,7 +179,7 @@ class FormatWriter(formatOps: FormatOps) {
 
             // update "{"
             locations(beg) =
-              if (inParentheses) bloc
+              if (inParentheses || (state.mod ne Space)) bloc
                 .copy(replace = "(", state = state.copy(prev = prevBegState))
               else {
                 // remove space after "{"
@@ -194,7 +194,7 @@ class FormatWriter(formatOps: FormatOps) {
             val prevEndLoc = locations(idx - 1)
             val prevEndState = prevEndLoc.state
             val newPrevEndState =
-              if (inParentheses) prevEndState
+              if (inParentheses || (prevEndState.mod ne Space)) prevEndState
               else {
                 // remove space before "}"
                 val split = prevEndState.split.withMod(NoSplit)

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -8453,9 +8453,7 @@ object a {
 >>>
 object a {
   foo := bar {
-    val baz = qux { x => plugh =>
-      xyzzy
-    }
+    val baz = qux(x => plugh => xyzzy)
     val baz = qux(x => quux => fred)
   }
 }
@@ -8475,9 +8473,7 @@ object a {
 >>>
 object a {
   foo := bar {
-    val baz = qux { x => plugh =>
-      xyzzy
-    }
+    val baz = qux(x => plugh => xyzzy)
     val baz = qux(x => quux => fred)
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -8445,6 +8445,9 @@ object a {
     val baz = qux(x => {
       plugh => xyzzy
     })
+    val baz = qux(x => {
+      quux => fred
+    })
   }
 }
 >>>
@@ -8453,6 +8456,7 @@ object a {
     val baz = qux { x => plugh =>
       xyzzy
     }
+    val baz = qux(x => quux => fred)
   }
 }
 <<< no braces around nested lambda, braces around outer
@@ -8463,6 +8467,9 @@ object a {
     val baz = qux { x => 
       plugh => xyzzy
     }
+    val baz = qux { x => 
+      quux => fred
+    }
   }
 }
 >>>
@@ -8471,5 +8478,6 @@ object a {
     val baz = qux { x => plugh =>
       xyzzy
     }
+    val baz = qux(x => quux => fred)
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -7947,6 +7947,9 @@ object a {
     val baz = qux(x => {
       plugh => xyzzy
     })
+    val baz = qux(x => {
+      quux => fred
+    })
   }
 }
 >>>
@@ -7955,6 +7958,7 @@ object a {
     val baz = qux { x => plugh =>
       xyzzy
     }
+    val baz = qux(x => quux => fred)
   }
 }
 <<< no braces around nested lambda, braces around outer
@@ -7965,6 +7969,9 @@ object a {
     val baz = qux { x => 
       plugh => xyzzy
     }
+    val baz = qux { x => 
+      quux => fred
+    }
   }
 }
 >>>
@@ -7973,5 +7980,6 @@ object a {
     val baz = qux { x => plugh =>
       xyzzy
     }
+    val baz = qux(x => quux => fred)
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -7955,9 +7955,7 @@ object a {
 >>>
 object a {
   foo := bar {
-    val baz = qux { x => plugh =>
-      xyzzy
-    }
+    val baz = qux(x => plugh => xyzzy)
     val baz = qux(x => quux => fred)
   }
 }
@@ -7977,9 +7975,7 @@ object a {
 >>>
 object a {
   foo := bar {
-    val baz = qux { x => plugh =>
-      xyzzy
-    }
+    val baz = qux(x => plugh => xyzzy)
     val baz = qux(x => quux => fred)
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -8392,9 +8392,7 @@ object a {
 >>>
 object a {
   foo := bar {
-    val baz = qux { x => plugh =>
-      xyzzy
-    }
+    val baz = qux(x => plugh => xyzzy)
     val baz = qux(x => quux => fred)
   }
 }
@@ -8414,9 +8412,7 @@ object a {
 >>>
 object a {
   foo := bar {
-    val baz = qux { x => plugh =>
-      xyzzy
-    }
+    val baz = qux(x => plugh => xyzzy)
     val baz = qux(x => quux => fred)
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -8384,6 +8384,9 @@ object a {
     val baz = qux(x => {
       plugh => xyzzy
     })
+    val baz = qux(x => {
+      quux => fred
+    })
   }
 }
 >>>
@@ -8392,6 +8395,7 @@ object a {
     val baz = qux { x => plugh =>
       xyzzy
     }
+    val baz = qux(x => quux => fred)
   }
 }
 <<< no braces around nested lambda, braces around outer
@@ -8402,6 +8406,9 @@ object a {
     val baz = qux { x => 
       plugh => xyzzy
     }
+    val baz = qux { x => 
+      quux => fred
+    }
   }
 }
 >>>
@@ -8410,5 +8417,6 @@ object a {
     val baz = qux { x => plugh =>
       xyzzy
     }
+    val baz = qux(x => quux => fred)
   }
 }

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -8529,6 +8529,9 @@ object a {
     val baz = qux(x => {
       plugh => xyzzy
     })
+    val baz = qux(x => {
+      quux => fred
+    })
   }
 }
 >>>
@@ -8537,6 +8540,9 @@ object a {
     bar {
       val baz = qux { x => plugh =>
         xyzzy
+      }
+      val baz = qux { x => quux =>
+        fred
       }
     }
 }
@@ -8548,6 +8554,9 @@ object a {
     val baz = qux { x => 
       plugh => xyzzy
     }
+    val baz = qux { x => 
+      quux => fred
+    }
   }
 }
 >>>
@@ -8556,6 +8565,9 @@ object a {
     bar {
       val baz = qux { x => plugh =>
         xyzzy
+      }
+      val baz = qux { x => quux =>
+        fred
       }
     }
 }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5815,3 +5815,18 @@ object a {
          "only in hashbang classpath"
        )
 }
+<<< braces to parens in one-line apply: overflow with braces, fit with parens
+maxColumn = 32
+rewrite.rules = [RedundantBraces]
+===
+object a:
+  def foo() =
+    if bar then
+      baz { _ => qux() }
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+    def foo() =
+-     if bar then baz(_ => qux())
++     if bar then
++        baz(_ => qux())

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -5824,9 +5824,6 @@ object a:
     if bar then
       baz { _ => qux() }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-    def foo() =
--     if bar then baz(_ => qux())
-+     if bar then
-+        baz(_ => qux())
+object a:
+   def foo() =
+     if bar then baz(_ => qux())

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5568,10 +5568,6 @@ object a:
     if bar then
       baz { _ => qux() }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a:
--   def foo() =
--     if bar then baz(_ => qux())
-+   def foo() = if bar then
-+      baz(_ => qux())
+object a:
+   def foo() =
+     if bar then baz(_ => qux())

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5559,3 +5559,19 @@ object a {
          "only in hashbang classpath"
        )
 }
+<<< braces to parens in one-line apply: overflow with braces, fit with parens
+maxColumn = 32
+rewrite.rules = [RedundantBraces]
+===
+object a:
+  def foo() =
+    if bar then
+      baz { _ => qux() }
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a:
+-   def foo() =
+-     if bar then baz(_ => qux())
++   def foo() = if bar then
++      baz(_ => qux())

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5856,3 +5856,15 @@ object a {
          "only in hashbang classpath"
        )
 }
+<<< braces to parens in one-line apply: overflow with braces, fit with parens
+maxColumn = 32
+rewrite.rules = [RedundantBraces]
+===
+object a:
+  def foo() =
+    if bar then baz { _ => qux() }
+>>>
+object a:
+   def foo() =
+     if bar then
+        baz(_ => qux())

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -5866,5 +5866,4 @@ object a:
 >>>
 object a:
    def foo() =
-     if bar then
-        baz(_ => qux())
+     if bar then baz(_ => qux())

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -5991,3 +5991,16 @@ object a {
          "only in hashbang classpath"
        )
 }
+<<< braces to parens in one-line apply: overflow with braces, fit with parens
+maxColumn = 32
+rewrite.rules = [RedundantBraces]
+===
+object a:
+  def foo() = if bar then baz { _ => qux() }
+>>>
+object a:
+   def foo() =
+     if bar then
+        baz { _ =>
+          qux()
+        }


### PR DESCRIPTION
Let's not use the Space split when we know that it will be removed along with the brace being change to paren.

This will allow us to avoid non-idempotent formatting problems as these spaces might cause the code to overflow the line narrowly, which would not happen without the spaces.

Helps with #4133.
