### PR TITLE
Add literal.binPrefix setting to format binary literals.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4873,6 +4873,8 @@ literals.long=Upper
 
 ### `literals.binPrefix`
 
+> Since v3.8.4.
+
 ```scala mdoc:defaults
 literals.binPrefix
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4792,6 +4792,8 @@ Default formatting:
 0x1Abl
 10E-1
 10e-1D
+0B111
+0b111l
 ```
 
 Each `literals.*` setting has three available options: `Upper`, `Lower`,
@@ -4867,6 +4869,22 @@ literals.long=Upper
 ---
 0xaAaA
 0xaAaAl
+```
+
+### `literals.binPrefix`
+
+```scala mdoc:defaults
+literals.binPrefix
+```
+
+Responsible for the case of binary integer literals prefix `0b`
+
+```scala mdoc:scalafmt
+literals.binPrefix=Lower
+literals.long=Upper
+---
+0B111
+0B111l
 ```
 
 ### `literals.scientific`

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Literals.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Literals.scala
@@ -8,6 +8,7 @@ case class Literals(
     double: Case = Case.Lower,
     hexDigits: Case = Case.Lower,
     hexPrefix: Case = Case.Lower,
+    binPrefix: Case = Case.Lower,
     scientific: Case = Case.Lower,
 )
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LiteralOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LiteralOps.scala
@@ -14,15 +14,21 @@ object LiteralOps {
     *   - FF123 is a body
     *   - L is a long suffix
     *
+    * and for 0b1010L
+    *   - 0b is a bin prefix
+    *   - 1010 is a body
+    *   - L is a long suffix
+    *
     * Then
-    *   - literals.hexPrefix applies to prefix
-    *   - literals.hexDigits applies to body and
+    *   - literals.hexPrefix or literals.binPrefix applies to prefix
+    *   - literals.hexDigits applies to body (if hex) and
     *   - literals.long applies to suffix
     */
   def prettyPrintInteger(str: String)(implicit style: ScalafmtConfig): String =
-    if (str.endsWith("L") || str.endsWith("l")) prettyPrintHex(str.dropRight(1)) +
-      style.literals.long.process(str.takeRight(1))
-    else prettyPrintHex(str)
+    if (str.endsWith("L") || str.endsWith("l"))
+      prettyPrintHexOrBin(str.dropRight(1)) +
+        style.literals.long.process(str.takeRight(1))
+    else prettyPrintHexOrBin(str)
 
   def prettyPrintFloat(str: String)(implicit style: ScalafmtConfig): String =
     prettyPrintFloatingPoint(str, 'F', 'f', style.literals.float)
@@ -53,10 +59,12 @@ object LiteralOps {
       suffixCase.process(str.takeRight(1))
     else style.literals.scientific.process(str)
 
-  private def prettyPrintHex(
+  private def prettyPrintHexOrBin(
       str: String,
   )(implicit style: ScalafmtConfig): String =
     if (str.startsWith("0x") || str.startsWith("0X")) style.literals.hexPrefix
       .process(str.take(2)) + style.literals.hexDigits.process(str.drop(2))
-    else str // not a hex literal
+    else if (str.startsWith("0b") || str.startsWith("0B")) style.literals
+      .binPrefix.process(str.take(2)) + str.drop(2)
+    else str // not a hex or bin literal
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LiteralOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LiteralOps.scala
@@ -61,10 +61,13 @@ object LiteralOps {
 
   private def prettyPrintHexOrBin(
       str: String,
-  )(implicit style: ScalafmtConfig): String =
-    if (str.startsWith("0x") || str.startsWith("0X")) style.literals.hexPrefix
-      .process(str.take(2)) + style.literals.hexDigits.process(str.drop(2))
-    else if (str.startsWith("0b") || str.startsWith("0B")) style.literals
-      .binPrefix.process(str.take(2)) + str.drop(2)
-    else str // not a hex or bin literal
+  )(implicit style: ScalafmtConfig): String = {
+    val (prefix, body) = str.splitAt(2)
+    prefix match {
+      case "0x" | "0X" => style.literals.hexPrefix.process(prefix) +
+          style.literals.hexDigits.process(body)
+      case "0b" | "0B" => style.literals.binPrefix.process(prefix) + body
+      case _ => str
+    }
+  }
 }

--- a/scalafmt-tests/src/test/resources/literals/binary.stat
+++ b/scalafmt-tests/src/test/resources/literals/binary.stat
@@ -1,0 +1,30 @@
+<<< uppercase l by default
+0b111l
+>>>
+0b111L
+<<< lowercase l if specified
+literals.long = Lower
+===
+0b111L
+>>>
+0b111l
+<<< lowercase 0B by default
+0B111
+>>>
+0b111
+<<< uppercase 0b if specified
+literals.binPrefix = Upper
+===
+0b111
+>>>
+0B111
+<<< change both prefix and suffix
+0B111l
+>>>
+0b111L
+<<< unchanged
+literals.binPrefix = Unchanged
+===
+0B111 + 0b111
+>>>
+0B111 + 0b111


### PR DESCRIPTION
Add formatting to handle binary literals, which were added in Scala 3.5.0.
Those are of the form 0b111 or 0b111L and so are susceptible to both literals.binPrefix and literals.long.

The 3.5.0 release uses 0B111 in its examples, but the original SIP 42 uses 0b111. I chose 0b as the default, as it looks a lot nicer to me.

There is a new test file (`binary.stat`) and the documentation was updated (it's missing a `since` comment).

The changes address my own feature request: fixes #4176.