### PR TITLE
TreeOps: revise NL-optimization around functions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -104,12 +104,12 @@ object TreeOps {
       ftoks: FormatTokens,
   ): Boolean = SingleArgInBraces.orBlock(parent).exists(_._2 eq expr)
 
-  def extractStatementsIfAny(
-      tree: Tree,
-  )(implicit ftoks: FormatTokens): Seq[Tree] = tree match {
-    case SingleArgInBraces(_, fun: Term.FunctionTerm, _) => fun :: Nil
-    case t: Term.FunctionTerm if isBlockFunction(t) => t.body :: Nil
+  def extractStatementsIfAny(tree: Tree): Seq[Tree] = tree match {
     case t: Term.EnumeratorsBlock => getEnumStatements(t.enums)
+    case t: Term.PartialFunction => t.cases match {
+        case _ :: Nil => Nil
+        case x => x
+      }
     case t @ Tree.Block(s) =>
       if (!t.parent.is[CaseTree] || getSingleStatExceptEndMarker(s).isEmpty) s
       else s.drop(1)

--- a/scalafmt-tests/shared/src/test/resources/default/Idempotency.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/Idempotency.stat
@@ -194,19 +194,18 @@ val bindingFuture = Http().bindAndHandleSync({
       val responseParsingMerge = b.add {
         // the initial header parser we initially use for every connection,
         // will not be mutated, all "shared copy" parsers copy on first-write into the header cache
-        val rootParser =
-          new HttpResponseParser(parserSettings,
-                                 HttpHeaderParser(parserSettings) { info ⇒
-                                   if (parserSettings.illegalHeaderWarnings)
-                                     logParsingError(
-                                         info withSummaryPrepended "Illegal response header",
-                                         log,
-                                         parserSettings.errorLoggingVerbosity)
-                                 })
+        val rootParser = new HttpResponseParser(
+            parserSettings,
+            HttpHeaderParser(parserSettings) { info ⇒
+              if (parserSettings.illegalHeaderWarnings)
+                logParsingError(
+                    info withSummaryPrepended "Illegal response header",
+                    log,
+                    parserSettings.errorLoggingVerbosity)
+            })
         new ResponseParsingMerge(rootParser)
       }
 
     })
   }
 }
-

--- a/scalafmt-tests/shared/src/test/resources/default/Lambda.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/Lambda.stat
@@ -362,8 +362,7 @@ testAsync("Resource.make is equivalent to a partially applied bracket") { implic
 >>>
 testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
   check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String] /* c1 */ ) /* c2 */ =>
-    /*c3*/
-    acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f)
+    /*c3*/ acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f)
   }
 }
 <<< #1714 4
@@ -379,8 +378,7 @@ testAsync("Resource.make is equivalent to a partially applied bracket") { implic
 >>>
 testAsync("Resource.make is equivalent to a partially applied bracket") { implicit ec =>
   check { (acquire: IO[String], release: String => IO[Unit], f: String => IO[String] /* c1 */ ) /* c2 */ =>
-    /*c3*/
-    { acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f) }
+    /*c3*/ { acquire.bracket(f)(release) <-> Resource.make(acquire)(release).use(f) }
   }
 }
 <<< #1714 5

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9743,13 +9743,7 @@ validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
       s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
--  errorMessage =>
--    s"Error message is: $errorMessage, " +
--      s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
-+validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map { errorMessage =>
-+  s"Error message is: $errorMessage, " +
-+    s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
- }
+validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map { errorMessage =>
+  s"Error message is: $errorMessage, " +
+    s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9735,3 +9735,21 @@ class ClassEmitter {
     }
 
 }
+<<< #4133 lambda in braces, overflow after brace
+maxColumn = 76
+===
+validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
+  errorMessage => s"Error message is: $errorMessage, " +
+      s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
+-  errorMessage =>
+-    s"Error message is: $errorMessage, " +
+-      s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
++validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map { errorMessage =>
++  s"Error message is: $errorMessage, " +
++    s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
+ }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9130,3 +9130,19 @@ class ClassEmitter {
     }
 
 }
+<<< #4133 lambda in braces, overflow after brace
+maxColumn = 76
+===
+validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
+  errorMessage => s"Error message is: $errorMessage, " +
+      s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
+}
+>>>
+validateStructuralIntegrityWithReasonImpl(row, expectedSchema)
+  .map { errorMessage =>
+    s"Error message is: $errorMessage, " +
+      s"UnsafeRow status: ${getStructuralIntegrityStatus(
+          row,
+          expectedSchema
+        )}"
+  }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9533,3 +9533,16 @@ class ClassEmitter {
     }
 
 }
+<<< #4133 lambda in braces, overflow after brace
+maxColumn = 76
+===
+validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
+  errorMessage => s"Error message is: $errorMessage, " +
+      s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
+}
+>>>
+validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
+  errorMessage =>
+    s"Error message is: $errorMessage, " +
+      s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9810,3 +9810,19 @@ class ClassEmitter {
     }
 
 }
+<<< #4133 lambda in braces, overflow after brace
+maxColumn = 76
+===
+validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
+  errorMessage => s"Error message is: $errorMessage, " +
+      s"UnsafeRow status: ${getStructuralIntegrityStatus(row, expectedSchema)}"
+}
+>>>
+validateStructuralIntegrityWithReasonImpl(row, expectedSchema).map {
+  errorMessage =>
+    s"Error message is: $errorMessage, " +
+      s"UnsafeRow status: ${getStructuralIntegrityStatus(
+          row,
+          expectedSchema
+        )}"
+}


### PR DESCRIPTION
Don't call a statement:
- a single PartialFunction case
- a single function in braces, or its body

Follow-on to #4367. Helps with #4133.