### PR TITLE
BestFirstSearch: stop using State.allAltAreNL

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9787,3 +9787,36 @@ val finalProperties =
       loc
     ))
   }
+<<< #4133 lambda in parens rewritten to braces
+maxColumn = 80
+rewrite.rules = [RedundantBraces]
+===
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+    settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride = extraArgs.headOption.fold(identity[GenerationConfig](_))(newDir => {
+          config: GenerationConfig => config.add(OutputDir(newDir))
+        })
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_))(_ => {
+          config: GenerationConfig => config.remove[SiteRoot]
+        })
+      }.evaluated,
+    )
+}
+>>>
+object Build {
+  lazy val scaladoc = project
+    .in(file("scaladoc"))
+    .settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride =
+          extraArgs.headOption.fold(identity[GenerationConfig](_)) {
+            newDir => config: GenerationConfig => config.add(OutputDir(newDir))
+          }
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) {
+          _ => config: GenerationConfig => config.remove[SiteRoot]
+        }
+      }.evaluated
+    )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9184,3 +9184,34 @@ val finalProperties = properties.get(SupportsNamespaces.PROP_LOCATION)
     properties +
       (SupportsNamespaces.PROP_LOCATION -> makeQualifiedDBObjectPath(loc))
   }
+<<< #4133 lambda in parens rewritten to braces
+maxColumn = 80
+rewrite.rules = [RedundantBraces]
+===
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+    settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride = extraArgs.headOption.fold(identity[GenerationConfig](_))(newDir => {
+          config: GenerationConfig => config.add(OutputDir(newDir))
+        })
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_))(_ => {
+          config: GenerationConfig => config.remove[SiteRoot]
+        })
+      }.evaluated,
+    )
+}
+>>>
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc"))
+    .settings(generateScalaDocumentation := Def.inputTaskDyn {
+      val outputDirOverride = extraArgs.headOption
+        .fold(identity[GenerationConfig](_)) {
+          newDir => config: GenerationConfig => config.add(OutputDir(newDir))
+        }
+      val justAPI = justAPIArg
+        .fold(identity[GenerationConfig](_)) { _ => config: GenerationConfig =>
+          config.remove[SiteRoot]
+        }
+    }.evaluated)
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9585,3 +9585,35 @@ val finalProperties =
       loc
     ))
   }
+<<< #4133 lambda in parens rewritten to braces
+maxColumn = 80
+rewrite.rules = [RedundantBraces]
+===
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+    settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride = extraArgs.headOption.fold(identity[GenerationConfig](_))(newDir => {
+          config: GenerationConfig => config.add(OutputDir(newDir))
+        })
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_))(_ => {
+          config: GenerationConfig => config.remove[SiteRoot]
+        })
+      }.evaluated,
+    )
+}
+>>>
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+  settings(
+    generateScalaDocumentation := Def.inputTaskDyn {
+      val outputDirOverride =
+        extraArgs.headOption.fold(identity[GenerationConfig](_)) {
+          newDir => config: GenerationConfig => config.add(OutputDir(newDir))
+        }
+      val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) {
+        _ => config: GenerationConfig => config.remove[SiteRoot]
+      }
+    }.evaluated
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9871,3 +9871,44 @@ val finalProperties = properties
     properties +
       (SupportsNamespaces.PROP_LOCATION -> makeQualifiedDBObjectPath(loc))
   }
+<<< #4133 lambda in parens rewritten to braces
+maxColumn = 80
+rewrite.rules = [RedundantBraces]
+===
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+    settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride = extraArgs.headOption.fold(identity[GenerationConfig](_))(newDir => {
+          config: GenerationConfig => config.add(OutputDir(newDir))
+        })
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_))(_ => {
+          config: GenerationConfig => config.remove[SiteRoot]
+        })
+      }.evaluated,
+    )
+}
+>>>
+object Build {
+  lazy val scaladoc = project
+    .in(file("scaladoc"))
+    .settings(
+      generateScalaDocumentation :=
+        Def
+          .inputTaskDyn {
+            val outputDirOverride =
+              extraArgs
+                .headOption
+                .fold(identity[GenerationConfig](_)) {
+                  newDir => config: GenerationConfig =>
+                    config.add(OutputDir(newDir))
+                }
+            val justAPI =
+              justAPIArg.fold(identity[GenerationConfig](_)) {
+                _ => config: GenerationConfig =>
+                  config.remove[SiteRoot]
+              }
+          }
+          .evaluated
+    )
+}


### PR DESCRIPTION
The behaviour is non-idempotent since splits depend on source formatting but might produce different breaks. Helps with #4133.

