### PR TITLE
Router: price sole NL split in `=> <NL>` at 1

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -533,24 +533,25 @@ class Router(formatOps: FormatOps) {
             nlSplit(nft)(1),
           )
           implicit val beforeMultiline = style.newlines.getBeforeMultiline
-          def getNLOnlySplit(implicit l: FileLine) = Seq(nlSplit(nft)(0))
+          def getNLOnlySplit(cost: Int)(implicit l: FileLine) =
+            Seq(nlSplit(nft)(cost))
           def getFolded(isKeep: Boolean)(implicit l: FileLine) = CtrlBodySplits
             .foldedNonEmptyNonComment(body, nlSplit(nft), isKeep)
           if (
             isCaseBodyABlock(nft, owner) ||
             getClosingIfCaseBodyEnclosedAsBlock(nft, owner).isDefined
           ) Seq(baseSplit)
-          else if (nft.right.is[T.KwCase]) getNLOnlySplit
+          else if (nft.right.is[T.KwCase]) getNLOnlySplit(0)
           else if (hasBreak() && !beforeMultiline.ignoreSourceSplit)
             if ((beforeMultiline eq Newlines.keep) && !bodyIsEmpty)
               getFolded(isKeep = true).filter(_.isNL)
-            else getNLOnlySplit
+            else getNLOnlySplit(1)
           else if (bodyIsEmpty)
             if (rt.isAny[T.RightBrace, T.Semicolon])
               Seq(baseSplit, nlSplit(nft)(1))
-            else getNLOnlySplit
+            else getNLOnlySplit(1)
           else if (beforeMultiline eq Newlines.unfold)
-            if (style.newlines.unfold) getNLOnlySplit else withSlbSplit
+            if (style.newlines.unfold) getNLOnlySplit(0) else withSlbSplit
           else if (
             condIsDefined || beforeMultiline.eq(Newlines.classic) ||
             getSingleStatExceptEndMarker(body).isEmpty

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9662,6 +9662,33 @@ object a {
     }
   }
 }
+<<< #4133 applies and selects with a partial function 1
+maxColumn = 76
+runner.parser = source
+===
+val fieldsCasts = from.fields.zip(to.fields).map {
+  case (fromField, toField) => nullSafeCastFunction(fromField.dataType, toField.dataType, ctx)
+}
+>>>
+val fieldsCasts =
+  from.fields.zip(to.fields).map { case (fromField, toField) =>
+    nullSafeCastFunction(fromField.dataType, toField.dataType, ctx)
+  }
+<<< #4133 applies and selects with a partial function 2
+maxColumn = 76
+===
+val stats = Profiler.getStatistics().asScala.toSeq.map {
+  case (trace, count) => MethodCallTrace(trace.className, trace.methodName, trace.methodDescriptor) -> count.intValue
+}
+>>>
+val stats =
+  Profiler.getStatistics().asScala.toSeq.map { case (trace, count) =>
+    MethodCallTrace(
+      trace.className,
+      trace.methodName,
+      trace.methodDescriptor
+    ) -> count.intValue
+  }
 <<< #4133 partial function within apply, short
 rdd.map(
     {case (id, count) => (count, id)})

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9061,6 +9061,32 @@ object a {
       }
   }
 }
+<<< #4133 applies and selects with a partial function 1
+maxColumn = 76
+runner.parser = source
+===
+val fieldsCasts = from.fields.zip(to.fields).map {
+  case (fromField, toField) => nullSafeCastFunction(fromField.dataType, toField.dataType, ctx)
+}
+>>>
+val fieldsCasts = from.fields.zip(to.fields)
+  .map { case (fromField, toField) =>
+    nullSafeCastFunction(fromField.dataType, toField.dataType, ctx)
+  }
+<<< #4133 applies and selects with a partial function 2
+maxColumn = 76
+===
+val stats = Profiler.getStatistics().asScala.toSeq.map {
+  case (trace, count) => MethodCallTrace(trace.className, trace.methodName, trace.methodDescriptor) -> count.intValue
+}
+>>>
+val stats = Profiler.getStatistics().asScala.toSeq.map {
+  case (trace, count) => MethodCallTrace(
+      trace.className,
+      trace.methodName,
+      trace.methodDescriptor
+    ) -> count.intValue
+}
 <<< #4133 partial function within apply, short
 rdd.map(
     {case (id, count) => (count, id)})

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9459,6 +9459,32 @@ object a {
     }
   }
 }
+<<< #4133 applies and selects with a partial function 1
+maxColumn = 76
+runner.parser = source
+===
+val fieldsCasts = from.fields.zip(to.fields).map {
+  case (fromField, toField) => nullSafeCastFunction(fromField.dataType, toField.dataType, ctx)
+}
+>>>
+val fieldsCasts = from.fields.zip(to.fields).map {
+  case (fromField, toField) =>
+    nullSafeCastFunction(fromField.dataType, toField.dataType, ctx)
+}
+<<< #4133 applies and selects with a partial function 2
+maxColumn = 76
+===
+val stats = Profiler.getStatistics().asScala.toSeq.map {
+  case (trace, count) => MethodCallTrace(trace.className, trace.methodName, trace.methodDescriptor) -> count.intValue
+}
+>>>
+val stats = Profiler.getStatistics().asScala.toSeq.map {
+  case (trace, count) => MethodCallTrace(
+      trace.className,
+      trace.methodName,
+      trace.methodDescriptor
+    ) -> count.intValue
+}
 <<< #4133 partial function within apply, short
 rdd.map(
     {case (id, count) => (count, id)})

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9739,6 +9739,38 @@ object a {
       }
   }
 }
+<<< #4133 applies and selects with a partial function 1
+maxColumn = 76
+runner.parser = source
+===
+val fieldsCasts = from.fields.zip(to.fields).map {
+  case (fromField, toField) => nullSafeCastFunction(fromField.dataType, toField.dataType, ctx)
+}
+>>>
+val fieldsCasts = from
+  .fields
+  .zip(to.fields)
+  .map { case (fromField, toField) =>
+    nullSafeCastFunction(fromField.dataType, toField.dataType, ctx)
+  }
+<<< #4133 applies and selects with a partial function 2
+maxColumn = 76
+===
+val stats = Profiler.getStatistics().asScala.toSeq.map {
+  case (trace, count) => MethodCallTrace(trace.className, trace.methodName, trace.methodDescriptor) -> count.intValue
+}
+>>>
+val stats = Profiler
+  .getStatistics()
+  .asScala
+  .toSeq
+  .map { case (trace, count) =>
+    MethodCallTrace(
+      trace.className,
+      trace.methodName,
+      trace.methodDescriptor
+    ) -> count.intValue
+  }
 <<< #4133 partial function within apply, short
 rdd.map(
     {case (id, count) => (count, id)})


### PR DESCRIPTION
Follow-on to #4366. Helps with #4133.