### PR TITLE
Router: no break after `=>` in lambda w/ type

### DIFF
--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(34839832)
+  override protected def totalStatesVisited: Option[Int] = Some(34839737)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -7556,11 +7556,11 @@ object Build:
      .settings(
        generateScalaDocumentation := Def.inputTaskDyn {
          val outputDirOverride =
-           extraArgs.headOption.fold(identity[GenerationConfig](_)) {
-             newDir => config: GenerationConfig => config.add(OutputDir(newDir))
+           extraArgs.headOption.fold(identity[GenerationConfig](_)) { newDir =>
+             config: GenerationConfig => config.add(OutputDir(newDir))
            }
-         val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) {
-           _ => config: GenerationConfig => config.remove[SiteRoot]
+         val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) { _ =>
+           config: GenerationConfig => config.remove[SiteRoot]
          }
        }.evaluated
      )

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -7529,3 +7529,38 @@ tag match
    case TYPEREFsymbol | TYPEREFdirect | TERMREFsymbol | TERMREFdirect =>
      node.refPrivate = in0.readByte() == PRIVATE;
    case _ =>
+<<< #4133 lambda in parens rewritten to braces
+maxColumn = 80
+rewrite {
+  rules = [RedundantBraces]
+  scala3.removeOptionalBraces = yes
+}
+===
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+    settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride = extraArgs.headOption.fold(identity[GenerationConfig](_))(newDir => {
+          config: GenerationConfig => config.add(OutputDir(newDir))
+        })
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_))(_ => {
+          config: GenerationConfig => config.remove[SiteRoot]
+        })
+      }.evaluated,
+    )
+}
+>>>
+object Build:
+   lazy val scaladoc = project
+     .in(file("scaladoc"))
+     .settings(
+       generateScalaDocumentation := Def.inputTaskDyn {
+         val outputDirOverride =
+           extraArgs.headOption.fold(identity[GenerationConfig](_)) {
+             newDir => config: GenerationConfig => config.add(OutputDir(newDir))
+           }
+         val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) {
+           _ => config: GenerationConfig => config.remove[SiteRoot]
+         }
+       }.evaluated
+     )

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7243,3 +7243,36 @@ tag match
    case TYPEREFsymbol | TYPEREFdirect | TERMREFsymbol | TERMREFdirect =>
      node.refPrivate = in0.readByte() == PRIVATE;
    case _ =>
+<<< #4133 lambda in parens rewritten to braces
+maxColumn = 80
+rewrite {
+  rules = [RedundantBraces]
+  scala3.removeOptionalBraces = yes
+}
+===
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+    settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride = extraArgs.headOption.fold(identity[GenerationConfig](_))(newDir => {
+          config: GenerationConfig => config.add(OutputDir(newDir))
+        })
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_))(_ => {
+          config: GenerationConfig => config.remove[SiteRoot]
+        })
+      }.evaluated,
+    )
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+          }
+-       val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) { _ =>
+-         config: GenerationConfig =>
+-            config.remove[SiteRoot]
+-       }
++       val justAPI = justAPIArg
++         .fold(identity[GenerationConfig](_)) { _ => config: GenerationConfig =>
++           config.remove[SiteRoot]
++         }
+      }.evaluated)

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7264,15 +7264,14 @@ object Build {
     )
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-          }
--       val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) { _ =>
--         config: GenerationConfig =>
--            config.remove[SiteRoot]
--       }
-+       val justAPI = justAPIArg
-+         .fold(identity[GenerationConfig](_)) { _ => config: GenerationConfig =>
-+           config.remove[SiteRoot]
-+         }
-      }.evaluated)
+object Build:
+   lazy val scaladoc = project.in(file("scaladoc"))
+     .settings(generateScalaDocumentation := Def.inputTaskDyn {
+       val outputDirOverride = extraArgs.headOption
+         .fold(identity[GenerationConfig](_)) { newDir =>
+           config: GenerationConfig => config.add(OutputDir(newDir))
+         }
+       val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) { _ =>
+         config: GenerationConfig => config.remove[SiteRoot]
+       }
+     }.evaluated)

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7584,11 +7584,11 @@ object Build:
    settings(
      generateScalaDocumentation := Def.inputTaskDyn {
        val outputDirOverride =
-         extraArgs.headOption.fold(identity[GenerationConfig](_)) {
-           newDir => config: GenerationConfig => config.add(OutputDir(newDir))
+         extraArgs.headOption.fold(identity[GenerationConfig](_)) { newDir =>
+           config: GenerationConfig => config.add(OutputDir(newDir))
          }
-       val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) {
-         _ => config: GenerationConfig => config.remove[SiteRoot]
+       val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) { _ =>
+         config: GenerationConfig => config.remove[SiteRoot]
        }
      }.evaluated
    )

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7558,3 +7558,37 @@ tag match
    case TYPEREFsymbol | TYPEREFdirect | TERMREFsymbol | TERMREFdirect =>
      node.refPrivate = in0.readByte() == PRIVATE;
    case _ =>
