### PR TITLE
Router: refactor lambda splits for `{...`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -338,7 +338,10 @@ object TreeOps {
   def treeDepth(tree: Tree): Int = tree match {
     case Member.ParamClauseGroup(tparams, paramss) =>
       maxTreeDepth(tparams +: paramss)
-    case Member.SyntaxValuesClause(v) => maxTreeDepth(v)
+    case Member.SyntaxValuesClause(v) => v match {
+        case (b: Tree.Block) :: Nil => maxTreeDepth(b.stats)
+        case _ => maxTreeDepth(v)
+      }
     case _ =>
       val children = tree.children
       if (children.isEmpty) 0 else 1 + maxTreeDepth(children)

--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47261025)
+  override protected def totalStatesVisited: Option[Int] = Some(47254724)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -51,7 +51,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47438272)
+  override protected def totalStatesVisited: Option[Int] = Some(47431899)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34662237)
+  override protected def totalStatesVisited: Option[Int] = Some(34661174)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(43185694)
+  override protected def totalStatesVisited: Option[Int] = Some(43184755)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(32292040)
+  override protected def totalStatesVisited: Option[Int] = Some(32288017)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34863414)
+  override protected def totalStatesVisited: Option[Int] = Some(34858906)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(70730388)
+  override protected def totalStatesVisited: Option[Int] = Some(70715510)
 
   override protected def builds =
     Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
@@ -18,7 +18,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(74823957)
+  override protected def totalStatesVisited: Option[Int] = Some(74807834)
 
   override protected def builds =
     Seq(getBuild("v3.5.3", dialects.Scala213, 2756))

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10938,8 +10938,8 @@ object a {
 >>>
 object a {
   def union(other: Dataset[T]): Dataset[T] =
-    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) {
-      builder => builder.setIsAll(true)
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) { builder =>
+      builder.setIsAll(true)
     }
 }
 <<< #4133 braces to parens with func

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10902,3 +10902,80 @@ object a {
     }
   }
 }
+<<< #4133 braces to parens with two curried params
+maxColumn = 74
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+Utils.tryWithSafeFinally {
+  serializeStream.writeObject(partitioner)
+} {
+  serializeStream.close()
+}
+>>>
+Utils.tryWithSafeFinally {
+  serializeStream.writeObject(partitioner)
+} {
+  serializeStream.close()
+}
+<<< #4133 braces to parens with func
+preset = default
+newlines.source = fold
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+rewrite {
+  rules = [RedundantBraces, RedundantParens]
+  redundantBraces.preset = all
+}
+===
+object a {
+  def union(other: Dataset[T]): Dataset[T] = {
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) { builder =>
+      builder.setIsAll(true)
+    }
+  }
+}
+>>>
+object a {
+  def union(other: Dataset[T]): Dataset[T] =
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) {
+      builder => builder.setIsAll(true)
+    }
+}
+<<< #4133 braces to parens with func
+maxColumn = 68
+rewrite.rules = [RedundantBraces]
+===
+val worker = Flow[T]
+  .fold(new FirstCollectorState(factory): CollectorState[T, R]) { (state, elem) =>
+    state.update(elem)
+  }
+>>>
+val worker = Flow[T]
+  .fold(new FirstCollectorState(factory): CollectorState[T, R]) {
+    (state, elem) =>
+      state.update(elem)
+  }
+<<< #4133 braces to parens with func, originally in parens with body block
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+repeatTakeMapAndFold = fuse(
+  Source
+    .repeat(new MutableElement(0))
+    .take(ElementCount)
+    .map(addFunc)
+    .map(addFunc)
+    .fold(new MutableElement(0))((acc, x) => { acc.value += x.value; acc })
+    .toMat(testSink)(Keep.right))
+>>>
+repeatTakeMapAndFold = fuse(
+  Source
+    .repeat(new MutableElement(0))
+    .take(ElementCount)
+    .map(addFunc)
+    .map(addFunc)
+    .fold(new MutableElement(0)) { (acc, x) => acc.value += x.value; acc }
+    .toMat(testSink)(Keep.right)
+)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10188,3 +10188,78 @@ object a {
   val defaultMethodNames = defaultGetterNames
     .map(_.replace { case DefaultGetterName(methName, _) => methName })
 }
