### PR TITLE
Use FormatToken in policies, indents etc.

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -188,6 +188,9 @@ class FormatTokens(leftTok2tok: Map[TokenHash, Int])(val arr: Array[FT])
   final def nextNonCommentSameLineAfter(curr: FT): FT =
     nextNonCommentSameLine(next(curr))
 
+  final def nextAfterNonCommentSameLine(curr: FT): FT =
+    next(nextNonCommentSameLine(curr))
+
   final def nextNonComment(curr: FT): FT =
     findToken(curr, next)(!_.right.is[T.Comment])
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
@@ -15,7 +15,7 @@ case class ModExt(mod: Modification, indents: Seq[Indent] = Seq.empty) {
   @inline
   def isNL: Boolean = mod.isNL
 
-  def withIndent(length: => Length, expire: => T, when: ExpiresOn): ModExt =
+  def withIndent(length: => Length, expire: => FT, when: ExpiresOn): ModExt =
     length match {
       case Length.Num(0, _) => this
       case x => withIndentImpl(Indent(x, expire, when))
@@ -23,7 +23,7 @@ case class ModExt(mod: Modification, indents: Seq[Indent] = Seq.empty) {
 
   def withIndentOpt(
       length: => Length,
-      expire: Option[T],
+      expire: Option[FT],
       when: ExpiresOn,
   ): ModExt = expire.fold(this)(withIndent(length, _, when))
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -31,7 +31,7 @@ object PolicyOps {
 
   object PenalizeAllNewlines {
     def apply(
-        expire: T,
+        expire: FT,
         penalty: Int,
         penalizeLambdas: Boolean = true,
         noSyntaxNL: Boolean = false,
@@ -45,15 +45,15 @@ object PolicyOps {
       )
   }
 
-  def penalizeNewlineByNesting(from: T, to: T)(implicit
+  def penalizeNewlineByNesting(before: FT, after: FT)(implicit
       fileLine: FileLine,
-  ): Policy = Policy.End < from ==>
-    Policy.before(to, prefix = "PNL()") { case Decision(FT(l, _, m), s) =>
+  ): Policy = Policy.End < before ==> Policy.beforeLeft(after, prefix = "PNL()") {
+    case Decision(FT(l, _, m), s) =>
       val nonBoolPenalty = if (TokenOps.isBoolOperator(l)) 0 else 5
       val penalty = TreeOps.nestedSelect(m.leftOwner) +
         TreeOps.nestedApplies(m.rightOwner) + nonBoolPenalty
       s.map(x => if (x.isNL) x.withPenalty(penalty) else x)
-    }
+  }
 
   /** Forces all splits up to including expire to be on a single line.
     * @param okSLC
@@ -82,15 +82,15 @@ object PolicyOps {
   object SingleLineBlock {
 
     def apply(
-        expire: T,
+        expire: FT,
         exclude: TokenRanges = TokenRanges.empty,
         okSLC: Boolean = false,
         noSyntaxNL: Boolean = false,
         rank: Int = 0,
     )(implicit fileLine: FileLine, style: ScalafmtConfig): Policy =
-      policyWithExclude(exclude, Policy.End.On, Policy.End.After)(
+      policyWithExclude(exclude, Policy.End.OnLeft, Policy.End.OnRight)(
         new SingleLineBlock(
-          Policy.End == expire,
+          Policy.End <= expire,
           okSLC = okSLC,
           noSyntaxNL = noSyntaxNL,
           rank = rank,
@@ -99,52 +99,51 @@ object PolicyOps {
   }
 
   final class DecideNewlinesOnlyBeforeToken(
-      val token: T,
+      val token: FT,
       split: Option[Split],
       val rank: Int = 0,
       ifAny: Boolean = false,
   )(implicit fileLine: FileLine)
       extends Policy.Clause {
-    override val endPolicy: Policy.End.WithPos = Policy.End == token
+    override val endPolicy: Policy.End.WithPos = Policy.End <= token
     override val noDequeue: Boolean = false
     override val prefix: String = "NB"
     override val f: Policy.Pf = split match {
       case Some(s) => {
-        case d: Decision if d.formatToken.right eq token =>
+        case d: Decision if d.formatToken.right eq token.left =>
           d.onlyNewlinesWithFallback(s)
       }
       case _ if ifAny => {
-        case d: Decision if d.formatToken.right eq token =>
+        case d: Decision if d.formatToken.right eq token.left =>
           d.onlyNewlinesIfAvailable
       }
       case _ => {
-        case d: Decision if d.formatToken.right eq token =>
+        case d: Decision if d.formatToken.right eq token.left =>
           d.onlyNewlinesWithoutFallback
       }
     }
   }
 
   final class DecideNewlinesOnlyAfterToken(
-      val token: T,
+      val token: FT,
       split: Option[Split],
       val rank: Int = 0,
       ifAny: Boolean = false,
   )(implicit fileLine: FileLine)
       extends Policy.Clause {
-    override val endPolicy: Policy.End.WithPos = Policy.End > token
+    override val endPolicy: Policy.End.WithPos = Policy.End >= token
     override val noDequeue: Boolean = false
     override val prefix: String = "NA"
     override val f: Policy.Pf = split match {
       case Some(s) => {
-        case d: Decision if d.formatToken.left eq token =>
+        case d: Decision if d.formatToken eq token =>
           d.onlyNewlinesWithFallback(s)
       }
       case _ if ifAny => {
-        case d: Decision if d.formatToken.left eq token =>
-          d.onlyNewlinesIfAvailable
+        case d: Decision if d.formatToken eq token => d.onlyNewlinesIfAvailable
       }
       case _ => {
-        case d: Decision if d.formatToken.left eq token =>
+        case d: Decision if d.formatToken eq token =>
           d.onlyNewlinesWithoutFallback
       }
     }
@@ -152,11 +151,11 @@ object PolicyOps {
 
   def policyWithExclude(
       exclude: TokenRanges,
-      endLt: T => Policy.End.WithPos,
-      endRt: T => Policy.End.WithPos,
+      endLt: FT => Policy.End.WithPos,
+      endRt: FT => Policy.End.WithPos,
   )(lastPolicy: Policy)(implicit fileLine: FileLine): Policy = exclude.ranges
     .foldLeft(lastPolicy) { case (policy, range) =>
-      (lastPolicy <== endLt(range.lt.left)) ==> (endRt(range.rt.left) ==> policy)
+      (lastPolicy <== endLt(range.lt)) ==> (endRt(range.rt) ==> policy)
     }
 
   def delayedBreakPolicy(
@@ -164,82 +163,80 @@ object PolicyOps {
       exclude: TokenRanges = TokenRanges.empty,
   )(onBreakPolicy: Policy)(implicit fileLine: FileLine): Policy =
     Policy ? onBreakPolicy.isEmpty ||
-      policyWithExclude(exclude, Policy.End.On, Policy.End.After)(
+      policyWithExclude(exclude, Policy.End.OnLeft, Policy.End.OnRight)(
         new Policy.Map(end, desc = onBreakPolicy.toString)({ s =>
           if (s.isNL) s.orPolicy(onBreakPolicy) else s
         }),
       )
 
-  def delayedBreakPolicyBefore(token: T)(onBreakPolicy: Policy): Policy =
+  def delayedBreakPolicyBefore(token: FT)(onBreakPolicy: Policy): Policy =
     delayedBreakPolicy(Policy.End < token)(onBreakPolicy)
 
-  def delayedBreakPolicyFor(token: T)(f: T => Policy): Policy =
+  def delayedBreakPolicyFor(token: FT)(f: FT => Policy): Policy =
     delayedBreakPolicyBefore(token)(f(token))
 
-  def decideNewlinesOnlyBeforeClose(close: T)(implicit
+  def decideNewlinesOnlyBeforeClose(close: FT)(implicit
       fileLine: FileLine,
   ): Policy = decideNewlinesOnlyBeforeClose(0)(close)
 
-  def decideNewlinesOnlyBeforeClose(rank: Int)(close: T)(implicit
+  def decideNewlinesOnlyBeforeClose(rank: Int)(close: FT)(implicit
       fileLine: FileLine,
   ): Policy = decideNewlinesOnlyBeforeClose(Split(Newline, 0), rank)(close)
 
-  def decideNewlinesOnlyBeforeClose(split: Split, rank: Int = 0)(close: T)(
+  def decideNewlinesOnlyBeforeClose(split: Split, rank: Int = 0)(close: FT)(
       implicit fileLine: FileLine,
   ): Policy = new DecideNewlinesOnlyBeforeToken(close, Option(split), rank)
 
-  def decideNewlinesOnlyBeforeCloseOnBreak(close: T)(implicit
+  def decideNewlinesOnlyBeforeCloseOnBreak(close: FT)(implicit
       fileLine: FileLine,
   ): Policy = decideNewlinesOnlyBeforeCloseOnBreak(0)(close)
 
-  def decideNewlinesOnlyBeforeCloseOnBreak(rank: Int)(close: T)(implicit
+  def decideNewlinesOnlyBeforeCloseOnBreak(rank: Int)(close: FT)(implicit
       fileLine: FileLine,
   ): Policy = delayedBreakPolicyFor(close)(decideNewlinesOnlyBeforeClose(rank))
 
-  def decideNewlinesOnlyBeforeToken(token: T)(implicit
+  def decideNewlinesOnlyBeforeToken(token: FT)(implicit
       fileLine: FileLine,
   ): Policy = decideNewlinesOnlyBeforeToken(0)(token)
 
   def decideNewlinesOnlyBeforeToken(rank: Int, ifAny: Boolean = false)(
-      token: T,
+      token: FT,
   )(implicit fileLine: FileLine): Policy =
     new DecideNewlinesOnlyBeforeToken(token, None, rank = rank, ifAny = ifAny)
 
-  def decideNewlinesOnlyAfterClose(close: T)(implicit
+  def decideNewlinesOnlyAfterClose(close: FT)(implicit
       fileLine: FileLine,
   ): Policy = decideNewlinesOnlyAfterClose(0)(close)
 
-  def decideNewlinesOnlyAfterClose(rank: Int)(close: T)(implicit
+  def decideNewlinesOnlyAfterClose(rank: Int)(close: FT)(implicit
       fileLine: FileLine,
   ): Policy = decideNewlinesOnlyAfterClose(Split(Newline, 0), rank)(close)
 
-  def decideNewlinesOnlyAfterClose(split: Split, rank: Int = 0)(close: T)(
+  def decideNewlinesOnlyAfterClose(split: Split, rank: Int = 0)(close: FT)(
       implicit fileLine: FileLine,
   ): Policy = new DecideNewlinesOnlyAfterToken(close, Option(split), rank)
 
-  def decideNewlinesOnlyAfterToken(token: T)(implicit
+  def decideNewlinesOnlyAfterToken(token: FT)(implicit
       fileLine: FileLine,
   ): Policy = decideNewlinesOnlyAfterToken(0)(token)
 
   def decideNewlinesOnlyAfterToken(rank: Int, ifAny: Boolean = false)(
-      token: T,
+      token: FT,
   )(implicit fileLine: FileLine): Policy =
     new DecideNewlinesOnlyAfterToken(token, None, rank = rank, ifAny = ifAny)
 
   def unindentAtExclude(exclude: TokenRanges, indent: Length): Policy = exclude
     .ranges.foldLeft(Policy.noPolicy) { case (policy, range) =>
       val (lt, rt) = (range.lt, range.rt)
-      val ltl = lt.left
-      val rtl = rt.left
-      val trigger = rtl
-      val unindent = Indent(indent, rtl, ExpiresOn.After)
+      val trigger = rt.left
+      val unindent = Indent(indent, rt, ExpiresOn.After)
       val triggeredIndent = Indent.before(unindent, trigger)
       val triggerUnindent = Policy
-        .on(rtl, prefix = "UNIND{") { case Decision(`lt`, s) =>
+        .onLeft(rt, prefix = "UNIND{") { case Decision(`lt`, s) =>
           s.map(_.withIndent(triggeredIndent))
         }
-      val cancelUnindent = delayedBreakPolicy(Policy.End == ltl) {
-        Policy.after(ltl, rank = 1, prefix = "UNIND}") { // use rank to apply after policy above
+      val cancelUnindent = delayedBreakPolicy(Policy.End <= lt) {
+        Policy.onRight(lt, rank = 1, prefix = "UNIND}") { // use rank to apply after policy above
           case Decision(`lt`, s) => s.map(_.switch(trigger, false))
         }
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -575,7 +575,7 @@ object TreeOps {
     case _ => Some(false)
   }.isDefined
 
-  def getEndOfFirstCall(tree: Tree)(implicit ftoks: FormatTokens): Option[T] = {
+  def getEndOfFirstCall(tree: Tree)(implicit ftoks: FormatTokens) = {
     @tailrec
     def traverse(tree: Tree, res: Option[Tree]): Option[Tree] = tree match {
       case t: Term.Select if res.isDefined => traverse(t.qual, Some(t.qual))
@@ -586,7 +586,7 @@ object TreeOps {
         traverse(arg, res)
       case _ => res
     }
-    traverse(tree, None).map(_.tokens.last)
+    traverse(tree, None).map(ftoks.getLast)
   }
 
   @inline

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(43852198)
+  override protected def totalStatesVisited: Option[Int] = Some(43852194)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(54848258)
+  override protected def totalStatesVisited: Option[Int] = Some(54848254)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))


### PR DESCRIPTION
This way, the checks are more precise, and we reduce the probability of comparing with a token that has been removed.