### PR TITLE
Router: no NL after `<-` in `()` enums for scala3

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -2717,7 +2717,7 @@ class Router(formatOps: FormatOps) {
       if (!style.align.arrowEnumeratorGenerator) Seq.empty
       else Seq(Indent(StateColumn, expire, After))
     getSplitsDefValEquals(body, endFt, spaceIndents) {
-      CtrlBodySplits.get(body, spaceIndents) {
+      def splits = CtrlBodySplits.get(body, spaceIndents) {
         if (spaceIndents.nonEmpty) Split(Space, 0).withIndents(spaceIndents)
         else {
           val noSlb = body match {
@@ -2729,6 +2729,13 @@ class Router(formatOps: FormatOps) {
           else Split(Space, 0).withSingleLine(expire)
         }
       }(cost => CtrlBodySplits.withIndent(Split(Newline2x(ft), cost), endFt))
+      body.parent.parent match {
+        case Some(pp: Term.EnumeratorsBlock)
+            if style.dialect.allowSignificantIndentation &&
+              isEnclosedInParens(pp) =>
+          Seq(Split(Space, 0).withIndents(spaceIndents))
+        case _ => splits
+      }
     }
   }
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10422,3 +10422,19 @@ object A {
         (Seq(), Seq())
   ): Unit = ???
 }
+<<< #4219
+object a {
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+}
+>>>
+object a {
+  val expression =
+    for (
+      x <-
+        loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+      y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+    ) yield x + y
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9730,3 +9730,18 @@ object A {
         (Seq(), Seq())
   ): Unit = ???
 }
+<<< #4219
+object a {
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+}
+>>>
+object a {
+  val expression = for (
+    x <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10172,3 +10172,19 @@ object A {
   def f(a: (Seq[Int], Seq[Int]) =
     (Seq(), Seq())): Unit = ???
 }
+<<< #4219
+object a {
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+}
+>>>
+object a {
+  val expression = for (
+    x <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -10530,3 +10530,19 @@ object A {
         (Seq(), Seq())
   ): Unit = ???
 }
+<<< #4219
+object a {
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+}
+>>>
+object a {
+  val expression =
+    for (
+      x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+      y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+    )
+      yield x + y
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -3981,8 +3981,7 @@ object a:
 object a:
    val abstractTypeNames =
      for (
-       parent <-
-         parents;
+       parent <- parents;
        mbr <- parent.abstractTypeMembers if qualifies(mbr.symbol)
      )
        yield mbr.name.asTypeName
@@ -7350,9 +7349,8 @@ object a:
   ) yield x + y
 >>>
 object a:
-   val expression = for (
-     x <-
-       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-     y <-
-       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
-   ) yield x + y
+   val expression =
+     for (
+       x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -7342,3 +7342,17 @@ object Parsers:
    enum Location(inArgs: Boolean):
       case InPatternArgs extends Location(false, true,
             true) // InParens not true, since it might be an alternative
+<<< #4219
+object a:
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+>>>
+object a:
+   val expression = for (
+     x <-
+       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+     y <-
+       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+   ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7062,3 +7062,17 @@ object Parsers:
       case InPatternArgs extends Location(
             false, true, true
           ) // InParens not true, since it might be an alternative
+<<< #4219
+object a:
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+>>>
+object a:
+   val expression = for (
+     x <-
+       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+     y <-
+       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+   ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7071,8 +7071,6 @@ object a:
 >>>
 object a:
    val expression = for (
-     x <-
-       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-     y <-
-       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+     y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
    ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3942,8 +3942,7 @@ object a:
 object a:
    val abstractTypeNames =
      for (
-       parent <-
-         parents;
+       parent <- parents;
        mbr <- parent.abstractTypeMembers if qualifies(mbr.symbol)
      )
        yield mbr.name.asTypeName
@@ -7381,8 +7380,6 @@ object a:
 >>>
 object a:
    val expression = for (
-     x <-
-       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-     y <-
-       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+     y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
    ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7372,3 +7372,17 @@ object Parsers:
    enum Location(inArgs: Boolean):
       case InPatternArgs extends Location(false, true,
             true) // InParens not true, since it might be an alternative
+<<< #4219
+object a:
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+>>>
+object a:
+   val expression = for (
+     x <-
+       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+     y <-
+       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+   ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7634,3 +7634,17 @@ object Parsers:
       case InPatternArgs extends Location(
             false, true, true
           ) // InParens not true, since it might be an alternative
+<<< #4219
+object a:
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+>>>
+object a:
+   val expression =
+     for (
+       x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     )
+       yield x + y

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1785537, "total explored")
+      assertEquals(Debug.explored, 1785448, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1784976, "total explored")
+      assertEquals(Debug.explored, 1785537, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Fixes #4219.