### PR TITLE
FormatOps: ignore source NL in binpacking ctors

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1050,9 +1050,7 @@ class FormatOps(
         case _ => Right(style.newlines.fold)
       }
       val exclude = style.binPack.parentConstructors match {
-        case BinPack.ParentCtors.Always
-            if ft.noBreak || style.newlines.sourceIgnored =>
-          insideBracesBlock(ft, lastToken, true)
+        case BinPack.ParentCtors.Always => insideBracesBlock(ft, lastToken, true)
         case _ => TokenRanges.empty
       }
       val noSyntaxNL = extendsThenWith

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9835,10 +9835,12 @@ trait FunctionInstances extends FunctionInstances0 {
     }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   implicit def function6Instance[T1, T2, T3, T4, T5,
--      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
-+      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *]
-+    with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
-     new Monad[(T1, T2, T3, T4, T5, T6) => *]
+trait FunctionInstances extends FunctionInstances0 {
+  implicit def function6Instance[T1, T2, T3, T4, T5,
+      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *]
+    with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+    new Monad[(T1, T2, T3, T4, T5, T6) => *]
+      with BindRec[(T1, T2, T3, T4, T5, T6) => *] {
+      //
+    }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9820,3 +9820,25 @@ object Build {
       }.evaluated
     )
 }
+<<< #4133 monads with binpack and no newlines in types
+maxColumn = 80
+binPack.preset = always
+newlines {
+  avoidInResultType = true
+  sometimesBeforeColonInMethodReturnType = false
+}
+===
+trait FunctionInstances extends FunctionInstances0 {
+  implicit def function6Instance[T1, T2, T3, T4, T5, T6]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+    new Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] {
+      //
+    }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   implicit def function6Instance[T1, T2, T3, T4, T5,
+-      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
++      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *]
++    with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+     new Monad[(T1, T2, T3, T4, T5, T6) => *]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9215,3 +9215,28 @@ object Build {
         }
     }.evaluated)
 }
+<<< #4133 monads with binpack and no newlines in types
+maxColumn = 80
+binPack.preset = always
+newlines {
+  avoidInResultType = true
+  sometimesBeforeColonInMethodReturnType = false
+}
+===
+trait FunctionInstances extends FunctionInstances0 {
+  implicit def function6Instance[T1, T2, T3, T4, T5, T6]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+    new Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] {
+      //
+    }
+}
+>>>
+trait FunctionInstances extends FunctionInstances0 {
+  implicit def function6Instance[
+      T1, T2, T3, T4, T5,
+      T6
+  ]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+    new Monad[(T1, T2, T3, T4, T5, T6) => *]
+      with BindRec[(T1, T2, T3, T4, T5, T6) => *] {
+      //
+    }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9632,10 +9632,12 @@ trait FunctionInstances extends FunctionInstances0 {
     }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   implicit def function6Instance[T1, T2, T3, T4, T5,
--      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
-+      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *]
-+    with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
-     new Monad[(T1, T2, T3, T4, T5, T6) => *]
+trait FunctionInstances extends FunctionInstances0 {
+  implicit def function6Instance[T1, T2, T3, T4, T5,
+      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *]
+    with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+    new Monad[(T1, T2, T3, T4, T5, T6) => *]
+      with BindRec[(T1, T2, T3, T4, T5, T6) => *] {
+      //
+    }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9617,3 +9617,25 @@ object Build {
     }.evaluated
   )
 }
+<<< #4133 monads with binpack and no newlines in types
+maxColumn = 80
+binPack.preset = always
+newlines {
+  avoidInResultType = true
+  sometimesBeforeColonInMethodReturnType = false
+}
+===
+trait FunctionInstances extends FunctionInstances0 {
+  implicit def function6Instance[T1, T2, T3, T4, T5, T6]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+    new Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] {
+      //
+    }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   implicit def function6Instance[T1, T2, T3, T4, T5,
+-      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
++      T6]: Monad[(T1, T2, T3, T4, T5, T6) => *]
++    with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+     new Monad[(T1, T2, T3, T4, T5, T6) => *]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9912,3 +9912,28 @@ object Build {
           .evaluated
     )
 }
+<<< #4133 monads with binpack and no newlines in types
+maxColumn = 80
+binPack.preset = always
+newlines {
+  avoidInResultType = true
+  sometimesBeforeColonInMethodReturnType = false
+}
+===
+trait FunctionInstances extends FunctionInstances0 {
+  implicit def function6Instance[T1, T2, T3, T4, T5, T6]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+    new Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] {
+      //
+    }
+}
+>>>
+trait FunctionInstances extends FunctionInstances0 {
+  implicit def function6Instance[
+      T1, T2, T3, T4, T5,
+      T6
+  ]: Monad[(T1, T2, T3, T4, T5, T6) => *] with BindRec[(T1, T2, T3, T4, T5, T6) => *] =
+    new Monad[(T1, T2, T3, T4, T5, T6) => *]
+      with BindRec[(T1, T2, T3, T4, T5, T6) => *] {
+      //
+    }
+}


### PR DESCRIPTION
Otherwise, leads to non-idempotent formatting. Helps with #4133.