### PR TITLE
TreeOps: get owners via token range, not position

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9632,3 +9632,33 @@ class UDFRegistration {
     ).toOption :: Nil
   }
 }
+<<< #4133 infix after xml block
+maxColumn = 80
+===
+object a {
+  private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++ <td>queued</td>++ {
+      if (firstFailureReason.nonEmpty) {
+        // Waiting batches have not run yet, so must have no failure reasons.
+        <td>-</td>
+      } else {
+        Nil
+      }
+    }
+  }
+}
+>>>
+object a {
+  private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+    baseRow(batch) ++ createOutputOperationProgressBar(
+      batch
+    ) ++ <td>queued</td> ++ {
+      if (firstFailureReason.nonEmpty) {
+        // Waiting batches have not run yet, so must have no failure reasons.
+        <td>-</td>
+      } else {
+        Nil
+      }
+    }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9035,3 +9035,30 @@ class UDFRegistration {
         .toOption :: Nil
   }
 }
+<<< #4133 infix after xml block
+maxColumn = 80
+===
+object a {
+  private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++ <td>queued</td>++ {
+      if (firstFailureReason.nonEmpty) {
+        // Waiting batches have not run yet, so must have no failure reasons.
+        <td>-</td>
+      } else {
+        Nil
+      }
+    }
+  }
+}
+>>>
+object a {
+  private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++
+      <td>queued</td> ++ {
+        if (firstFailureReason.nonEmpty) {
+          // Waiting batches have not run yet, so must have no failure reasons.
+          <td>-</td>
+        } else { Nil }
+      }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9429,3 +9429,33 @@ class UDFRegistration {
     ).toOption :: Nil
   }
 }
+<<< #4133 infix after xml block
+maxColumn = 80
+===
+object a {
+  private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++ <td>queued</td>++ {
+      if (firstFailureReason.nonEmpty) {
+        // Waiting batches have not run yet, so must have no failure reasons.
+        <td>-</td>
+      } else {
+        Nil
+      }
+    }
+  }
+}
+>>>
+object a {
+  private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+    baseRow(batch) ++ createOutputOperationProgressBar(
+      batch
+    ) ++ <td>queued</td> ++ {
+      if (firstFailureReason.nonEmpty) {
+        // Waiting batches have not run yet, so must have no failure reasons.
+        <td>-</td>
+      } else {
+        Nil
+      }
+    }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9710,3 +9710,41 @@ class UDFRegistration {
           .toOption :: Nil
   }
 }
+<<< #4133 infix after xml block
+maxColumn = 80
+===
+object a {
+  private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++ <td>queued</td>++ {
+      if (firstFailureReason.nonEmpty) {
+        // Waiting batches have not run yet, so must have no failure reasons.
+        <td>-</td>
+      } else {
+        Nil
+      }
+    }
+  }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+-    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++ <td>queued</td>
+-    ++ {
+-      if (firstFailureReason.nonEmpty) {
+-        // Waiting batches have not run yet, so must have no failure reasons.
+-        <td>-</td>
+-      } else {
+-        Nil
++    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++
++      <td>queued</td>
++      ++ {
++        if (firstFailureReason.nonEmpty) {
++          // Waiting batches have not run yet, so must have no failure reasons.
++          <td>-</td>
++        } else {
++          Nil
++        }
+       }
+-    }
+   }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9726,25 +9726,16 @@ object a {
   }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
--    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++ <td>queued</td>
--    ++ {
--      if (firstFailureReason.nonEmpty) {
--        // Waiting batches have not run yet, so must have no failure reasons.
--        <td>-</td>
--      } else {
--        Nil
-+    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++
-+      <td>queued</td>
-+      ++ {
-+        if (firstFailureReason.nonEmpty) {
-+          // Waiting batches have not run yet, so must have no failure reasons.
-+          <td>-</td>
-+        } else {
-+          Nil
-+        }
-       }
--    }
-   }
+object a {
+  private def waitingBatchRow(batch: BatchUIData): Seq[Node] = {
+    baseRow(batch) ++ createOutputOperationProgressBar(batch) ++
+      <td>queued</td> ++ {
+        if (firstFailureReason.nonEmpty) {
+          // Waiting batches have not run yet, so must have no failure reasons.
+          <td>-</td>
+        } else {
+          Nil
+        }
+      }
+  }
+}


### PR DESCRIPTION
This allows us to handle tokens which occupy no space, such as Xml.End or Xml.Start. Helps with #4133.