### PR TITLE
Router: allow breaks in any double-quote strings

### DIFF
--- a/scalafmt-tests/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/src/test/resources/default/Apply.stat
@@ -1503,8 +1503,23 @@ object a {
       ) // Very long comment here because I need to have more than 80 characters
     )
 }
-<<< #2257 oveflow with interpolation
+<<< #2257 oveflow with interpolation, long
 maxColumn = 110
+newlines.avoidForSimpleOverflow = [tooLong,punct]
+===
+val request = Request(
+  applicationid = appId.some,
+  description = s"Very ${call.session.callType.description} loooong closed with caaare request ${param(call.countt)} ${AnotherParam.code}",
+  siteinfo = None,
+)
+>>>
+val request = Request(
+    applicationid = appId.some,
+    description = s"Very ${call.session.callType.description} loooong closed with caaare request ${param(call.countt)} ${AnotherParam.code}",
+    siteinfo = None
+)
+<<< #2257 oveflow with interpolation, short
+maxColumn = 90
 newlines.avoidForSimpleOverflow = [tooLong,punct]
 ===
 val request = Request(

--- a/scalafmt-tests/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/src/test/resources/newlines/source.source
@@ -14,7 +14,10 @@ package a.b.c
 import a.b.c
 object a {
   val a =
-    s"${a.b.c.d}"
+    s"${a
+        .b
+        .c
+        .d}"
   val b =
     foo[
       a.b.c.d.e

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -9074,3 +9074,64 @@ object a {
       )
   )
 }
+<<< #4187 dangling
+optIn.configStyleArguments = false
+danglingParentheses.preset = true
+maxColumn = 98
+===
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+>>>
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}"
+  )
+}
+<<< #4187 !dangling
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+maxColumn = 98
+===
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+>>>
+object a {
+  logWarning(log"Session plan cache is disabled due to non-positive cache size." +
+    log" Current value of " +
+    log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+<<< #4133 overflow select within interpolate
+object a {
+  def lub(tp1: Type, tp2: Type, canConstrain: Boolean = false, isSoft: Boolean = true): Type = /*>|>*/ trace(s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)", subtyping, show = true) /*<|<*/ {
+    // foo
+  }
+}
+>>>
+object a {
+  def lub(
+      tp1: Type,
+      tp2: Type,
+      canConstrain: Boolean = false,
+      isSoft: Boolean = true
+  ): Type = /*>|>*/ trace(
+    s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+    subtyping,
+    show = true
+  ) /*<|<*/ {
+    // foo
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -9092,7 +9092,10 @@ object a {
   logWarning(
     log"Session plan cache is disabled due to non-positive cache size." +
       log" Current value of " +
-      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}"
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE)
+        )}"
   )
 }
 <<< #4187 !dangling
@@ -9110,9 +9113,12 @@ object a {
 }
 >>>
 object a {
-  logWarning(log"Session plan cache is disabled due to non-positive cache size." +
-    log" Current value of " +
-    log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
 }
 <<< #4133 overflow select within interpolate
 object a {

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -8449,3 +8449,64 @@ object a {
     )
   )
 }
+<<< #4187 dangling
+optIn.configStyleArguments = false
+danglingParentheses.preset = true
+maxColumn = 98
+===
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+>>>
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}"
+  )
+}
+<<< #4187 !dangling
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+maxColumn = 98
+===
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+>>>
+object a {
+  logWarning(log"Session plan cache is disabled due to non-positive cache size." +
+    log" Current value of " +
+    log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+<<< #4133 overflow select within interpolate
+object a {
+  def lub(tp1: Type, tp2: Type, canConstrain: Boolean = false, isSoft: Boolean = true): Type = /*>|>*/ trace(s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)", subtyping, show = true) /*<|<*/ {
+    // foo
+  }
+}
+>>>
+object a {
+  def lub(
+      tp1: Type,
+      tp2: Type,
+      canConstrain: Boolean = false,
+      isSoft: Boolean = true
+  ): Type = /*>|>*/ trace(
+    s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+    subtyping,
+    show = true
+  ) /*<|<*/ {
+    // foo
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -8466,8 +8466,13 @@ object a {
 object a {
   logWarning(
     log"Session plan cache is disabled due to non-positive cache size." +
-      log" Current value of " +
-      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}"
+      log" Current value of " + log"'${MDC(
+          LogKeys.CONFIG,
+          Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key
+        )}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE)
+        )}"
   )
 }
 <<< #4187 !dangling
