### PR TITLE
FormatOps: opt-braces `catch` uses newlines.source

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2133,7 +2133,8 @@ class FormatOps(
           val x = t.catchp
           val nlOnly = x match {
             // to avoid next expression being interpreted as body
-            case head :: Nil => isEmptyTree(head.body) && t.finallyp.isEmpty
+            case head :: Nil => shouldBreakInOptionalBraces(ft, nft) ||
+              t.finallyp.isEmpty && isEmptyTree(head.body)
             case _ => true
           }
           WithStats(ft, nft, x.headOption, x.last, Some(t), nlOnly = nlOnly)


### PR DESCRIPTION
Helps with #4133.