### PR TITLE
Router: zero cost for dot NL in braces-to-parens

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -391,7 +391,7 @@ class Router(formatOps: FormatOps) {
         val noSplitMod = xmlSpace(leftOwner)
         val (slbMod, slbParensExclude) =
           if (singleLineDecisionOpt.isEmpty) (noSplitMod, None)
-          else getBracesToParensMod(closeFT, noSplitMod)
+          else getBracesToParensMod(closeFT, noSplitMod, isWithinBraces = true)
         val singleLineSplitOpt = {
           if (slbParensExclude eq null) None else singleLineDecisionOpt
         }.map { sld =>
@@ -1595,7 +1595,8 @@ class Router(formatOps: FormatOps) {
                   .exists(x => isTokenLastOrAfter(x.left, roPos))
             }
           } =>
-        val mod = getBracesToParensMod(matching(lb), Space)._1
+        val mod =
+          getBracesToParensMod(matching(lb), Space, isWithinBraces = false)._1
         Seq(Split(mod, 0))
 
       // Delim
@@ -1969,7 +1970,8 @@ class Router(formatOps: FormatOps) {
                   }).filter { _ =>
                     implicit val ft: FormatToken = next(ftAfterRight)
                     val rb = matching(ftAfterRight.right)
-                    getBracesToParensMod(rb, Space)._1 ne Space
+                    getBracesToParensMod(rb, Space, isWithinBraces = true)._1 ne
+                      Space
                   }
                 val nlPenalty = bracesToParensOwner.fold(0)(nestedApplies(_) + 1)
                 val noSplit = Split(modSpace, 0)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1964,7 +1964,7 @@ class Router(formatOps: FormatOps) {
                 val bracesToParensOwner =
                   if (!ftAfterRight.right.is[T.LeftBrace]) None
                   else (ftAfterRight.rightOwner match {
-                    case t: Member.ArgClause => Some(t)
+                    case t: Member.ArgClause if t.values.lengthCompare(1) == 0 => Some(t)
                     case t: Term.Block => t.parent.filter(_.is[Member.ArgClause])
                     case _ => None
                   }).filter { _ =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -69,7 +69,8 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
       case b: Term.Block => checkApply(b) && canRewriteBlockWithParens(b) &&
         b.parent.exists(ftoks.getLast(_) eq rb)
       case f: Term.FunctionTerm => checkApply(f) && canRewriteFuncWithParens(f)
-      case t @ SingleArgInBraces(_, arg, _) => isParentAnApply(t) &&
+      case t @ Term.ArgClause(arg :: Nil, _) => isParentAnApply(t) &&
+        ftoks.getDelimsIfEnclosed(t).exists(_._2 eq rb) &&
         canRewriteStatWithParens(arg)
       case _ => false
     })

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -10645,9 +10645,8 @@ val newExprs = exprs.map { _.transform {
   case a: AttributeReference => attrMap.getOrElse(a, a)
 }}
 >>>
-val newExprs = exprs.map {
-  _.transform { case a: AttributeReference => attrMap.getOrElse(a, a) }
-}
+val newExprs = exprs
+  .map(_.transform { case a: AttributeReference => attrMap.getOrElse(a, a) })
 <<< #4133 overflow comment with a forced break 1 
 maxColumn = 76
 newlines.avoidForSimpleOverflow = [tooLong, punct, slc]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11133,3 +11133,17 @@ val WatchHeartBeatInterval: FiniteDuration =
       _ > Duration.Zero,
       "watch-failure-detector.heartbeat-interval must be > 0"
     )
+<<< #4133 braces-to-parens with select, apply of nested apply, with overflow
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+def commaSeparated[T](part: () => T): List[T] =
+  in.currentRegion.withCommasExpected {
+    commaSeparatedRest(part(), part)
+  }
+>>>
+def commaSeparated[T](part: () => T): List[T] =
+  in.currentRegion.withCommasExpected {
+    commaSeparatedRest(part(), part)
+  }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10405,3 +10405,19 @@ val WatchHeartBeatInterval: FiniteDuration = WatchFailureDetectorConfig
     _ > Duration.Zero,
     "watch-failure-detector.heartbeat-interval must be > 0"
   )
