### PR TITLE
Router: fix performance of chained apply calls, with anon functions

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1063,7 +1063,9 @@ class Router(formatOps: FormatOps) {
                   else if (splitsForAssign.isDefined) singleLine(3)
                   else singleLine(10)
                 val kof = style.newlines.keep && needDifferentFromOneArgPerLine
-                val noOptimal = style.newlines.keep && !useOneArgPerLineSplit
+                val noOptimal = style.newlines.keep && !useOneArgPerLineSplit ||
+                  singleArgument && !excludeBlocks.isEmpty &&
+                  excludeBlocks.ranges.forall(_.lt.is[T.LeftParen])
                 val okIndent = rightIsComment || handleImplicit
                 Split(noSplitMod, 0, policy = noSplitPolicy).withOptimalToken(
                   optimal,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -965,6 +965,7 @@ class Router(formatOps: FormatOps) {
             )
           }
 
+        @tailrec
         def isExcludedTree(tree: Tree): Boolean = tree match {
           case t: Init => t.argClauses.nonEmpty
           case t: Term.Apply => t.argClause.nonEmpty
@@ -972,6 +973,7 @@ class Router(formatOps: FormatOps) {
           case t: Tree.WithCasesBlock => t.casesBlock.cases.nonEmpty
           case t: Term.New => t.init.argClauses.nonEmpty
           case _: Term.NewAnonymous => true
+          case t: Term.AnonymousFunction => isExcludedTree(t.body)
           case _ => false
         }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -876,6 +876,11 @@ object TreeOps {
       case t: Term.Apply => isFewerBraces(t)
       case t: Term.ApplyInfix => isFewerBracesLhs(t.argClause)
       case Term.ArgClause(arg :: Nil, _) => isFewerBracesLhs(arg)
+      case t: Term.AnonymousFunction => t.body match {
+          case t: Term.Apply => isFewerBraces(t)
+          case t: Term.ApplyInfix => isFewerBracesLhs(t.argClause)
+          case _ => false
+        }
       case _ => false
     })
 
@@ -888,6 +893,11 @@ object TreeOps {
       case t: Term.Apply => isFewerBraces(t)
       case t: Term.ApplyInfix => isFewerBracesRhs(t.lhs)
       case Term.ArgClause(arg :: Nil, _) => isFewerBracesRhs(arg)
+      case t: Term.AnonymousFunction => t.body match {
+          case t: Term.Apply => isFewerBraces(t)
+          case t: Term.ApplyInfix => isFewerBracesRhs(t.lhs)
+          case _ => false
+        }
       case _ => false
     })
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source.source
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source.source
@@ -69,7 +69,7 @@ private[parser] trait CacheControlHeader { this: Parser with CommonRules with Co
     clearSB() ~ zeroOrMore(!'"' ~ !',' ~ qdtext ~ appendSB() | `quoted-pair`) ~ push(sb.toString)
   }
 }
->>> { stateVisits = 41013 }
+>>> { stateVisits = 42976, stateVisits2 = 42976 }
 /** Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
   */
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10151,3 +10151,257 @@ object a {
         }
   }
 }
