### PR TITLE
FormatOps: remove redundant check for LeftParen

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -185,8 +185,7 @@ class FormatOps(
       ft: FormatToken,
   )(implicit style: ScalafmtConfig): Boolean =
     (ft.meta.rightOwner match {
-      case _: Member.ArgClause => ft.right.is[T.LeftParen] &&
-        style.newlines.isBeforeOpenParenCallSite
+      case _: Member.ArgClause => style.newlines.isBeforeOpenParenCallSite
       case t => isJustBeforeTree(ft)(t)
     }) && notInfixRhs(ft, tokenIsChecked = true)
 


### PR DESCRIPTION
This method is invoked only for such cases anyway, as the name implies. Helps with #4133.