### PR TITLE
FormatOps: no blank within infix if not enclosed

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -484,8 +484,10 @@ class FormatOps(
               rtidx >= 0 && (atokens(rtidx) eq ft.right) // no rewritten tokens
             }
           }
-        val useSpace = ft.noBreak || !okToBreak
-        val split = Split(if (useSpace) spaceMod else Newline2x(ft), 0)
+        val mod =
+          if (ft.noBreak || !okToBreak) spaceMod
+          else Newline2x(isFullInfixEnclosed && ft.hasBlankLine)
+        val split = Split(mod, 0)
         if (isBeforeOp && isFewerBracesRhs(app.arg)) Seq(split)
         else Seq(InfixSplits.withNLIndent(split, app, fullInfix))
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2308,8 +2308,7 @@ class Router(formatOps: FormatOps) {
         val lastToken = getLastToken(leftOwner.asInstanceOf[Term.ForYield].body)
         val indent = Indent(style.indent.main, lastToken, ExpiresOn.After)
         if (style.newlines.avoidAfterYield && !rightOwner.is[Term.If]) {
-          val nextFt = nextNonCommentSameLine(ft)
-          val noIndent = nextFt.eq(ft) || nextFt.noBreak
+          val noIndent = !isRightCommentWithBreak(ft)
           Seq(Split(Space, 0).withIndent(indent, noIndent))
         } else Seq(
           // Either everything fits in one line or break on =>

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9710,22 +9710,28 @@ class ClassEmitter {
 
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-         chainProto :::
--        (
--          genIdentBracketSelect(
--            prototypeFor(ctorVar),
--            "constructor"
--          ) := ctorVar
--        ) ::
-+        (genIdentBracketSelect(
-+          prototypeFor(ctorVar),
-+          "constructor"
-+        ) := ctorVar) ::
- ∙
--      // Inheritable constructor
--      js.JSDocConstructor(inheritableCtorDef.head) ::
-+        // Inheritable constructor
-+        js.JSDocConstructor(inheritableCtorDef.head) ::
-         inheritableCtorDef.tail :::
+class ClassEmitter {
+
+  def genScalaClassConstructor =
+
+    if (useESClass) {
+      for {
+        chainProto <- chainProtoWithGlobals
+      } yield
+      // Real constructor
+      js.JSDocConstructor(realCtorDef.head) ::
+        realCtorDef.tail :::
+        chainProto :::
+        (genIdentBracketSelect(
+          prototypeFor(ctorVar),
+          "constructor"
+        ) := ctorVar) ::
+        // Inheritable constructor
+        js.JSDocConstructor(inheritableCtorDef.head) ::
+        inheritableCtorDef.tail :::
+        (globalVar(VarField.h, className).prototype := prototypeFor(
+          ctorVar
+        )) :: Nil
+    }
+
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9718,20 +9718,20 @@ class ClassEmitter {
       for {
         chainProto <- chainProtoWithGlobals
       } yield
-      // Real constructor
-      js.JSDocConstructor(realCtorDef.head) ::
-        realCtorDef.tail :::
-        chainProto :::
-        (genIdentBracketSelect(
-          prototypeFor(ctorVar),
-          "constructor"
-        ) := ctorVar) ::
-        // Inheritable constructor
-        js.JSDocConstructor(inheritableCtorDef.head) ::
-        inheritableCtorDef.tail :::
-        (globalVar(VarField.h, className).prototype := prototypeFor(
-          ctorVar
-        )) :: Nil
+        // Real constructor
+        js.JSDocConstructor(realCtorDef.head) ::
+          realCtorDef.tail :::
+          chainProto :::
+          (genIdentBracketSelect(
+            prototypeFor(ctorVar),
+            "constructor"
+          ) := ctorVar) ::
+          // Inheritable constructor
+          js.JSDocConstructor(inheritableCtorDef.head) ::
+          inheritableCtorDef.tail :::
+          (globalVar(VarField.h, className).prototype := prototypeFor(
+            ctorVar
+          )) :: Nil
     }
 
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9676,3 +9676,56 @@ rdd.map(
     {case (id, count) => (count, id)})
 >>>
 rdd.map({ case (id, count) => (count, id) })
+<<< #4133 RedundantParens around infix with an embedded blank lin
+maxColumn = 80
+rewrite {
+  rules = [RedundantParens, RedundantBraces]
+  redundantBraces.maxLines = 100
+  redundantParens.infixSide = all
+}
+===
+class ClassEmitter {
+
+  def genScalaClassConstructor = {
+
+    if (useESClass) {
+      for {
+        chainProto <- chainProtoWithGlobals
+      } yield {
+        (
+          // Real constructor
+          js.JSDocConstructor(realCtorDef.head) ::
+          realCtorDef.tail :::
+          chainProto :::
+          (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") := ctorVar) ::
+
+          // Inheritable constructor
+          js.JSDocConstructor(inheritableCtorDef.head) ::
+          inheritableCtorDef.tail :::
+          (globalVar(VarField.h, className).prototype := prototypeFor(ctorVar)) :: Nil
+        )
+      }
+    }
+  }
+
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+         chainProto :::
+-        (
+-          genIdentBracketSelect(
+-            prototypeFor(ctorVar),
+-            "constructor"
+-          ) := ctorVar
+-        ) ::
++        (genIdentBracketSelect(
++          prototypeFor(ctorVar),
++          "constructor"
++        ) := ctorVar) ::
+ ∙
+-      // Inheritable constructor
+-      js.JSDocConstructor(inheritableCtorDef.head) ::
++        // Inheritable constructor
++        js.JSDocConstructor(inheritableCtorDef.head) ::
+         inheritableCtorDef.tail :::

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9075,3 +9075,58 @@ rdd.map(
     {case (id, count) => (count, id)})
 >>>
 rdd.map({ case (id, count) => (count, id) })
+<<< #4133 RedundantParens around infix with an embedded blank lin
+maxColumn = 80
+rewrite {
+  rules = [RedundantParens, RedundantBraces]
+  redundantBraces.maxLines = 100
+  redundantParens.infixSide = all
+}
+===
+class ClassEmitter {
+
+  def genScalaClassConstructor = {
+
+    if (useESClass) {
+      for {
+        chainProto <- chainProtoWithGlobals
+      } yield {
+        (
+          // Real constructor
+          js.JSDocConstructor(realCtorDef.head) ::
+          realCtorDef.tail :::
+          chainProto :::
+          (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") := ctorVar) ::
+
+          // Inheritable constructor
+          js.JSDocConstructor(inheritableCtorDef.head) ::
+          inheritableCtorDef.tail :::
+          (globalVar(VarField.h, className).prototype := prototypeFor(ctorVar)) :: Nil
+        )
+      }
+    }
+  }
+
+}
+>>>
+class ClassEmitter {
+
+  def genScalaClassConstructor =
+
+    if (useESClass) {
+      for {
+        chainProto <- chainProtoWithGlobals
+      } yield
+      // Real constructor
+      js.JSDocConstructor(realCtorDef.head) :: realCtorDef.tail :::
+        chainProto :::
+        (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") :=
+          ctorVar) ::
+        // Inheritable constructor
+        js.JSDocConstructor(inheritableCtorDef.head) ::
+        inheritableCtorDef.tail :::
+        (globalVar(VarField.h, className).prototype := prototypeFor(ctorVar)) ::
+        Nil
+    }
+
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9117,16 +9117,16 @@ class ClassEmitter {
       for {
         chainProto <- chainProtoWithGlobals
       } yield
-      // Real constructor
-      js.JSDocConstructor(realCtorDef.head) :: realCtorDef.tail :::
-        chainProto :::
-        (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") :=
-          ctorVar) ::
-        // Inheritable constructor
-        js.JSDocConstructor(inheritableCtorDef.head) ::
-        inheritableCtorDef.tail :::
-        (globalVar(VarField.h, className).prototype := prototypeFor(ctorVar)) ::
-        Nil
+        // Real constructor
+        js.JSDocConstructor(realCtorDef.head) :: realCtorDef.tail :::
+          chainProto :::
+          (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") :=
+            ctorVar) ::
+          // Inheritable constructor
+          js.JSDocConstructor(inheritableCtorDef.head) ::
+          inheritableCtorDef.tail :::
+          (globalVar(VarField.h, className).prototype :=
+            prototypeFor(ctorVar)) :: Nil
     }
 
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9473,3 +9473,45 @@ rdd.map(
     {case (id, count) => (count, id)})
 >>>
 rdd.map({ case (id, count) => (count, id) })
+<<< #4133 RedundantParens around infix with an embedded blank lin
+maxColumn = 80
+rewrite {
+  rules = [RedundantParens, RedundantBraces]
+  redundantBraces.maxLines = 100
+  redundantParens.infixSide = all
+}
+===
+class ClassEmitter {
+
+  def genScalaClassConstructor = {
+
+    if (useESClass) {
+      for {
+        chainProto <- chainProtoWithGlobals
+      } yield {
+        (
+          // Real constructor
+          js.JSDocConstructor(realCtorDef.head) ::
+          realCtorDef.tail :::
+          chainProto :::
+          (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") := ctorVar) ::
+
+          // Inheritable constructor
+          js.JSDocConstructor(inheritableCtorDef.head) ::
+          inheritableCtorDef.tail :::
+          (globalVar(VarField.h, className).prototype := prototypeFor(ctorVar)) :: Nil
+        )
+      }
+    }
+  }
+
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ ∙
+-      // Inheritable constructor
+-      js.JSDocConstructor(inheritableCtorDef.head) ::
++        // Inheritable constructor
++        js.JSDocConstructor(inheritableCtorDef.head) ::
+         inheritableCtorDef.tail :::

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9515,21 +9515,21 @@ class ClassEmitter {
       for {
         chainProto <- chainProtoWithGlobals
       } yield
-      // Real constructor
-      js.JSDocConstructor(realCtorDef.head) ::
-        realCtorDef.tail :::
-        chainProto :::
-        (genIdentBracketSelect(
-          prototypeFor(ctorVar),
-          "constructor"
-        ) := ctorVar) ::
-        // Inheritable constructor
-        js.JSDocConstructor(inheritableCtorDef.head) ::
-        inheritableCtorDef.tail :::
-        (globalVar(
-          VarField.h,
-          className
-        ).prototype := prototypeFor(ctorVar)) :: Nil
+        // Real constructor
+        js.JSDocConstructor(realCtorDef.head) ::
+          realCtorDef.tail :::
+          chainProto :::
+          (genIdentBracketSelect(
+            prototypeFor(ctorVar),
+            "constructor"
+          ) := ctorVar) ::
+          // Inheritable constructor
+          js.JSDocConstructor(inheritableCtorDef.head) ::
+          inheritableCtorDef.tail :::
+          (globalVar(
+            VarField.h,
+            className
+          ).prototype := prototypeFor(ctorVar)) :: Nil
     }
 
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9507,11 +9507,29 @@ class ClassEmitter {
 
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- ∙
--      // Inheritable constructor
--      js.JSDocConstructor(inheritableCtorDef.head) ::
-+        // Inheritable constructor
-+        js.JSDocConstructor(inheritableCtorDef.head) ::
-         inheritableCtorDef.tail :::
+class ClassEmitter {
+
+  def genScalaClassConstructor =
+
+    if (useESClass) {
+      for {
+        chainProto <- chainProtoWithGlobals
+      } yield
+      // Real constructor
+      js.JSDocConstructor(realCtorDef.head) ::
+        realCtorDef.tail :::
+        chainProto :::
+        (genIdentBracketSelect(
+          prototypeFor(ctorVar),
+          "constructor"
+        ) := ctorVar) ::
+        // Inheritable constructor
+        js.JSDocConstructor(inheritableCtorDef.head) ::
+        inheritableCtorDef.tail :::
+        (globalVar(
+          VarField.h,
+          className
+        ).prototype := prototypeFor(ctorVar)) :: Nil
+    }
+
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9797,16 +9797,16 @@ class ClassEmitter {
       for {
         chainProto <- chainProtoWithGlobals
       } yield
-      // Real constructor
-      js.JSDocConstructor(realCtorDef.head) :: realCtorDef.tail :::
-        chainProto :::
-        (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") :=
-          ctorVar) ::
-        // Inheritable constructor
-        js.JSDocConstructor(inheritableCtorDef.head) ::
-        inheritableCtorDef.tail :::
-        (globalVar(VarField.h, className).prototype := prototypeFor(ctorVar)) ::
-        Nil
+        // Real constructor
+        js.JSDocConstructor(realCtorDef.head) :: realCtorDef.tail :::
+          chainProto :::
+          (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") :=
+            ctorVar) ::
+          // Inheritable constructor
+          js.JSDocConstructor(inheritableCtorDef.head) ::
+          inheritableCtorDef.tail :::
+          (globalVar(VarField.h, className).prototype :=
+            prototypeFor(ctorVar)) :: Nil
     }
 
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9755,3 +9755,58 @@ rdd.map(
 rdd.map({ case (id, count) =>
   (count, id)
 })
+<<< #4133 RedundantParens around infix with an embedded blank lin
+maxColumn = 80
+rewrite {
+  rules = [RedundantParens, RedundantBraces]
+  redundantBraces.maxLines = 100
+  redundantParens.infixSide = all
+}
+===
+class ClassEmitter {
+
+  def genScalaClassConstructor = {
+
+    if (useESClass) {
+      for {
+        chainProto <- chainProtoWithGlobals
+      } yield {
+        (
+          // Real constructor
+          js.JSDocConstructor(realCtorDef.head) ::
+          realCtorDef.tail :::
+          chainProto :::
+          (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") := ctorVar) ::
+
+          // Inheritable constructor
+          js.JSDocConstructor(inheritableCtorDef.head) ::
+          inheritableCtorDef.tail :::
+          (globalVar(VarField.h, className).prototype := prototypeFor(ctorVar)) :: Nil
+        )
+      }
+    }
+  }
+
+}
+>>>
+class ClassEmitter {
+
+  def genScalaClassConstructor =
+
+    if (useESClass) {
+      for {
+        chainProto <- chainProtoWithGlobals
+      } yield
+      // Real constructor
+      js.JSDocConstructor(realCtorDef.head) :: realCtorDef.tail :::
+        chainProto :::
+        (genIdentBracketSelect(prototypeFor(ctorVar), "constructor") :=
+          ctorVar) ::
+        // Inheritable constructor
+        js.JSDocConstructor(inheritableCtorDef.head) ::
+        inheritableCtorDef.tail :::
+        (globalVar(VarField.h, className).prototype := prototypeFor(ctorVar)) ::
+        Nil
+    }
+
+}


### PR DESCRIPTION
Also, in Router, fix indent after `yield` w/ NL+comment. Helps with #4133.