### PR TITLE
Router: lower NL penalty for braces-to-parens case

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -452,10 +452,10 @@ class Router(formatOps: FormatOps) {
             def argClausePenalty(t: Term.ArgClause)(isFunc: Term => Boolean) =
               t.values match {
                 case arg :: Nil =>
-                  if (isFunc(arg)) Some((nestedApplies(t), 3))
+                  if (isFunc(arg)) Some((nestedApplies(t), 2))
                   else t.parent match {
                     case Some(p: Term.Apply) =>
-                      Some((nestedApplies(p), 1 + treeDepth(p.fun)))
+                      Some((nestedApplies(p), treeDepth(p.fun)))
                     case _ => None
                   }
                 case _ => None

--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47254724)
+  override protected def totalStatesVisited: Option[Int] = Some(47254706)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -51,7 +51,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47431899)
+  override protected def totalStatesVisited: Option[Int] = Some(47431883)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34661174)
+  override protected def totalStatesVisited: Option[Int] = Some(34661248)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(43184755)
+  override protected def totalStatesVisited: Option[Int] = Some(43184810)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(32288009)
+  override protected def totalStatesVisited: Option[Int] = Some(32287892)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34858898)
+  override protected def totalStatesVisited: Option[Int] = Some(34858763)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(70715510)
+  override protected def totalStatesVisited: Option[Int] = Some(70715532)
 
   override protected def builds =
     Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
@@ -18,7 +18,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(74807834)
+  override protected def totalStatesVisited: Option[Int] = Some(74807885)
 
   override protected def builds =
     Seq(getBuild("v3.5.3", dialects.Scala213, 2756))

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10918,6 +10918,53 @@ Utils.tryWithSafeFinally {
 } {
   serializeStream.close()
 }
+<<< #4133 braces to parens with two curried params 2
+maxColumn = 74
+rewrite.rules = [RedundantBraces]
+===
+adjustStart(accept(AT)) {
+  ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
+}
+>>>
+adjustStart(accept(AT)) {
+  ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
+}
+<<< #4133 braces to parens with two curried params, second func
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+>>>
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+<<< #4133 braces to parens with two curried params, second func and comment
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  // dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+>>>
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  // dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
 <<< #4133 braces to parens with func
 preset = default
 newlines.source = fold

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10210,14 +10210,9 @@ adjustStart(accept(AT)) {
   ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--adjustStart(accept(AT))(ensureApplied(
--  parArgumentExprss(wrapNew(simpleType1()))
--))
-+adjustStart(
-+  accept(AT)
-+)(ensureApplied(parArgumentExprss(wrapNew(simpleType1()))))
+adjustStart(accept(AT)) {
+  ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
+}
 <<< #4133 braces to parens with two curried params, second func
 maxColumn = 76
 newlines.avoidForSimpleOverflow = all
@@ -10230,20 +10225,12 @@ val offsets = Utils.tryWithResource {
   buffer.asLongBuffer
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--val offsets = Utils.tryWithResource(new DataInputStream(
--  Files.newInputStream(indexFile.toPath)
--)) { dis =>
--  dis.readFully(buffer.array)
--  buffer.asLongBuffer
--}
-+val offsets = Utils
-+  .tryWithResource(new DataInputStream(Files.newInputStream(indexFile.toPath))) {
-+    dis =>
-+      dis.readFully(buffer.array)
-+      buffer.asLongBuffer
-+  }
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
 <<< #4133 braces to parens with two curried params, second func and comment
 maxColumn = 76
 newlines.avoidForSimpleOverflow = all

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10202,6 +10202,66 @@ Utils.tryWithSafeFinally {
 Utils.tryWithSafeFinally {
   serializeStream.writeObject(partitioner)
 }(serializeStream.close())
+<<< #4133 braces to parens with two curried params 2
+maxColumn = 74
+rewrite.rules = [RedundantBraces]
+===
+adjustStart(accept(AT)) {
+  ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-adjustStart(accept(AT))(ensureApplied(
+-  parArgumentExprss(wrapNew(simpleType1()))
+-))
++adjustStart(
++  accept(AT)
++)(ensureApplied(parArgumentExprss(wrapNew(simpleType1()))))
+<<< #4133 braces to parens with two curried params, second func
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-val offsets = Utils.tryWithResource(new DataInputStream(
+-  Files.newInputStream(indexFile.toPath)
+-)) { dis =>
+-  dis.readFully(buffer.array)
+-  buffer.asLongBuffer
+-}
++val offsets = Utils
++  .tryWithResource(new DataInputStream(Files.newInputStream(indexFile.toPath))) {
++    dis =>
++      dis.readFully(buffer.array)
++      buffer.asLongBuffer
++  }
+<<< #4133 braces to parens with two curried params, second func and comment
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  // dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+>>>
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  // dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
 <<< #4133 braces to parens with func
 preset = default
 newlines.source = fold

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10671,6 +10671,53 @@ Utils.tryWithSafeFinally {
 } {
   serializeStream.close()
 }
+<<< #4133 braces to parens with two curried params 2
+maxColumn = 74
+rewrite.rules = [RedundantBraces]
+===
+adjustStart(accept(AT)) {
+  ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
+}
+>>>
+adjustStart(accept(AT)) {
+  ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
+}
+<<< #4133 braces to parens with two curried params, second func
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+>>>
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+<<< #4133 braces to parens with two curried params, second func and comment
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  // dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+>>>
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  // dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
 <<< #4133 braces to parens with func
 preset = default
 newlines.source = fold

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11061,6 +11061,55 @@ Utils.tryWithSafeFinally {
 } {
   serializeStream.close()
 }
+<<< #4133 braces to parens with two curried params 2
+maxColumn = 74
+rewrite.rules = [RedundantBraces]
+===
+adjustStart(accept(AT)) {
+  ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
+}
+>>>
+adjustStart(accept(AT)) {
+  ensureApplied(parArgumentExprss(wrapNew(simpleType1())))
+}
+<<< #4133 braces to parens with two curried params, second func
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+>>>
+val offsets =
+  Utils.tryWithResource {
+    new DataInputStream(Files.newInputStream(indexFile.toPath))
+  } { dis =>
+    dis.readFully(buffer.array)
+    buffer.asLongBuffer
+  }
+<<< #4133 braces to parens with two curried params, second func and comment
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+val offsets = Utils.tryWithResource {
+  new DataInputStream(Files.newInputStream(indexFile.toPath))
+} { dis =>
+  // dis.readFully(buffer.array)
+  buffer.asLongBuffer
+}
+>>>
+val offsets =
+  Utils.tryWithResource {
+    new DataInputStream(Files.newInputStream(indexFile.toPath))
+  } { dis =>
+    // dis.readFully(buffer.array)
+    buffer.asLongBuffer
+  }
 <<< #4133 braces to parens with func
 preset = default
 newlines.source = fold

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1499055, "total explored")
+      assertEquals(explored, 1499037, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1498031, "total explored")
+      assertEquals(explored, 1499055, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
This will give slight preference NOT to rewrite and avoid non-idempotent formatting.