### PR TITLE
RedundantBraces: replace paren w/ brace if comment

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -313,6 +313,10 @@ object FormatTokensRewrite {
       claimedRule(ft.meta.idx)
 
     @inline
+    def claimedRuleOnLeft(ft: FormatToken): Option[Replacement] =
+      claimedRule(ft.meta.idx - 1)
+
+    @inline
     private[rewrite] def claimedRule(ftIdx: Int): Option[Replacement] = claimed
       .get(ftIdx).map(tokens.apply).filter(_ ne null)
 

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1142,6 +1142,204 @@ object a {
   val foo = bar.baz { case x => y }
   val foo = bar.baz { case x => y }
 }
+<<< single-block partial function with block one-arg apply, with comments
+object a {
+  val foo = bar { // c1
+    { // c2
+      case x => y
+      // c3
+    } // c4
+  }
+  val foo = bar { // c1
+    { // c2
+    { // c3
+      case x => y
+      // c4
+    } // c5
+    } // c6
+  }
+  val foo = bar { // c1
+    { // c2
+    { // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    } // c7
+    } // c8
+  }
+  val foo = bar.baz { // c1
+    { // c2
+      case x => y
+      // c3
+    } // c4
+  }
+  val foo = bar.baz { // c1
+    { // c2
+    { // c3
+      case x => y
+      // c4
+    } // c5
+    } // c6
+  }
+  val foo = bar.baz { // c1
+    { // c2
+    { // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    } // c7
+    } // c8
+  }
+}
+>>>
+object a {
+  val foo = bar { // c1
+    { // c2
+      case x => y
+      // c3
+    } // c4
+  }
+  val foo = bar { // c1
+    // c2
+    { // c3
+      case x => y
+      // c4
+    } // c5
+    // c6
+  }
+  val foo = bar { // c1
+    // c2
+    // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    // c7
+    // c8
+  }
+  val foo = bar.baz { // c1
+    { // c2
+      case x => y
+      // c3
+    } // c4
+  }
+  val foo = bar.baz { // c1
+    // c2
+    { // c3
+      case x => y
+      // c4
+    } // c5
+    // c6
+  }
+  val foo = bar.baz { // c1
+    // c2
+    // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    // c7
+    // c8
+  }
+}
+<<< single-block partial function with block one-arg apply, with comments and parens
+object a {
+  val foo = bar ( // c1
+    { // c2
+      case x => y
+      // c3
+    } // c4
+  )
+  val foo = bar ( // c1
+    { // c2
+    { // c3
+      case x => y
+      // c4
+    } // c5
+    } // c6
+  )
+  val foo = bar ( // c1
+    { // c2
+    { // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    } // c7
+    } // c8
+  )
+  val foo = bar.baz ( // c1
+    { // c2
+      case x => y
+      // c3
+    } // c4
+  )
+  val foo = bar.baz ( // c1
+    { // c2
+    { // c3
+      case x => y
+      // c4
+    } // c5
+    } // c6
+  )
+  val foo = bar.baz ( // c1
+    { // c2
+    { // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    } // c7
+    } // c8
+  )
+}
+>>>
+object a {
+  val foo = bar // c1
+  { // c2
+    case x => y
+    // c3
+  } // c4
+  val foo = bar // c1
+  { // c2
+    { // c3
+      case x => y
+      // c4
+    } // c5
+  } // c6
+  val foo = bar // c1
+  { // c2
+    // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    // c7
+  } // c8
+  val foo = bar.baz // c1
+  { // c2
+    case x => y
+    // c3
+  } // c4
+  val foo = bar.baz // c1
+  { // c2
+    { // c3
+      case x => y
+      // c4
+    } // c5
+  } // c6
+  val foo = bar.baz // c1
+  { // c2
+    // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    // c7
+  } // c8
+}
 <<< init-only secondary ctors
 class a(vi: Int, vs: String) {
   def this() = {

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1297,20 +1297,20 @@ object a {
 }
 >>>
 object a {
-  val foo = bar // c1
-  { // c2
+  val foo = bar { // c1
+    // c2
     case x => y
     // c3
   } // c4
-  val foo = bar // c1
-  { // c2
+  val foo = bar { // c1
+    // c2
     { // c3
       case x => y
       // c4
     } // c5
   } // c6
-  val foo = bar // c1
-  { // c2
+  val foo = bar { // c1
+    // c2
     // c3
     { // c4
       case x => y
@@ -1318,20 +1318,20 @@ object a {
     } // c6
     // c7
   } // c8
-  val foo = bar.baz // c1
-  { // c2
+  val foo = bar.baz { // c1
+    // c2
     case x => y
     // c3
   } // c4
-  val foo = bar.baz // c1
-  { // c2
+  val foo = bar.baz { // c1
+    // c2
     { // c3
       case x => y
       // c4
     } // c5
   } // c6
-  val foo = bar.baz // c1
-  { // c2
+  val foo = bar.baz { // c1
+    // c2
     // c3
     { // c4
       case x => y

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1496759, "total explored")
+      assertEquals(explored, 1497319, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
If we simply remove the parenthesis, then the comment will end up before the brace, unlike originally. Let's replace instead.