+<<< #4133 lambda in parens rewritten to braces
+maxColumn = 80
+rewrite {
+  rules = [RedundantBraces]
+  scala3.removeOptionalBraces = yes
+}
+===
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+    settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride = extraArgs.headOption.fold(identity[GenerationConfig](_))(newDir => {
+          config: GenerationConfig => config.add(OutputDir(newDir))
+        })
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_))(_ => {
+          config: GenerationConfig => config.remove[SiteRoot]
+        })
+      }.evaluated,
+    )
+}
+>>>
+object Build:
+   lazy val scaladoc = project.in(file("scaladoc")).
+   settings(
+     generateScalaDocumentation := Def.inputTaskDyn {
+       val outputDirOverride =
+         extraArgs.headOption.fold(identity[GenerationConfig](_)) {
+           newDir => config: GenerationConfig => config.add(OutputDir(newDir))
+         }
+       val justAPI = justAPIArg.fold(identity[GenerationConfig](_)) {
+         _ => config: GenerationConfig => config.remove[SiteRoot]
+       }
+     }.evaluated
+   )

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7838,3 +7838,42 @@ tag match
    case TYPEREFsymbol | TYPEREFdirect | TERMREFsymbol | TERMREFdirect =>
      node.refPrivate = in0.readByte() == PRIVATE;
    case _ =>
+<<< #4133 lambda in parens rewritten to braces
+maxColumn = 80
+rewrite {
+  rules = [RedundantBraces]
+  scala3.removeOptionalBraces = yes
+}
+===
+object Build {
+  lazy val scaladoc = project.in(file("scaladoc")).
+    settings(
+      generateScalaDocumentation := Def.inputTaskDyn {
+        val outputDirOverride = extraArgs.headOption.fold(identity[GenerationConfig](_))(newDir => {
+          config: GenerationConfig => config.add(OutputDir(newDir))
+        })
+        val justAPI = justAPIArg.fold(identity[GenerationConfig](_))(_ => {
+          config: GenerationConfig => config.remove[SiteRoot]
+        })
+      }.evaluated,
+    )
+}
+>>>
+Idempotency violated
+=> Diff (- obtained, + expected)
+                  .headOption
+-                 .fold(identity[GenerationConfig](_)) { newDir =>
+-                   config: GenerationConfig =>
+-                      config.add(OutputDir(newDir))
++                 .fold(identity[GenerationConfig](_)) {
++                   newDir => config: GenerationConfig =>
++                     config.add(OutputDir(newDir))
+                  }
+              val justAPI =
+-               justAPIArg.fold(identity[GenerationConfig](_)) { _ =>
+-                 config: GenerationConfig =>
+-                    config.remove[SiteRoot]
++               justAPIArg.fold(identity[GenerationConfig](_)) {
++                 _ => config: GenerationConfig =>
++                   config.remove[SiteRoot]
+                }

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -7859,21 +7859,23 @@ object Build {
     )
 }
 >>>
-Idempotency violated
-=> Diff (- obtained, + expected)
-                  .headOption
--                 .fold(identity[GenerationConfig](_)) { newDir =>
--                   config: GenerationConfig =>
--                      config.add(OutputDir(newDir))
-+                 .fold(identity[GenerationConfig](_)) {
-+                   newDir => config: GenerationConfig =>
-+                     config.add(OutputDir(newDir))
-                  }
-              val justAPI =
--               justAPIArg.fold(identity[GenerationConfig](_)) { _ =>
--                 config: GenerationConfig =>
--                    config.remove[SiteRoot]
-+               justAPIArg.fold(identity[GenerationConfig](_)) {
-+                 _ => config: GenerationConfig =>
-+                   config.remove[SiteRoot]
-                }
+object Build:
+   lazy val scaladoc = project
+     .in(file("scaladoc"))
+     .settings(
+       generateScalaDocumentation :=
+         Def
+           .inputTaskDyn {
+             val outputDirOverride =
+               extraArgs
+                 .headOption
+                 .fold(identity[GenerationConfig](_)) { newDir =>
+                   config: GenerationConfig => config.add(OutputDir(newDir))
+                 }
+             val justAPI =
+               justAPIArg.fold(identity[GenerationConfig](_)) { _ =>
+                 config: GenerationConfig => config.remove[SiteRoot]
+               }
+           }
+           .evaluated
+     )

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1114736, "total explored")
+      assertEquals(explored, 1119018, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1119018, "total explored")
+      assertEquals(explored, 1116417, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Otherwise, it looks like a "fewer braces" invocation and will be parsed as such.