+<<< #4133 braces to parens with two curried params
+maxColumn = 74
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+Utils.tryWithSafeFinally {
+  serializeStream.writeObject(partitioner)
+} {
+  serializeStream.close()
+}
+>>>
+Utils.tryWithSafeFinally(serializeStream.writeObject(partitioner)) {
+  serializeStream.close()
+}
+<<< #4133 braces to parens with func
+preset = default
+newlines.source = fold
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+rewrite {
+  rules = [RedundantBraces, RedundantParens]
+  redundantBraces.preset = all
+}
+===
+object a {
+  def union(other: Dataset[T]): Dataset[T] = {
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) { builder =>
+      builder.setIsAll(true)
+    }
+  }
+}
+>>>
+object a {
+  def union(other: Dataset[T]): Dataset[T] =
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) {
+      builder => builder.setIsAll(true)
+    }
+}
+<<< #4133 braces to parens with func
+maxColumn = 68
+rewrite.rules = [RedundantBraces]
+===
+val worker = Flow[T]
+  .fold(new FirstCollectorState(factory): CollectorState[T, R]) { (state, elem) =>
+    state.update(elem)
+  }
+>>>
+val worker = Flow[T]
+  .fold(new FirstCollectorState(factory): CollectorState[T, R]) {
+    (state, elem) => state.update(elem)
+  }
+<<< #4133 braces to parens with func, originally in parens with body block
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+repeatTakeMapAndFold = fuse(
+  Source
+    .repeat(new MutableElement(0))
+    .take(ElementCount)
+    .map(addFunc)
+    .map(addFunc)
+    .fold(new MutableElement(0))((acc, x) => { acc.value += x.value; acc })
+    .toMat(testSink)(Keep.right))
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+   Source.repeat(new MutableElement(0)).take(ElementCount).map(addFunc)
+-    .map(addFunc).fold(new MutableElement(0)) { (acc, x) =>
+-      acc.value += x.value; acc
+-    }.toMat(testSink)(Keep.right)
++    .map(addFunc)
++    .fold(new MutableElement(0)) { (acc, x) => acc.value += x.value; acc }
++    .toMat(testSink)(Keep.right)
+ )

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10199,9 +10199,9 @@ Utils.tryWithSafeFinally {
   serializeStream.close()
 }
 >>>
-Utils.tryWithSafeFinally(serializeStream.writeObject(partitioner)) {
-  serializeStream.close()
-}
+Utils.tryWithSafeFinally {
+  serializeStream.writeObject(partitioner)
+}(serializeStream.close())
 <<< #4133 braces to parens with func
 preset = default
 newlines.source = fold
@@ -10222,8 +10222,8 @@ object a {
 >>>
 object a {
   def union(other: Dataset[T]): Dataset[T] =
-    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) {
-      builder => builder.setIsAll(true)
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) { builder =>
+      builder.setIsAll(true)
     }
 }
 <<< #4133 braces to parens with func
@@ -10253,13 +10253,9 @@ repeatTakeMapAndFold = fuse(
     .fold(new MutableElement(0))((acc, x) => { acc.value += x.value; acc })
     .toMat(testSink)(Keep.right))
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-   Source.repeat(new MutableElement(0)).take(ElementCount).map(addFunc)
--    .map(addFunc).fold(new MutableElement(0)) { (acc, x) =>
--      acc.value += x.value; acc
--    }.toMat(testSink)(Keep.right)
-+    .map(addFunc)
-+    .fold(new MutableElement(0)) { (acc, x) => acc.value += x.value; acc }
-+    .toMat(testSink)(Keep.right)
- )
+repeatTakeMapAndFold = fuse(
+  Source.repeat(new MutableElement(0)).take(ElementCount).map(addFunc)
+    .map(addFunc).fold(new MutableElement(0)) { (acc, x) =>
+      acc.value += x.value; acc
+    }.toMat(testSink)(Keep.right)
+)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10691,8 +10691,8 @@ object a {
 >>>
 object a {
   def union(other: Dataset[T]): Dataset[T] =
-    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) {
-      builder => builder.setIsAll(true)
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) { builder =>
+      builder.setIsAll(true)
     }
 }
 <<< #4133 braces to parens with func

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10655,3 +10655,80 @@ object a {
     }
   }
 }
