### PR TITLE
CommunitySuite: check out projects under target/

### DIFF
--- a/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/TestHelpers.scala
+++ b/scalafmt-tests-community/common/src/main/scala/org/scalafmt/community/common/TestHelpers.scala
@@ -18,7 +18,7 @@ import munit.diff.console.AnsiColors
 object TestHelpers {
 
   private[common] val communityProjectsDirectory = Paths
-    .get("scalafmt-tests-community/community-projects")
+    .get("scalafmt-tests-community/target/community-projects")
 
   private val ignoreParts = List(
     ".git/",


### PR DESCRIPTION
Otherwise, we'd need to add the directory to .gitignore.