+<<< #4133 spark: massive chain of applies with anonymous function calls
+maxColumn = 80
+runner.maxStateVisits = 10000000
+runner.optimizer.maxVisitsPerToken=1000000
+===
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
+    packages
+      .map(_.filterNot(_.getName.contains("$")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+        !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+        !f.getCanonicalPath.contains("org/apache/spark/unsafe/types/CalendarInterval")))
+      .map(_.filterNot(_.getCanonicalPath.contains("python")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/collection")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/kvstore")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/connect/")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/execution")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/internal")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+  }
+}
+>>> { stateVisits = 1239, stateVisits2 = 699 }
+object a {
+  private def ignoreUndocumentedPackages(
+      packages: Seq[Seq[File]]
+  ): Seq[Seq[File]] = {
+    packages
+      .map(_.filterNot(_.getName.contains("$")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/examples"))
+      )
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/internal"))
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(
+        _.filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+            !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+        )
+      )
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/executor"))
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains(
+            "org/apache/spark/ExecutorAllocationClient"
+          )
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains(
+            "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+          )
+        )
+      )
+      .map(
+        _.filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+            !f.getCanonicalPath.contains(
+              "org/apache/spark/unsafe/types/CalendarInterval"
+            )
+        )
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("python")))
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/util/collection")
+        )
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/util/kvstore")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/catalyst")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/connect/")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/execution")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/internal")
+        )
+      )
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive"))
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+        )
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org.apache.spark.sql.errors"))
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro"))
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+  }
+}
+<<< #4133 #4133 spark: massive chain of applies with function calls
+maxColumn = 80
+runner.maxStateVisits = 10000000
+runner.optimizer.maxVisitsPerToken=1000000
+===
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
+    packages
+      .map(filterNot(getName.contains("$")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/network")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+        !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+        !f.getCanonicalPath.contains("org/apache/spark/unsafe/types/CalendarInterval")))
+      .map(filterNot(getCanonicalPath.contains("python")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/collection")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/kvstore")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/connect/")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/execution")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(filterNot(getCanonicalPath.contains("SSLOptions")))
+  }
+}
+>>> { stateVisits = 800, stateVisits2 = 556 }
+object a {
+  private def ignoreUndocumentedPackages(
+      packages: Seq[Seq[File]]
+  ): Seq[Seq[File]] = {
+    packages
+      .map(filterNot(getName.contains("$")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/network")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(
+        filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+            !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+        )
+      )
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(
+        filterNot(
+          getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")
+        )
+      )
+      .map(
+        filterNot(
+          getCanonicalPath.contains(
+            "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+          )
+        )
+      )
+      .map(
+        filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+            !f.getCanonicalPath.contains(
+              "org/apache/spark/unsafe/types/CalendarInterval"
+            )
+        )
+      )
+      .map(filterNot(getCanonicalPath.contains("python")))
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/util/collection"))
+      )
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/util/kvstore"))
+      )
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalyst"))
+      )
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/sql/connect/"))
+      )
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/sql/execution"))
+      )
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/sql/internal"))
+      )
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(
+        filterNot(
+          getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+        )
+      )
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(filterNot(getCanonicalPath.contains("SSLOptions")))
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9316,7 +9316,7 @@ private object MemoMap {
         }
       }
 }
->>> { stateVisits = 724, stateVisits2 = 724 }
+>>> { stateVisits = 879, stateVisits2 = 879 }
 private object MemoMap {
   def make(implicit
       trace: Trace
@@ -9356,9 +9356,9 @@ private object MemoMap {
                       Any
                     ]) =>
                       finalizerRef.get
-                        .flatMap(
-                          _(exit)
-                        )
+                        .flatMap(_(
+                          exit
+                        ))
                   )
                 } yield (
                   resource,
@@ -9529,8 +9529,7 @@ object a {
 }
 <<< #4133 spark: massive chain of applies with anonymous function calls
 maxColumn = 80
-runner.maxStateVisits = 10000000
-runner.optimizer.maxVisitsPerToken=1000000
+runner.maxStateVisits = 300000
 ===
 object a {
   private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
@@ -9568,81 +9567,61 @@ object a {
       .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
   }
 }
->>> { stateVisits = 4496133, stateVisits2 = 4496133 }
+>>> { stateVisits = 260217, stateVisits2 = 260217 }
 object a {
   private def ignoreUndocumentedPackages(
       packages: Seq[Seq[File]]
   ): Seq[Seq[File]] = {
-    packages.map(_.filterNot(_.getName.contains("$"))).map(
-      _.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy"))
-    ).map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/examples")))
-      .map(
-        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/internal"))
-      ).map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+    packages.map(_.filterNot(_.getName.contains("$")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/examples")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/internal")
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
-      .map(
-        _.filterNot(f =>
-          f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
-            !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
-        )
-      ).map(
-        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/executor"))
-      ).map(
-        _.filterNot(
-          _.getCanonicalPath
-            .contains("org/apache/spark/ExecutorAllocationClient")
-        )
-      ).map(
-        _.filterNot(
-          _.getCanonicalPath.contains(
-            "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
-          )
-        )
-      ).map(
-        _.filterNot(f =>
-          f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
-            !f.getCanonicalPath
-              .contains("org/apache/spark/unsafe/types/CalendarInterval")
-        )
-      ).map(_.filterNot(_.getCanonicalPath.contains("python"))).map(
-        _.filterNot(
-          _.getCanonicalPath.contains("org/apache/spark/util/collection")
-        )
-      )
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+          !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/executor")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")
+      )).map(_.filterNot(_.getCanonicalPath.contains(
+        "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+      ))).map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+          !f.getCanonicalPath
+            .contains("org/apache/spark/unsafe/types/CalendarInterval")
+      )).map(_.filterNot(_.getCanonicalPath.contains("python")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/util/collection")
+      ))
       .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
-      .map(
-        _.filterNot(
-          _.getCanonicalPath.contains("org/apache/spark/util/kvstore")
-        )
-      ).map(
-        _.filterNot(
-          _.getCanonicalPath.contains("org/apache/spark/sql/catalyst")
-        )
-      ).map(
-        _.filterNot(
-          _.getCanonicalPath.contains("org/apache/spark/sql/connect/")
-        )
-      ).map(
-        _.filterNot(
-          _.getCanonicalPath.contains("org/apache/spark/sql/execution")
-        )
-      ).map(
-        _.filterNot(
-          _.getCanonicalPath.contains("org/apache/spark/sql/internal")
-        )
-      ).map(
-        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive"))
-      ).map(
-        _.filterNot(
-          _.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
-        )
-      ).map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
-      .map(
-        _.filterNot(_.getCanonicalPath.contains("org.apache.spark.sql.errors"))
-      ).map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive"))).map(
-        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro"))
-      ).map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/util/kvstore")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/catalyst")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/connect/")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/execution")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/internal")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/hive")
+      )).map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org.apache.spark.sql.errors")
+      )).map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/v2/avro")
+      )).map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
   }
 }
 <<< #4133 #4133 spark: massive chain of applies with function calls

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -828,7 +828,7 @@ object a {
       })(result)))))))
   }).getMessage should ===("Ur state be b0rked")
 }
