### PR TITLE
Router: use SpaceOrNoSplit instead of custom rule

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
@@ -65,16 +65,14 @@ case class ModExt(mod: Modification, indents: Seq[Indent] = Seq.empty) {
     * for {
     *   a <- new Integer {
     *           value = 1
-    *         }
+    *        }
     *   x <- if (variable) doSomething
-    *       else doAnything
+    *        else doAnything
     * }
     * ```
     */
-  def getActualIndents(offset: Int): Seq[ActualIndent] = {
-    val adjustedOffset = if (mod eq Space) offset + 1 else offset
-    indents.flatMap(_.withStateOffset(adjustedOffset))
-  }
+  def getActualIndents(offset: Int): Seq[ActualIndent] = indents
+    .flatMap(_.withStateOffset(offset + mod.length))
 
 }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -75,3 +75,10 @@ object Space extends Modification {
     else Newline2x(FormatToken.hasBlankLine(nl))
   def orNL(ft: FormatToken): Modification = orNL(ft.newlinesBetween)
 }
+
+case class SpaceOrNoSplit(policy: Policy.End.WithPos) extends Modification {
+  override val newlines: Int = 0
+  override val length: Int = 1
+
+  override def toString: String = "SPorNS"
+}

--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(48193019)
+  override protected def totalStatesVisited: Option[Int] = Some(48163081)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -51,7 +51,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(48372795)
+  override protected def totalStatesVisited: Option[Int] = Some(48342732)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(35856745)
+  override protected def totalStatesVisited: Option[Int] = Some(35837156)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(44618123)
+  override protected def totalStatesVisited: Option[Int] = Some(44596615)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(33385186)
+  override protected def totalStatesVisited: Option[Int] = Some(33365450)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(36033019)
+  override protected def totalStatesVisited: Option[Int] = Some(36011287)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(72481328)
+  override protected def totalStatesVisited: Option[Int] = Some(72398899)
 
   override protected def builds =
     Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
@@ -18,7 +18,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(76650858)
+  override protected def totalStatesVisited: Option[Int] = Some(76561809)
 
   override protected def builds =
     Seq(getBuild("v3.5.3", dialects.Scala213, 2756))

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10618,3 +10618,25 @@ object a {
     waitingForVisit.prepend(mapStage.rdd)
   // Otherwise there's no need to follow the dependency back
 }
+<<< #4133 braces to parens for single-line apply, with rewrite
+maxColumn = 76
+preset = default
+newlines.source = fold
+newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
+rewrite.rules = [RedundantBraces, RedundantParens]
+===
+convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) { tokens =>
+  safeParser.parse(tokens)
+}.flatten
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-convertStream(inputStream, tokenizer, handleHeader, parser.options.charset)(
+-  tokens => safeParser.parse(tokens)
+-).flatten
++convertStream(
++  inputStream,
++  tokenizer,
++  handleHeader,
++  parser.options.charset
++)(tokens => safeParser.parse(tokens)).flatten

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10629,14 +10629,6 @@ convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) { to
   safeParser.parse(tokens)
 }.flatten
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--convertStream(inputStream, tokenizer, handleHeader, parser.options.charset)(
--  tokens => safeParser.parse(tokens)
--).flatten
-+convertStream(
-+  inputStream,
-+  tokenizer,
-+  handleHeader,
-+  parser.options.charset
-+)(tokens => safeParser.parse(tokens)).flatten
+convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) {
+  tokens => safeParser.parse(tokens)
+}.flatten

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9931,14 +9931,6 @@ convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) { to
   safeParser.parse(tokens)
 }.flatten
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--convertStream(inputStream, tokenizer, handleHeader, parser.options.charset)(
--  tokens => safeParser.parse(tokens)
--).flatten
-+convertStream(
-+  inputStream,
-+  tokenizer,
-+  handleHeader,
-+  parser.options.charset
-+)(tokens => safeParser.parse(tokens)).flatten
+convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) {
+  tokens => safeParser.parse(tokens)
+}.flatten

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9920,3 +9920,25 @@ object a {
   if (!mapStage.isAvailable) waitingForVisit.prepend(mapStage.rdd)
   // Otherwise there's no need to follow the dependency back
 }
+<<< #4133 braces to parens for single-line apply, with rewrite
+maxColumn = 76
+preset = default
+newlines.source = fold
+newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
+rewrite.rules = [RedundantBraces, RedundantParens]
+===
+convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) { tokens =>
+  safeParser.parse(tokens)
+}.flatten
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-convertStream(inputStream, tokenizer, handleHeader, parser.options.charset)(
+-  tokens => safeParser.parse(tokens)
+-).flatten
++convertStream(
++  inputStream,
++  tokenizer,
++  handleHeader,
++  parser.options.charset
++)(tokens => safeParser.parse(tokens)).flatten

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10378,14 +10378,6 @@ convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) { to
   safeParser.parse(tokens)
 }.flatten
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--convertStream(inputStream, tokenizer, handleHeader, parser.options.charset)(
--  tokens => safeParser.parse(tokens)
--).flatten
-+convertStream(
-+  inputStream,
-+  tokenizer,
-+  handleHeader,
-+  parser.options.charset
-+)(tokens => safeParser.parse(tokens)).flatten
+convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) {
+  tokens => safeParser.parse(tokens)
+}.flatten

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10367,3 +10367,25 @@ object a {
     waitingForVisit.prepend(mapStage.rdd)
   // Otherwise there's no need to follow the dependency back
 }
+<<< #4133 braces to parens for single-line apply, with rewrite
+maxColumn = 76
+preset = default
+newlines.source = fold
+newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
+rewrite.rules = [RedundantBraces, RedundantParens]
+===
+convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) { tokens =>
+  safeParser.parse(tokens)
+}.flatten
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-convertStream(inputStream, tokenizer, handleHeader, parser.options.charset)(
+-  tokens => safeParser.parse(tokens)
+-).flatten
++convertStream(
++  inputStream,
++  tokenizer,
++  handleHeader,
++  parser.options.charset
++)(tokens => safeParser.parse(tokens)).flatten

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -10748,3 +10748,25 @@ object a {
     waitingForVisit.prepend(mapStage.rdd)
   // Otherwise there's no need to follow the dependency back
 }
+<<< #4133 braces to parens for single-line apply, with rewrite
+maxColumn = 76
+preset = default
+newlines.source = fold
+newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
+rewrite.rules = [RedundantBraces, RedundantParens]
+===
+convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) { tokens =>
+  safeParser.parse(tokens)
+}.flatten
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-convertStream(inputStream, tokenizer, handleHeader, parser.options.charset)(
+-  tokens => safeParser.parse(tokens)
+-).flatten
++convertStream(
++  inputStream,
++  tokenizer,
++  handleHeader,
++  parser.options.charset
++)(tokens => safeParser.parse(tokens)).flatten

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -10759,14 +10759,6 @@ convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) { to
   safeParser.parse(tokens)
 }.flatten
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--convertStream(inputStream, tokenizer, handleHeader, parser.options.charset)(
--  tokens => safeParser.parse(tokens)
--).flatten
-+convertStream(
-+  inputStream,
-+  tokenizer,
-+  handleHeader,
-+  parser.options.charset
-+)(tokens => safeParser.parse(tokens)).flatten
+convertStream(inputStream, tokenizer, handleHeader, parser.options.charset) {
+  tokens => safeParser.parse(tokens)
+}.flatten

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1499380, "total explored")
+      assertEquals(explored, 1499684, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1499684, "total explored")
+      assertEquals(explored, 1498911, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Add SpaceOrNoSplit, handle State etc.
    
This new modification would serve as a space unless we encounter, on the same line, a terminating token, in which case it will become a NoSplit.

This will allow us to re-implement conversion of braces to parens for one-line apply without having to worry about possibly non-idempotent additional formatting rules.
