### PR TITLE
FormatOps: definite NL in OptionalBraces.BlockImpl

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1940,7 +1940,7 @@ class FormatOps(
               if !hasSingleTermStat(t) && isBlockStart(t, nft) =>
             Some(new OptionalBracesRegion {
               def owner = t.parent
-              def splits = Some(getSplitsMaybeBlock(ft, nft, t))
+              def splits = Some(getSplits(ft, t, forceNL = true))
               def rightBrace = treeLast(t)
             })
           case _ => None


### PR DESCRIPTION
No need to call the `maybe`-block method. Helps with #4133.