### PR TITLE
Router: bp=defnsite `(` use first comma as optimal

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1106,11 +1106,13 @@ class Router(formatOps: FormatOps) {
             .map(p => PenalizeAllNewlines(close, p + 3))
           val afterClose = after(close)
 
-          val nextCommaOneline = argumentStarts.get(ft.meta.idx).flatMap { x =>
-            val noNeed = isSeqSingle(getArgs(leftOwner)) ||
-              !style.binPack.defnSiteFor(isBracket).isOneline
-            if (noNeed) None else findFirstOnRight[T.Comma](getLast(x), close)
+          val binpack = style.binPack.defnSiteFor(isBracket)
+          val firstArg = argumentStarts.get(ft.meta.idx)
+          val nextComma = firstArg.flatMap { x =>
+            val ok = isSeqMulti(getArgs(leftOwner))
+            if (ok) findFirstOnRight[T.Comma](getLast(x), close) else None
           }
+          val nextCommaOneline = if (binpack.isOneline) nextComma else None
 
           val flags = getBinpackDefnSiteFlags(ft, prev(afterClose))
           val (nlOnly, nlCloseOnOpen) = flags.nlOpenClose()
@@ -1140,7 +1142,7 @@ class Router(formatOps: FormatOps) {
                     else s.map(x => if (x.isNL) x.withPenalty(p) else x)
                 }
               }
-              getNoSplit(nextCommaOneline.map(endOfSingleLineBlock))
+              getNoSplit(nextComma.map(endOfSingleLineBlock))
                 .andPolicy((opensPolicy | penalizeBrackets) & noNLPolicy())
             }
 

--- a/scalafmt-tests/shared/src/test/resources/default/TypeArguments.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/TypeArguments.stat
@@ -487,7 +487,6 @@ def props[M[_[_]], F[_]: Async, I: KeyDecoder, State, Event: PersistentEncoder: 
 object a {
   def deploy[M[_[_]]: FunctorK, F[_], State, Event: PersistentEncoder: PersistentDecoder,
              K: KeyEncoder: KeyDecoder] = ???
-  def props[
-      M[_[_]], F[_]: Async, I: KeyDecoder, State, Event: PersistentEncoder: PersistentDecoder]() =
-    ???
+  def props[M[_[_]], F[_]: Async, I: KeyDecoder, State,
+            Event: PersistentEncoder: PersistentDecoder]() = ???
 }

--- a/scalafmt-tests/shared/src/test/resources/scalajs/DefDef.stat
+++ b/scalafmt-tests/shared/src/test/resources/scalajs/DefDef.stat
@@ -240,8 +240,8 @@ object a {
 >>>
 object a {
   object b {
-    def applyDynamicNamed(name: String)(fields: (
-            String, Any)*): Object with Dynamic = sys.error("stub")
+    def applyDynamicNamed(name: String)(
+        fields: (String, Any)*): Object with Dynamic = sys.error("stub")
   }
 }
 <<< weird breaking #252, oneline


### PR DESCRIPTION
It makes it consistent with how the rest of the arguments are handled, in the "comma" rule below. Helps with #4133.