->>> { stateVisits = 1071 }
+>>> { stateVisits = 652, stateVisits2 = 652 }
 object a {
   (intercept[java.lang.IllegalStateException] {
     wrap(result ⇒
@@ -6778,7 +6778,7 @@ object a {
   sb.append((if (lsb < 10) ('0' + lsb).asInstanceOf[Char]
              else ('a' + (lsb - 10)).asInstanceOf[Char]))
 }
->>> { stateVisits = 2279 }
+>>> { stateVisits = 1571, stateVisits2 = 1571 }
 object a {
   sb.append((if (msb < 10) ('0' + msb).asInstanceOf[Char]
              else ('a' + (msb - 10)).asInstanceOf[Char]))
@@ -6835,7 +6835,7 @@ object a {
     }
   ))
 }
->>> { stateVisits = 2057 }
+>>> { stateVisits = 2039, stateVisits2 = 2039 }
 object a {
   buffer.append((
     if (!fetchContent) {
@@ -6895,7 +6895,7 @@ object a {
     }
   ))
 }
->>> { stateVisits = 986, stateVisits2 = 986 }
+>>> { stateVisits = 968, stateVisits2 = 968 }
 object a {
   buffer
     .append((if (!fetchContent) {
@@ -7465,7 +7465,7 @@ class a {
     case _ => stepNoBreak(inner)(in)
   }
 }
->>> { stateVisits = 1010 }
+>>> { stateVisits = 988, stateVisits2 = 988 }
 class a {
   def step(
       inner: Iteratee[E, A]
@@ -9202,7 +9202,7 @@ object Build {
       }.evaluated,
     )
 }
->>> { stateVisits = 1607 }
+>>> { stateVisits = 1597, stateVisits2 = 1597 }
 object Build {
   lazy val scaladoc = project.in(file("scaladoc"))
     .settings(generateScalaDocumentation := Def.inputTaskDyn {
@@ -9316,7 +9316,7 @@ private object MemoMap {
         }
       }
 }
->>> { stateVisits = 879, stateVisits2 = 879 }
+>>> { stateVisits = 871, stateVisits2 = 871 }
 private object MemoMap {
   def make(implicit
       trace: Trace
@@ -9450,7 +9450,7 @@ object a {
         }
   }
 }
->>> { stateVisits = 4731, stateVisits2 = 4731 }
+>>> { stateVisits = 4053, stateVisits2 = 4053 }
 object a {
   private object MemoMap {
     def make(implicit trace: Trace): UIO[MemoMap] = Ref.Synchronized
@@ -9567,7 +9567,7 @@ object a {
       .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
   }
 }
->>> { stateVisits = 260217, stateVisits2 = 260217 }
+>>> { stateVisits = 194795, stateVisits2 = 194795 }
 object a {
   private def ignoreUndocumentedPackages(
       packages: Seq[Seq[File]]
@@ -9665,7 +9665,7 @@ object a {
       .map(filterNot(getCanonicalPath.contains("SSLOptions")))
   }
 }
->>> { stateVisits = 14057, stateVisits2 = 14057 }
+>>> { stateVisits = 12414, stateVisits2 = 12414 }
 object a {
   private def ignoreUndocumentedPackages(
       packages: Seq[Seq[File]]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9527,3 +9527,209 @@ object a {
       }
   }
 }
+<<< #4133 spark: massive chain of applies with anonymous function calls
+maxColumn = 80
+runner.maxStateVisits = 10000000
+runner.optimizer.maxVisitsPerToken=1000000
+===
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
+    packages
+      .map(_.filterNot(_.getName.contains("$")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+        !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+        !f.getCanonicalPath.contains("org/apache/spark/unsafe/types/CalendarInterval")))
+      .map(_.filterNot(_.getCanonicalPath.contains("python")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/collection")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/kvstore")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/connect/")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/execution")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/internal")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+  }
+}
+>>> { stateVisits = 4496133, stateVisits2 = 4496133 }
+object a {
+  private def ignoreUndocumentedPackages(
+      packages: Seq[Seq[File]]
+  ): Seq[Seq[File]] = {
+    packages.map(_.filterNot(_.getName.contains("$"))).map(
+      _.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy"))
+    ).map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/internal"))
+      ).map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(
+        _.filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+            !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+        )
+      ).map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/executor"))
+      ).map(
+        _.filterNot(
+          _.getCanonicalPath
+            .contains("org/apache/spark/ExecutorAllocationClient")
+        )
+      ).map(
+        _.filterNot(
+          _.getCanonicalPath.contains(
+            "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+          )
+        )
+      ).map(
+        _.filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+            !f.getCanonicalPath
+              .contains("org/apache/spark/unsafe/types/CalendarInterval")
+        )
+      ).map(_.filterNot(_.getCanonicalPath.contains("python"))).map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/util/collection")
+        )
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/util/kvstore")
+        )
+      ).map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/catalyst")
+        )
+      ).map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/connect/")
+        )
+      ).map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/execution")
+        )
+      ).map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/internal")
+        )
+      ).map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive"))
+      ).map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+        )
+      ).map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org.apache.spark.sql.errors"))
+      ).map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive"))).map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro"))
+      ).map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+  }
+}
+<<< #4133 #4133 spark: massive chain of applies with function calls
+maxColumn = 80
+runner.maxStateVisits = 10000000
+runner.optimizer.maxVisitsPerToken=1000000
+===
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
+    packages
+      .map(filterNot(getName.contains("$")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/network")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+        !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+        !f.getCanonicalPath.contains("org/apache/spark/unsafe/types/CalendarInterval")))
+      .map(filterNot(getCanonicalPath.contains("python")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/collection")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/kvstore")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/connect/")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/execution")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(filterNot(getCanonicalPath.contains("SSLOptions")))
+  }
+}
+>>> { stateVisits = 14057, stateVisits2 = 14057 }
+object a {
+  private def ignoreUndocumentedPackages(
+      packages: Seq[Seq[File]]
+  ): Seq[Seq[File]] = {
+    packages.map(filterNot(getName.contains("$")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/network")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+          !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+      )).map(filterNot(getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")
+      )).map(filterNot(getCanonicalPath.contains(
+        "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+      ))).map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+          !f.getCanonicalPath
+            .contains("org/apache/spark/unsafe/types/CalendarInterval")
+      )).map(filterNot(getCanonicalPath.contains("python"))).map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/util/collection")
+      )).map(filterNot(getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/util/kvstore")
+      )).map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/catalyst")
+      )).map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/connect/")
+      )).map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/execution")
+      )).map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/internal")
+      )).map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+      )).map(filterNot(getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(filterNot(getCanonicalPath.contains("SSLOptions")))
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9943,3 +9943,217 @@ object a {
         }
   }
 }