+<<< #4133 braces to parens with two curried params
+maxColumn = 74
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+Utils.tryWithSafeFinally {
+  serializeStream.writeObject(partitioner)
+} {
+  serializeStream.close()
+}
+>>>
+Utils.tryWithSafeFinally {
+  serializeStream.writeObject(partitioner)
+} {
+  serializeStream.close()
+}
+<<< #4133 braces to parens with func
+preset = default
+newlines.source = fold
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+rewrite {
+  rules = [RedundantBraces, RedundantParens]
+  redundantBraces.preset = all
+}
+===
+object a {
+  def union(other: Dataset[T]): Dataset[T] = {
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) { builder =>
+      builder.setIsAll(true)
+    }
+  }
+}
+>>>
+object a {
+  def union(other: Dataset[T]): Dataset[T] =
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) {
+      builder => builder.setIsAll(true)
+    }
+}
+<<< #4133 braces to parens with func
+maxColumn = 68
+rewrite.rules = [RedundantBraces]
+===
+val worker = Flow[T]
+  .fold(new FirstCollectorState(factory): CollectorState[T, R]) { (state, elem) =>
+    state.update(elem)
+  }
+>>>
+val worker = Flow[T]
+  .fold(new FirstCollectorState(factory): CollectorState[T, R]) {
+    (state, elem) =>
+      state.update(elem)
+  }
+<<< #4133 braces to parens with func, originally in parens with body block
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+repeatTakeMapAndFold = fuse(
+  Source
+    .repeat(new MutableElement(0))
+    .take(ElementCount)
+    .map(addFunc)
+    .map(addFunc)
+    .fold(new MutableElement(0))((acc, x) => { acc.value += x.value; acc })
+    .toMat(testSink)(Keep.right))
+>>>
+repeatTakeMapAndFold = fuse(
+  Source
+    .repeat(new MutableElement(0))
+    .take(ElementCount)
+    .map(addFunc)
+    .map(addFunc)
+    .fold(new MutableElement(0)) { (acc, x) => acc.value += x.value; acc }
+    .toMat(testSink)(Keep.right)
+)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11045,3 +11045,84 @@ object a {
     }
   }
 }
+<<< #4133 braces to parens with two curried params
+maxColumn = 74
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+Utils.tryWithSafeFinally {
+  serializeStream.writeObject(partitioner)
+} {
+  serializeStream.close()
+}
+>>>
+Utils.tryWithSafeFinally {
+  serializeStream.writeObject(partitioner)
+} {
+  serializeStream.close()
+}
+<<< #4133 braces to parens with func
+preset = default
+newlines.source = fold
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+rewrite {
+  rules = [RedundantBraces, RedundantParens]
+  redundantBraces.preset = all
+}
+===
+object a {
+  def union(other: Dataset[T]): Dataset[T] = {
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) { builder =>
+      builder.setIsAll(true)
+    }
+  }
+}
+>>>
+object a {
+  def union(other: Dataset[T]): Dataset[T] =
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) {
+      builder => builder.setIsAll(true)
+    }
+}
+<<< #4133 braces to parens with func
+maxColumn = 68
+rewrite.rules = [RedundantBraces]
+===
+val worker = Flow[T]
+  .fold(new FirstCollectorState(factory): CollectorState[T, R]) { (state, elem) =>
+    state.update(elem)
+  }
+>>>
+val worker =
+  Flow[T].fold(
+    new FirstCollectorState(factory): CollectorState[T, R]
+  ) { (state, elem) =>
+    state.update(elem)
+  }
+<<< #4133 braces to parens with func, originally in parens with body block
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+repeatTakeMapAndFold = fuse(
+  Source
+    .repeat(new MutableElement(0))
+    .take(ElementCount)
+    .map(addFunc)
+    .map(addFunc)
+    .fold(new MutableElement(0))((acc, x) => { acc.value += x.value; acc })
+    .toMat(testSink)(Keep.right))
+>>>
+repeatTakeMapAndFold = fuse(
+  Source
+    .repeat(new MutableElement(0))
+    .take(ElementCount)
+    .map(addFunc)
+    .map(addFunc)
+    .fold(new MutableElement(0)) { (acc, x) =>
+      acc.value += x.value;
+      acc
+    }
+    .toMat(testSink)(Keep.right)
+)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11081,8 +11081,8 @@ object a {
 >>>
 object a {
   def union(other: Dataset[T]): Dataset[T] =
-    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) {
-      builder => builder.setIsAll(true)
+    buildSetOp(other, proto.SetOperation.SetOpType.SET_OP_TYPE_UNION) { builder =>
+      builder.setIsAll(true)
     }
 }
 <<< #4133 braces to parens with func

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1959,9 +1959,9 @@ object a {
       numBreaks: Int,
       nest: Int,
   ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
-    .takeWhile(_.minBreaks <= numBreaks).find { x =>
-      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
-    }.flatMap(_.blanks)
+    .takeWhile(_.minBreaks <= numBreaks)
+    .find(x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find()))
+    .flatMap(_.blanks)
 }
 <<< fold ctrl body with redundant braces, !trailing commas
 maxColumn = 80
