### PR TITLE
Router: fold `else` only after non-empty block

### DIFF
--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47842614)
+  override protected def totalStatesVisited: Option[Int] = Some(47842622)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -51,7 +51,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(48021731)
+  override protected def totalStatesVisited: Option[Int] = Some(48021739)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(35263229)
+  override protected def totalStatesVisited: Option[Int] = Some(35262645)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(43937370)
+  override protected def totalStatesVisited: Option[Int] = Some(43936814)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(71558097)
+  override protected def totalStatesVisited: Option[Int] = Some(71558113)
 
   override protected def builds =
     Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
@@ -18,7 +18,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(75699361)
+  override protected def totalStatesVisited: Option[Int] = Some(75699377)
 
   override protected def builds =
     Seq(getBuild("v3.5.3", dialects.Scala213, 2756))

--- a/scalafmt-tests/shared/src/test/resources/default/String.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/String.stat
@@ -333,7 +333,8 @@ object a {
 object a {
   def b = {
     try {
-      if (false) {} else {
+      if (false) {}
+      else {
         info("Uber JAR disabled, but current working directory does not look " +
           s"like an engine project directory. Please delete lib/${core.getName} manually.")
       }

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
@@ -202,3 +202,126 @@ object a {
     unsupportedCollectionType(tag.runtimeClass)
   }
 }
+<<< #4133 if-else with braces, some blocks are empty, have only comment, !if-else
+object a {
+  if (sym.isClassConstructor) {
+    constructorTrees += dd
+  } else if (exposed && sym.is(Accessor, butNot = Lazy)) {
+    // Exposed accessors must not be emitted, since the field they access is enough.
+  } else if (sym.hasAnnotation(jsdefn.JSOptionalAnnot)) {
+    // Optional methods must not be emitted
+  } else {
+    generatedMethods ++= genMethod(dd)
+  }
+}
+>>>
+object a {
+  if (sym.isClassConstructor) {
+    constructorTrees += dd
+  } else if (exposed && sym.is(Accessor, butNot = Lazy)) {
+    // Exposed accessors must not be emitted, since the field they access is enough.
+  } else if (sym.hasAnnotation(jsdefn.JSOptionalAnnot)) {
+    // Optional methods must not be emitted
+  } else {
+    generatedMethods ++= genMethod(dd)
+  }
+}
+<<< #4133 if-else with braces, some blocks are empty, have only comment, scala3, !if-else
+runner.dialect = scala3
+rewrite.scala3.convertToNewSyntax = true
+===
+object a {
+  if (sym.isClassConstructor) {
+    constructorTrees += dd
+  } else if (exposed && sym.is(Accessor, butNot = Lazy)) {
+    // Exposed accessors must not be emitted, since the field they access is enough.
+  } else if (sym.hasAnnotation(jsdefn.JSOptionalAnnot)) {
+    // Optional methods must not be emitted
+  } else {
+    generatedMethods ++= genMethod(dd)
+  }
+}
+>>>
+object a {
+  if sym.isClassConstructor then {
+    constructorTrees += dd
+  } else if exposed && sym.is(Accessor, butNot = Lazy) then {
+    // Exposed accessors must not be emitted, since the field they access is enough.
+  } else if sym.hasAnnotation(jsdefn.JSOptionalAnnot) then {
+    // Optional methods must not be emitted
+  } else {
+    generatedMethods ++= genMethod(dd)
+  }
+}
+<<< #4133 if-else with braces, some blocks are empty, have only comment, scala3, if-else
+runner.dialect = scala3
+rewrite.scala3.convertToNewSyntax = true
+rewrite.redundantBraces.ifElseExpressions = true
+===
+object a {
+  if (sym.isClassConstructor) {
+    constructorTrees += dd
+  } else if (exposed && sym.is(Accessor, butNot = Lazy)) {
+    // Exposed accessors must not be emitted, since the field they access is enough.
+  } else if (sym.hasAnnotation(jsdefn.JSOptionalAnnot)) {
+    // Optional methods must not be emitted
+  } else {
+    generatedMethods ++= genMethod(dd)
+  }
+}
+>>>
+object a {
+  if sym.isClassConstructor then constructorTrees += dd
+  else if exposed && sym.is(Accessor, butNot = Lazy) then {
+    // Exposed accessors must not be emitted, since the field they access is enough.
+  } else if sym.hasAnnotation(jsdefn.JSOptionalAnnot) then {
+    // Optional methods must not be emitted
+  } else generatedMethods ++= genMethod(dd)
+}
+<<< if-else with one block completely empty, !if-else
+object a {
+  if (template.isEmpty || hasModifiers || definition.exists(it => it.contains(CASE) && !it.contains(OBJECT))) {} else {
+    if (sb.length >= 2 && sb.substring(sb.length - 2, sb.length()) == "()" && !(sb.length > 2 && sb.charAt(sb.length - 3) == ')')) {
+      sb.delete(sb.length - 2, sb.length())
+    }
+  }
+}
+>>>
+object a {
+  if (
+    template.isEmpty || hasModifiers || definition
+      .exists(it => it.contains(CASE) && !it.contains(OBJECT))
+  ) {} else {
+    if (
+      sb.length >= 2 && sb.substring(
+        sb.length - 2,
+        sb.length()
+      ) == "()" && !(sb.length > 2 && sb.charAt(sb.length - 3) == ')')
+    ) {
+      sb.delete(sb.length - 2, sb.length())
+    }
+  }
+}
+<<< if-else with one block completely empty, if-else
+rewrite.redundantBraces.ifElseExpressions = true
+===
+object a {
+  if (template.isEmpty || hasModifiers || definition.exists(it => it.contains(CASE) && !it.contains(OBJECT))) {} else {
+    if (sb.length >= 2 && sb.substring(sb.length - 2, sb.length()) == "()" && !(sb.length > 2 && sb.charAt(sb.length - 3) == ')')) {
+      sb.delete(sb.length - 2, sb.length())
+    }
+  }
+}
+>>>
+object a {
+  if (
+    template.isEmpty || hasModifiers || definition
+      .exists(it => it.contains(CASE) && !it.contains(OBJECT))
+  ) {} else if (
+    sb.length >= 2 && sb.substring(
+      sb.length - 2,
+      sb.length()
+    ) == "()" && !(sb.length > 2 && sb.charAt(sb.length - 3) == ')')
+  )
+    sb.delete(sb.length - 2, sb.length())
+}

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
@@ -291,7 +291,8 @@ object a {
   if (
     template.isEmpty || hasModifiers || definition
       .exists(it => it.contains(CASE) && !it.contains(OBJECT))
-  ) {} else {
+  ) {}
+  else {
     if (
       sb.length >= 2 && sb.substring(
         sb.length - 2,
@@ -317,7 +318,8 @@ object a {
   if (
     template.isEmpty || hasModifiers || definition
       .exists(it => it.contains(CASE) && !it.contains(OBJECT))
-  ) {} else if (
+  ) {}
+  else if (
     sb.length >= 2 && sb.substring(
       sb.length - 2,
       sb.length()

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1484614, "total explored")
+      assertEquals(explored, 1484618, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1483242, "total explored")
+      assertEquals(explored, 1484614, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Check for empty blocks, or for non-blocks.
