### PR TITLE
Update libraries needed for cross compilation with Scala Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -174,7 +174,7 @@ lazy val cli = project.in(file("scalafmt-cli")).settings(
       oldStrategy(x)
   },
   libraryDependencies ++= Seq(
-    "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
+    "org.scalameta" %% "munit-diff" % "1.0.2",
     "com.martiansoftware" % "nailgun-server" % "0.9.1",
     "com.github.scopt" %% "scopt" % "4.1.0",
   ),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val scalacheckV = "1.18.0"
   val coursier    = "2.1.10"
   val munitV      = "1.0.1"
-  val mdocV       = "2.5.4"
+  val mdocV       = "2.6.1"
 
   val scalapb = Def.setting {
     ExclusionRule(

--- a/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -9,6 +9,8 @@ import java.nio.file.Paths
 
 import scala.io.Source
 
+import munit.{diff => difflib}
+
 sealed abstract class InputMethod {
   def readInput(options: CliOptions): String
   def path: Path


### PR DESCRIPTION
 * Replace diffutils library with munit-diff: munit-diff is a reimplementation of the diffutils, necessary for cross compilation with Scala Native.
 * Upgrade mdoc to 2.6.1: needed for mdoc-parser specifically, which only since 2.6.0 is available for Scala Native

Part of the Scala Native cross compilation effort (https://github.com/scalameta/scalafmt/pull/4279) (whichever PR gets merged first, I will be sure to rebase the other one).