### PR TITLE
Docstrings: `blankFirstLine=fold` takes precedence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4120,7 +4120,8 @@ This variant used to be called `JavaDoc`.
 docstrings.style = Asterisk
 ---
 /** Skip first line, format intermediate lines with an asterisk
-  * below the first asterisk of the first line (aka JavaDoc)
+  * below the first asterisk of the first line (aka JavaDoc).
+  * Since v3.8.4, `blankFirstLine = fold` takes precedence.
   */
 ```
 
@@ -4282,9 +4283,10 @@ Takes the following values:
 - `unfold`: will enforce a blank first line
   (replaced `yes` in v3.8.2)
 
-> Since v2.7.5. Ignored for `docstrings.style = keep` or
-> `docstrings.style = Asterisk` or
-> `docstrings.wrap = no`.
+> Since v2.7.5.
+>
+> - Ignored for `docstrings.style = keep` or `docstrings.wrap = no`.
+> - [since v3.8.4] For `docstrings.style = Asterisk`, only `fold` changes default behaviour.
 
 ```scala mdoc:scalafmt
 # do not force a blank first line

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
@@ -30,8 +30,8 @@ case class Docstrings(
   def withoutRewrites: Docstrings =
     copy(removeEmpty = false, wrap = Wrap.keep, style = Preserve)
 
-  def skipFirstLineIf(wasBlank: Boolean): Boolean = style.skipFirstLine
-    .orElse(blankFirstLine).exists {
+  def skipFirstLineIf(wasBlank: Boolean): Boolean = style
+    .skipFirstLine(blankFirstLine).exists {
       case BlankFirstLine.unfold => true
       case BlankFirstLine.fold => false
       case BlankFirstLine.keep => wasBlank
@@ -47,21 +47,24 @@ object Docstrings {
     .deriveCodecEx(Docstrings()).noTypos
 
   sealed abstract class Style {
-    def skipFirstLine: Option[BlankFirstLine]
+    def skipFirstLine(v: Option[BlankFirstLine]): Option[BlankFirstLine]
   }
   case object Preserve extends Style {
-    override def skipFirstLine: Option[BlankFirstLine] =
+    def skipFirstLine(v: Option[BlankFirstLine]): Option[BlankFirstLine] =
       Some(BlankFirstLine.keep)
   }
   case object Asterisk extends Style {
-    override def skipFirstLine: Option[BlankFirstLine] =
-      Some(BlankFirstLine.unfold)
+    def skipFirstLine(v: Option[BlankFirstLine]): Option[BlankFirstLine] =
+      v match {
+        case v @ Some(BlankFirstLine.fold) => v
+        case _ => Some(BlankFirstLine.unfold)
+      }
   }
   case object SpaceAsterisk extends Style {
-    override def skipFirstLine: Option[BlankFirstLine] = None
+    def skipFirstLine(v: Option[BlankFirstLine]): Option[BlankFirstLine] = v
   }
   case object AsteriskSpace extends Style {
-    override def skipFirstLine: Option[BlankFirstLine] = None
+    def skipFirstLine(v: Option[BlankFirstLine]): Option[BlankFirstLine] = v
   }
 
   implicit val reader: ConfCodecEx[Style] = ReaderUtil

--- a/scalafmt-tests/shared/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/shared/src/test/resources/test/JavaDoc.stat
@@ -1574,11 +1574,9 @@ object a {
 object a {
 
   /** alias for [[literal]] */
-  /**
-   * alias for [[literal]]
+  /** alias for [[literal]]
    */
-  /**
-   * alias for [[literal]]
+  /** alias for [[literal]]
    * alias for [[literal]]
    */
 }


### PR DESCRIPTION
Fixes #4528.