### PR TITLE
Use Token.text instead of Token.syntax

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -433,7 +433,7 @@ object FormatTokens {
     var fmtWasOff = false
     val arr = tokens.toArray
     def process(right: Token): Unit = {
-      val rmeta = FormatToken.TokenMeta(owner(right), right.syntax)
+      val rmeta = FormatToken.TokenMeta(owner(right), right.text)
       if (left eq null) fmtWasOff = isFormatOff(right)
       else {
         val between = arr.slice(wsIdx, tokIdx)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -13,7 +13,7 @@ case class Provided(ft: FormatToken) extends Modification {
   override val newlines: Int = ft.newlinesBetween
   override lazy val length: Int =
     if (isNL) betweenText.indexOf('\n') else betweenText.length
-  lazy val betweenText: String = ft.between.map(_.syntax).mkString
+  lazy val betweenText: String = ft.between.map(_.text).mkString
 }
 
 case object NoSplit extends Modification {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -56,7 +56,7 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
 
     def moveOpenDelim(prev: Token, open: Token): Unit = {
       // move delimiter (before comment or newline)
-      builder += TokenPatch.AddRight(prev, open.syntax, keepTok = true)
+      builder += TokenPatch.AddRight(prev, open.text, keepTok = true)
       builder += TokenPatch.Remove(open)
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -37,7 +37,7 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
   def getIndex(token: T) = tokenTraverser.getIndex(token)
 
   def applyPatches: String = tokens.iterator
-    .map(x => patchBuilder.get(x.start -> x.end).fold(x.syntax)(_.newTok))
+    .map(x => patchBuilder.get(x.start -> x.end).fold(x.text)(_.newTok))
     .mkString
 
   def addPatchSet(patches: TokenPatch*): Unit =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -92,7 +92,7 @@ object LoggerOps {
 
   def log(t: Tree): String = log(t, false)
   def log(t: Tree, tokensOnly: Boolean): String = {
-    val tokens = s"TOKENS: ${t.tokens.map(x => reveal(x.syntax)).mkString(",")}"
+    val tokens = s"TOKENS: ${t.tokens.map(x => reveal(x.text)).mkString(",")}"
     if (tokensOnly) tokens
     else s"""|TYPE: ${treeInfo(t)}
              |SOURCE: $t


### PR DESCRIPTION
Syntax might not include backticks which could be present in the code.