### PR TITLE
RedundantBraces: keep partial function braces

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1135,24 +1135,12 @@ object a {
 }
 >>>
 object a {
-  val foo = bar { case x =>
-    y
-  }
-  val foo = bar { case x =>
-    y
-  }
-  val foo = bar { case x =>
-    y
-  }
-  val foo = bar.baz { case x =>
-    y
-  }
-  val foo = bar.baz { case x =>
-    y
-  }
-  val foo = bar.baz { case x =>
-    y
-  }
+  val foo = bar { case x => y }
+  val foo = bar { case x => y }
+  val foo = bar { case x => y }
+  val foo = bar.baz { case x => y }
+  val foo = bar.baz { case x => y }
+  val foo = bar.baz { case x => y }
 }
 <<< init-only secondary ctors
 class a(vi: Int, vs: String) {

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
@@ -148,3 +148,52 @@ final class RemoteSettings(val config: Config) {
         "watch-failure-detector.expected-response-after > 0"
       )
 }
+<<< #4133 partial func in block, from spark, ifElseExpressions
+rewrite.redundantBraces.ifElseExpressions = true
+===
+object a {
+  val toIterator: Any => Iterator[_] = if (lenient) {
+    {
+      case i: scala.collection.Iterable[_] => i.iterator
+      case l: java.util.List[_] => l.iterator().asScala
+      case a: Array[_] => a.iterator
+      case o => unsupportedCollectionType(o.getClass)
+    }
+  } else {
+    unsupportedCollectionType(tag.runtimeClass)
+  }
+}
+>>>
+object a {
+  val toIterator: Any => Iterator[_] = if (lenient) {
+    case i: scala.collection.Iterable[_] => i.iterator
+    case l: java.util.List[_]            => l.iterator().asScala
+    case a: Array[_]                     => a.iterator
+    case o => unsupportedCollectionType(o.getClass)
+  }
+  else
+    unsupportedCollectionType(tag.runtimeClass)
+}
+<<< #4133 partial func in block, from spark, !ifElseExpressions
+rewrite.redundantBraces.ifElseExpressions = false
+===
+object a {
+  val toIterator: Any => Iterator[_] = if (lenient) {
+    {
+      case i: scala.collection.Iterable[_] => i.iterator
+      case l: java.util.List[_] => l.iterator().asScala
+      case a: Array[_] => a.iterator
+      case o => unsupportedCollectionType(o.getClass)
+    }
+  } else {
+    unsupportedCollectionType(tag.runtimeClass)
+  }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+     case o => unsupportedCollectionType(o.getClass)
+-  }
+-  else {
++  } else {
+     unsupportedCollectionType(tag.runtimeClass)

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
@@ -190,10 +190,15 @@ object a {
   }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-     case o => unsupportedCollectionType(o.getClass)
--  }
--  else {
-+  } else {
-     unsupportedCollectionType(tag.runtimeClass)
+object a {
+  val toIterator: Any => Iterator[_] = if (lenient) {
+    {
+      case i: scala.collection.Iterable[_] => i.iterator
+      case l: java.util.List[_]            => l.iterator().asScala
+      case a: Array[_]                     => a.iterator
+      case o => unsupportedCollectionType(o.getClass)
+    }
+  } else {
+    unsupportedCollectionType(tag.runtimeClass)
+  }
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1496827, "total explored")
+      assertEquals(explored, 1496759, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1496399, "total explored")
+      assertEquals(explored, 1496827, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Instead, remove block(s) containing that partial function.