### PR TITLE
Separate regex patterns to jvm-only directory in preparation for Scala Native

### DIFF
--- a/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/RegexCompat.scala
+++ b/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/RegexCompat.scala
@@ -1,0 +1,88 @@
+package org.scalafmt.internal
+
+import java.util.regex.Pattern
+
+private[scalafmt] object RegexCompat {
+
+  @inline
+  val trailingSpace = Pattern.compile("\\h++$", Pattern.MULTILINE)
+
+  // "slc" stands for single-line comment
+  @inline
+  val slcLine = Pattern.compile("^/\\/\\/*+\\h*+(.*?)\\h*+$")
+
+  @inline
+  val slcDelim = Pattern.compile("\\h++")
+
+  // "mlc" stands for multi-line comment
+  @inline
+  val mlcHeader = Pattern.compile("^/\\*\\h*+(?:\n\\h*+[*]*+\\h*+)?")
+
+  @inline
+  val mlcLineDelim = Pattern.compile("\\h*+\n\\h*+[*]*+\\h*+")
+
+  @inline
+  val mlcParagraphEnd = Pattern.compile("[.:!?=]$")
+
+  @inline
+  val mlcParagraphBeg = Pattern.compile("^(?:[-*@=]|\\d++[.:])")
+
+  @inline
+  private val leadingAsteriskSpace = Pattern.compile("(?<=\n)\\h*+(?=[*][^*])")
+
+  @inline
+  val docstringLine = Pattern
+    .compile("^(?:\\h*+\\*)?(\\h*+)(.*?)\\h*+$", Pattern.MULTILINE)
+
+  @inline
+  private val emptyLines = "\\h*+(\n\\h*+\\*?\\h*+)*"
+
+  @inline
+  val emptyDocstring = Pattern.compile(s"^/\\*\\*$emptyLines\\*/$$")
+
+  @inline
+  val onelineDocstring = {
+    val oneline = "[^*\n\\h](?:[^\n]*[^\n\\h])?"
+    Pattern.compile(s"^/\\*\\*$emptyLines($oneline)$emptyLines\\*/$$")
+  }
+
+  @inline
+  val docstringLeadingSpace = Pattern.compile("^\\h++")
+
+  @inline
+  def compileStripMarginPattern(pipe: Char) = Pattern
+    .compile(s"(?<=\n)\\h*+(?=\\$pipe)")
+
+  @inline
+  def compileStripMarginPatternWithLineContent(pipe: Char) = Pattern
+    .compile(s"\n(\\h*+\\$pipe)?([^\n]*+)")
+
+  @inline
+  val stripMarginPattern = compileStripMarginPattern('|')
+
+  @inline
+  val stripMarginPatternWithLineContent =
+    compileStripMarginPatternWithLineContent('|')
+
+  @inline
+  private val leadingPipeSpace = compileStripMarginPattern('|')
+
+  @inline
+  private def getStripMarginPattern(pipe: Char) =
+    if (pipe == '|') leadingPipeSpace else compileStripMarginPattern(pipe)
+
+  @inline
+  def replaceAllStripMargin(text: String, spaces: String, pipe: Char): String =
+    getStripMarginPattern(pipe).matcher(text).replaceAll(spaces)
+
+  @inline
+  def replaceAllLeadingAsterisk(trimmed: String, spaces: String): String =
+    leadingAsteriskSpace.matcher(trimmed).replaceAll(spaces)
+
+  // Replaces baseText.split("(?={beforeText})")
+  @inline
+  def splitByBeforeTextMatching(
+      baseText: String,
+      beforeText: String,
+  ): Array[String] = baseText.split(s"(?=$beforeText)")
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/cli/FileTestOps.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/cli/FileTestOps.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.cli
 
 import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.internal.RegexCompat
 import org.scalafmt.sysops.AbsoluteFile
 import org.scalafmt.sysops.FileOps
 
@@ -15,7 +16,7 @@ object FileTestOps {
     */
   def string2dir(layout: String): AbsoluteFile = {
     val root = AbsoluteFile(Files.createTempDirectory("root"))
-    layout.split("(?=\n/)").foreach { row =>
+    RegexCompat.splitByBeforeTextMatching(layout, "\n/").foreach { row =>
       val path :: contents :: Nil = row.stripPrefix("\n").split("\n", 2).toList
       val file = root / path.stripPrefix("/")
       file.parent.mkdirs()


### PR DESCRIPTION
Part of the Scala Native cross compilation effort (https://github.com/scalameta/scalafmt/pull/4279)