### PR TITLE
Router: keep `then` NL cost at 1 even if no space

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2008,12 +2008,12 @@ class Router(formatOps: FormatOps) {
           Split(Newline, 1),
         )
       case FormatToken(_, _: T.KwThen | _: T.KwDo, _) =>
-        if (style.newlines.sourceIgnored || noBreak()) Seq(
-          Split(Space, 0)
+        val okSpace = style.newlines.sourceIgnored || noBreak()
+        Seq(
+          Split(!okSpace, 0)(Space)
             .withOptimalToken(nextNonCommentSameLineAfter(ft).left),
           Split(Newline, 1),
         )
-        else Seq(Split(Newline, 0))
       // Last else branch
       case FormatToken(_: T.KwElse, _, _) if (leftOwner match {
             case t: Term.If => t.elsep match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -263,6 +263,8 @@ case class Split(
   def withIndentOpt(indent: => Option[Indent]): Split =
     withMod(modExt.withIndentOpt(indent))
 
+  def withIndents(indents: Indent*): Split = withMod(modExt.withIndents(indents))
+
   def withIndents(indents: Seq[Indent], ignore: Boolean = false): Split =
     withMod(modExt.withIndents(indents), ignore)
 

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -95,7 +95,20 @@ extension [A](
    def add2(b: A) = a + b
 
    def add3(b: A) = a + b
-<<< if(cond) indentation 
+<<< #4133 if cond overflow before then
+object a:
+   if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using         gadtCtx)    then {
+     // c1
+   }
+>>>
+object a:
+   if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using
+        gadtCtx
+      )
+   then {
+     // c1
+   }
+<<< if(cond) indentation
 trait A:
   val cond =
     if (true)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -96,7 +96,20 @@ extension [A](
    def add2(b: A) = a + b
 
    def add3(b: A) = a + b
-<<< if(cond) indentation 
+<<< #4133 if cond overflow before then
+object a:
+   if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using         gadtCtx)    then {
+     // c1
+   }
+>>>
+object a:
+   if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using
+        gadtCtx
+      )
+   then {
+     // c1
+   }
+<<< if(cond) indentation
 trait A:
   val cond =
     if (true)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -111,7 +111,7 @@ Idempotency violated
     if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using
 -        gadtCtx
 -      )
-+      gadtCtx)
++        gadtCtx)
     then {
 <<< if(cond) indentation
 trait A:

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -106,13 +106,12 @@ object a:
      // c1
    }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-    if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using
--        gadtCtx
--      )
-+        gadtCtx)
-    then {
+object a:
+   if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using
+        gadtCtx)
+   then {
+     // c1
+   }
 <<< if(cond) indentation
 trait A:
   val cond =

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -100,7 +100,20 @@ extension [A](a: Map[
    def add2(b: A) = a + b
 
    def add3(b: A) = a + b
-<<< if(cond) indentation 
+<<< #4133 if cond overflow before then
+object a:
+   if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using         gadtCtx)    then {
+     // c1
+   }
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+    if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using
+-        gadtCtx
+-      )
++      gadtCtx)
+    then {
+<<< if(cond) indentation
 trait A:
   val cond =
     if (true)

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -96,7 +96,20 @@ extension [A](
    def add2(b: A) = a + b
 
    def add3(b: A) = a + b
-<<< if(cond) indentation 
+<<< #4133 if cond overflow before then
+object a:
+   if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using         gadtCtx)    then {
+     // c1
+   }
+>>>
+object a:
+   if reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using
+        gadtCtx
+      )
+   then {
+     // c1
+   }
+<<< if(cond) indentation
 trait A:
   val cond =
     if (true)


### PR DESCRIPTION
Helps with #4133.