### PR TITLE
Policy: compare starts, not ends

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -430,19 +430,22 @@ object Policy {
     }
     case object After extends End {
       def apply(token: Token): WithPos = new End.WithPos {
-        def notExpiredBy(ft: FormatToken): Boolean = ft.left.end <= token.end
+        def notExpiredBy(ft: FormatToken): Boolean = ft.left.start <=
+          token.start
         override def toString: String = s">${token.structure}"
       }
     }
     case object Before extends End {
       def apply(token: Token): WithPos = new End.WithPos {
-        def notExpiredBy(ft: FormatToken): Boolean = ft.right.end < token.end
+        def notExpiredBy(ft: FormatToken): Boolean = ft.right.start <
+          token.start
         override def toString: String = s"<${token.structure}"
       }
     }
     case object On extends End {
       def apply(token: Token): WithPos = new End.WithPos {
-        def notExpiredBy(ft: FormatToken): Boolean = ft.right.end <= token.end
+        def notExpiredBy(ft: FormatToken): Boolean = ft.right.start <=
+          token.start
         override def toString: String = s"@${token.structure}"
       }
     }

--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47842622)
+  override protected def totalStatesVisited: Option[Int] = Some(47842896)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -51,7 +51,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(48021739)
+  override protected def totalStatesVisited: Option[Int] = Some(48022013)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(35262343)
+  override protected def totalStatesVisited: Option[Int] = Some(35262413)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(32923004)
+  override protected def totalStatesVisited: Option[Int] = Some(32923088)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(35522785)
+  override protected def totalStatesVisited: Option[Int] = Some(35522867)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(71558113)
+  override protected def totalStatesVisited: Option[Int] = Some(71558119)
 
   override protected def builds =
     Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
@@ -18,7 +18,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(75699377)
+  override protected def totalStatesVisited: Option[Int] = Some(75699407)
 
   override protected def builds =
     Seq(getBuild("v3.5.3", dialects.Scala213, 2756))

--- a/scalafmt-tests/shared/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/Advanced.stat
@@ -456,7 +456,7 @@ js.Function(List(objParam, depthParam), js.Return {
                                     depth)
                     })
                   })
