### PR TITLE
ConvertToNewScala3Syntax: remove `:_`/`@_` as unit

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/scala3/Vararg.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/Vararg.stat
@@ -32,23 +32,11 @@ node match {
     false
 }
 >>>
-test does not parse: [dialect scala3] illegal start of simple pattern
-          Node3(TERMREFpkg, Seq("scala.annotation.internal"), zxc),
-          children:*
-        )
-        ^
-      ) =>
-    children.filterNot(_.tag == IMPORT).exists {
-      case Node3(TYPEDEF, Seq("SourceFile"), _) => true
-====== full result: ======
 node match {
   case Node3(
         PACKAGE,
         _,
-        Seq(
-          Node3(TERMREFpkg, Seq("scala.annotation.internal"), zxc),
-          children:*
-        )
+        Seq(Node3(TERMREFpkg, Seq("scala.annotation.internal"), zxc), children*)
       ) =>
     children.filterNot(_.tag == IMPORT).exists {
       case Node3(TYPEDEF, Seq("SourceFile"), _) => true

--- a/scalafmt-tests/shared/src/test/resources/scala3/Vararg.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/Vararg.stat
@@ -19,3 +19,41 @@ a match {
 val a = List(0, 1, 1*2)
 >>>
 val a = List(0, 1, 1 * 2)
+<<< #4133 intellij-scala tasty-reader TreePrinter.scala
+rewrite.scala3.convertToNewSyntax = true
+===
+node match {
+  case Node3(PACKAGE, _, Seq(Node3(TERMREFpkg, Seq("scala.annotation.internal"), zxc), children: _*)) =>
+    children.filterNot(_.tag == IMPORT).exists {
+      case Node3(TYPEDEF, Seq("SourceFile"), _) => true
+      case _ => false
+    }
+  case _ =>
+    false
+}
+>>>
+test does not parse: [dialect scala3] illegal start of simple pattern
+          Node3(TERMREFpkg, Seq("scala.annotation.internal"), zxc),
+          children:*
+        )
+        ^
+      ) =>
+    children.filterNot(_.tag == IMPORT).exists {
+      case Node3(TYPEDEF, Seq("SourceFile"), _) => true
+====== full result: ======
+node match {
+  case Node3(
+        PACKAGE,
+        _,
+        Seq(
+          Node3(TERMREFpkg, Seq("scala.annotation.internal"), zxc),
+          children:*
+        )
+      ) =>
+    children.filterNot(_.tag == IMPORT).exists {
+      case Node3(TYPEDEF, Seq("SourceFile"), _) => true
+      case _                                    => false
+    }
+  case _ =>
+    false
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1785581, "total explored")
+      assertEquals(Debug.explored, 1785622, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1785448, "total explored")
+      assertEquals(Debug.explored, 1785581, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Helps with #4133.