+<<< #4133 braces-to-parens with select, apply of nested apply, with overflow
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+def commaSeparated[T](part: () => T): List[T] =
+  in.currentRegion.withCommasExpected {
+    commaSeparatedRest(part(), part)
+  }
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+-def commaSeparated[T](part: () => T): List[T] = in.currentRegion
+-  .withCommasExpected(commaSeparatedRest(part(), part))
++def commaSeparated[T](part: () => T): List[T] =
++  in.currentRegion.withCommasExpected(commaSeparatedRest(part(), part))

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -9950,9 +9950,8 @@ val newExprs = exprs.map { _.transform {
   case a: AttributeReference => attrMap.getOrElse(a, a)
 }}
 >>>
-val newExprs = exprs.map {
-  _.transform { case a: AttributeReference => attrMap.getOrElse(a, a) }
-}
+val newExprs = exprs
+  .map(_.transform { case a: AttributeReference => attrMap.getOrElse(a, a) })
 <<< #4133 overflow comment with a forced break 1 
 maxColumn = 76
 newlines.avoidForSimpleOverflow = [tooLong, punct, slc]
@@ -10186,9 +10185,8 @@ object a {
 }
 >>>
 object a {
-  val defaultMethodNames = defaultGetterNames.map {
-    _.replace { case DefaultGetterName(methName, _) => methName }
-  }
+  val defaultMethodNames = defaultGetterNames
+    .map(_.replace { case DefaultGetterName(methName, _) => methName })
 }
 <<< #4133 braces to parens with two curried params
 maxColumn = 74
@@ -10227,12 +10225,12 @@ val offsets = Utils.tryWithResource {
   buffer.asLongBuffer
 }
 >>>
-val offsets = Utils.tryWithResource {
-  new DataInputStream(Files.newInputStream(indexFile.toPath))
-} { dis =>
-  dis.readFully(buffer.array)
-  buffer.asLongBuffer
-}
+val offsets = Utils
+  .tryWithResource(new DataInputStream(Files.newInputStream(indexFile.toPath))) {
+    dis =>
+      dis.readFully(buffer.array)
+      buffer.asLongBuffer
+  }
 <<< #4133 braces to parens with two curried params, second func and comment
 maxColumn = 76
 newlines.avoidForSimpleOverflow = all
@@ -10304,9 +10302,9 @@ repeatTakeMapAndFold = fuse(
 >>>
 repeatTakeMapAndFold = fuse(
   Source.repeat(new MutableElement(0)).take(ElementCount).map(addFunc)
-    .map(addFunc).fold(new MutableElement(0)) { (acc, x) =>
-      acc.value += x.value; acc
-    }.toMat(testSink)(Keep.right)
+    .map(addFunc)
+    .fold(new MutableElement(0)) { (acc, x) => acc.value += x.value; acc }
+    .toMat(testSink)(Keep.right)
 )
 <<< #4133 parens to braces, with function as argument
 maxColumn = 72
@@ -10374,9 +10372,8 @@ val properties = propertyArgs.map {
   }
 }
 >>>
-val properties = propertyArgs.map {
-  _.drop(2).span(_ != '=') match { case (key, v) => key -> v.tail }
-}
+val properties = propertyArgs
+  .map(_.drop(2).span(_ != '=') match { case (key, v) => key -> v.tail })
 <<< #4133 braces-to-parens with select, apply of nested for-yield, with overflow
 maxColumn = 74
 newlines.avoidForSimpleOverflow = all
@@ -10388,9 +10385,9 @@ runtime.unsafe.run {
   } yield ()
 }.getOrThrowFiberFailure()
 >>>
-runtime.unsafe.run {
-  for { _ <- ZIO.foreachDiscard(1.to(n))(_ => ZIO.yieldNow) } yield ()
-}.getOrThrowFiberFailure()
+runtime.unsafe
+  .run(for { _ <- ZIO.foreachDiscard(1.to(n))(_ => ZIO.yieldNow) } yield ())
+  .getOrThrowFiberFailure()
 <<< #4133 first call in removed braces
 maxColumn = 78
 newlines.avoidForSimpleOverflow = all
@@ -10415,9 +10412,5 @@ def commaSeparated[T](part: () => T): List[T] =
     commaSeparatedRest(part(), part)
   }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
