### PR TITLE
RedundantBraces: keep braces around Term.Xml

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -465,13 +465,15 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
   }
 
   private def innerOk(b: Term.Block)(s: Stat): Boolean = s match {
+    case _: Term.FunctionTerm | _: Term.Xml => false
     case t: Term.NewAnonymous =>
       // can't allow: new A with B .foo
       // can allow if: no ".foo", no "with B", or has braces
       !b.parent.exists(_.is[Term.Select]) ||
       t.templ.inits.lengthCompare(1) <= 0 || t.templ.stats.nonEmpty ||
       t.tokens.last.is[Token.RightBrace]
-    case tree => tree.is[Term] && tree.isNot[Term.FunctionTerm]
+    case _: Term => true
+    case _ => false
   }
 
   private def okToRemoveBlockWithinApply(b: Term.Block)(implicit

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
@@ -116,11 +116,18 @@ val content = {
     </body>
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   <body class={
--      tpl.kind + (if (tpl.isType) " type" else " value")
--    }>
-+    tpl.kind + (if (tpl.isType) " type" else " value")
-+  }>
-     </body>
+val content = {
+  val owner = {
+    <p id="owner">{
+      templatesToHtml(
+        tpl.inTemplate.toRoot.reverse.tail,
+        scala.xml.Text(".")
+      )
+    }</p>
+  }
+
+  <body class={
+    tpl.kind + (if (tpl.isType) " type" else " value")
+  }>
+    </body>
+}

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBracesStrInterpolation.stat
@@ -104,3 +104,23 @@ object Test {
 <testcase id={ id }/>
 >>>
 <testcase id={id}/>
+<<< braces around xml, followed by another xml
+maxColumn = 60
+===
+val content = {
+    val owner = {
+        <p id="owner">{ templatesToHtml(tpl.inTemplate.toRoot.reverse.tail, scala.xml.Text(".")) }</p>
+    }
+
+    <body class={ tpl.kind + (if (tpl.isType) " type" else " value") }>
+    </body>
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   <body class={
+-      tpl.kind + (if (tpl.isType) " type" else " value")
+-    }>
++    tpl.kind + (if (tpl.isType) " type" else " value")
++  }>
+     </body>


### PR DESCRIPTION
Otherwise, two adjacent but separate xml elements might get merged into one if the separating braces are removed. Helps with #4133.