### PR TITLE
RedundantBraces: keep between `return` and comment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -270,6 +270,8 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
           case Some(_: Term.Interpolate) => handleInterpolation
           case Some(_: Term.Xml) => null
           case Some(_: Term.Annotate) => null
+          case Some(_: Term.Return) if ftoks.next(ft).right.is[Token.Comment] =>
+            null
           case Some(p: Case) =>
             val ok = settings.generalExpressions &&
               ((p.body eq t) || shouldRemoveSingleStatBlock(t))

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1974,3 +1974,62 @@ object a {
 object a {
   val sym = tree.symbol.orElse(return)
 }
+<<< #4133 braces in `return` value, with leading comment
+rewrite.redundantBraces.maxLines = 100
+===
+object a {
+  if (!sameLength(hkargs, hkparams)) return {
+    // Any and Nothing are kind-overloaded
+    if (arg == AnyClass || arg == NothingClass) NoKindErrors
+    // shortcut: always set error, whether explainTypesOrNot
+    else kindErrors.arityError(arg -> param)
+  }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+     return
+-  // Any and Nothing are kind-overloaded
+-  if (arg == AnyClass || arg == NothingClass) NoKindErrors
+-  // shortcut: always set error, whether explainTypesOrNot
+-  else kindErrors.arityError(arg -> param)
++    // Any and Nothing are kind-overloaded
++    if (arg == AnyClass || arg == NothingClass) NoKindErrors
++    // shortcut: always set error, whether explainTypesOrNot
++    else kindErrors.arityError(arg -> param)
+ }
+<<< #4133 braces in `return` value, with trailing comment
+rewrite.redundantBraces.maxLines = 100
+===
+object a {
+  if (!sameLength(hkargs, hkparams)) return {
+    if (arg == AnyClass || arg == NothingClass) NoKindErrors
+    else kindErrors.arityError(arg -> param)
+    // Any and Nothing are kind-overloaded
+    // shortcut: always set error, whether explainTypesOrNot
+  }
+}
+>>>
+object a {
+  if (!sameLength(hkargs, hkparams)) return {
+    if (arg == AnyClass || arg == NothingClass) NoKindErrors
+    else kindErrors.arityError(arg -> param)
+    // Any and Nothing are kind-overloaded
+    // shortcut: always set error, whether explainTypesOrNot
+  }
+}
+<<< #4133 braces in `return` value, without comment
+rewrite.redundantBraces.maxLines = 100
+===
+object a {
+  if (!sameLength(hkargs, hkparams)) return {
+    if (arg == AnyClass || arg == NothingClass) NoKindErrors
+    else kindErrors.arityError(arg -> param)
+  }
+}
+>>>
+object a {
+  if (!sameLength(hkargs, hkparams))
+    return if (arg == AnyClass || arg == NothingClass) NoKindErrors
+    else kindErrors.arityError(arg -> param)
+}

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1986,18 +1986,14 @@ object a {
   }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-     return
--  // Any and Nothing are kind-overloaded
--  if (arg == AnyClass || arg == NothingClass) NoKindErrors
--  // shortcut: always set error, whether explainTypesOrNot
--  else kindErrors.arityError(arg -> param)
-+    // Any and Nothing are kind-overloaded
-+    if (arg == AnyClass || arg == NothingClass) NoKindErrors
-+    // shortcut: always set error, whether explainTypesOrNot
-+    else kindErrors.arityError(arg -> param)
- }
+object a {
+  if (!sameLength(hkargs, hkparams)) return {
+    // Any and Nothing are kind-overloaded
+    if (arg == AnyClass || arg == NothingClass) NoKindErrors
+    // shortcut: always set error, whether explainTypesOrNot
+    else kindErrors.arityError(arg -> param)
+  }
+}
 <<< #4133 braces in `return` value, with trailing comment
 rewrite.redundantBraces.maxLines = 100
 ===


### PR DESCRIPTION
Helps with #4133.