### PR TITLE
FormatOps: fix ForYield as CtrlBody

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -93,16 +93,26 @@ class FormatTokens(leftTok2tok: Map[TokenHash, Int])(val arr: Array[FormatToken]
     case _ => false
   }
 
+  def getHeadAndLastIfEnclosed(
+      tokens: Tokens,
+      tree: Tree,
+  ): Option[(FormatToken, Option[FormatToken])] = getHeadOpt(tokens, tree)
+    .map { head =>
+      head -> matchingOpt(head.left).flatMap { other =>
+        val last = getLastNonTrivial(tokens, tree)
+        if (last eq other) Some(last) else None
+      }
+    }
+  def getHeadAndLastIfEnclosed(
+      tree: Tree,
+  ): Option[(FormatToken, Option[FormatToken])] =
+    getHeadAndLastIfEnclosed(tree.tokens, tree)
+
   def getDelimsIfEnclosed(
       tokens: Tokens,
       tree: Tree,
-  ): Option[(FormatToken, FormatToken)] = getHeadOpt(tokens, tree)
-    .flatMap { head =>
-      matchingOpt(head.left).flatMap { other =>
-        val last = getLastNonTrivial(tokens, tree)
-        if (last eq other) Some((head, last)) else None
-      }
-    }
+  ): Option[(FormatToken, FormatToken)] = getHeadAndLastIfEnclosed(tokens, tree)
+    .flatMap { case (head, lastOpt) => lastOpt.map(last => (head, last)) }
   def getDelimsIfEnclosed(tree: Tree): Option[(FormatToken, FormatToken)] =
     getDelimsIfEnclosed(tree.tokens, tree)
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9893,3 +9893,261 @@ object Multipart {
       //
     }
 }