@@ -1987,9 +1987,9 @@ object a {
       numBreaks: Int,
       nest: Int
   ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
-    .takeWhile(_.minBreaks <= numBreaks).find { x =>
-      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
-    }.flatMap(_.blanks)
+    .takeWhile(_.minBreaks <= numBreaks)
+    .find(x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find()))
+    .flatMap(_.blanks)
 }
 <<< #4108 try with redundant parens in block, scala212
 runner.dialect = scala212

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -7469,3 +7469,15 @@ foo match {
          case _ => genConstant(value); generatedType = tpeTK(tree)
        }
 }
+<<< #4133 single-quote interpolation with partial function
+maxColumn = 70
+===
+names {
+  s"`$name0${index.toString.toCharArray.nn.map {x => (x - '0' + '₀').toChar}.mkString}`"
+}
+>>>
+names {
+  s"`$name0${index.toString.toCharArray.nn.map { x =>
+      (x - '0' + '₀').toChar
+    }.mkString}`"
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7184,3 +7184,15 @@ foo match {
          case _ => genConstant(value); generatedType = tpeTK(tree)
        }
 }
+<<< #4133 single-quote interpolation with partial function
+maxColumn = 70
+===
+names {
+  s"`$name0${index.toString.toCharArray.nn.map {x => (x - '0' + '₀').toChar}.mkString}`"
+}
+>>>
+names {
+  s"`$name0${index.toString.toCharArray.nn.map { x =>
+      (x - '0' + '₀').toChar
+    }.mkString}`"
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7498,3 +7498,15 @@ foo match {
          case _ => genConstant(value); generatedType = tpeTK(tree)
        }
 }
+<<< #4133 single-quote interpolation with partial function
+maxColumn = 70
+===
+names {
+  s"`$name0${index.toString.toCharArray.nn.map {x => (x - '0' + '₀').toChar}.mkString}`"
+}
+>>>
+names {
+  s"`$name0${index.toString.toCharArray.nn.map { x =>
+      (x - '0' + '₀').toChar
+    }.mkString}`"
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7767,3 +7767,20 @@ foo match {
            generatedType = tpeTK(tree)
        }
 }
+<<< #4133 single-quote interpolation with partial function
+maxColumn = 70
+===
+names {
+  s"`$name0${index.toString.toCharArray.nn.map {x => (x - '0' + '₀').toChar}.mkString}`"
+}
+>>>
+names {
+  s"`$name0${index
+      .toString
+      .toCharArray
+      .nn
+      .map { x =>
+        (x - '0' + '₀').toChar
+      }
+      .mkString}`"
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1498133, "total explored")
+      assertEquals(explored, 1496883, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1495308, "total explored")
+      assertEquals(explored, 1498133, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
- merge the no-exclude SLB split into the lambda split
- set cost of NL split to align with one for `(...`
- this helps with cases when braces are rewritten to parens
  - also, when computing tree depth, skip blocks (could be rewritten)
- fix NL penalties for `{...` and `=>...`
  - align them for functions in braces and in parens