### PR TITLE
FormatOps: don't force break before right paren

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -11,9 +11,12 @@ case class Decision(formatToken: FormatToken, splits: Seq[Split]) {
 
   @inline
   def onlyNewlinesWithFallback(default: => Split): Seq[Split] = Decision
-    .onlyNewlinesWithFallback(splits, default)
+    .onlyNewlinesWithFallback(splits, Seq(default))
 
   def onlyNewlinesWithoutFallback: Seq[Split] = onlyNewlineSplits
+
+  def onlyNewlinesIfAvailable: Seq[Split] = Decision
+    .onlyNewlinesWithFallback(splits, splits)
 
   @inline
   private def onlyNewlineSplits: Seq[Split] = Decision.onlyNewlineSplits(splits)
@@ -34,9 +37,9 @@ object Decision {
   def filterNewlineSplits(s: Seq[Split], isNL: Boolean): Seq[Split] = s
     .filter(_.isNL == isNL)
 
-  def onlyNewlinesWithFallback(s: Seq[Split], fb: => Split): Seq[Split] = {
+  def onlyNewlinesWithFallback(s: Seq[Split], fb: => Seq[Split]): Seq[Split] = {
     val filtered = onlyNewlineSplits(s)
-    if (filtered.nonEmpty) filtered else Seq(fb)
+    if (filtered.nonEmpty) filtered else fb
   }
 
 }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantParens.stat
@@ -555,16 +555,13 @@ object a {
 object a {
   val b = c + (d.match
     case true  => true
-    case false => false
-  )
+    case false => false)
   val b = c + (d.match
     case true  => true
-    case false => false
-  ) + e
+    case false => false) + e
   val b = c + (d match
     case true  => true
-    case false => false
-  )
+    case false => false)
 }
 <<< #2194 5 unary
 object a {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -6661,6 +6661,82 @@ object a:
            qux // c2
         end baz
      )(quux)
+<<< scala.js tucked close paren after optional braces region, dangling
+binPack.preset = always
+danglingParentheses.preset = true
+runner.optimizer {
+  forceConfigStyleMinSpan = 500
+  forceConfigStyleMinArgCount = 5
+}
+===
+object a:
+    def handleNewLine(lastToken: Token) =
+      if indentIsSignificant then
+            currentRegion match
+              case r =>
+                handleNewIndentWidth(r.enclosing, ir =>
+                  if next.token == DOT
+                  then
+                    ir.otherIndentWidths += nextWidth
+                  else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
+>>>
+object a:
+   def handleNewLine(lastToken: Token) =
+     if indentIsSignificant then
+        currentRegion match
+           case r =>
+             handleNewIndentWidth(r.enclosing,
+               ir =>
+                 if next.token == DOT
+                 then ir.otherIndentWidths += nextWidth
+                 else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""
+                    )
+             )
+<<< scala.js tucked close paren after optional braces region, !dangling
+binPack.preset = always
+danglingParentheses.preset = false
+runner.optimizer {
+  forceConfigStyleMinSpan = 500
+  forceConfigStyleMinArgCount = 5
+}
+===
+object a:
+    def handleNewLine(lastToken: Token) =
+      if indentIsSignificant then
+            currentRegion match
+              case r =>
+                handleNewIndentWidth(r.enclosing, ir =>
+                  if next.token == DOT
+                  then
+                    ir.otherIndentWidths += nextWidth
+                  else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
+>>>
+BestFirstSearch:285 Failed to format
+UNABLE TO FORMAT,
+tok #67/69: [67] )∙): RightParen [678..679) [] RightParen [679..680)
+policies:
+  NA:[FormatOps:2285]>679d
+  (PNL+5:[Router:1227]@680d & tuckSJS:[FormatOps:2701]@680d)
+  NA:[FormatOps:2222]>680d
+  NA:[FormatOps:1900]>680d
+splits (before policy):
+  NoSplit:[Router:2432](cost=0, indents=[], NoPolicy)
+splits (after policy):
 <<< scala.js overflow within for-yield dangling
 binPack.preset = always
 danglingParentheses.preset = true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -1070,8 +1070,7 @@ object Foo:
           if a.someField.otherField
             .function()
             .exists(SomeObjectLongName.isTrue) =>
-        None
-   )
+        None)
 <<< #2425 partial function
 val f: String => String =
   case "horses" => "are neat"
