### PR TITLE
PolicyOps: expire SLB exclude On in apply/select

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1165,7 +1165,7 @@ class Router(formatOps: FormatOps) {
               else {
                 def getSlb(implicit l: FileLine) = SingleLineBlock(
                   close,
-                  exclude = excludeBlocks,
+                  exclude = excludeBlocks.excludeCloseDelim,
                   noSyntaxNL = multipleArgs,
                 )
                 val needDifferentFromOneArgPerLine = newlinePolicy.nonEmpty &&
@@ -1960,6 +1960,7 @@ class Router(formatOps: FormatOps) {
                   val end = nextSelect
                     .fold(expire)(x => getLastNonTrivialToken(x.qual))
                   val exclude = insideBracesBlock(ft, end, parensToo = true)
+                    .excludeCloseDelim
                   Split(modSpace, 0).withSingleLine(end, exclude = exclude)
                 }
               Seq(noSplit, nlSplitBase)

--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47255098)
+  override protected def totalStatesVisited: Option[Int] = Some(47100766)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -51,7 +51,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(47432293)
+  override protected def totalStatesVisited: Option[Int] = Some(47277877)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34661420)
+  override protected def totalStatesVisited: Option[Int] = Some(34655844)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(43185150)
+  override protected def totalStatesVisited: Option[Int] = Some(43180047)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(32287892)
+  override protected def totalStatesVisited: Option[Int] = Some(32272482)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34858763)
+  override protected def totalStatesVisited: Option[Int] = Some(34839825)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(70715816)
+  override protected def totalStatesVisited: Option[Int] = Some(70297920)
 
   override protected def builds =
     Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
@@ -18,7 +18,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(74808431)
+  override protected def totalStatesVisited: Option[Int] = Some(74388417)
 
   override protected def builds =
     Seq(getBuild("v3.5.3", dialects.Scala213, 2756))

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11046,3 +11046,40 @@ val seqArgs =
       val wrap = gen.mkWrapArray(Ident(param), parTp)
     }
   }
+<<< #4133 nested apply followed by select
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+===
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava)
+  }
+}
+>>>
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(
+      cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava
+    )
+  }
+}
+<<< #4133 braces-to-parens with nested apply followed by select
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+rewrite {
+  rules = [RedundantBraces, RedundantParens]
+  redundantBraces.preset = all
+}
+===
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map { cookie => new DefaultCookie(cookie.name, cookie.value) }.asJava)
+  }
+}
+>>>
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String =
+    encoder.encode(cookies.map { cookie =>
+      new DefaultCookie(cookie.name, cookie.value)
+    }.asJava)
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10325,3 +10325,44 @@ val seqArgs = map3(newPs, oldPs, isRepeated) { (param, oldParam, isRep) =>
     val wrap = gen.mkWrapArray(Ident(param), parTp)
   }
 }
+<<< #4133 nested apply followed by select
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+===
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava)
+  }
+}
+>>>
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(
+      cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava
+    )
+  }
+}
+<<< #4133 braces-to-parens with nested apply followed by select
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+rewrite {
+  rules = [RedundantBraces, RedundantParens]
+  redundantBraces.preset = all
+}
+===
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map { cookie => new DefaultCookie(cookie.name, cookie.value) }.asJava)
+  }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a {
+-  def encodeCookieHeader(cookies: Seq[Cookie]): String = encoder.encode(
+-    cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava
+-  )
++  def encodeCookieHeader(cookies: Seq[Cookie]): String = encoder
++    .encode(cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value))
++      .asJava)
+ }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9578,7 +9578,7 @@ object a {
       .map(_.filterNot(_.getCanonicalPath.contains("SSLOptions")))
   }
 }
->>> { stateVisits = 187751, stateVisits2 = 187751 }
+>>> { stateVisits = 3833, stateVisits2 = 3833 }
 object a {
   private def ignoreUndocumentedPackages(
       packages: Seq[Seq[File]]
@@ -10356,13 +10356,9 @@ object a {
   }
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
- object a {
--  def encodeCookieHeader(cookies: Seq[Cookie]): String = encoder.encode(
--    cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava
--  )
-+  def encodeCookieHeader(cookies: Seq[Cookie]): String = encoder
-+    .encode(cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value))
-+      .asJava)
- }
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = encoder
+    .encode(cookies.map { cookie =>
+      new DefaultCookie(cookie.name, cookie.value)
+    }.asJava)
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10799,3 +10799,40 @@ val seqArgs = map3(newPs, oldPs, isRepeated) {
       val wrap = gen.mkWrapArray(Ident(param), parTp)
     }
 }
+<<< #4133 nested apply followed by select
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+===
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava)
+  }
+}
+>>>
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map(cookie =>
+      new DefaultCookie(cookie.name, cookie.value)
+    ).asJava)
+  }
+}
+<<< #4133 braces-to-parens with nested apply followed by select
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+rewrite {
+  rules = [RedundantBraces, RedundantParens]
+  redundantBraces.preset = all
+}
+===
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map { cookie => new DefaultCookie(cookie.name, cookie.value) }.asJava)
+  }
+}
+>>>
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String =
+    encoder.encode(cookies.map { cookie =>
+      new DefaultCookie(cookie.name, cookie.value)
+    }.asJava)
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11196,3 +11196,53 @@ val seqArgs =
       val wrap = gen.mkWrapArray(Ident(param), parTp)
     }
   }
+<<< #4133 nested apply followed by select
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+===
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava)
+  }
+}
+>>>
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(
+      cookies.map(cookie => new DefaultCookie(cookie.name, cookie.value)).asJava
+    )
+  }
+}
+<<< #4133 braces-to-parens with nested apply followed by select
+maxColumn = 80
+newlines.avoidForSimpleOverflow = all
+rewrite {
+  rules = [RedundantBraces, RedundantParens]
+  redundantBraces.preset = all
+}
+===
+object a {
+  def encodeCookieHeader(cookies: Seq[Cookie]): String = {
+    encoder.encode(cookies.map { cookie => new DefaultCookie(cookie.name, cookie.value) }.asJava)
+  }
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+ object a {
+-  def encodeCookieHeader(cookies: Seq[Cookie]): String = encoder.encode(
+-    cookies
+-      .map { cookie =>
+-        new DefaultCookie(cookie.name, cookie.value)
+-      }
+-      .asJava
+-  )
++  def encodeCookieHeader(cookies: Seq[Cookie]): String =
++    encoder.encode(
++      cookies
++        .map { cookie =>
++          new DefaultCookie(cookie.name, cookie.value)
++        }
++        .asJava
++    )
+ }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1503703, "total explored")
+      assertEquals(explored, 1114863, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1502510, "total explored")
+      assertEquals(explored, 1503703, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
This fixes a non-idempotency bug and leads to a massive improvement in state traversal.
