### PR TITLE
Router: move up check for no NL after `<-` enums

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -7345,12 +7345,36 @@ object Parsers:
 object a:
   val expression = for (
     x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    z <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
   ) yield x + y
 >>>
 object a:
    val expression =
      for (
        x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       z <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     ) yield x + y
+<<< #4219 forceBeforeAssign
+newlines.forceBeforeAssign = any
+===
+object a:
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    z <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+>>>
+object a:
+   val expression =
+     for (
+       x <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       z <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
      ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -3981,7 +3981,8 @@ object a:
 object a:
    val abstractTypeNames =
      for (
-       parent <- parents;
+       parent <-
+         parents;
        mbr <- parent.abstractTypeMembers if qualifies(mbr.symbol)
      )
        yield mbr.name.asTypeName
@@ -7355,7 +7356,8 @@ object a:
      for (
        x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
        y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       z <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+       z <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
      ) yield x + y
 <<< #4219 forceBeforeAssign
 newlines.forceBeforeAssign = any
@@ -7371,10 +7373,8 @@ object a:
 object a:
    val expression =
      for (
-       x <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       y <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
        z <-
          loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
      ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7066,11 +7066,35 @@ object Parsers:
 object a:
   val expression = for (
     x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    z <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
   ) yield x + y
 >>>
 object a:
    val expression = for (
      x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-     y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+     z <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
    ) yield x + y
+<<< #4219 forceBeforeAssign
+newlines.forceBeforeAssign = any
+===
+object a:
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    z <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+>>>
+object a:
+   val expression =
+     for (
+       x <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       z <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7091,10 +7091,7 @@ object a:
 object a:
    val expression =
      for (
-       x <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       y <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       z <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+       x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       z <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
      ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -3942,7 +3942,8 @@ object a:
 object a:
    val abstractTypeNames =
      for (
-       parent <- parents;
+       parent <-
+         parents;
        mbr <- parent.abstractTypeMembers if qualifies(mbr.symbol)
      )
        yield mbr.name.asTypeName
@@ -7384,7 +7385,8 @@ object a:
    val expression = for (
      x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
      y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-     z <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     z <-
+       loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
    ) yield x + y
 <<< #4219 forceBeforeAssign
 newlines.forceBeforeAssign = any
@@ -7400,10 +7402,8 @@ object a:
 object a:
    val expression =
      for (
-       x <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       y <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
        z <-
          loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
      ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7375,11 +7375,35 @@ object Parsers:
 object a:
   val expression = for (
     x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    z <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
   ) yield x + y
 >>>
 object a:
    val expression = for (
      x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-     y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+     z <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
    ) yield x + y
+<<< #4219 forceBeforeAssign
+newlines.forceBeforeAssign = any
+===
+object a:
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    z <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+>>>
+object a:
+   val expression =
+     for (
+       x <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       z <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     ) yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7665,11 +7665,8 @@ object a:
 object a:
    val expression =
      for (
-       x <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       y <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       z <-
-         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+       x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       z <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
      )
        yield x + y

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7638,13 +7638,38 @@ object Parsers:
 object a:
   val expression = for (
     x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    z <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
   ) yield x + y
 >>>
 object a:
    val expression =
      for (
        x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
-       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+       y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       z <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+     )
+       yield x + y
+<<< #4219 forceBeforeAssign
+newlines.forceBeforeAssign = any
+===
+object a:
+  val expression = for (
+    x <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    y <- loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+    z <-
+      loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
+  ) yield x + y
+>>>
+object a:
+   val expression =
+     for (
+       x <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       y <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu;
+       z <-
+         loremipsumdolorsitametconsecteturadipiscingelitseddoeiusmodtemporincididu
      )
        yield x + y

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1785622, "total explored")
+      assertEquals(Debug.explored, 1785882, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
It might have been overridden by `newlines.forceBeforeAssign` param. Follow-on to #4219.