+<<< #4133 spark: massive chain of applies with anonymous function calls
+maxColumn = 80
+runner.maxStateVisits = 10000000
+runner.optimizer.maxVisitsPerToken=1000000
+===
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
+    packages
+      .map(_.filterNot(_.getName.contains("$")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+        !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+        !f.getCanonicalPath.contains("org/apache/spark/unsafe/types/CalendarInterval")))
+      .map(_.filterNot(_.getCanonicalPath.contains("python")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/collection")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/kvstore")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/connect/")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/execution")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/internal")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+  }
+}
+>>> { stateVisits = 839, stateVisits2 = 516 }
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]])
+      : Seq[Seq[File]] = {
+    packages
+      .map(_.filterNot(_.getName.contains("$")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/examples")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/internal")
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+          !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/executor")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains(
+        "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+      )))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+          !f.getCanonicalPath.contains(
+            "org/apache/spark/unsafe/types/CalendarInterval"
+          )
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains("python")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/util/collection")
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/util/kvstore")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/catalyst")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/connect/")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/execution")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/internal")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/hive")
+      ))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org.apache.spark.sql.errors")
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
+      .map(_.filterNot(
+        _.getCanonicalPath.contains("org/apache/spark/sql/v2/avro")
+      ))
+      .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+  }
+}
+<<< #4133 #4133 spark: massive chain of applies with function calls
+maxColumn = 80
+runner.maxStateVisits = 10000000
+runner.optimizer.maxVisitsPerToken=1000000
+===
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
+    packages
+      .map(filterNot(getName.contains("$")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/network")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+        !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+        !f.getCanonicalPath.contains("org/apache/spark/unsafe/types/CalendarInterval")))
+      .map(filterNot(getCanonicalPath.contains("python")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/collection")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/kvstore")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/connect/")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/execution")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(filterNot(getCanonicalPath.contains("SSLOptions")))
+  }
+}
+>>> { stateVisits = 619, stateVisits2 = 412 }
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]])
+      : Seq[Seq[File]] = {
+    packages
+      .map(filterNot(getName.contains("$")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/network")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+          !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+      ))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")
+      ))
+      .map(filterNot(getCanonicalPath.contains(
+        "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+      )))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+          !f.getCanonicalPath.contains(
+            "org/apache/spark/unsafe/types/CalendarInterval"
+          )
+      ))
+      .map(filterNot(getCanonicalPath.contains("python")))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/util/collection")
+      ))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/util/kvstore")
+      ))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/catalyst")
+      ))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/connect/")
+      ))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/execution")
+      ))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/internal")
+      ))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(filterNot(
+        getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+      ))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(filterNot(getCanonicalPath.contains("SSLOptions")))
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -10260,3 +10260,255 @@ object a {
       }
   }
 }
