### PR TITLE
BestFirstSearch: recurse right after opening brace

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -140,8 +140,7 @@ private class BestFirstSearch private (range: Set[Range])(implicit
         val noBlockClose = start == curr && 0 != maxCost || !noOptZone ||
           !style.runner.optimizer.recurseOnBlocks
         val blockClose =
-          if (noBlockClose) None
-          else getBlockCloseToRecurse(tokens.prev(splitToken), stop)
+          if (noBlockClose) None else getBlockCloseToRecurse(splitToken, stop)
         if (blockClose.nonEmpty) blockClose.foreach { end =>
           shortestPathMemo(curr, end, depth + 1, maxCost).foreach(enqueue)
         }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5799,8 +5799,8 @@ object a:
        .AnyRefMap[String, collection.mutable.ListBuffer[Path]]()
      val isJava12OrHigher = scala.util.Properties.isJavaAtLeast("12")
      rootsForRelease.foreach(root =>
-       Files.walk(root).iterator().asScala.filter(Files.isDirectory(_)).foreach {
-         p =>
+       Files.walk(root).iterator().asScala.filter(Files.isDirectory(_))
+         .foreach { p =>
             val moduleNamePathElementCount = if (isJava12OrHigher) 1 else 0
             if (
               p.getNameCount > root.getNameCount + moduleNamePathElementCount
@@ -5814,7 +5814,7 @@ object a:
                 new collection.mutable.ListBuffer
               ) += p
             }
-       }
+         }
      )
      index
    }
@@ -5832,8 +5832,8 @@ object a:
 >>>
 object a:
    rootsForRelease_foreach(root =>
-     Files.walkingIterator().useScalaFilter(Files__Is__Directory).foreach {
-       p =>
+     Files.walkingIterator().useScalaFilter(Files__Is__Directory)
+       .foreach { p =>
           val_moduleNamePathElementCount_е_0
           if (
             p_getNameCount_g_root_getNameCount_p_moduleNamePathElementCount
@@ -5843,7 +5843,7 @@ object a:
               packageDotted__new_collectionMutableListBuffer
             )
           }
-     }
+       }
    )
 <<< braces to parens in one-line apply: overflow with braces, fit with parens
 maxColumn = 32


### PR DESCRIPTION
For some reason, the earlier implementation would only recurse after the first non-brace character. Logically, if we want to process a block as a unit, we should start with the left brace and end with the right. Helps with #4133.