### PR TITLE
ScalafmtDynamicSession: check config has a parent

### DIFF
--- a/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicSession.scala
+++ b/scalafmt-dynamic/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicSession.scala
@@ -58,7 +58,9 @@ private object ScalafmtDynamicSession {
   ): ScalafmtDynamicSession = {
     val newcfg = {
       if (!cfg.needGitAutoCRLF) None
-      else GitOps.FactoryImpl(AbsoluteFile(config.getParent)).getAutoCRLF
+      else GitOps.FactoryImpl(
+        Option(config.getParent).fold(AbsoluteFile.userDir)(AbsoluteFile.apply),
+      ).getAutoCRLF
     }.fold(cfg)(cfg.withGitAutoCRLF)
     new ScalafmtDynamicSession(properties, newcfg)
   }


### PR DESCRIPTION
Otherwise, it might lead to a NullPointerException.