@@ -6700,8 +6699,7 @@ object a:
                       em"""The start of this line does not match any of the previous indentation widths.
                           |Indentation width of current line : $nextWidth
                           |This falls between previous widths: ${ir.width} and $lw"""
-                    )
-             )
+                    ))
 <<< scala.js tucked close paren after optional braces region, !dangling
 binPack.preset = always
 danglingParentheses.preset = false
@@ -6726,17 +6724,21 @@ object a:
                           |Indentation width of current line : $nextWidth
                           |This falls between previous widths: ${ir.width} and $lw"""))
 >>>
-BestFirstSearch:285 Failed to format
-UNABLE TO FORMAT,
-tok #67/69: [67] )∙): RightParen [678..679) [] RightParen [679..680)
-policies:
-  NA:[FormatOps:2285]>679d
-  (PNL+5:[Router:1227]@680d & tuckSJS:[FormatOps:2701]@680d)
-  NA:[FormatOps:2222]>680d
-  NA:[FormatOps:1900]>680d
-splits (before policy):
-  NoSplit:[Router:2432](cost=0, indents=[], NoPolicy)
-splits (after policy):
+object a:
+   def handleNewLine(lastToken: Token) =
+     if indentIsSignificant then
+        currentRegion match
+           case r =>
+             handleNewIndentWidth(r.enclosing,
+               ir =>
+                 if next.token == DOT
+                 then ir.otherIndentWidths += nextWidth
+                 else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
 <<< scala.js overflow within for-yield dangling
 binPack.preset = always
 danglingParentheses.preset = true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -6393,6 +6393,85 @@ object a:
          qux // c2
       end baz
    )(quux)
+<<< scala.js tucked close paren after optional braces region, dangling
+binPack.preset = always
+danglingParentheses.preset = true
+runner.optimizer {
+  forceConfigStyleMinSpan = 500
+  forceConfigStyleMinArgCount = 5
+}
+===
+object a:
+    def handleNewLine(lastToken: Token) =
+      if indentIsSignificant then
+            currentRegion match
+              case r =>
+                handleNewIndentWidth(r.enclosing, ir =>
+                  if next.token == DOT
+                  then
+                    ir.otherIndentWidths += nextWidth
+                  else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
+>>>
+object a:
+   def handleNewLine(lastToken: Token) = if indentIsSignificant then
+      currentRegion match
+         case r => handleNewIndentWidth(
+             r.enclosing,
+             ir =>
+               if next.token == DOT then ir.otherIndentWidths += nextWidth
+               else
+                  val lw = lastWidth
+                  errorButContinue(
+                    em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir
+                        .width} and $lw"""
+                  )
+           )
+<<< scala.js tucked close paren after optional braces region, !dangling
+binPack.preset = always
+danglingParentheses.preset = false
+runner.optimizer {
+  forceConfigStyleMinSpan = 500
+  forceConfigStyleMinArgCount = 5
+}
+===
+object a:
+    def handleNewLine(lastToken: Token) =
+      if indentIsSignificant then
+            currentRegion match
+              case r =>
+                handleNewIndentWidth(r.enclosing, ir =>
+                  if next.token == DOT
+                  then
+                    ir.otherIndentWidths += nextWidth
+                  else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
+>>>
+object a:
+   def handleNewLine(lastToken: Token) = if indentIsSignificant then
+      currentRegion match
+         case r => handleNewIndentWidth(
+             r.enclosing,
+             ir =>
+               if next.token == DOT then ir.otherIndentWidths += nextWidth
+               else
+                  val lw = lastWidth
+                  errorButContinue(
+                    em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir
+                        .width} and $lw""")
+           )
 <<< scala.js overflow within for-yield dangling
 binPack.preset = always
 danglingParentheses.preset = true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -6470,8 +6470,7 @@ object a:
                     em"""The start of this line does not match any of the previous indentation widths.
                           |Indentation width of current line : $nextWidth
                           |This falls between previous widths: ${ir
-                        .width} and $lw""")
-           )
+                        .width} and $lw"""))
 <<< scala.js overflow within for-yield dangling
 binPack.preset = always
 danglingParentheses.preset = true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -1092,8 +1092,7 @@ object Foo:
           if a.someField.otherField.function().exists(
             SomeObjectLongName.isTrue
           ) =>
