### PR TITLE
Router: require NL before `}` if non-SLB `({`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1095,13 +1095,16 @@ class Router(formatOps: FormatOps) {
               else {
                 val noConfigStyle = noSplitForNL || newlinePolicy.isEmpty ||
                   !configStyleFlag
-                Split(NoSplit.orNL(noSplitForNL), cost, policy = newlinePolicy)
+                val policy =
+                  if (!noSplitForNL) newlinePolicy
+                  else decideNewlinesOnlyBeforeToken(matching(right).left)
+                Split(NoSplit.orNL(noSplitForNL), cost, policy = policy)
                   .andPolicy(Policy ? noConfigStyle && singleLine(4)).andPolicy(
                     Policy ? singleArgument && asInfixApp(args.head)
                       .map(InfixSplits(_, ft).nlPolicy),
                   )
               }
-            Seq(split.withIndent(indent))
+            Seq(split.withIndent(indent, ignore = !split.isNL))
           }
 
         splitsNoNL ++ splitsNL ++ splitsForAssign.getOrElse(Seq.empty)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -7506,8 +7506,9 @@ class a {
 class a {
   val o2 =
     v1.changes
-      .register(Witness({ i => result = result * i * i }
-      )) // result = 2 * 2 * 2 = 8
+      .register(Witness({ i =>
+        result = result * i * i
+      })) // result = 2 * 2 * 2 = 8
 }
 <<< SM 7.4.0: 53
 maxColumn = 76

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1429,10 +1429,9 @@ foo.mtd({
 )
 >>>
 foo.mtd({
-    x + 1
-    x + 2
-  },
-)
+  x + 1
+  x + 2
+})
 <<< rewrite with trailing commas: func, allowFolding
 rewrite.trailingCommas.style = keep
 rewrite.trailingCommas.allowFolding = true
@@ -1458,10 +1457,9 @@ foo.mtd1({ x =>
 )
 >>>
 foo.mtd1({ x =>
-    x + 1
-    x + 2
-  },
-)
+  x + 1
+  x + 2
+})
 <<< rewrite with trailing commas: func in parens, infix after, allowFolding
 rewrite.trailingCommas.style = keep
 rewrite.trailingCommas.allowFolding = true
@@ -1688,11 +1686,10 @@ foo.mtd({
 )
 >>>
 foo.mtd({
-    bar match {
-      case x => x + 1
-    }
-  },
-)
+  bar match {
+    case x => x + 1
+  }
+})
 <<< with infix (from sbt-scalafmt plugin)
 maxColumn = 80
 newlines.source = fold

--- a/scalafmt-tests/shared/src/test/resources/trailing-commas/trailingCommasPreserve.stat
+++ b/scalafmt-tests/shared/src/test/resources/trailing-commas/trailingCommasPreserve.stat
@@ -480,9 +480,8 @@ foo.mtd({
   )
 >>>
 foo.mtd({ case x =>
-    x + 1
-  },
-)
+  x + 1
+})
 <<< binpack arg !indentCallSiteOnce, !allowFolding
 binPack.unsafeCallSite = true
 rewrite.trailingCommas.allowFolding = false

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1343034, "total explored")
+      assertEquals(Debug.explored, 1342195, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Helps with #4133.