### PR TITLE
Imports: do not expand nor sort import wildcards

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/rewrite/Imports.source
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/Imports.source
@@ -835,9 +835,10 @@ rewrite.imports.expand = true
 ===
 import a.{x, y => z, given}
 import a.{*, given}
-import a.{x, given, given Z}
+import a.{x, given, given Z, _}
 >>>
 import a.*
+import a._
 import a.given
 import a.given Z
 import a.x

--- a/scalafmt-tests/shared/src/test/resources/rewrite/Imports.source
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/Imports.source
@@ -837,11 +837,10 @@ import a.{x, y => z, given}
 import a.{*, given}
 import a.{x, given, given Z, _}
 >>>
-import a.*
-import a._
-import a.given
 import a.given Z
 import a.x
+import a.{*, given}
+import a.{given, _}
 import a.{y => z, given}
 <<< #3189 ascii !expand
 rewrite.imports.sort = ascii
@@ -862,7 +861,7 @@ import a.{x, y => z, given}
 import a.{*, given}
 import a.{x, given, given Z}
 >>>
-import a.*
+import a.{*, given}
 import a.{y => z, given}
 import a.given
 import a.given Z
@@ -886,7 +885,7 @@ import a.{x, y => z, given}
 import a.{*, given}
 import a.{x, given, given Z}
 >>>
-import a.*
+import a.{*, given}
 import a.{y => z, given}
 import a.given
 import a.given Z

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1498850, "total explored")
+      assertEquals(explored, 1498882, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
This leads to re-ordering of `given` and `_`, which is incorrect. Revealed in scalameta/sbt-scalafmt#332.