### PR TITLE
CommunityTests: split into separate projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       matrix:
         java: [ '11' ]
         os: [windows-latest, ubuntu-latest]
+        group: [Scala2, Scala3, Other]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +55,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'sbt'
-      - run: sbt communityTests/test
+      - run: sbt communityTests${{ matrix.group }}/test
   formatting:
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -218,18 +218,28 @@ lazy val tests = crossProject(JVMPlatform).withoutSuffixFor(JVMPlatform)
     }),
   ).enablePlugins(BuildInfoPlugin).dependsOn(core, dynamic, cli)
 
-lazy val communityTests = project.in(file("scalafmt-tests-community")).settings(
-  publish / skip := true,
-  libraryDependencies ++= Seq(
-    // Test dependencies
-    "com.lihaoyi" %% "scalatags" % "0.13.1",
-    scalametaTestkit,
-    munit.value,
-  ),
-  scalacOptions ++= scalacJvmOptions.value,
-  javaOptions += "-Dfile.encoding=UTF8",
-  buildInfoPackage := "org.scalafmt.tests",
-).enablePlugins(BuildInfoPlugin).dependsOn(coreJVM)
+lazy val communityTestsCommon = project
+  .in(file("scalafmt-tests-community/common")).settings(
+    communityTestsSettings,
+    libraryDependencies ++= Seq(
+      // Test dependencies
+      "com.lihaoyi" %% "scalatags" % "0.13.1",
+      scalametaTestkit,
+      munit.value,
+    ),
+  ).enablePlugins(BuildInfoPlugin).dependsOn(coreJVM)
+
+lazy val communityTestsScala2 = project
+  .in(file("scalafmt-tests-community/scala2")).settings(communityTestsSettings)
+  .enablePlugins(BuildInfoPlugin).dependsOn(communityTestsCommon)
+
+lazy val communityTestsScala3 = project
+  .in(file("scalafmt-tests-community/scala3")).settings(communityTestsSettings)
+  .enablePlugins(BuildInfoPlugin).dependsOn(communityTestsCommon)
+
+lazy val communityTestsOther = project
+  .in(file("scalafmt-tests-community/other")).settings(communityTestsSettings)
+  .enablePlugins(BuildInfoPlugin).dependsOn(communityTestsCommon)
 
 lazy val benchmarks = project.in(file("scalafmt-benchmarks")).settings(
   publish / skip := true,
@@ -285,4 +295,11 @@ lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
   ),
   buildInfoPackage := "org.scalafmt",
   buildInfoObject := "Versions",
+)
+
+lazy val communityTestsSettings: Seq[Def.Setting[_]] = Seq(
+  publish / skip := true,
+  scalacOptions ++= scalacJvmOptions.value,
+  javaOptions += "-Dfile.encoding=UTF8",
+  buildInfoPackage := "org.scalafmt.tests",
 )

--- a/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/CommunityBuild.scala
+++ b/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/CommunityBuild.scala
@@ -1,4 +1,4 @@
-package org.scalafmt.community
+package org.scalafmt.community.common
 
 import scala.meta._
 

--- a/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/CommunityRepoSuite.scala
+++ b/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/CommunityRepoSuite.scala
@@ -1,4 +1,4 @@
-package org.scalafmt.community
+package org.scalafmt.community.common
 
 import scala.meta._
 

--- a/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/CommunitySuite.scala
+++ b/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/CommunitySuite.scala
@@ -1,4 +1,4 @@
-package org.scalafmt.community
+package org.scalafmt.community.common
 
 import org.scalafmt.config._
 
@@ -13,7 +13,7 @@ abstract class CommunitySuite extends FunSuite {
 
   import TestHelpers._
 
-  override val munitTimeout = new duration.FiniteDuration(5, duration.MINUTES)
+  override val munitTimeout = new duration.FiniteDuration(10, duration.MINUTES)
 
   protected def builds: Seq[CommunityBuild]
 
@@ -57,7 +57,7 @@ abstract class CommunitySuite extends FunSuite {
   }
 
   private def fetchCommunityBuild(implicit build: CommunityBuild): Path = {
-    try Files.createDirectory(communityDirectory)
+    try Files.createDirectories(communityProjectsDirectory)
     catch { case _: FileAlreadyExistsException => }
 
     val log = new StringBuilder
@@ -73,7 +73,7 @@ abstract class CommunitySuite extends FunSuite {
       log.clear()
     }
 
-    val folderPath = communityDirectory.resolve(build.name)
+    val folderPath = communityProjectsDirectory.resolve(build.name)
     val folder = folderPath.toString
 
     if (!Files.exists(folderPath)) runCmd(

--- a/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/TestHelpers.scala
+++ b/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/TestHelpers.scala
@@ -1,4 +1,4 @@
-package org.scalafmt.community
+package org.scalafmt.community.common
 
 import org.scalafmt.CompatCollections.JavaConverters._
 import org.scalafmt.CompatCollections.ParConverters._
@@ -17,8 +17,8 @@ import munit.diff.console.AnsiColors
 
 object TestHelpers {
 
-  val communityDirectory = Paths
-    .get("scalafmt-tests-community/target/community-projects")
+  private[common] val communityProjectsDirectory = Paths
+    .get("scalafmt-tests-community/community-projects")
 
   private val ignoreParts = List(
     ".git/",

--- a/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/TestStats.scala
+++ b/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/TestStats.scala
@@ -1,4 +1,4 @@
-package org.scalafmt.community
+package org.scalafmt.community.common
 
 case class TestStats(
     checkedFiles: Int,

--- a/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/TestStyles.scala
+++ b/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/TestStyles.scala
@@ -1,4 +1,4 @@
-package org.scalafmt.community
+package org.scalafmt.community.common
 
 import org.scalafmt.config._
 import org.scalafmt.rewrite._

--- a/scalafmt-tests-community/other/src/test/scala/org/scalafmt/community/other/CommunityMunitSuite.scala
+++ b/scalafmt-tests-community/other/src/test/scala/org/scalafmt/community/other/CommunityMunitSuite.scala
@@ -1,4 +1,6 @@
-package org.scalafmt.community
+package org.scalafmt.community.other
+
+import org.scalafmt.community.common.CommunityRepoSuite
 
 import scala.meta._
 

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -1,4 +1,6 @@
-package org.scalafmt.community
+package org.scalafmt.community.scala2
+
+import org.scalafmt.community.common.CommunityRepoSuite
 
 import scala.meta._
 

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -1,4 +1,6 @@
-package org.scalafmt.community
+package org.scalafmt.community.scala3
+
+import org.scalafmt.community.common.CommunityRepoSuite
 
 import scala.meta._
 


### PR DESCRIPTION
The tests run too long, so let's split them apart so we can run them in parallel. Helps with #4133.