+<<< #4133 complex nested applies/lambdas with for and tuple, narrow
+private object MemoMap {
+  def make(implicit trace: Trace): UIO[MemoMap] =
+    Ref.Synchronized
+      .map { ref =>
+        new MemoMap { self =>
+          final def getOrElseMemoize[E, A, B](scope: Scope)(
+            layer: ZLayer[A, E, B]
+          ): ZIO[A, E, ZEnvironment[B]] =
+            ref.modifyZIO { map =>
+              map.get(layer) match {
+                case None =>
+                  for {
+                    memoized = (
+                                 promise.await.onExit {
+                                   case Exit.Failure(_) => ZIO.unit
+                                   case Exit.Success(_) => observers.update(_ + 1)
+                                 },
+                                 (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                               )
+                  } yield (resource, if (layer.isFresh) map else map.updated(layer, memoized))
+              }
+            }.flatten
+        }
+      }
+}
+>>> { stateVisits = 311, stateVisits2 = 250 }
+private object MemoMap {
+  def make(implicit
+      trace: Trace
+  ): UIO[MemoMap] =
+    Ref.Synchronized
+      .map { ref =>
+        new MemoMap { self =>
+          final def getOrElseMemoize[
+              E,
+              A,
+              B
+          ](scope: Scope)(
+              layer: ZLayer[A, E, B]
+          ): ZIO[A, E, ZEnvironment[
+            B
+          ]] =
+            ref.modifyZIO { map =>
+              map.get(layer) match {
+                case None =>
+                  for {
+                    memoized = (
+                      promise.await
+                        .onExit {
+                          case Exit
+                                .Failure(
+                                  _
+                                ) =>
+                            ZIO.unit
+                          case Exit
+                                .Success(
+                                  _
+                                ) =>
+                            observers
+                              .update(
+                                _ + 1
+                              )
+                        },
+                      (exit: Exit[
+                        Any,
+                        Any
+                      ]) =>
+                        finalizerRef.get
+                          .flatMap(
+                            _(exit)
+                          )
+                    )
+                  } yield (
+                    resource,
+                    if (layer.isFresh)
+                      map
+                    else
+                      map.updated(
+                        layer,
+                        memoized
+                      )
+                  )
+              }
+            }.flatten
+        }
+      }
+}
+<<< #4133 complex nested applies/lambdas with for and tuple, wide and long
+maxColumn = 80
+===
+object a {
+  private object MemoMap {
+    def make(implicit trace: Trace): UIO[MemoMap] =
+      Ref.Synchronized
+        .make[Map[ZLayer[Nothing, Any, Any], (IO[Any, Any], Exit[Any, Any] => UIO[Any])]](Map.empty)
+        .map { ref =>
+          new MemoMap { self =>
+            final def getOrElseMemoize[E, A, B](scope: Scope)(
+              layer: ZLayer[A, E, B]
+            ): ZIO[A, E, ZEnvironment[B]] =
+              ref.modifyZIO { map =>
+                map.get(layer) match {
+                  case Some((acquire, release)) =>
+                    val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
+                      .asInstanceOf[IO[E, (FiberRefs.Patch, ZEnvironment[B])]]
+                      .flatMap { case (patch, b) => ZIO.patchFiberRefs(patch).as(b) }
+                      .onExit {
+                        case Exit.Success(_) => scope.addFinalizerExit(release)
+                        case Exit.Failure(_) => ZIO.unit
+                      }
+
+                    ZIO.succeed((cached, map))
+                  case None =>
+                    for {
+                      observers    <- Ref.make(0)
+                      promise      <- Promise.make[E, (FiberRefs.Patch, ZEnvironment[B])]
+                      finalizerRef <- Ref.make[Exit[Any, Any] => UIO[Any]](_ => ZIO.unit)
+
+                      resource = ZIO.uninterruptibleMask { restore =>
+                                   for {
+                                     a          <- ZIO.environment[A]
+                                     outerScope  = scope
+                                     innerScope <- Scope.make
+                                     tp <-
+                                       restore(
+                                         layer
+                                           .scope(innerScope)
+                                           .flatMap(_.apply(self).diffFiberRefs)
+                                       ).exit.flatMap {
+                                         case e @ Exit.Failure(cause) =>
+                                           promise.failCause(cause) *> innerScope.close(e) *> ZIO
+                                             .failCause(cause)
+
+                                         case Exit.Success((patch, b)) =>
+                                           for {
+                                             _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
+                                                    ZIO.whenZIO(observers.modify(n => (n == 1, n - 1)))(
+                                                      innerScope.close(e)
+                                                    )
+                                                  }
+                                             _ <- observers.update(_ + 1)
+                                             outerFinalizer <-
+                                               outerScope.addFinalizerExit(e => finalizerRef.get.flatMap(_.apply(e)))
+                                             _ <- promise.succeed((patch, b))
+                                           } yield b
+                                       }
+                                   } yield tp
+                                 }
+
+                      memoized = (
+                                   promise.await.onExit {
+                                     case Exit.Failure(_) => ZIO.unit
+                                     case Exit.Success(_) => observers.update(_ + 1)
+                                   },
+                                   (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                                 )
+                    } yield (resource, if (layer.isFresh) map else map.updated(layer, memoized))
+
+                }
+              }.flatten
+          }
+        }
+  }
+}
+>>> { stateVisits = 1062, stateVisits2 = 943 }
+object a {
+  private object MemoMap {
+    def make(implicit trace: Trace): UIO[MemoMap] =
+      Ref.Synchronized
+        .make[Map[
+          ZLayer[Nothing, Any, Any],
+          (IO[Any, Any], Exit[Any, Any] => UIO[Any])
+        ]](Map.empty)
+        .map { ref =>
+          new MemoMap { self =>
+            final def getOrElseMemoize[E, A, B](scope: Scope)(
+                layer: ZLayer[A, E, B]
+            ): ZIO[A, E, ZEnvironment[B]] =
+              ref.modifyZIO { map =>
+                map.get(layer) match {
+                  case Some((acquire, release)) =>
+                    val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
+                      .asInstanceOf[IO[E, (FiberRefs.Patch, ZEnvironment[B])]]
+                      .flatMap { case (patch, b) =>
+                        ZIO.patchFiberRefs(patch).as(b)
+                      }
+                      .onExit {
+                        case Exit.Success(_) => scope.addFinalizerExit(release)
+                        case Exit.Failure(_) => ZIO.unit
+                      }
+
+                    ZIO.succeed((cached, map))
+                  case None =>
+                    for {
+                      observers <- Ref.make(0)
+                      promise <- Promise
+                        .make[E, (FiberRefs.Patch, ZEnvironment[B])]
+                      finalizerRef <- Ref.make[Exit[Any, Any] => UIO[Any]](_ =>
+                        ZIO.unit
+                      )
+
+                      resource = ZIO.uninterruptibleMask { restore =>
+                        for {
+                          a <- ZIO.environment[A]
+                          outerScope = scope
+                          innerScope <- Scope.make
+                          tp <-
+                            restore(
+                              layer
+                                .scope(innerScope)
+                                .flatMap(_.apply(self).diffFiberRefs)
+                            ).exit.flatMap {
+                              case e @ Exit.Failure(cause) =>
+                                promise.failCause(cause) *> innerScope.close(
+                                  e
+                                ) *> ZIO
+                                  .failCause(cause)
+
+                              case Exit.Success((patch, b)) =>
+                                for {
+                                  _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
+                                    ZIO.whenZIO(
+                                      observers.modify(n => (n == 1, n - 1))
+                                    )(
+                                      innerScope.close(e)
+                                    )
+                                  }
+                                  _ <- observers.update(_ + 1)
+                                  outerFinalizer <-
+                                    outerScope.addFinalizerExit(e =>
+                                      finalizerRef.get.flatMap(_.apply(e))
+                                    )
+                                  _ <- promise.succeed((patch, b))
+                                } yield b
+                            }
+                        } yield tp
+                      }
+
+                      memoized = (
+                        promise.await.onExit {
+                          case Exit.Failure(_) => ZIO.unit
+                          case Exit.Success(_) => observers.update(_ + 1)
+                        },
+                        (exit: Exit[Any, Any]) =>
+                          finalizerRef.get.flatMap(_(exit))
+                      )
+                    } yield (
+                      resource,
+                      if (layer.isFresh) map else map.updated(layer, memoized)
+                    )
+
+                }
+              }.flatten
+          }
+        }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9290,3 +9290,110 @@ object Multipart {
       //
     }
 }
+<<< SKIP #4133 complex nested applies/lambdas with for and tuple, narrow
+private object MemoMap {
+  def make(implicit trace: Trace): UIO[MemoMap] =
+    Ref.Synchronized
+      .map { ref =>
+        new MemoMap { self =>
+          final def getOrElseMemoize[E, A, B](scope: Scope)(
+            layer: ZLayer[A, E, B]
+          ): ZIO[A, E, ZEnvironment[B]] =
+            ref.modifyZIO { map =>
+              map.get(layer) match {
+                case None =>
+                  for {
+                    memoized = (
+                                 promise.await.onExit {
+                                   case Exit.Failure(_) => ZIO.unit
+                                   case Exit.Success(_) => observers.update(_ + 1)
+                                 },
+                                 (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                               )
+                  } yield (resource, if (layer.isFresh) map else map.updated(layer, memoized))
+              }
+            }.flatten
+        }
+      }
+}
+>>>
+FormatTests:54 [e]: org.scalafmt.Error$SearchStateExploded: Search state exploded on '[158] (∙layer: LeftParen [851..852) [] Ident(layer) [852..857)', line 20: exceeded `runner.optimizer.maxVisitsPerToken`=10000 [see https://scalameta.org/scalafmt/docs/configuration.html#search-state-exploded]
+<<< SKIP #4133 complex nested applies/lambdas with for and tuple, wide and long
+maxColumn = 80
+===
+object a {
+  private object MemoMap {
+    def make(implicit trace: Trace): UIO[MemoMap] =
+      Ref.Synchronized
+        .make[Map[ZLayer[Nothing, Any, Any], (IO[Any, Any], Exit[Any, Any] => UIO[Any])]](Map.empty)
+        .map { ref =>
+          new MemoMap { self =>
+            final def getOrElseMemoize[E, A, B](scope: Scope)(
+              layer: ZLayer[A, E, B]
+            ): ZIO[A, E, ZEnvironment[B]] =
+              ref.modifyZIO { map =>
+                map.get(layer) match {
+                  case Some((acquire, release)) =>
+                    val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
+                      .asInstanceOf[IO[E, (FiberRefs.Patch, ZEnvironment[B])]]
+                      .flatMap { case (patch, b) => ZIO.patchFiberRefs(patch).as(b) }
+                      .onExit {
+                        case Exit.Success(_) => scope.addFinalizerExit(release)
+                        case Exit.Failure(_) => ZIO.unit
+                      }
+
+                    ZIO.succeed((cached, map))
+                  case None =>
+                    for {
+                      observers    <- Ref.make(0)
+                      promise      <- Promise.make[E, (FiberRefs.Patch, ZEnvironment[B])]
+                      finalizerRef <- Ref.make[Exit[Any, Any] => UIO[Any]](_ => ZIO.unit)
+
+                      resource = ZIO.uninterruptibleMask { restore =>
+                                   for {
+                                     a          <- ZIO.environment[A]
+                                     outerScope  = scope
+                                     innerScope <- Scope.make
+                                     tp <-
+                                       restore(
+                                         layer
+                                           .scope(innerScope)
+                                           .flatMap(_.apply(self).diffFiberRefs)
+                                       ).exit.flatMap {
+                                         case e @ Exit.Failure(cause) =>
+                                           promise.failCause(cause) *> innerScope.close(e) *> ZIO
+                                             .failCause(cause)
+
+                                         case Exit.Success((patch, b)) =>
+                                           for {
+                                             _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
+                                                    ZIO.whenZIO(observers.modify(n => (n == 1, n - 1)))(
+                                                      innerScope.close(e)
+                                                    )
+                                                  }
+                                             _ <- observers.update(_ + 1)
+                                             outerFinalizer <-
+                                               outerScope.addFinalizerExit(e => finalizerRef.get.flatMap(_.apply(e)))
+                                             _ <- promise.succeed((patch, b))
+                                           } yield b
+                                       }
+                                   } yield tp
+                                 }
+
+                      memoized = (
+                                   promise.await.onExit {
+                                     case Exit.Failure(_) => ZIO.unit
+                                     case Exit.Success(_) => observers.update(_ + 1)
+                                   },
+                                   (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                                 )
+                    } yield (resource, if (layer.isFresh) map else map.updated(layer, memoized))
+
+                }
+              }.flatten
+          }
+        }
+  }
+}
+>>>
+FormatTests:54 [e]: org.scalafmt.Error$SearchStateExploded: Search state exploded on '[556] if∙(: KwIf [3640..3642) [ ] LeftParen [3643..3644)', line 67: exceeded `runner.maxStateVisits`=150000 [see https://scalameta.org/scalafmt/docs/configuration.html#search-state-exploded]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -1629,8 +1629,8 @@ object a {
 }
 >>>
 object a {
-  def a = for (a <- b; if cc < dd)
-    yield a
+  def a =
+    for (a <- b; if cc < dd) yield a
 }
 <<< 7.2: enumerator short, guard long
 maxColumn = 28
@@ -9290,7 +9290,7 @@ object Multipart {
       //
     }
 }
-<<< SKIP #4133 complex nested applies/lambdas with for and tuple, narrow
+<<< #4133 complex nested applies/lambdas with for and tuple, narrow
 private object MemoMap {
   def make(implicit trace: Trace): UIO[MemoMap] =
     Ref.Synchronized
@@ -9316,9 +9316,64 @@ private object MemoMap {
         }
       }
 }
->>>
-FormatTests:54 [e]: org.scalafmt.Error$SearchStateExploded: Search state exploded on '[158] (∙layer: LeftParen [851..852) [] Ident(layer) [852..857)', line 20: exceeded `runner.optimizer.maxVisitsPerToken`=10000 [see https://scalameta.org/scalafmt/docs/configuration.html#search-state-exploded]
-<<< SKIP #4133 complex nested applies/lambdas with for and tuple, wide and long
+>>> { stateVisits = 724, stateVisits2 = 724 }
+private object MemoMap {
+  def make(implicit
+      trace: Trace
+  ): UIO[MemoMap] = Ref.Synchronized
+    .map { ref =>
+      new MemoMap {
+        self =>
+        final def getOrElseMemoize[
+            E,
+            A,
+            B
+        ](scope: Scope)(
+            layer: ZLayer[A, E, B]
+        ): ZIO[A, E, ZEnvironment[B]] =
+          ref.modifyZIO { map =>
+            map.get(layer) match {
+              case None => for {
+                  memoized = (
+                    promise.await
+                      .onExit {
+                        case Exit
+                              .Failure(
+                                _
+                              ) =>
+                          ZIO.unit
+                        case Exit
+                              .Success(
+                                _
+                              ) =>
+                          observers
+                            .update(
+                              _ + 1
+                            )
+                      },
+                    (exit: Exit[
+                      Any,
+                      Any
+                    ]) =>
+                      finalizerRef.get
+                        .flatMap(
+                          _(exit)
+                        )
+                  )
+                } yield (
+                  resource,
+                  if (layer.isFresh) map
+                  else map.updated(
+                    layer,
+                    memoized
+                  )
+                )
+            }
+          }.flatten
+      }
+    }
+}
+<<< #4133 complex nested applies/lambdas with for and tuple, wide and long
 maxColumn = 80
 ===
 object a {
@@ -9395,5 +9450,80 @@ object a {
         }
   }
 }
->>>
-FormatTests:54 [e]: org.scalafmt.Error$SearchStateExploded: Search state exploded on '[556] if∙(: KwIf [3640..3642) [ ] LeftParen [3643..3644)', line 67: exceeded `runner.maxStateVisits`=150000 [see https://scalameta.org/scalafmt/docs/configuration.html#search-state-exploded]
+>>> { stateVisits = 4731, stateVisits2 = 4731 }
+object a {
+  private object MemoMap {
+    def make(implicit trace: Trace): UIO[MemoMap] = Ref.Synchronized
+      .make[Map[
+        ZLayer[Nothing, Any, Any],
+        (IO[Any, Any], Exit[Any, Any] => UIO[Any])
+      ]](Map.empty).map { ref =>
+        new MemoMap {
+          self => final def getOrElseMemoize[E, A, B](scope: Scope)(
+              layer: ZLayer[A, E, B]
+          ): ZIO[A, E, ZEnvironment[B]] = ref.modifyZIO { map =>
+            map.get(layer) match {
+              case Some((acquire, release)) =>
+                val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
+                  .asInstanceOf[IO[E, (FiberRefs.Patch, ZEnvironment[B])]]
+                  .flatMap { case (patch, b) =>
+                    ZIO.patchFiberRefs(patch).as(b)
+                  }.onExit {
+                    case Exit.Success(_) => scope.addFinalizerExit(release)
+                    case Exit.Failure(_) => ZIO.unit
+                  }
+
+                ZIO.succeed((cached, map))
+              case None => for {
+                  observers <- Ref.make(0)
+                  promise <- Promise.make[E, (FiberRefs.Patch, ZEnvironment[B])]
+                  finalizerRef <- Ref
+                    .make[Exit[Any, Any] => UIO[Any]](_ => ZIO.unit)
+
+                  resource = ZIO.uninterruptibleMask { restore =>
+                    for {
+                      a <- ZIO.environment[A]
+                      outerScope = scope
+                      innerScope <- Scope.make
+                      tp <- restore(
+                        layer.scope(innerScope)
+                          .flatMap(_.apply(self).diffFiberRefs)
+                      ).exit.flatMap {
+                        case e @ Exit.Failure(cause) => promise
+                            .failCause(cause) *> innerScope.close(e) *>
+                            ZIO.failCause(cause)
+
+                        case Exit.Success((patch, b)) => for {
+                            _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
+                              ZIO.whenZIO(
+                                observers.modify(n => (n == 1, n - 1))
+                              )(innerScope.close(e))
+                            }
+                            _ <- observers.update(_ + 1)
+                            outerFinalizer <- outerScope.addFinalizerExit(e =>
+                              finalizerRef.get.flatMap(_.apply(e))
+                            )
+                            _ <- promise.succeed((patch, b))
+                          } yield b
+                      }
+                    } yield tp
+                  }
+
+                  memoized = (
+                    promise.await.onExit {
+                      case Exit.Failure(_) => ZIO.unit
+                      case Exit.Success(_) => observers.update(_ + 1)
+                    },
+                    (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                  )
+                } yield (
+                  resource,
+                  if (layer.isFresh) map else map.updated(layer, memoized)
+                )
+
+            }
+          }.flatten
+        }
+      }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -1748,8 +1748,8 @@ object a {
 }
 >>>
 object a {
-  def a = for (a <- b; if cc < dd)
-    yield a
+  def a =
+    for (a <- b; if cc < dd) yield a
 }
 <<< 7.2: enumerator short, guard long
 maxColumn = 30
@@ -9851,7 +9851,7 @@ object a {
         }
   }
 }
->>> { stateVisits = 858, stateVisits2 = 739 }
+>>> { stateVisits = 860, stateVisits2 = 741 }
 object a {
   private object MemoMap {
     def make(implicit trace: Trace): UIO[MemoMap] =

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9690,3 +9690,256 @@ object Multipart {
       //
     }
 }
+<<< #4133 complex nested applies/lambdas with for and tuple, narrow
+private object MemoMap {
+  def make(implicit trace: Trace): UIO[MemoMap] =
+    Ref.Synchronized
+      .map { ref =>
+        new MemoMap { self =>
+          final def getOrElseMemoize[E, A, B](scope: Scope)(
+            layer: ZLayer[A, E, B]
+          ): ZIO[A, E, ZEnvironment[B]] =
+            ref.modifyZIO { map =>
+              map.get(layer) match {
+                case None =>
+                  for {
+                    memoized = (
+                                 promise.await.onExit {
+                                   case Exit.Failure(_) => ZIO.unit
+                                   case Exit.Success(_) => observers.update(_ + 1)
+                                 },
+                                 (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                               )
+                  } yield (resource, if (layer.isFresh) map else map.updated(layer, memoized))
+              }
+            }.flatten
+        }
+      }
+}
+>>> { stateVisits = 271, stateVisits2 = 221 }
+private object MemoMap {
+  def make(implicit
+      trace: Trace
+  ): UIO[MemoMap] =
+    Ref.Synchronized
+      .map { ref =>
+        new MemoMap { self =>
+          final def getOrElseMemoize[
+              E,
+              A,
+              B
+          ](scope: Scope)(
+              layer: ZLayer[A, E, B]
+          ): ZIO[
+            A,
+            E,
+            ZEnvironment[B]
+          ] =
+            ref.modifyZIO { map =>
+              map.get(layer) match {
+                case None =>
+                  for {
+                    memoized = (
+                      promise.await.onExit {
+                        case Exit.Failure(
+                              _
+                            ) =>
+                          ZIO.unit
+                        case Exit.Success(
+                              _
+                            ) =>
+                          observers.update(
+                            _ + 1
+                          )
+                      },
+                      (exit: Exit[
+                        Any,
+                        Any
+                      ]) =>
+                        finalizerRef.get.flatMap(
+                          _(exit)
+                        )
+                    )
+                  } yield (
+                    resource,
+                    if (layer.isFresh)
+                      map
+                    else map.updated(
+                      layer,
+                      memoized
+                    )
+                  )
+              }
+            }.flatten
+        }
+      }
+}
+<<< #4133 complex nested applies/lambdas with for and tuple, wide and long
+maxColumn = 80
+===
+object a {
+  private object MemoMap {
+    def make(implicit trace: Trace): UIO[MemoMap] =
+      Ref.Synchronized
+        .make[Map[ZLayer[Nothing, Any, Any], (IO[Any, Any], Exit[Any, Any] => UIO[Any])]](Map.empty)
+        .map { ref =>
+          new MemoMap { self =>
+            final def getOrElseMemoize[E, A, B](scope: Scope)(
+              layer: ZLayer[A, E, B]
+            ): ZIO[A, E, ZEnvironment[B]] =
+              ref.modifyZIO { map =>
+                map.get(layer) match {
+                  case Some((acquire, release)) =>
+                    val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
+                      .asInstanceOf[IO[E, (FiberRefs.Patch, ZEnvironment[B])]]
+                      .flatMap { case (patch, b) => ZIO.patchFiberRefs(patch).as(b) }
+                      .onExit {
+                        case Exit.Success(_) => scope.addFinalizerExit(release)
+                        case Exit.Failure(_) => ZIO.unit
+                      }
+
+                    ZIO.succeed((cached, map))
+                  case None =>
+                    for {
+                      observers    <- Ref.make(0)
+                      promise      <- Promise.make[E, (FiberRefs.Patch, ZEnvironment[B])]
+                      finalizerRef <- Ref.make[Exit[Any, Any] => UIO[Any]](_ => ZIO.unit)
+
+                      resource = ZIO.uninterruptibleMask { restore =>
+                                   for {
+                                     a          <- ZIO.environment[A]
+                                     outerScope  = scope
+                                     innerScope <- Scope.make
+                                     tp <-
+                                       restore(
+                                         layer
+                                           .scope(innerScope)
+                                           .flatMap(_.apply(self).diffFiberRefs)
+                                       ).exit.flatMap {
+                                         case e @ Exit.Failure(cause) =>
+                                           promise.failCause(cause) *> innerScope.close(e) *> ZIO
+                                             .failCause(cause)
+
+                                         case Exit.Success((patch, b)) =>
+                                           for {
+                                             _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
+                                                    ZIO.whenZIO(observers.modify(n => (n == 1, n - 1)))(
+                                                      innerScope.close(e)
+                                                    )
+                                                  }
+                                             _ <- observers.update(_ + 1)
+                                             outerFinalizer <-
+                                               outerScope.addFinalizerExit(e => finalizerRef.get.flatMap(_.apply(e)))
+                                             _ <- promise.succeed((patch, b))
+                                           } yield b
+                                       }
+                                   } yield tp
+                                 }
+
+                      memoized = (
+                                   promise.await.onExit {
+                                     case Exit.Failure(_) => ZIO.unit
+                                     case Exit.Success(_) => observers.update(_ + 1)
+                                   },
+                                   (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                                 )
+                    } yield (resource, if (layer.isFresh) map else map.updated(layer, memoized))
+
+                }
+              }.flatten
+          }
+        }
+  }
+}
+>>> { stateVisits = 858, stateVisits2 = 739 }
+object a {
+  private object MemoMap {
+    def make(implicit trace: Trace): UIO[MemoMap] =
+      Ref.Synchronized
+        .make[Map[
+          ZLayer[Nothing, Any, Any],
+          (IO[Any, Any], Exit[Any, Any] => UIO[Any])
+        ]](Map.empty)
+        .map { ref =>
+          new MemoMap { self =>
+            final def getOrElseMemoize[E, A, B](scope: Scope)(
+                layer: ZLayer[A, E, B]
+            ): ZIO[A, E, ZEnvironment[B]] =
+              ref.modifyZIO { map =>
+                map.get(layer) match {
+                  case Some((acquire, release)) =>
+                    val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
+                      .asInstanceOf[IO[E, (FiberRefs.Patch, ZEnvironment[B])]]
+                      .flatMap { case (patch, b) =>
+                        ZIO.patchFiberRefs(patch).as(b)
+                      }
+                      .onExit {
+                        case Exit.Success(_) => scope.addFinalizerExit(release)
+                        case Exit.Failure(_) => ZIO.unit
+                      }
+
+                    ZIO.succeed((cached, map))
+                  case None =>
+                    for {
+                      observers <- Ref.make(0)
+                      promise <-
+                        Promise.make[E, (FiberRefs.Patch, ZEnvironment[B])]
+                      finalizerRef <-
+                        Ref.make[Exit[Any, Any] => UIO[Any]](_ => ZIO.unit)
+
+                      resource = ZIO.uninterruptibleMask { restore =>
+                        for {
+                          a <- ZIO.environment[A]
+                          outerScope = scope
+                          innerScope <- Scope.make
+                          tp <-
+                            restore(
+                              layer
+                                .scope(innerScope)
+                                .flatMap(_.apply(self).diffFiberRefs)
+                            ).exit.flatMap {
+                              case e @ Exit.Failure(cause) =>
+                                promise.failCause(cause) *> innerScope.close(
+                                  e
+                                ) *> ZIO
+                                  .failCause(cause)
+
+                              case Exit.Success((patch, b)) =>
+                                for {
+                                  _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
+                                    ZIO.whenZIO(observers.modify(n =>
+                                      (n == 1, n - 1)
+                                    ))(
+                                      innerScope.close(e)
+                                    )
+                                  }
+                                  _ <- observers.update(_ + 1)
+                                  outerFinalizer <-
+                                    outerScope.addFinalizerExit(e =>
+                                      finalizerRef.get.flatMap(_.apply(e))
+                                    )
+                                  _ <- promise.succeed((patch, b))
+                                } yield b
+                            }
+                        } yield tp
+                      }
+
+                      memoized = (
+                        promise.await.onExit {
+                          case Exit.Failure(_) => ZIO.unit
+                          case Exit.Success(_) => observers.update(_ + 1)
+                        },
+                        (exit: Exit[Any, Any]) =>
+                          finalizerRef.get.flatMap(_(exit))
+                      )
+                    } yield (
+                      resource,
+                      if (layer.isFresh) map else map.updated(layer, memoized)
+                    )
+
+                }
+              }.flatten
+          }
+        }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9986,3 +9986,277 @@ object Multipart {
       //
     }
 }
+<<< #4133 complex nested applies/lambdas with for and tuple, narrow
+private object MemoMap {
+  def make(implicit trace: Trace): UIO[MemoMap] =
+    Ref.Synchronized
+      .map { ref =>
+        new MemoMap { self =>
+          final def getOrElseMemoize[E, A, B](scope: Scope)(
+            layer: ZLayer[A, E, B]
+          ): ZIO[A, E, ZEnvironment[B]] =
+            ref.modifyZIO { map =>
+              map.get(layer) match {
+                case None =>
+                  for {
+                    memoized = (
+                                 promise.await.onExit {
+                                   case Exit.Failure(_) => ZIO.unit
+                                   case Exit.Success(_) => observers.update(_ + 1)
+                                 },
+                                 (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                               )
+                  } yield (resource, if (layer.isFresh) map else map.updated(layer, memoized))
+              }
+            }.flatten
+        }
+      }
+}
+>>> { stateVisits = 369 }
+private object MemoMap {
+  def make(implicit
+      trace: Trace
+  ): UIO[MemoMap] = Ref
+    .Synchronized
+    .map { ref =>
+      new MemoMap {
+        self =>
+        final def getOrElseMemoize[
+            E,
+            A,
+            B
+        ](scope: Scope)(
+            layer: ZLayer[A, E, B]
+        ): ZIO[A, E, ZEnvironment[B]] =
+          ref
+            .modifyZIO { map =>
+              map.get(layer) match {
+                case None =>
+                  for {
+                    memoized =
+                      (
+                        promise
+                          .await
+                          .onExit {
+                            case Exit
+                                  .Failure(
+                                    _
+                                  ) =>
+                              ZIO.unit
+                            case Exit
+                                  .Success(
+                                    _
+                                  ) =>
+                              observers
+                                .update(
+                                  _ + 1
+                                )
+                          },
+                        (
+                          exit: Exit[
+                            Any,
+                            Any
+                          ]
+                        ) =>
+                          finalizerRef
+                            .get
+                            .flatMap(
+                              _(exit)
+                            )
+                      )
+                  } yield (
+                    resource,
+                    if (layer.isFresh)
+                      map
+                    else
+                      map.updated(
+                        layer,
+                        memoized
+                      )
+                  )
+              }
+            }
+            .flatten
+      }
+    }
+}
+<<< #4133 complex nested applies/lambdas with for and tuple, wide and long
+maxColumn = 80
+===
+object a {
+  private object MemoMap {
+    def make(implicit trace: Trace): UIO[MemoMap] =
+      Ref.Synchronized
+        .make[Map[ZLayer[Nothing, Any, Any], (IO[Any, Any], Exit[Any, Any] => UIO[Any])]](Map.empty)
+        .map { ref =>
+          new MemoMap { self =>
+            final def getOrElseMemoize[E, A, B](scope: Scope)(
+              layer: ZLayer[A, E, B]
+            ): ZIO[A, E, ZEnvironment[B]] =
+              ref.modifyZIO { map =>
+                map.get(layer) match {
+                  case Some((acquire, release)) =>
+                    val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
+                      .asInstanceOf[IO[E, (FiberRefs.Patch, ZEnvironment[B])]]
+                      .flatMap { case (patch, b) => ZIO.patchFiberRefs(patch).as(b) }
+                      .onExit {
+                        case Exit.Success(_) => scope.addFinalizerExit(release)
+                        case Exit.Failure(_) => ZIO.unit
+                      }
+
+                    ZIO.succeed((cached, map))
+                  case None =>
+                    for {
+                      observers    <- Ref.make(0)
+                      promise      <- Promise.make[E, (FiberRefs.Patch, ZEnvironment[B])]
+                      finalizerRef <- Ref.make[Exit[Any, Any] => UIO[Any]](_ => ZIO.unit)
+
+                      resource = ZIO.uninterruptibleMask { restore =>
+                                   for {
+                                     a          <- ZIO.environment[A]
+                                     outerScope  = scope
+                                     innerScope <- Scope.make
+                                     tp <-
+                                       restore(
+                                         layer
+                                           .scope(innerScope)
+                                           .flatMap(_.apply(self).diffFiberRefs)
+                                       ).exit.flatMap {
+                                         case e @ Exit.Failure(cause) =>
+                                           promise.failCause(cause) *> innerScope.close(e) *> ZIO
+                                             .failCause(cause)
+
+                                         case Exit.Success((patch, b)) =>
+                                           for {
+                                             _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
+                                                    ZIO.whenZIO(observers.modify(n => (n == 1, n - 1)))(
+                                                      innerScope.close(e)
+                                                    )
+                                                  }
+                                             _ <- observers.update(_ + 1)
+                                             outerFinalizer <-
+                                               outerScope.addFinalizerExit(e => finalizerRef.get.flatMap(_.apply(e)))
+                                             _ <- promise.succeed((patch, b))
+                                           } yield b
+                                       }
+                                   } yield tp
+                                 }
+
+                      memoized = (
+                                   promise.await.onExit {
+                                     case Exit.Failure(_) => ZIO.unit
+                                     case Exit.Success(_) => observers.update(_ + 1)
+                                   },
+                                   (exit: Exit[Any, Any]) => finalizerRef.get.flatMap(_(exit))
+                                 )
+                    } yield (resource, if (layer.isFresh) map else map.updated(layer, memoized))
+
+                }
+              }.flatten
+          }
+        }
+  }
+}
+>>> { stateVisits = 1049, stateVisits2 = 1049 }
+object a {
+  private object MemoMap {
+    def make(implicit trace: Trace): UIO[MemoMap] = Ref
+      .Synchronized
+      .make[Map[
+        ZLayer[Nothing, Any, Any],
+        (IO[Any, Any], Exit[Any, Any] => UIO[Any])
+      ]](Map.empty)
+      .map { ref =>
+        new MemoMap {
+          self =>
+          final def getOrElseMemoize[E, A, B](
+              scope: Scope
+          )(layer: ZLayer[A, E, B]): ZIO[A, E, ZEnvironment[B]] =
+            ref
+              .modifyZIO { map =>
+                map.get(layer) match {
+                  case Some((acquire, release)) =>
+                    val cached: ZIO[Any, E, ZEnvironment[B]] = acquire
+                      .asInstanceOf[IO[E, (FiberRefs.Patch, ZEnvironment[B])]]
+                      .flatMap { case (patch, b) =>
+                        ZIO.patchFiberRefs(patch).as(b)
+                      }
+                      .onExit {
+                        case Exit.Success(_) =>
+                          scope.addFinalizerExit(release)
+                        case Exit.Failure(_) =>
+                          ZIO.unit
+                      }
+
+                    ZIO.succeed((cached, map))
+                  case None =>
+                    for {
+                      observers <- Ref.make(0)
+                      promise <- Promise.make[
+                        E,
+                        (FiberRefs.Patch, ZEnvironment[B])
+                      ]
+                      finalizerRef <- Ref.make[Exit[Any, Any] => UIO[Any]](_ =>
+                        ZIO.unit
+                      )
+
+                      resource = ZIO.uninterruptibleMask { restore =>
+                        for {
+                          a <- ZIO.environment[A]
+                          outerScope = scope
+                          innerScope <- Scope.make
+                          tp <- restore(
+                            layer
+                              .scope(innerScope)
+                              .flatMap(_.apply(self).diffFiberRefs)
+                          ).exit
+                            .flatMap {
+                              case e @ Exit.Failure(cause) =>
+                                promise.failCause(cause) *>
+                                  innerScope.close(e) *> ZIO.failCause(cause)
+
+                              case Exit.Success((patch, b)) =>
+                                for {
+                                  _ <- finalizerRef.set { (e: Exit[Any, Any]) =>
+                                    ZIO.whenZIO(
+                                      observers.modify(n => (n == 1, n - 1))
+                                    )(innerScope.close(e))
+                                  }
+                                  _ <- observers.update(_ + 1)
+                                  outerFinalizer <- outerScope.addFinalizerExit(
+                                    e => finalizerRef.get.flatMap(_.apply(e))
+                                  )
+                                  _ <- promise.succeed((patch, b))
+                                } yield b
+                            }
+                        } yield tp
+                      }
+
+                      memoized =
+                        (
+                          promise
+                            .await
+                            .onExit {
+                              case Exit.Failure(_) =>
+                                ZIO.unit
+                              case Exit.Success(_) =>
+                                observers.update(_ + 1)
+                            },
+                          (exit: Exit[Any, Any]) =>
+                            finalizerRef.get.flatMap(_(exit))
+                        )
+                    } yield (
+                      resource,
+                      if (layer.isFresh)
+                        map
+                      else
+                        map.updated(layer, memoized)
+                    )
+
+                }
+              }
+              .flatten
+        }
+      }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -6479,9 +6479,8 @@ object a:
 >>>
 object a:
    def foo =
-      val bar =
-        for (baz <- bazs) yield
-           def foo = baz
+      val bar = for (baz <- bazs) yield
+         def foo = baz
 <<< #4133 enclosed for-yield with added end marker
 rewrite.scala3 {
   convertToNewSyntax = true

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -6788,9 +6788,8 @@ object a:
 >>>
 object a:
    def foo =
-      val bar =
-        for (baz <- bazs) yield
-           def foo = baz
+      val bar = for (baz <- bazs) yield
+         def foo = baz
 <<< #4133 enclosed for-yield with added end marker
 rewrite.scala3 {
   convertToNewSyntax = true

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1342195, "total explored")
+      assertEquals(Debug.explored, 1349686, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1349686, "total explored")
+      assertEquals(Debug.explored, 1360425, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Terminate the single-line block policy on `yield` if the body is not a block. Also, use that token as optimal, instead of the last body token. Helps with #4133.