--def commaSeparated[T](part: () => T): List[T] = in.currentRegion
--  .withCommasExpected(commaSeparatedRest(part(), part))
-+def commaSeparated[T](part: () => T): List[T] =
-+  in.currentRegion.withCommasExpected(commaSeparatedRest(part(), part))
+def commaSeparated[T](part: () => T): List[T] = in.currentRegion
+  .withCommasExpected(commaSeparatedRest(part(), part))

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10883,3 +10883,17 @@ val WatchHeartBeatInterval: FiniteDuration =
       _ > Duration.Zero,
       "watch-failure-detector.heartbeat-interval must be > 0"
     )
+<<< #4133 braces-to-parens with select, apply of nested apply, with overflow
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+def commaSeparated[T](part: () => T): List[T] =
+  in.currentRegion.withCommasExpected {
+    commaSeparatedRest(part(), part)
+  }
+>>>
+def commaSeparated[T](part: () => T): List[T] =
+  in.currentRegion.withCommasExpected {
+    commaSeparatedRest(part(), part)
+  }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10394,9 +10394,8 @@ val newExprs = exprs.map { _.transform {
   case a: AttributeReference => attrMap.getOrElse(a, a)
 }}
 >>>
-val newExprs = exprs.map {
-  _.transform { case a: AttributeReference => attrMap.getOrElse(a, a) }
-}
+val newExprs = exprs
+  .map(_.transform { case a: AttributeReference => attrMap.getOrElse(a, a) })
 <<< #4133 overflow comment with a forced break 1 
 maxColumn = 76
 newlines.avoidForSimpleOverflow = [tooLong, punct, slc]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -10778,9 +10778,8 @@ val newExprs = exprs.map { _.transform {
   case a: AttributeReference => attrMap.getOrElse(a, a)
 }}
 >>>
-val newExprs = exprs.map {
-  _.transform { case a: AttributeReference => attrMap.getOrElse(a, a) }
-}
+val newExprs = exprs
+  .map(_.transform { case a: AttributeReference => attrMap.getOrElse(a, a) })
 <<< #4133 overflow comment with a forced break 1 
 maxColumn = 76
 newlines.avoidForSimpleOverflow = [tooLong, punct, slc]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11287,3 +11287,18 @@ val WatchHeartBeatInterval: FiniteDuration = WatchFailureDetectorConfig
     _ > Duration.Zero,
     "watch-failure-detector.heartbeat-interval must be > 0"
   )
+<<< #4133 braces-to-parens with select, apply of nested apply, with overflow
+maxColumn = 76
+newlines.avoidForSimpleOverflow = all
+rewrite.rules = [RedundantBraces]
+===
+def commaSeparated[T](part: () => T): List[T] =
+  in.currentRegion.withCommasExpected {
+    commaSeparatedRest(part(), part)
+  }
+>>>
+def commaSeparated[T](part: () => T): List[T] = in
+  .currentRegion
+  .withCommasExpected {
+    commaSeparatedRest(part(), part)
+  }

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1959,9 +1959,9 @@ object a {
       numBreaks: Int,
       nest: Int,
   ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
-    .takeWhile(_.minBreaks <= numBreaks).find { x =>
-      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
-    }.flatMap(_.blanks)
+    .takeWhile(_.minBreaks <= numBreaks)
+    .find(x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find()))
+    .flatMap(_.blanks)
 }
 <<< fold ctrl body with redundant braces, !trailing commas
 maxColumn = 80
@@ -1987,9 +1987,9 @@ object a {
       numBreaks: Int,
       nest: Int
   ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
-    .takeWhile(_.minBreaks <= numBreaks).find { x =>
-      x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find())
-    }.flatMap(_.blanks)
+    .takeWhile(_.minBreaks <= numBreaks)
+    .find(x => x.checkNest(nest) && x.pattern.forall(_.matcher(prefix).find()))
+    .flatMap(_.blanks)
 }
 <<< #4108 try with redundant parens in block, scala212
 runner.dialect = scala212

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1115896, "total explored")
+      assertEquals(explored, 1116220, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1116220, "total explored")
+      assertEquals(explored, 1114174, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Instead of penalizing the split, set its cost to zero.
Also, do the same even for parens, to avoid non-idempotence.