+<<< #4133 spark: massive chain of applies with anonymous function calls
+maxColumn = 80
+runner.maxStateVisits = 10000000
+runner.optimizer.maxVisitsPerToken=1000000
+===
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
+    packages
+      .map(_.filterNot(_.getName.contains("$")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+        !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend")))
+      .map(_.filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+        !f.getCanonicalPath.contains("org/apache/spark/unsafe/types/CalendarInterval")))
+      .map(_.filterNot(_.getCanonicalPath.contains("python")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/collection")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/kvstore")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/connect/")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/execution")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/internal")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+  }
+}
+>>> { stateVisits = 1237, stateVisits2 = 1237 }
+object a {
+  private def ignoreUndocumentedPackages(
+      packages: Seq[Seq[File]]
+  ): Seq[Seq[File]] = {
+    packages
+      .map(_.filterNot(_.getName.contains("$")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/examples"))
+      )
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/internal"))
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/network")))
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(
+        _.filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+            !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+        )
+      )
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/executor"))
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath
+            .contains("org/apache/spark/ExecutorAllocationClient")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath
+            .contains(
+              "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+            )
+        )
+      )
+      .map(
+        _.filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+            !f.getCanonicalPath
+              .contains("org/apache/spark/unsafe/types/CalendarInterval")
+        )
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("python")))
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/util/collection")
+        )
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/util/kvstore")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/catalyst")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/connect/")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/execution")
+        )
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/internal")
+        )
+      )
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/hive"))
+      )
+      .map(
+        _.filterNot(
+          _.getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+        )
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org.apache.spark.sql.errors"))
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("org/apache/hive")))
+      .map(
+        _.filterNot(_.getCanonicalPath.contains("org/apache/spark/sql/v2/avro"))
+      )
+      .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
+  }
+}
+<<< #4133 #4133 spark: massive chain of applies with function calls
+maxColumn = 80
+runner.maxStateVisits = 10000000
+runner.optimizer.maxVisitsPerToken=1000000
+===
+object a {
+  private def ignoreUndocumentedPackages(packages: Seq[Seq[File]]): Seq[Seq[File]] = {
+    packages
+      .map(filterNot(getName.contains("$")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/network")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+        !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend")))
+      .map(filterNot(f =>
+        f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+        !f.getCanonicalPath.contains("org/apache/spark/unsafe/types/CalendarInterval")))
+      .map(filterNot(getCanonicalPath.contains("python")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/collection")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/kvstore")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalyst")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/connect/")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/execution")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(filterNot(getCanonicalPath.contains("SSLOptions")))
+  }
+}
+>>> { stateVisits = 791, stateVisits2 = 791 }
+object a {
+  private def ignoreUndocumentedPackages(
+      packages: Seq[Seq[File]]
+  ): Seq[Seq[File]] = {
+    packages
+      .map(filterNot(getName.contains("$")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/deploy")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/examples")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/internal")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/memory")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/network")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/rpc")))
+      .map(
+        filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/shuffle") &&
+            !f.getCanonicalPath.contains("org/apache/spark/shuffle/api")
+        )
+      )
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/executor")))
+      .map(
+        filterNot(
+          getCanonicalPath.contains("org/apache/spark/ExecutorAllocationClient")
+        )
+      )
+      .map(
+        filterNot(
+          getCanonicalPath.contains(
+            "org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend"
+          )
+        )
+      )
+      .map(
+        filterNot(f =>
+          f.getCanonicalPath.contains("org/apache/spark/unsafe") &&
+            !f.getCanonicalPath
+              .contains("org/apache/spark/unsafe/types/CalendarInterval")
+        )
+      )
+      .map(filterNot(getCanonicalPath.contains("python")))
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/util/collection"))
+      )
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/util/io")))
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/util/kvstore"))
+      )
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/sql/catalyst"))
+      )
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/sql/connect/"))
+      )
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/sql/execution"))
+      )
+      .map(
+        filterNot(getCanonicalPath.contains("org/apache/spark/sql/internal"))
+      )
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/hive")))
+      .map(
+        filterNot(
+          getCanonicalPath.contains("org/apache/spark/sql/catalog/v2/utils")
+        )
+      )
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.errors")))
+      .map(filterNot(getCanonicalPath.contains("org.apache.spark.sql.errors")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/hive")))
+      .map(filterNot(getCanonicalPath.contains("org/apache/spark/sql/v2/avro")))
+      .map(filterNot(getCanonicalPath.contains("SSLOptions")))
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1005,7 +1005,7 @@ object Foo:
     case a: A if a.someField.otherField.function().exists(SomeObjectLongName.isTrue) =>
       None
   )
->>> { stateVisits = 1020, stateVisits2 = 1024 }
+>>> { stateVisits = 917, stateVisits2 = 921 }
 object Foo:
    def bar = process(
      arg match

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1919019, "total explored")
+      assertEquals(Debug.explored, 1784043, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 10390541, "total explored")
+      assertEquals(Debug.explored, 1919019, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1360425, "total explored")
+      assertEquals(Debug.explored, 10390541, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
- Router: go inside AnonymousFunction to match body
- Router: no optimal on `(...` if use exclude blocks
Helps with #4133.