### PR TITLE
FormatTokens: move `getBraces` from TreeOps

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -122,6 +122,14 @@ class FormatTokens(leftTok2tok: Map[TokenHash, Int])(val arr: Array[FormatToken]
     isEnclosedInMatching(tree.tokens, tree)
 
   @inline
+  def getBracesIfEnclosed(tree: Tree): Option[(FormatToken, FormatToken)] =
+    getDelimsIfEnclosed(tree).filter(_._1.left.is[Token.LeftBrace])
+
+  @inline
+  def isEnclosedInBraces(tree: Tree): Boolean = getDelimsIfEnclosed(tree)
+    .exists(_._1.left.is[Token.LeftBrace])
+
+  @inline
   private def areMatchingParens(close: Token)(open: => Token): Boolean = close
     .is[Token.RightParen] && areMatching(close)(open)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -412,7 +412,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
         // Leave this alone for now.
         // In future there should be an option to surround such expressions with parens instead of braces
         if (isSeqMulti(t.values)) okToRemoveBlockWithinApply(b)
-        else (t.pos.start != b.pos.start) && SingleArgInBraces.inBraces(t)
+        else (t.pos.start != b.pos.start) && ftoks.isEnclosedInBraces(t)
 
       case d: Defn.Def =>
         def disqualifiedByUnit = !settings.includeUnitMethods &&

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -64,13 +64,9 @@ object TreeOps {
       case _ => None
     }
     @inline
-    def inBraces(tree: Tree)(implicit ftoks: FormatTokens): Boolean =
-      getBraces(tree).isDefined
-    @inline
-    def getBraces(tree: Tree)(implicit
+    private def getBraces(tree: Tree)(implicit
         ftoks: FormatTokens,
-    ): Option[(FormatToken, FormatToken)] = ftoks.getDelimsIfEnclosed(tree)
-      .filter(_._1.left.is[LeftBrace])
+    ): Option[(FormatToken, FormatToken)] = ftoks.getBracesIfEnclosed(tree)
 
     def orBlock(tree: Tree)(implicit
         ftoks: FormatTokens,


### PR DESCRIPTION
Helps with #4133.