### PR TITLE
Router: use single non-NL default split before `}`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -651,8 +651,9 @@ class Router(formatOps: FormatOps) {
           )
         }
 
-      case FormatToken(_, T.RightBrace(), _) =>
-        Seq(Split(xmlSpace(rightOwner), 0), Split(Newline2x(ft), 0))
+      case FormatToken(_, _: T.RightBrace, _) =>
+        Seq(Split(if (ft.hasBlankLine) Newline2x else xmlSpace(rightOwner), 0))
+
       case FormatToken(_: T.KwPackage, _, _) if leftOwner.is[Pkg] =>
         Seq(Split(Space, 0))
       // Opening [ with no leading space.

--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47222304)
+  override protected def totalStatesVisited: Option[Int] = Some(47222320)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -51,7 +51,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47399052)
+  override protected def totalStatesVisited: Option[Int] = Some(47399068)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34638031)
+  override protected def totalStatesVisited: Option[Int] = Some(34637924)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(43154091)
+  override protected def totalStatesVisited: Option[Int] = Some(43153935)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(32258416)
+  override protected def totalStatesVisited: Option[Int] = Some(32258332)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34826925)
+  override protected def totalStatesVisited: Option[Int] = Some(34827225)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(70619646)
+  override protected def totalStatesVisited: Option[Int] = Some(70619605)
 
   override protected def builds =
     Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
@@ -18,7 +18,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(74709793)
+  override protected def totalStatesVisited: Option[Int] = Some(74709754)
 
   override protected def builds =
     Seq(getBuild("v3.5.3", dialects.Scala213, 2756))

--- a/scalafmt-tests/shared/src/test/resources/default/Idempotency.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/Idempotency.stat
@@ -26,9 +26,8 @@ val bindingFuture = Http().bindAndHandleSync({
     {
       val bindingFuture = Http().bindAndHandleSync(
           { case HttpRequest(_, _, headers, _, _) ⇒
-            val upgrade = headers.collectFirst { case u: UpgradeToWebSocket ⇒
-              u
-            }.get
+            val upgrade =
+              headers.collectFirst { case u: UpgradeToWebSocket ⇒ u }.get
             upgrade.handleMessages(
                 Flow.fromSinkAndSource(Sink.ignore,
                                        Source.fromPublisher(source)),

--- a/scalafmt-tests/shared/src/test/resources/unit/Apply.stat
+++ b/scalafmt-tests/shared/src/test/resources/unit/Apply.stat
@@ -24,9 +24,8 @@ new DenseMatrix(
   isTranspose = !from.isTranspose)
 >>>
 new DenseMatrix(
-    data = from.data map {
-      _.conjugate
-    },
+    data =
+      from.data map { _.conjugate },
     offset = from.offset,
     cols = from.rows,
     rows = from.cols,

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1487221, "total explored")
+      assertEquals(explored, 1486615, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
The usual NL split is forced through NB policy used with `{`.