### PR TITLE
FormatOps: fix extension formatting

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -2047,9 +2047,11 @@ class FormatOps(
             else Some(getSplits(blockTree, true)),
           )
         ft.meta.leftOwner match {
-          case ParamClauseParent(t: Defn.ExtensionGroup)
-              if isBlockStart(t.body, nft) =>
-            createImpl(t, t.body)(Some(getSplitsMaybeBlock(nft, t.body)))
+          case ParamClauseParent(pp: Defn.ExtensionGroup)
+              if !nft.right.is[T.LeftBrace] && (tokenBefore(pp.body) eq ft) =>
+            createImpl(pp, pp.body)(Some(
+              getSplits(pp.body, shouldBreakInOptionalBraces(ft, nft)),
+            ))
           case t: Term.If if !nft.right.is[T.KwThen] && {
                 !isTreeSingleExpr(t.thenp) ||
                 getLastNotTrailingCommentOpt(t.thenp).exists(_.isLeft) ||
@@ -2404,19 +2406,6 @@ class FormatOps(
 
     private def isTreeUsingOptionalBraces(tree: Tree): Boolean =
       !isTreeSingleExpr(tree) && !tokenBefore(tree).left.is[T.LeftBrace]
-
-    private def isJustBeforeTrees(ft: FormatToken)(trees: Seq[Tree]): Boolean =
-      trees.headOption.exists(isJustBeforeTree(ft))
-
-    private def isJustBeforeExprs(ft: FormatToken)(
-        tree: Tree.WithExprs,
-    ): Boolean = isJustBeforeTrees(ft)(tree.exprs)
-
-    private def isBlockStart(tree: Tree, ft: FormatToken): Boolean =
-      tree match {
-        case t: Term.Block => isJustBeforeExprs(ft)(t)
-        case _ => false
-      }
 
     @inline
     private def treeLast(tree: Tree): Option[FormatToken] = getLastOpt(tree)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -575,20 +575,10 @@ class Router(formatOps: FormatOps) {
       case FormatToken(
             _: T.RightParen,
             _,
-            ParamClauseParentLeft(extGroup: Defn.ExtensionGroup),
-          ) if !LeftParenOrBrace(nextNonComment(ft).right) =>
-        if (dialect.allowSignificantIndentation) {
-          val expireToken = getLastToken(extGroup)
-          def nlSplit(cost: Int = 0)(implicit fileLine: FileLine) =
-            Split(Newline2x(ft), cost)
-              .withIndent(style.indent.getSignificant, expireToken, After)
-          style.newlines.source match {
-            case Newlines.unfold => Seq(nlSplit())
-            case Newlines.keep if hasBreak() => Seq(nlSplit())
-            case _ =>
-              Seq(Split(Space, 0).withSingleLine(expireToken), nlSplit(cost = 1))
-          }
-        } else Seq(Split(Space, 0))
+            ParamClauseParentLeft(_: Defn.ExtensionGroup),
+          )
+          if !dialect.allowSignificantIndentation &&
+            !LeftParenOrBrace(nextNonComment(ft).right) => Seq(Split(Space, 0))
 
       case FormatToken(left, right, StartsStatementRight(_)) =>
         val annoRight = right.is[T.At]

--- a/scalafmt-tests/src/test/resources/scala3/Extension.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Extension.stat
@@ -338,3 +338,17 @@ extension (s: String)
   def foo(): Unit = ???
 >>>
 extension(s: String) def foo(): Unit = ???
+<<< #4133 with removing optional braces
+rewrite.scala3.removeOptionalBraces = yes
+===
+object a:
+  extension (sv: String) {
+    def asVersion: Version = Version(sv)
+  }
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a:
+-  extension (sv: String) def asVersion: Version = Version(sv)
++  extension (sv: String)
++    def asVersion: Version = Version(sv)

--- a/scalafmt-tests/src/test/resources/scala3/Extension.stat
+++ b/scalafmt-tests/src/test/resources/scala3/Extension.stat
@@ -346,9 +346,5 @@ object a:
     def asVersion: Version = Version(sv)
   }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a:
--  extension (sv: String) def asVersion: Version = Version(sv)
-+  extension (sv: String)
-+    def asVersion: Version = Version(sv)
+object a:
+  extension (sv: String) def asVersion: Version = Version(sv)


### PR DESCRIPTION
Move all significant-indentation formatting to OptionalBraces, and keep only non-significant-indentation case in Router. Helps with #4133.