### PR TITLE
Fix redundant braces around infix (top-level, and using `return`)

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1563,13 +1563,13 @@ class Router(formatOps: FormatOps) {
         }
 
       case FormatToken(_, _: T.Semicolon, _) => Seq(Split(NoSplit, 0))
-      case FormatToken(_: T.KwReturn, _, _) =>
+      case FormatToken(_: T.KwReturn, r, _) =>
         val mod =
           if (hasBlankLine) Newline2x
           else leftOwner match {
             case Term.Return(unit: Lit.Unit) if unit.tokens.isEmpty =>
-              // Always force blank line for Unit "return".
-              Newline
+              if (r.is[T.RightParen]) Space(style.spaces.inParentheses)
+              else Newline //  force blank line for Unit "return".
             case _ => Space
           }
         Seq(Split(mod, 0))

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1954,16 +1954,14 @@ object a {
   } 
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-     (this eq that) ||
--    (if (explainSwitch)
--       explain("<:", isSubType(_: Type, _: Type), this, that)
--     else isSubType(this, that))
-+      (if (explainSwitch)
-+         explain("<:", isSubType(_: Type, _: Type), this, that)
-+       else isSubType(this, that))
- }
+object a {
+  if (settings.areStatisticsEnabled) stat_<:<(that)
+  else
+    (this eq that) ||
+    (if (explainSwitch)
+       explain("<:", isSubType(_: Type, _: Type), this, that)
+     else isSubType(this, that))
+}
 <<< #4133 using `return` and complex interaction with RedundantParens and AvoidInfix
 maxColumn = 72
 rewrite.redundantBraces.maxLines = 100

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1940,3 +1940,44 @@ object a {
     // no need to call enter explicitly
   }
 }
+<<< #4133 removing braces preserves "top-level" infix designation
+maxColumn = 68
+rewrite.redundantBraces.maxLines = 100
+rewrite.redundantBraces.ifElseExpressions = yes
+===
+object a {
+  if (settings.areStatisticsEnabled) stat_<:<(that)
+  else {
+    (this eq that) ||
+    (if (explainSwitch) explain("<:", isSubType(_: Type, _: Type), this, that)
+     else isSubType(this, that))
+  } 
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+     (this eq that) ||
+-    (if (explainSwitch)
+-       explain("<:", isSubType(_: Type, _: Type), this, that)
+-     else isSubType(this, that))
++      (if (explainSwitch)
++         explain("<:", isSubType(_: Type, _: Type), this, that)
++       else isSubType(this, that))
+ }
+<<< #4133 using `return` and complex interaction with RedundantParens and AvoidInfix
+maxColumn = 72
+rewrite.redundantBraces.maxLines = 100
+rewrite.rules = [RedundantBraces, RedundantParens, AvoidInfix]
+===
+object a {
+  val sym    = tree.symbol orElse { return }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a {
+-  val sym = tree.symbol.orElse(
+-    return
+-  )
++  val sym = tree.symbol.orElse(return)
+ }

--- a/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/src/test/resources/rewrite/RedundantBraces.stat
@@ -1973,11 +1973,6 @@ object a {
   val sym    = tree.symbol orElse { return }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a {
--  val sym = tree.symbol.orElse(
--    return
--  )
-+  val sym = tree.symbol.orElse(return)
- }
+object a {
+  val sym = tree.symbol.orElse(return)
+}


### PR DESCRIPTION
Helps with #4133.