### PR TITLE
State: add lineId and use it in state ordering

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -21,7 +21,7 @@ private class BestFirstSearch private (range: Set[Range])(implicit
   import TreeOps._
   import formatOps._
 
-  implicit val stateOrdering: Ordering[State] = State.Ordering
+  implicit val stateOrdering: Ordering[State] = State.Ordering.get(initStyle)
 
   /** Precomputed table of splits for each token.
     */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -23,8 +23,8 @@ object LoggerOps {
 
   def log(s: State): String = {
     val policies = s.policy.policies.map(_.toString).mkString("P[", ",", "]")
-    s"d=${s.depth} w=${s.cost} i=${s.indentation} col=${s
-        .column}; $policies; s=${log(s.split)}"
+    s"d=${s.depth} w=${s.cost} i=${s.indentation} col=${s.column} #nl=${s
+        .lineId}; $policies; s=${log(s.split)}"
   }
   def log(split: Split): String = s"$split"
 

--- a/scalafmt-tests/src/test/resources/scalajs/Apply.stat
+++ b/scalafmt-tests/src/test/resources/scalajs/Apply.stat
@@ -1374,8 +1374,7 @@ object a {
     prevArgsCount => varDefs.take(prevArgsCount).toList.map(_.ref))
   val rhs = genScalaArg(sym, index, formalArgsRegistry, param, static)(
     prevArgsCount => varDefs.take(prevArgsCount).toList.map(_.ref))
-  val rhs = genScalaArg(prevArgsCount =>
-    varDefs.take(prevArgsCount).toList.map(_.ref))(
+  val rhs = genScalaArg(prevArgsCount => varDefs.take(prevArgsCount).toList.map(_.ref))(
     sym, index, formalArgsRegistry, param, static, captures = Nil)
 }
 <<< don't break after equals if bp, !overflow


### PR DESCRIPTION
In addition to prioritizing states by cost and depth, let's also prefer optionally states with fewer lines, using them for fold and keep values of newlines.source. Helps with #4133.