### PR TITLE
FormatOps: move `isJustBeforeTree` to FormatTokens

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -165,7 +165,7 @@ class FormatOps(
   final def isInfixRhs(ft: FormatToken): Boolean = {
     val tree = ft.meta.rightOwner
     @inline
-    def checkToken = tokenJustBeforeOpt(tree).contains(ft)
+    def checkToken = isJustBeforeTree(ft)(tree)
     tree.parent.exists {
       case ia: Member.Infix => (ia.op eq tree) || (ia.arg eq tree) &&
         (ft.right.is[T.LeftParen] || checkToken)
@@ -178,7 +178,7 @@ class FormatOps(
   final def startsNewBlockOnRight(ft: FormatToken): Boolean =
     ft.meta.rightOwner match {
       case _: Member.ArgClause => false
-      case t => tokenBeforeOpt(t).contains(ft)
+      case t => isJustBeforeTree(ft)(t)
     }
 
   /** js.native is very special in Scala.js.
@@ -2369,11 +2369,8 @@ class FormatOps(
     private def isTreeUsingOptionalBraces(tree: Tree): Boolean =
       !isTreeSingleExpr(tree) && !tokenBefore(tree).left.is[T.LeftBrace]
 
-    private def isJustBeforeTree(ft: FormatToken)(tree: Tree): Boolean =
-      tokenJustBeforeOpt(tree).contains(ft)
-
     private def isJustBeforeTrees(ft: FormatToken)(trees: Seq[Tree]): Boolean =
-      tokenJustBeforeOpt(trees).contains(ft)
+      trees.headOption.exists(isJustBeforeTree(ft))
 
     private def isJustBeforeExprs(ft: FormatToken)(
         tree: Tree.WithExprs,
@@ -2464,7 +2461,7 @@ class FormatOps(
 
     private object BlockImpl extends Factory {
       def getBlocks(ft: FormatToken, nft: FormatToken, all: Boolean): Result = {
-        def ok(stat: Tree): Boolean = tokenJustBeforeOpt(stat).contains(nft)
+        def ok(stat: Tree): Boolean = isJustBeforeTree(nft)(stat)
         val leftOwner = ft.meta.leftOwner
         findTreeWithParentSimple(nft.meta.rightOwner)(_ eq leftOwner) match {
           case Some(t: Term.Block) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -309,6 +309,15 @@ class FormatTokens(leftTok2tok: Map[TokenHash, Int])(val arr: Array[FormatToken]
   def tokenJustBeforeOpt(trees: Seq[Tree]): Option[FormatToken] = trees
     .headOption.flatMap(tokenJustBeforeOpt)
 
+  def isTokenHeadOf(tok: => Token, tree: Tree): Boolean =
+    getHeadOpt(tree) match {
+      case None => false
+      case Some(x) => x.left eq tok
+    }
+
+  def isJustBeforeTree(ft: FormatToken)(tree: Tree): Boolean =
+    isTokenHeadOf(ft.right, tree)
+
   /* the following methods return the last format token such that
    * its `left` is before the parameter and is not a comment */
   @inline


### PR DESCRIPTION
Helps with #4133.