### PR TITLE
FormatWriter: align on actual splits, not original

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1173,7 +1173,7 @@ class FormatWriter(formatOps: FormatOps) {
             columnShift += floc.shift
             if (floc.hasBreakAfter || ft.leftHasNewline) floc
             else {
-              getAlignNonSlcOwner(ft).foreach { nonSlcOwner =>
+              getAlignNonSlcOwner(ft, locations(idx)).foreach { nonSlcOwner =>
                 val (container, depth) =
                   getAlignContainer(nonSlcOwner.getOrElse(ft.meta.rightOwner))
                 def appendCandidate() = columnCandidates += new AlignStop(
@@ -1873,9 +1873,9 @@ object FormatWriter {
     if (useLeft) floc.state.prev.column else floc.state.column
   }
 
-  private def getAlignNonSlcOwner(
-      ft: FormatToken,
-  )(implicit floc: FormatLocation, tokens: FormatTokens): Option[Option[Tree]] = {
+  private def getAlignNonSlcOwner(ft: FormatToken, nextFloc: FormatLocation)(
+      implicit floc: FormatLocation,
+  ): Option[Option[Tree]] = {
     def getNonSlcOwner = ft.meta.rightOwner match {
       case name: Term.Name => name.parent match {
           case Some(p: Term.ApplyInfix) => p
@@ -1884,7 +1884,7 @@ object FormatWriter {
       case x => x
     }
 
-    val slc = ft.right.is[T.Comment] && tokens.isBreakAfterRight(ft) &&
+    val slc = ft.right.is[T.Comment] && nextFloc.hasBreakAfter &&
       !ft.rightHasNewline
     val code = if (slc) "//" else ft.meta.right.text
     floc.style.alignMap.get(code).flatMap { matchers =>

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -2118,9 +2118,15 @@ object a {
    }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-       case baz =>
--        val qux = Qux()
-+        val qux  = Qux()
-         xyzzy(
+object a {
+  def foo(barBarBarBar: BarBarBarBar) =
+    barBarBarBar match {
+      case baz =>
+        val qux = Qux()
+        xyzzy(
+          barBarBarBar,
+          qux /* barBarBarBarBarBar */
+        )
+        val quux = Quux()
+    }
+}

--- a/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/src/test/resources/align/DefaultWithAlign.stat
@@ -2105,3 +2105,22 @@ object a {
   private[this] def retry_cache_key(xxx: String) = s"some_short_string$xxx"
   private[this] val retry_timing_in_seconds      = 30 seconds
 }
+<<< #4133 align with a comment, one-line source but formatted multi-line
+maxColumn = 50
+align.preset = most
+===
+object a {
+   def foo(barBarBarBar: BarBarBarBar) = barBarBarBar match {
+      case baz =>
+        val qux = Qux()
+        xyzzy(barBarBarBar, qux /* barBarBarBarBarBar */)
+        val quux = Quux()
+   }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+       case baz =>
+-        val qux = Qux()
++        val qux  = Qux()
+         xyzzy(


### PR DESCRIPTION
Helps with #4133.