### PR TITLE
FormatOps: treat args in braces as nested open

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1457,6 +1457,8 @@ class FormatOps(
           val newres = getHead(tree) :: res
           args match {
             case (t: Member.Apply) :: Nil => getNestedOpens(t.argClause, newres)
+            case Tree.Block((t: Member.Apply) :: Nil) :: Nil =>
+              getNestedOpens(t.argClause, newres)
             case _ => newres
           }
         }


### PR DESCRIPTION
Equivalently to args in parens.