### PR TITLE
Router: modify select-like detection for comments

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -203,6 +203,10 @@ class FormatTokens(leftTok2tok: Map[TokenHash, Int])(val arr: Array[FormatToken]
     prevNonComment(prev(curr))
 
   @inline
+  final def prevBeforeNonComment(curr: FormatToken): FormatToken =
+    prev(prevNonComment(curr))
+
+  @inline
   final def prevNonCommentSameLineBefore(curr: FormatToken): FormatToken =
     prevNonCommentSameLine(prev(curr))
 

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -6328,7 +6328,58 @@ object a {
     // c2
     .foo(bar, baz)
 }
-<<<  try with match expr
+<<< comment in select chain, after dot 1
+object a {
+  foo.
+    // c2
+    bar(baz).foo(bar, baz)
+  foo. // c1
+    // c2
+    bar(baz).foo(bar, baz)
+  foo.bar(baz) // c1
+    . // c2
+    foo(bar, baz)
+}
+>>>
+object a {
+  foo
+    .
+      // c2
+    bar(baz)
+    .foo(bar, baz)
+  foo
+    . // c1
+      // c2
+    bar(baz)
+    .foo(bar, baz)
+  foo
+    .bar(baz) // c1
+    . // c2
+    foo(bar, baz)
+}
+<<< comment in select chain, after dot 2
+object a {
+  lazy val `scala3-sbt-bridge` = project.in(file("sbt-bridge/src")).
+    // We cannot depend on any bootstrapped project to compile the bridge, since the
+    // bridge is needed to compile these projects.
+    dependsOn(`scala3-compiler` % Provided).
+    settings(commonJavaSettings).
+    settings(foo)
+}
+>>>
+object a {
+  lazy val `scala3-sbt-bridge` = project
+    .in(file("sbt-bridge/src"))
+    .
+    // We cannot depend on any bootstrapped project to compile the bridge, since the
+    // bridge is needed to compile these projects.
+    dependsOn(
+      `scala3-compiler` % Provided
+    )
+    .settings(commonJavaSettings)
+    .settings(foo)
+}
+<<< try with match expr
 object a {
   try ta match {
     case Success(a) => bind(a); case Failure(e) => recover(e)

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -5868,7 +5868,54 @@ object a {
     // c2
     .foo(bar, baz)
 }
-<<<  try with match expr
+<<< comment in select chain, after dot 1
+object a {
+  foo.
+    // c2
+    bar(baz).foo(bar, baz)
+  foo. // c1
+    // c2
+    bar(baz).foo(bar, baz)
+  foo.bar(baz) // c1
+    . // c2
+    foo(bar, baz)
+}
+>>>
+object a {
+  foo
+    .
+      // c2
+    bar(baz).foo(bar, baz)
+  foo
+    . // c1
+      // c2
+    bar(baz).foo(bar, baz)
+  foo.bar(baz) // c1
+    . // c2
+    foo(bar, baz)
+}
+<<< comment in select chain, after dot 2
+object a {
+  lazy val `scala3-sbt-bridge` = project.in(file("sbt-bridge/src")).
+    // We cannot depend on any bootstrapped project to compile the bridge, since the
+    // bridge is needed to compile these projects.
+    dependsOn(`scala3-compiler` % Provided).
+    settings(commonJavaSettings).
+    settings(foo)
+}
+>>>
+object a {
+  lazy val `scala3-sbt-bridge` = project
+    .in(file("sbt-bridge/src"))
+    .
+    // We cannot depend on any bootstrapped project to compile the bridge, since the
+    // bridge is needed to compile these projects.
+    dependsOn(
+      `scala3-compiler` % Provided
+    ).settings(commonJavaSettings)
+    .settings(foo)
+}
+<<< try with match expr
 object a {
   try ta match {
     case Success(a) => bind(a); case Failure(e) => recover(e)

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -6119,7 +6119,51 @@ object a {
     // c2
     .foo(bar, baz)
 }
-<<<  try with match expr
+<<< comment in select chain, after dot 1
+object a {
+  foo.
+    // c2
+    bar(baz).foo(bar, baz)
+  foo. // c1
+    // c2
+    bar(baz).foo(bar, baz)
+  foo.bar(baz) // c1
+    . // c2
+    foo(bar, baz)
+}
+>>>
+object a {
+  foo.
+    // c2
+  bar(baz).foo(bar, baz)
+  foo. // c1
+      // c2
+    bar(baz).foo(bar, baz)
+  foo.bar(baz) // c1
+    . // c2
+    foo(bar, baz)
+}
+<<< comment in select chain, after dot 2
+object a {
+  lazy val `scala3-sbt-bridge` = project.in(file("sbt-bridge/src")).
+    // We cannot depend on any bootstrapped project to compile the bridge, since the
+    // bridge is needed to compile these projects.
+    dependsOn(`scala3-compiler` % Provided).
+    settings(commonJavaSettings).
+    settings(foo)
+}
+>>>
+object a {
+  lazy val `scala3-sbt-bridge` =
+    project.in(file("sbt-bridge/src")).
+        // We cannot depend on any bootstrapped project to compile the bridge, since the
+        // bridge is needed to compile these projects.
+      dependsOn(
+        `scala3-compiler` % Provided
+      ).settings(commonJavaSettings)
+      .settings(foo)
+}
+<<< try with match expr
 object a {
   try ta match {
     case Success(a) => bind(a); case Failure(e) => recover(e)

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -6293,7 +6293,58 @@ object a {
     // c2
     .foo(bar, baz)
 }
-<<<  try with match expr
+<<< comment in select chain, after dot 1
+object a {
+  foo.
+    // c2
+    bar(baz).foo(bar, baz)
+  foo. // c1
+    // c2
+    bar(baz).foo(bar, baz)
+  foo.bar(baz) // c1
+    . // c2
+    foo(bar, baz)
+}
+>>>
+object a {
+  foo
+    .
+      // c2
+    bar(baz)
+    .foo(bar, baz)
+  foo
+    . // c1
+      // c2
+    bar(baz)
+    .foo(bar, baz)
+  foo
+    .bar(baz) // c1
+    . // c2
+    foo(bar, baz)
+}
+<<< comment in select chain, after dot 2
+object a {
+  lazy val `scala3-sbt-bridge` = project.in(file("sbt-bridge/src")).
+    // We cannot depend on any bootstrapped project to compile the bridge, since the
+    // bridge is needed to compile these projects.
+    dependsOn(`scala3-compiler` % Provided).
+    settings(commonJavaSettings).
+    settings(foo)
+}
+>>>
+object a {
+  lazy val `scala3-sbt-bridge` = project
+    .in(file("sbt-bridge/src"))
+    .
+    // We cannot depend on any bootstrapped project to compile the bridge, since the
+    // bridge is needed to compile these projects.
+    dependsOn(
+      `scala3-compiler` % Provided
+    )
+    .settings(commonJavaSettings)
+    .settings(foo)
+}
+<<< try with match expr
 object a {
   try ta match {
     case Success(a) => bind(a); case Failure(e) => recover(e)


### PR DESCRIPTION
Unfortunately, checking the owner of a comment is not reliable as the parser deals only with positions of non-trivial tokens. Let's instead simply look for the dot which separates components of a select. Helps with #4133.