### PR TITLE
Update contributing-scalafmt.md

### DIFF
--- a/docs/contributing-scalafmt.md
+++ b/docs/contributing-scalafmt.md
@@ -5,7 +5,6 @@ title: Contributing
 
 ## Compiling project
 
-- It's recommended to use Java 8, the project has not been tested with Java 11.
 - The project is built with `sbt`, to install sbt see https://www.scala-sbt.org/
 - Use `sbt tests/test` instead of `sbt test`, the former runs modestly fast unit
   tests for the JVM while `sbt test` is slower because it runs cross-platform


### PR DESCRIPTION
The requirement to use Java 8 is misleading. First, the project cannot be compiled with Java 8 (it uses String#stripTrailing which was introduced in Java 11). Second, it works perfectly fine with Java 21, the current LTS.