->>> { stateVisits = 1712, stateVisits2 = 1738 }
+>>> { stateVisits = 1738, stateVisits2 = 1738 }
 js.Function(List(objParam, depthParam),
             js.Return {
               js.If(js.Apply(envField("isArrayOf", className),

--- a/scalafmt-tests/shared/src/test/resources/default/Apply.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/Apply.stat
@@ -5,7 +5,7 @@ List(Split(Space, 0).withPolicy(SingleLineBlock(close)),
              case Decision(t@FormatToken(_, `close`, _), s) =>
                Decision(t, List(Split(Newline, 0)))
            }).withIndent(2, close, Right))
->>> { stateVisits = 595, stateVisits2 = 626 }
+>>> { stateVisits = 626, stateVisits2 = 626 }
 List(Split(Space, 0).withPolicy(SingleLineBlock(close)),
      Split(nl, 1)
        .withPolicy({ case Decision(t @ FormatToken(_, `close`, _), s) =>

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -7442,3 +7442,30 @@ private[this] def __computeSerializedSize(): _root_.scala.Int =
       ) + __value.serializedSize;
    end if
    __size
+<<< #4133 convert to new syntax: add then at possible line end
+maxColumn = 74
+rewrite.scala3.convertToNewSyntax = true
+===
+foo match {
+  case Literal(value) => 
+    if (value.tag != UnitTag) (value.tag, expectedType) match {
+      case (IntTag,   LONG  ) => bc.lconst(value.longValue);       generatedType = LONG
+      case (FloatTag, DOUBLE) => bc.dconst(value.doubleValue);     generatedType = DOUBLE
+      case (NullTag,  _     ) => bc.emit(asm.Opcodes.ACONST_NULL); generatedType = srNullRef
+      case _                  => genConstant(value);               generatedType = tpeTK(tree)
+    }
+}
+>>>
+foo match {
+  case Literal(value) =>
+    if value.tag != UnitTag then
+       (value.tag, expectedType) match {
+         case (IntTag, LONG) =>
+           bc.lconst(value.longValue); generatedType = LONG
+         case (FloatTag, DOUBLE) =>
+           bc.dconst(value.doubleValue); generatedType = DOUBLE
+         case (NullTag, _) =>
+           bc.emit(asm.Opcodes.ACONST_NULL); generatedType = srNullRef
+         case _ => genConstant(value); generatedType = tpeTK(tree)
+       }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7158,3 +7158,24 @@ private[this] def __computeSerializedSize(): _root_.scala.Int =
         __value.serializedSize;
    end if
    __size
+<<< #4133 convert to new syntax: add then at possible line end
+maxColumn = 74
+rewrite.scala3.convertToNewSyntax = true
+===
+foo match {
+  case Literal(value) => 
+    if (value.tag != UnitTag) (value.tag, expectedType) match {
+      case (IntTag,   LONG  ) => bc.lconst(value.longValue);       generatedType = LONG
+      case (FloatTag, DOUBLE) => bc.dconst(value.doubleValue);     generatedType = DOUBLE
+      case (NullTag,  _     ) => bc.emit(asm.Opcodes.ACONST_NULL); generatedType = srNullRef
+      case _                  => genConstant(value);               generatedType = tpeTK(tree)
+    }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ foo match {
+-  case Literal(value) => if value.tag != UnitTag then
++  case Literal(value) =>
++    if value.tag != UnitTag then
+        (value.tag, expectedType) match {

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -1005,7 +1005,7 @@ object Foo:
     case a: A if a.someField.otherField.function().exists(SomeObjectLongName.isTrue) =>
       None
   )
->>> { stateVisits = 790, stateVisits2 = 794 }
+>>> { stateVisits = 794, stateVisits2 = 794 }
 object Foo:
    def bar = process(
      arg match
@@ -7172,10 +7172,15 @@ foo match {
     }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- foo match {
--  case Literal(value) => if value.tag != UnitTag then
-+  case Literal(value) =>
-+    if value.tag != UnitTag then
-        (value.tag, expectedType) match {
+foo match {
+  case Literal(value) => if value.tag != UnitTag then
+       (value.tag, expectedType) match {
+         case (IntTag, LONG) =>
+           bc.lconst(value.longValue); generatedType = LONG
+         case (FloatTag, DOUBLE) =>
+           bc.dconst(value.doubleValue); generatedType = DOUBLE
+         case (NullTag, _) =>
+           bc.emit(asm.Opcodes.ACONST_NULL); generatedType = srNullRef
+         case _ => genConstant(value); generatedType = tpeTK(tree)
+       }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7471,3 +7471,30 @@ private[this] def __computeSerializedSize(): _root_.scala.Int =
       ) + __value.serializedSize;
    end if
    __size
+<<< #4133 convert to new syntax: add then at possible line end
+maxColumn = 74
+rewrite.scala3.convertToNewSyntax = true
+===
+foo match {
+  case Literal(value) => 
+    if (value.tag != UnitTag) (value.tag, expectedType) match {
+      case (IntTag,   LONG  ) => bc.lconst(value.longValue);       generatedType = LONG
+      case (FloatTag, DOUBLE) => bc.dconst(value.doubleValue);     generatedType = DOUBLE
+      case (NullTag,  _     ) => bc.emit(asm.Opcodes.ACONST_NULL); generatedType = srNullRef
+      case _                  => genConstant(value);               generatedType = tpeTK(tree)
+    }
+}
+>>>
+foo match {
+  case Literal(value) =>
+    if value.tag != UnitTag then
+       (value.tag, expectedType) match {
+         case (IntTag, LONG) =>
+           bc.lconst(value.longValue); generatedType = LONG
+         case (FloatTag, DOUBLE) =>
+           bc.dconst(value.doubleValue); generatedType = DOUBLE
+         case (NullTag, _) =>
+           bc.emit(asm.Opcodes.ACONST_NULL); generatedType = srNullRef
+         case _ => genConstant(value); generatedType = tpeTK(tree)
+       }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7735,3 +7735,35 @@ private[this] def __computeSerializedSize(): _root_.scala.Int =
         ) + __value.serializedSize;
    end if
    __size
+<<< #4133 convert to new syntax: add then at possible line end
+maxColumn = 74
+rewrite.scala3.convertToNewSyntax = true
+===
+foo match {
+  case Literal(value) => 
+    if (value.tag != UnitTag) (value.tag, expectedType) match {
+      case (IntTag,   LONG  ) => bc.lconst(value.longValue);       generatedType = LONG
+      case (FloatTag, DOUBLE) => bc.dconst(value.doubleValue);     generatedType = DOUBLE
+      case (NullTag,  _     ) => bc.emit(asm.Opcodes.ACONST_NULL); generatedType = srNullRef
+      case _                  => genConstant(value);               generatedType = tpeTK(tree)
+    }
+}
+>>>
+foo match {
+  case Literal(value) =>
+    if value.tag != UnitTag then
+       (value.tag, expectedType) match {
+         case (IntTag, LONG) =>
+           bc.lconst(value.longValue);
+           generatedType = LONG
+         case (FloatTag, DOUBLE) =>
+           bc.dconst(value.doubleValue);
+           generatedType = DOUBLE
+         case (NullTag, _) =>
+           bc.emit(asm.Opcodes.ACONST_NULL);
+           generatedType = srNullRef
+         case _ =>
+           genConstant(value);
+           generatedType = tpeTK(tree)
+       }
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1486740, "total explored")
+      assertEquals(explored, 1488077, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -138,7 +138,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1485340, "total explored")
+      assertEquals(explored, 1486740, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
When inserting or replacing tokens, we'd use the same start but the end could encroach onto the next one, so let's not use it.