### PR TITLE
Router: ignore end marker for open paren indent

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2067,9 +2067,7 @@ class Router(formatOps: FormatOps) {
                 case _ => true
               } && {
                 val pft = prevNonCommentSameLine(beforeClose)
-                (pft eq beforeClose) && beforeClose.left.is[T.Comment] ||
-                pft.meta.leftOwner.is[Term.Name] && // end marker
-                prev(pft).meta.leftOwner.is[Term.EndMarker]
+                (pft eq beforeClose) && beforeClose.left.is[T.Comment]
               }
               Num(if (needIndent) style.indent.main else 0)
           }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -6151,6 +6151,51 @@ object a:
            qux // c2
         end baz
      )(quux)
+<<< #4133 enclosed for-yield with added end marker
+rewrite.scala3 {
+  convertToNewSyntax = true
+  insertEndMarkerMinLines = 5
+  removeOptionalBraces = yes
+}
+===
+object a {
+    (for {
+      bar <- bars
+    } yield {
+      baz
+
+      qux match {
+        case Qux1 =>
+          qux1
+
+        case Qux2 =>
+          qux2
+      }
+    }).quux
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+    (for bar <- bars
+-     yield
+-        baz
++   yield
++      baz
+ ∙
+-        qux match
+-           case Qux1 =>
+-             qux1
++      qux match
++         case Qux1 =>
++           qux1
+ ∙
+-           case Qux2 =>
+-             qux2
+-        end match
++         case Qux2 =>
++           qux2
++      end match
+    ).quux
 <<< redundant block within block, outer semicolon-terminated
 rewrite {
   rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -6174,28 +6174,19 @@ object a {
     }).quux
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-    (for bar <- bars
--     yield
--        baz
-+   yield
-+      baz
- ∙
--        qux match
--           case Qux1 =>
--             qux1
-+      qux match
-+         case Qux1 =>
-+           qux1
- ∙
--           case Qux2 =>
--             qux2
--        end match
-+         case Qux2 =>
-+           qux2
-+      end match
-    ).quux
+object a:
+   (for bar <- bars
+   yield
+      baz
+
+      qux match
+         case Qux1 =>
+           qux1
+
+         case Qux2 =>
+           qux2
+      end match
+   ).quux
 <<< redundant block within block, outer semicolon-terminated
 rewrite {
   rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -5885,6 +5885,38 @@ object a:
          qux // c2
       end baz
    )(quux)
+<<< #4133 enclosed for-yield with added end marker
+rewrite.scala3 {
+  convertToNewSyntax = true
+  insertEndMarkerMinLines = 5
+  removeOptionalBraces = yes
+}
+===
+object a {
+    (for {
+      bar <- bars
+    } yield {
+      baz
+
+      qux match {
+        case Qux1 =>
+          qux1
+
+        case Qux2 =>
+          qux2
+      }
+    }).quux
+}
+>>>
+object a:
+   (for bar <- bars yield
+      baz
+
+      qux match
+         case Qux1 => qux1
+
+         case Qux2 => qux2
+   ).quux
 <<< redundant block within block, outer semicolon-terminated
 rewrite {
   rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -6179,6 +6179,53 @@ object a:
            qux // c2
         end baz
      )(quux)
+<<< #4133 enclosed for-yield with added end marker
+rewrite.scala3 {
+  convertToNewSyntax = true
+  insertEndMarkerMinLines = 5
+  removeOptionalBraces = yes
+}
+===
+object a {
+    (for {
+      bar <- bars
+    } yield {
+      baz
+
+      qux match {
+        case Qux1 =>
+          qux1
+
+        case Qux2 =>
+          qux2
+      }
+    }).quux
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+    (for
+-        bar <- bars
+-     yield
+-        baz
++      bar <- bars
++   yield
++      baz
+ ∙
+-        qux match
+-           case Qux1 =>
+-             qux1
++      qux match
++         case Qux1 =>
++           qux1
+ ∙
+-           case Qux2 =>
+-             qux2
+-        end match
++         case Qux2 =>
++           qux2
++      end match
+    ).quux
 <<< redundant block within block, outer semicolon-terminated
 rewrite {
   rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -6202,30 +6202,20 @@ object a {
     }).quux
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-    (for
--        bar <- bars
--     yield
--        baz
-+      bar <- bars
-+   yield
-+      baz
- ∙
--        qux match
--           case Qux1 =>
--             qux1
-+      qux match
-+         case Qux1 =>
-+           qux1
- ∙
--           case Qux2 =>
--             qux2
--        end match
-+         case Qux2 =>
-+           qux2
-+      end match
-    ).quux
+object a:
+   (for
+      bar <- bars
+   yield
+      baz
+
+      qux match
+         case Qux1 =>
+           qux1
+
+         case Qux2 =>
+           qux2
+      end match
+   ).quux
 <<< redundant block within block, outer semicolon-terminated
 rewrite {
   rules = [RedundantBraces]

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -6335,6 +6335,43 @@ object a:
              qux // c2
           end baz
      )(quux)
+<<< #4133 enclosed for-yield with added end marker
+rewrite.scala3 {
+  convertToNewSyntax = true
+  insertEndMarkerMinLines = 5
+  removeOptionalBraces = yes
+}
+===
+object a {
+    (for {
+      bar <- bars
+    } yield {
+      baz
+
+      qux match {
+        case Qux1 =>
+          qux1
+
+        case Qux2 =>
+          qux2
+      }
+    }).quux
+}
+>>>
+object a:
+   (
+     for bar <- bars
+     yield
+        baz
+
+        qux match
+           case Qux1 =>
+             qux1
+
+           case Qux2 =>
+             qux2
+        end match
+   ).quux
 <<< redundant block within block, outer semicolon-terminated
 rewrite {
   rules = [RedundantBraces]


### PR DESCRIPTION
With our rewrite rules, end markers can be added later and hence cannot be consulted at this point. Also, turns out the fix in #4171 was to add the match on NewAnonymous and not the end marker. Helps with #4133.