### PR TITLE
BestFirstSearch: allow block close go past range

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -36,13 +36,11 @@ private class BestFirstSearch private (range: Set[Range])(implicit
 
   var stats = new StateStats(tokens, initStyle.runner)
 
-  private def getBlockCloseToRecurse(ft: FT, stop: T)(implicit
+  private def getBlockCloseToRecurse(ft: FT)(implicit
       style: ScalafmtConfig,
   ): Option[T] = getEndOfBlock(ft, parensToo = true).collect {
-    case close if close.left != stop && {
-          // Block must span at least 3 lines to be worth recursing.
-          tokens.width(ft, close) > style.maxColumn * 3
-        } => close.left
+    // Block must span at least 3 lines to be worth recursing.
+    case close if tokens.width(ft, close) > style.maxColumn * 3 => close.left
   }
 
   private val memo = mutable.Map.empty[Long, Option[State]]
@@ -111,7 +109,7 @@ private class BestFirstSearch private (range: Set[Range])(implicit
           noOptZoneOrBlock.isEmpty || !optimizer.recurseOnBlocks
         val blockCloseState =
           if (noBlockClose) None
-          else getBlockCloseToRecurse(splitToken, stop)
+          else getBlockCloseToRecurse(splitToken)
             .flatMap(shortestPathMemo(curr, _, depth + 1, isOpt))
         if (blockCloseState.nonEmpty) blockCloseState
           .foreach(_.foreach(Q.enqueue))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(40783820)
+  override protected def totalStatesVisited: Option[Int] = Some(40783579)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(44103702)
+  override protected def totalStatesVisited: Option[Int] = Some(44102882)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 


### PR DESCRIPTION
In reality, that's what has been happening so far since we used an exact comparison on `stop`.