### PR TITLE
FormatOps: in CtrlBody, be consistent about src NL

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1701,18 +1701,17 @@ class FormatOps(
     ): Seq[Split] = checkComment(nlSplitFunc) { x =>
       def getFolded(isKeep: Boolean) =
         foldedNonComment(body, nlSplitFunc, isKeep = isKeep, spaceIndents)
+      def getFoldedKeepNLOnly = getFolded(true).filter(_.isNL)
       style.newlines.getBeforeMultiline match {
         case Newlines.fold => getFolded(false)
         case Newlines.unfold =>
           unfoldedNonComment(body, nlSplitFunc, spaceIndents, false)
         case Newlines.classic if x.noBreak =>
           Option(classicNoBreakFunc).fold(getFolded(true)) { func =>
-            val spcSplit = func.forThisLine
-            val nlSplit = nlSplitFunc(spcSplit.getCost(_ + 1, 0)).forThisLine
-            Seq(spcSplit, nlSplit)
+            func.forThisLine +: getFoldedKeepNLOnly
           }
         case Newlines.keep if x.noBreak => getFolded(true)
-        case _ => getFolded(true).filter(_.isNL) // keep/classic with break
+        case _ => getFoldedKeepNLOnly // keep/classic with break
       }
     }
 

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -9166,15 +9166,16 @@ object a {
     catch { case _: RuntimeException => false }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-       in.readYesOrNo(
--        explain + replayQuestionMessage, {
--          echo("\nYou must enter y or n."); fn()
--        }
-+        explain + replayQuestionMessage,
-+        { echo("\nYou must enter y or n."); fn() }
-       )
+object a {
+  def fn(): Boolean =
+    try
+      in.readYesOrNo(
+        explain + replayQuestionMessage, {
+          echo("\nYou must enter y or n."); fn()
+        }
+      )
+    catch { case _: RuntimeException => false }
+}
 <<< #4133 control body with complex apply/select/try 2
 maxColumn = 70
 ===
@@ -9184,12 +9185,14 @@ object a {
     catch { case _: IllegalArgumentException => }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-         .map(alt =>
--          formalTypes(alt.info.paramTypes, argslen)
--            .map(ft => (ft, alt))
-+          formalTypes(alt.info.paramTypes, argslen).map(ft =>
-+            (ft, alt)
-+          )
-         )
+object a {
+  val altArgPts =
+    try
+      alts
+        .map(alt =>
+          formalTypes(alt.info.paramTypes, argslen)
+            .map(ft => (ft, alt))
+        )
+        .transpose
+    catch { case _: IllegalArgumentException => }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_classic.stat
@@ -9157,3 +9157,39 @@ object a {
       ()
   }
 }
+<<< #4133 control body with complex apply/select/try 1
+maxColumn = 70
+===
+object a {
+  def fn(): Boolean =
+    try in.readYesOrNo(explain + replayQuestionMessage, { echo("\nYou must enter y or n.") ; fn() })
+    catch { case _: RuntimeException => false }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+       in.readYesOrNo(
+-        explain + replayQuestionMessage, {
+-          echo("\nYou must enter y or n."); fn()
+-        }
++        explain + replayQuestionMessage,
++        { echo("\nYou must enter y or n."); fn() }
+       )
+<<< #4133 control body with complex apply/select/try 2
+maxColumn = 70
+===
+object a {
+  val altArgPts =
+    try alts.map(alt => formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))).transpose
+    catch { case _: IllegalArgumentException => }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+         .map(alt =>
+-          formalTypes(alt.info.paramTypes, argslen)
+-            .map(ft => (ft, alt))
++          formalTypes(alt.info.paramTypes, argslen).map(ft =>
++            (ft, alt)
++          )
+         )

--- a/scalafmt-tests/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_fold.stat
@@ -8535,3 +8535,36 @@ object a {
         nme.CONSTRUCTOR => ()
   }
 }
+<<< #4133 control body with complex apply/select/try 1
+maxColumn = 70
+===
+object a {
+  def fn(): Boolean =
+    try in.readYesOrNo(explain + replayQuestionMessage, { echo("\nYou must enter y or n.") ; fn() })
+    catch { case _: RuntimeException => false }
+}
+>>>
+object a {
+  def fn(): Boolean =
+    try in.readYesOrNo(
+        explain + replayQuestionMessage,
+        { echo("\nYou must enter y or n."); fn() }
+      )
+    catch { case _: RuntimeException => false }
+}
+<<< #4133 control body with complex apply/select/try 2
+maxColumn = 70
+===
+object a {
+  val altArgPts =
+    try alts.map(alt => formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))).transpose
+    catch { case _: IllegalArgumentException => }
+}
+>>>
+object a {
+  val altArgPts =
+    try alts.map(alt =>
+        formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))
+      ).transpose
+    catch { case _: IllegalArgumentException => }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_keep.stat
@@ -8961,3 +8961,36 @@ object a {
           .ANON_FUN_NAME | nme.CONSTRUCTOR => ()
   }
 }
+<<< #4133 control body with complex apply/select/try 1
+maxColumn = 70
+===
+object a {
+  def fn(): Boolean =
+    try in.readYesOrNo(explain + replayQuestionMessage, { echo("\nYou must enter y or n.") ; fn() })
+    catch { case _: RuntimeException => false }
+}
+>>>
+object a {
+  def fn(): Boolean =
+    try in.readYesOrNo(
+        explain + replayQuestionMessage,
+        { echo("\nYou must enter y or n."); fn() }
+      )
+    catch { case _: RuntimeException => false }
+}
+<<< #4133 control body with complex apply/select/try 2
+maxColumn = 70
+===
+object a {
+  val altArgPts =
+    try alts.map(alt => formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))).transpose
+    catch { case _: IllegalArgumentException => }
+}
+>>>
+object a {
+  val altArgPts =
+    try alts.map(alt =>
+        formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))
+      ).transpose
+    catch { case _: IllegalArgumentException => }
+}

--- a/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/src/test/resources/newlines/source_unfold.stat
@@ -9247,3 +9247,48 @@ object a {
         ()
     }
 }
+<<< #4133 control body with complex apply/select/try 1
+maxColumn = 70
+===
+object a {
+  def fn(): Boolean =
+    try in.readYesOrNo(explain + replayQuestionMessage, { echo("\nYou must enter y or n.") ; fn() })
+    catch { case _: RuntimeException => false }
+}
+>>>
+object a {
+  def fn(): Boolean =
+    try in.readYesOrNo(
+        explain + replayQuestionMessage, {
+          echo("\nYou must enter y or n.");
+          fn()
+        }
+      )
+    catch {
+      case _: RuntimeException =>
+        false
+    }
+}
+<<< #4133 control body with complex apply/select/try 2
+maxColumn = 70
+===
+object a {
+  val altArgPts =
+    try alts.map(alt => formalTypes(alt.info.paramTypes, argslen).map(ft => (ft, alt))).transpose
+    catch { case _: IllegalArgumentException => }
+}
+>>>
+object a {
+  val altArgPts =
+    try
+      alts
+        .map(alt =>
+          formalTypes(alt.info.paramTypes, argslen).map(ft =>
+            (ft, alt)
+          )
+        )
+        .transpose
+    catch {
+      case _: IllegalArgumentException =>
+    }
+}


### PR DESCRIPTION
Currently, the rule when break was present results in NL-only splits but those splits are different than the NL splits which would have been used had the break been absent. Fixes non-idempotency. Helps with #4133.