-        None
-   )
+        None)
 <<< #2425 partial function
 val f: String => String =
   case "horses" => "are neat"
@@ -6727,8 +6726,7 @@ object a:
                           |Indentation width of current line : $nextWidth
                           |This falls between previous widths: ${ir
                           .width} and $lw"""
-                    )
-             )
+                    ))
 <<< scala.js tucked close paren after optional braces region, !dangling
 binPack.preset = always
 danglingParentheses.preset = false
@@ -6753,18 +6751,23 @@ object a:
                           |Indentation width of current line : $nextWidth
                           |This falls between previous widths: ${ir.width} and $lw"""))
 >>>
-BestFirstSearch:285 Failed to format
-UNABLE TO FORMAT,
-tok #67/69: [67] )∙): RightParen [678..679) [] RightParen [679..680)
-policies:
-  NA:[FormatOps:2285]>679d
-  (PNL+5:[Router:1227]@680d & tuckSJS:[FormatOps:2701]@680d)
-  NA:[FormatOps:2222]>680d
-  PNL+1:[FormatOps:1484]@680d
-  NA:[FormatOps:1900]>680d
-splits (before policy):
-  NoSplit:[Router:2432](cost=0, indents=[], NoPolicy)
-splits (after policy):
+object a:
+   def handleNewLine(lastToken: Token) =
+     if indentIsSignificant then
+        currentRegion match
+           case r =>
+             handleNewIndentWidth(r.enclosing,
+               ir =>
+                 if next.token == DOT
+                 then
+                    ir.otherIndentWidths += nextWidth
+                 else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir
+                          .width} and $lw"""))
 <<< scala.js overflow within for-yield dangling
 binPack.preset = always
 danglingParentheses.preset = true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -6686,6 +6686,85 @@ object a:
            qux // c2
         end baz
      )(quux)
+<<< scala.js tucked close paren after optional braces region, dangling
+binPack.preset = always
+danglingParentheses.preset = true
+runner.optimizer {
+  forceConfigStyleMinSpan = 500
+  forceConfigStyleMinArgCount = 5
+}
+===
+object a:
+    def handleNewLine(lastToken: Token) =
+      if indentIsSignificant then
+            currentRegion match
+              case r =>
+                handleNewIndentWidth(r.enclosing, ir =>
+                  if next.token == DOT
+                  then
+                    ir.otherIndentWidths += nextWidth
+                  else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
+>>>
+object a:
+   def handleNewLine(lastToken: Token) =
+     if indentIsSignificant then
+        currentRegion match
+           case r =>
+             handleNewIndentWidth(r.enclosing,
+               ir =>
+                 if next.token == DOT
+                 then
+                    ir.otherIndentWidths += nextWidth
+                 else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir
+                          .width} and $lw"""
+                    )
+             )
+<<< scala.js tucked close paren after optional braces region, !dangling
+binPack.preset = always
+danglingParentheses.preset = false
+runner.optimizer {
+  forceConfigStyleMinSpan = 500
+  forceConfigStyleMinArgCount = 5
+}
+===
+object a:
+    def handleNewLine(lastToken: Token) =
+      if indentIsSignificant then
+            currentRegion match
+              case r =>
+                handleNewIndentWidth(r.enclosing, ir =>
+                  if next.token == DOT
+                  then
+                    ir.otherIndentWidths += nextWidth
+                  else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
+>>>
+BestFirstSearch:285 Failed to format
+UNABLE TO FORMAT,
+tok #67/69: [67] )∙): RightParen [678..679) [] RightParen [679..680)
+policies:
+  NA:[FormatOps:2285]>679d
+  (PNL+5:[Router:1227]@680d & tuckSJS:[FormatOps:2701]@680d)
+  NA:[FormatOps:2222]>680d
+  PNL+1:[FormatOps:1484]@680d
+  NA:[FormatOps:1900]>680d
+splits (before policy):
+  NoSplit:[Router:2432](cost=0, indents=[], NoPolicy)
+splits (after policy):
 <<< scala.js overflow within for-yield dangling
 binPack.preset = always
 danglingParentheses.preset = true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -6863,6 +6863,91 @@ object a:
              qux // c2
           end baz
      )(quux)