@@ -8485,9 +8490,13 @@ object a {
 }
 >>>
 object a {
-  logWarning(log"Session plan cache is disabled due to non-positive cache size." +
-    log" Current value of " +
-    log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " + log"'${MDC(
+          LogKeys.CONFIG,
+          Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
 }
 <<< #4133 overflow select within interpolate
 object a {
@@ -8503,7 +8512,8 @@ object a {
       canConstrain: Boolean = false,
       isSoft: Boolean = true
   ): Type = /*>|>*/ trace(
-    s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+    s"lub(${tp1.show}, ${tp2
+        .show}, canConstrain=$canConstrain, isSoft=$isSoft)",
     subtyping,
     show = true
   ) /*<|<*/ {

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -8879,3 +8879,70 @@ object a {
     )
   )
 }
+<<< #4187 dangling
+optIn.configStyleArguments = false
+danglingParentheses.preset = true
+maxColumn = 98
+===
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+>>>
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE)
+        )}"
+  )
+}
+<<< #4187 !dangling
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+maxColumn = 98
+===
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+>>>
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+<<< #4133 overflow select within interpolate
+object a {
+  def lub(tp1: Type, tp2: Type, canConstrain: Boolean = false, isSoft: Boolean = true): Type = /*>|>*/ trace(s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)", subtyping, show = true) /*<|<*/ {
+    // foo
+  }
+}
+>>>
+object a {
+  def lub(
+      tp1: Type,
+      tp2: Type,
+      canConstrain: Boolean = false,
+      isSoft: Boolean = true
+  ): Type = /*>|>*/ trace(
+    s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+    subtyping,
+    show = true
+  ) /*<|<*/ {
+    // foo
+  }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -9179,7 +9179,10 @@ object a {
   logWarning(
     log"Session plan cache is disabled due to non-positive cache size." +
       log" Current value of " +
-      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}"
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE)
+        )}"
   )
 }
 <<< #4187 !dangling
@@ -9197,9 +9200,12 @@ object a {
 }
 >>>
 object a {
-  logWarning(log"Session plan cache is disabled due to non-positive cache size." +
-    log" Current value of " +
-    log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
 }
 <<< #4133 overflow select within interpolate
 object a {
@@ -9216,7 +9222,8 @@ object a {
       isSoft: Boolean = true
   ): Type = /*>|>*/
     trace(
-      s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+      s"lub(${tp1.show}, ${tp2
+          .show}, canConstrain=$canConstrain, isSoft=$isSoft)",
       subtyping,
       show = true
     ) /*<|<*/ {

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -9161,3 +9161,65 @@ object a {
       )
   )
 }
+<<< #4187 dangling
+optIn.configStyleArguments = false
+danglingParentheses.preset = true
+maxColumn = 98
+===
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+>>>
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}"
+  )
+}
+<<< #4187 !dangling
+optIn.configStyleArguments = false
+danglingParentheses.preset = false
+maxColumn = 98
+===
+object a {
+  logWarning(
+    log"Session plan cache is disabled due to non-positive cache size." +
+      log" Current value of " +
+      log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(
+          LogKeys.CACHE_SIZE,
+          SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+>>>
+object a {
+  logWarning(log"Session plan cache is disabled due to non-positive cache size." +
+    log" Current value of " +
+    log"'${MDC(LogKeys.CONFIG, Connect.CONNECT_SESSION_PLAN_CACHE_SIZE.key)}' is ${MDC(LogKeys.CACHE_SIZE, SparkEnv.get.conf.get(Connect.CONNECT_SESSION_PLAN_CACHE_SIZE))}")
+}
+<<< #4133 overflow select within interpolate
+object a {
+  def lub(tp1: Type, tp2: Type, canConstrain: Boolean = false, isSoft: Boolean = true): Type = /*>|>*/ trace(s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)", subtyping, show = true) /*<|<*/ {
+    // foo
+  }
+}
+>>>
+object a {
+  def lub(
+      tp1: Type,
+      tp2: Type,
+      canConstrain: Boolean = false,
+      isSoft: Boolean = true
+  ): Type = /*>|>*/
+    trace(
+      s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+      subtyping,
+      show = true
+    ) /*<|<*/ {
+      // foo
+    }
+}

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces.stat
@@ -7238,3 +7238,22 @@ object a:
      .settings(
        moduleName := "scala-library"
      )
+<<< #4133 overflow select within interpolate
+object a:
+  def lub(tp1: Type, tp2: Type, canConstrain: Boolean = false, isSoft: Boolean = true): Type = /*>|>*/ trace(s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)", subtyping, show = true) /*<|<*/ {
+    // foo
+  }
+>>>
+object a:
+   def lub(
+       tp1: Type,
+       tp2: Type,
+       canConstrain: Boolean = false,
+       isSoft: Boolean = true
+   ): Type = /*>|>*/ trace(
+     s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+     subtyping,
+     show = true
+   ) /*<|<*/ {
+     // foo
+   }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -6971,3 +6971,22 @@ object a:
        dottyCompiler(Bootstrapped) %
          "provided; compile->runtime; test->test")
      .settings(moduleName := "scala-library")
