### PR TITLE
Router: penalize break after `{` in args

### DIFF
--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47222320)
+  override protected def totalStatesVisited: Option[Int] = Some(47236348)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -51,7 +51,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47399068)
+  override protected def totalStatesVisited: Option[Int] = Some(47413622)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34637924)
+  override protected def totalStatesVisited: Option[Int] = Some(34646234)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(43153935)
+  override protected def totalStatesVisited: Option[Int] = Some(43165033)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(32258332)
+  override protected def totalStatesVisited: Option[Int] = Some(32264582)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34827225)
+  override protected def totalStatesVisited: Option[Int] = Some(34834391)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(70619605)
+  override protected def totalStatesVisited: Option[Int] = Some(70667003)
 
   override protected def builds =
     Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
@@ -18,7 +18,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(74709754)
+  override protected def totalStatesVisited: Option[Int] = Some(74759780)
 
   override protected def builds =
     Seq(getBuild("v3.5.3", dialects.Scala213, 2756))

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10830,3 +10830,20 @@ system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil).recoverWith {
           }
       }
 }
+<<< #4133 redundant braces with nested partial function 
+maxColumn = 76
+rewrite.rules = [RedundantBraces]
+===
+object a {
+  val defaultMethodNames = defaultGetterNames.map { _.replace {
+    case DefaultGetterName(methName, _) => methName
+  }}
+}
+>>>
+object a {
+  val defaultMethodNames = defaultGetterNames.map {
+    _.replace { case DefaultGetterName(methName, _) =>
+      methName
+    }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10120,3 +10120,22 @@ system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil).recoverWith {
         }
       }
 }
+<<< #4133 redundant braces with nested partial function 
+maxColumn = 76
+rewrite.rules = [RedundantBraces]
+===
+object a {
+  val defaultMethodNames = defaultGetterNames.map { _.replace {
+    case DefaultGetterName(methName, _) => methName
+  }}
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a {
+-  val defaultMethodNames = defaultGetterNames.map(_.replace {
+-    case DefaultGetterName(methName, _) => methName
+-  })
++  val defaultMethodNames = defaultGetterNames
++    .map(_.replace { case DefaultGetterName(methName, _) => methName })
+ }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9212,7 +9212,7 @@ object Build {
       }.evaluated,
     )
 }
->>> { stateVisits = 1296, stateVisits2 = 1296 }
+>>> { stateVisits = 2300, stateVisits2 = 1144 }
 object Build {
   lazy val scaladoc = project.in(file("scaladoc"))
     .settings(generateScalaDocumentation := Def.inputTaskDyn {
@@ -9460,7 +9460,7 @@ object a {
         }
   }
 }
->>> { stateVisits = 2428, stateVisits2 = 2428 }
+>>> { stateVisits = 2449, stateVisits2 = 2449 }
 object a {
   private object MemoMap {
     def make(implicit trace: Trace): UIO[MemoMap] = Ref.Synchronized
@@ -10130,12 +10130,7 @@ object a {
   }}
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a {
--  val defaultMethodNames = defaultGetterNames.map(_.replace {
--    case DefaultGetterName(methName, _) => methName
--  })
-+  val defaultMethodNames = defaultGetterNames
-+    .map(_.replace { case DefaultGetterName(methName, _) => methName })
- }
+object a {
+  val defaultMethodNames = defaultGetterNames
+    .map(_.replace { case DefaultGetterName(methName, _) => methName })
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10582,3 +10582,20 @@ system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil).recoverWith {
             }
       }
 }
+<<< #4133 redundant braces with nested partial function 
+maxColumn = 76
+rewrite.rules = [RedundantBraces]
+===
+object a {
+  val defaultMethodNames = defaultGetterNames.map { _.replace {
+    case DefaultGetterName(methName, _) => methName
+  }}
+}
+>>>
+object a {
+  val defaultMethodNames = defaultGetterNames.map {
+    _.replace {
+      case DefaultGetterName(methName, _) => methName
+    }
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -10970,3 +10970,20 @@ system
           }
       }
   }
+<<< #4133 redundant braces with nested partial function 
+maxColumn = 76
+rewrite.rules = [RedundantBraces]
+===
+object a {
+  val defaultMethodNames = defaultGetterNames.map { _.replace {
+    case DefaultGetterName(methName, _) => methName
+  }}
+}
+>>>
+object a {
+  val defaultMethodNames = defaultGetterNames.map {
+    _.replace { case DefaultGetterName(methName, _) =>
+      methName
+    }
+  }
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1486615, "total explored")
+      assertEquals(explored, 1486932, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1486932, "total explored")
+      assertEquals(explored, 1488289, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
For `fold` case, using zero cost for the closing brace leads to cases of non-idempotence; lets increase the cost of the opening brace in those cases only, to account for that.