+<<< scala.js tucked close paren after optional braces region, dangling
+binPack.preset = always
+danglingParentheses.preset = true
+runner.optimizer {
+  forceConfigStyleMinSpan = 500
+  forceConfigStyleMinArgCount = 5
+}
+===
+object a:
+    def handleNewLine(lastToken: Token) =
+      if indentIsSignificant then
+            currentRegion match
+              case r =>
+                handleNewIndentWidth(r.enclosing, ir =>
+                  if next.token == DOT
+                  then
+                    ir.otherIndentWidths += nextWidth
+                  else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
+>>>
+object a:
+   def handleNewLine(lastToken: Token) =
+     if indentIsSignificant then
+        currentRegion match
+           case r =>
+             handleNewIndentWidth(
+               r.enclosing,
+               ir =>
+                 if next.token == DOT then
+                    ir.otherIndentWidths += nextWidth
+                 else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir
+                          .width} and $lw"""
+                    )
+             )
+<<< scala.js tucked close paren after optional braces region, !dangling
+binPack.preset = always
+danglingParentheses.preset = false
+runner.optimizer {
+  forceConfigStyleMinSpan = 500
+  forceConfigStyleMinArgCount = 5
+}
+===
+object a:
+    def handleNewLine(lastToken: Token) =
+      if indentIsSignificant then
+            currentRegion match
+              case r =>
+                handleNewIndentWidth(r.enclosing, ir =>
+                  if next.token == DOT
+                  then
+                    ir.otherIndentWidths += nextWidth
+                  else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir.width} and $lw"""))
+>>>
+object a:
+   def handleNewLine(lastToken: Token) =
+     if indentIsSignificant then
+        currentRegion match
+           case r =>
+             handleNewIndentWidth(
+               r.enclosing,
+               ir =>
+                 if next.token == DOT then
+                    ir.otherIndentWidths += nextWidth
+                 else
+                    val lw = lastWidth
+                    errorButContinue(
+                      em"""The start of this line does not match any of the previous indentation widths.
+                          |Indentation width of current line : $nextWidth
+                          |This falls between previous widths: ${ir
+                          .width} and $lw""")
+             )
 <<< scala.js overflow within for-yield dangling
 binPack.preset = always
 danglingParentheses.preset = true

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -6946,8 +6946,7 @@ object a:
                       em"""The start of this line does not match any of the previous indentation widths.
                           |Indentation width of current line : $nextWidth
                           |This falls between previous widths: ${ir
-                          .width} and $lw""")
-             )
+                          .width} and $lw"""))
 <<< scala.js overflow within for-yield dangling
 binPack.preset = always
 danglingParentheses.preset = true


### PR DESCRIPTION
Sometimes it will have to be tucked, and a conflicting policy will also remove all newlines, leading to no available splits remaining. Helps with #4133.