### PR TITLE
Router: exclude close delim in `{...` SLB ranges

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -419,7 +419,7 @@ class Router(formatOps: FormatOps) {
             )
           Split(slbMod, 0).withSingleLine(
             expire,
-            exclude = exclude,
+            exclude = exclude.excludeCloseDelim,
             noOptimal = style.newlines.fold && !exclude.isEmpty &&
               exclude.ranges.forall(_.lt.left.is[T.LeftParen]),
             noSyntaxNL = true,


### PR DESCRIPTION
As already done for `(...` and `, ...`