### PR TITLE
Router: check if "NL" for `(` is actually not NL

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9662,3 +9662,17 @@ object a {
     }
   }
 }
+<<< #4133 partial function within apply, short
+rdd.map(
+    {case (id, count) => (count, id)})
+>>>
+rdd.map({ case (id, count) =>
+  (count, id)
+})
+<<< #4133 partial function within apply, long
+maxColumn = 80
+===
+rdd.map(
+    {case (id, count) => (count, id)})
+>>>
+rdd.map({ case (id, count) => (count, id) })

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9062,3 +9062,17 @@ object a {
       }
   }
 }
+<<< #4133 partial function within apply, short
+rdd.map(
+    {case (id, count) => (count, id)})
+>>>
+rdd.map({ case (id, count) =>
+  (count, id)
+})
+<<< #4133 partial function within apply, long
+maxColumn = 80
+===
+rdd.map(
+    {case (id, count) => (count, id)})
+>>>
+rdd.map({ case (id, count) => (count, id) })

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9463,22 +9463,13 @@ object a {
 rdd.map(
     {case (id, count) => (count, id)})
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- rdd.map({ case (id, count) =>
--  (count, id)
--})
-+    (count, id)
-+  }
-+)
+rdd.map({ case (id, count) =>
+  (count, id)
+})
 <<< #4133 partial function within apply, long
 maxColumn = 80
 ===
 rdd.map(
     {case (id, count) => (count, id)})
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--rdd.map({ case (id, count) => (count, id) })
-+rdd.map({ case (id, count) => (count, id) }
-+)
+rdd.map({ case (id, count) => (count, id) })

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9459,3 +9459,26 @@ object a {
     }
   }
 }
+<<< #4133 partial function within apply, short
+rdd.map(
+    {case (id, count) => (count, id)})
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ rdd.map({ case (id, count) =>
+-  (count, id)
+-})
++    (count, id)
++  }
++)
+<<< #4133 partial function within apply, long
+maxColumn = 80
+===
+rdd.map(
+    {case (id, count) => (count, id)})
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-rdd.map({ case (id, count) => (count, id) })
++rdd.map({ case (id, count) => (count, id) }
++)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9739,3 +9739,19 @@ object a {
       }
   }
 }
+<<< #4133 partial function within apply, short
+rdd.map(
+    {case (id, count) => (count, id)})
+>>>
+rdd.map({ case (id, count) =>
+  (count, id)
+})
+<<< #4133 partial function within apply, long
+maxColumn = 80
+===
+rdd.map(
+    {case (id, count) => (count, id)})
+>>>
+rdd.map({ case (id, count) =>
+  (count, id)
+})


### PR DESCRIPTION
That will require that the regular no-NL split is produced, as well. Helps with #4133.