### PR TITLE
Router: don't penalize NL before `:` if keeping

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1429,16 +1429,21 @@ class Router(formatOps: FormatOps) {
           def penalizeNewlines(extra: Int)(implicit fileLine: FileLine) =
             PenalizeAllNewlines(expire, Constants.BracketPenalty + extra)
           val indent = style.indent.getDefnSite(leftOwner)
-          val nlPenalty = 2 + treeDepth(returnType)
-          Seq(
-            Split(style.newlines.keepBreak(hasBreak()), 0)(sameLineSplit)
-              .withPolicy(penalizeNewlines(0)),
-            // Spark style guide allows this:
-            // https://github.com/databricks/scala-style-guide#indent
-            Split(Newline, Constants.SparkColonNewline + nlPenalty)
-              .withIndent(indent, expire, After)
-              .withPolicy(penalizeNewlines(nlPenalty)),
+          if (style.newlines.keepBreak(hasBreak())) Seq(
+            Split(Newline, 1).withIndent(indent, expire, After)
+              .withPolicy(penalizeNewlines(1)),
           )
+          else {
+            val nlPenalty = 2 + treeDepth(returnType)
+            Seq(
+              Split(sameLineSplit, 0).withPolicy(penalizeNewlines(0)),
+              // Spark style guide allows this:
+              // https://github.com/databricks/scala-style-guide#indent
+              Split(Newline, Constants.SparkColonNewline + nlPenalty)
+                .withIndent(indent, expire, After)
+                .withPolicy(penalizeNewlines(nlPenalty)),
+            )
+          }
         }
       case FormatToken(_: T.Colon, _, ColonDeclTpeLeft(returnType))
           if style.newlines.avoidInResultType =>

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
   override def afterAll(): Unit = {
     logger.debug(s"Total explored: ${Debug.explored}")
     if (!onlyUnit && !onlyManual)
-      assertEquals(Debug.explored, 1777089, "total explored")
+      assertEquals(Debug.explored, 1777077, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Follow-on to #4389. Helps with #4133.