+<<< #4133 overflow select within interpolate
+object a:
+  def lub(tp1: Type, tp2: Type, canConstrain: Boolean = false, isSoft: Boolean = true): Type = /*>|>*/ trace(s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)", subtyping, show = true) /*<|<*/ {
+    // foo
+  }
+>>>
+object a:
+   def lub(
+       tp1: Type,
+       tp2: Type,
+       canConstrain: Boolean = false,
+       isSoft: Boolean = true
+   ): Type = /*>|>*/ trace(
+     s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+     subtyping,
+     show = true
+   ) /*<|<*/ {
+     // foo
+   }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -6984,7 +6984,8 @@ object a:
        canConstrain: Boolean = false,
        isSoft: Boolean = true
    ): Type = /*>|>*/ trace(
-     s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+     s"lub(${tp1.show}, ${tp2
+         .show}, canConstrain=$canConstrain, isSoft=$isSoft)",
      subtyping,
      show = true
    ) /*<|<*/ {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7280,3 +7280,22 @@ object a:
      .settings(
        moduleName := "scala-library"
      )
+<<< #4133 overflow select within interpolate
+object a:
+  def lub(tp1: Type, tp2: Type, canConstrain: Boolean = false, isSoft: Boolean = true): Type = /*>|>*/ trace(s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)", subtyping, show = true) /*<|<*/ {
+    // foo
+  }
+>>>
+object a:
+   def lub(
+       tp1: Type,
+       tp2: Type,
+       canConstrain: Boolean = false,
+       isSoft: Boolean = true
+   ): Type = /*>|>*/ trace(
+     s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+     subtyping,
+     show = true
+   ) /*<|<*/ {
+     // foo
+   }

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7522,7 +7522,8 @@ object a:
        isSoft: Boolean = true
    ): Type = /*>|>*/
      trace(
-       s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+       s"lub(${tp1.show}, ${tp2
+           .show}, canConstrain=$canConstrain, isSoft=$isSoft)",
        subtyping,
        show = true
      ) /*<|<*/ {

--- a/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7508,3 +7508,23 @@ object a:
        dottyCompiler(Bootstrapped) %
          "provided; compile->runtime; test->test")
      .settings(moduleName := "scala-library")
+<<< #4133 overflow select within interpolate
+object a:
+  def lub(tp1: Type, tp2: Type, canConstrain: Boolean = false, isSoft: Boolean = true): Type = /*>|>*/ trace(s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)", subtyping, show = true) /*<|<*/ {
+    // foo
+  }
+>>>
+object a:
+   def lub(
+       tp1: Type,
+       tp2: Type,
+       canConstrain: Boolean = false,
+       isSoft: Boolean = true
+   ): Type = /*>|>*/
+     trace(
+       s"lub(${tp1.show}, ${tp2.show}, canConstrain=$canConstrain, isSoft=$isSoft)",
+       subtyping,
+       show = true
+     ) /*<|<*/ {
+       // foo
+     }


### PR DESCRIPTION
Previously, we would only allow that in triple-quote strings. However, for classic/keep try to avoid break if one wasn't present. Helps with #4133. Fixes #4187.
