### PR TITLE
BinPack: use binPack.parentCtors=source explicitly

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -967,15 +967,15 @@ class FormatOps(
       }
     else if (isFirstCtor) {
       val nlPolicy = ctorWithChain(owners, lastFt)
-      val nlOnelineTag = style.binPack.parentConstructors match {
+      val parentCtors = style.binPack.parentConstructors
+      val nlOnelineTag = parentCtors match {
+        case BinPack.ParentCtors.source => Right(style.newlines.fold)
         case BinPack.ParentCtors.Oneline => Right(true)
         case BinPack.ParentCtors.OnelineIfPrimaryOneline =>
           Left(SplitTag.OnelineWithChain)
-        case BinPack.ParentCtors.Always | BinPack.ParentCtors.Never =>
-          Right(false)
-        case _ => Right(style.newlines.fold)
+        case _ => Right(false)
       }
-      val exclude = style.binPack.parentConstructors match {
+      val exclude = parentCtors match {
         case BinPack.ParentCtors.Always => insideBracesBlock(ft, lastFt, true)
         case _ => TokenRanges.empty
       }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11167,3 +11167,37 @@ def stop(step: Double, ndir: Double, nx: Double): Boolean =
     || (ndir < 1e-12 * nx) // gradient relatively too small
     || (ndir < 1e-32) // gradient absolutely too small; numerical issues may lurk
   )
+<<< #4542 narrow
+maxColumn = 40
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(
+    a: Int,
+    b: Double,
+    c: String
+) extends SomeBaseClass
+    with SomeTrait
+<<< #4542 medium
+maxColumn = 50
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(a: Int, b: Double, c: String)
+    extends SomeBaseClass
+    with SomeTrait
+<<< #4542 wide
+maxColumn = 100
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(a: Int, b: Double, c: String) extends SomeBaseClass with SomeTrait

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10435,3 +10435,35 @@ def stop(step: Double, ndir: Double, nx: Double): Boolean =
   || (ndir < 1e-12 * nx) // gradient relatively too small
   || (ndir < 1e-32) // gradient absolutely too small; numerical issues may lurk
   )
+<<< #4542 narrow
+maxColumn = 40
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(
+    a: Int,
+    b: Double,
+    c: String
+) extends SomeBaseClass with SomeTrait
+<<< #4542 medium
+maxColumn = 50
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(a: Int, b: Double, c: String)
+    extends SomeBaseClass with SomeTrait
+<<< #4542 wide
+maxColumn = 100
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(a: Int, b: Double, c: String) extends SomeBaseClass with SomeTrait

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10917,3 +10917,39 @@ def stop(step: Double, ndir: Double, nx: Double): Boolean =
     || (ndir < 1e-12 * nx) // gradient relatively too small
     || (ndir < 1e-32) // gradient absolutely too small; numerical issues may lurk
   )
+<<< #4542 narrow
+maxColumn = 40
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(
+    a: Int,
+    b: Double,
+    c: String
+) extends SomeBaseClass
+    with SomeTrait
+<<< #4542 medium
+maxColumn = 50
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(a: Int, b: Double, c: String)
+    extends SomeBaseClass
+    with SomeTrait
+<<< #4542 wide
+maxColumn = 100
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(a: Int, b: Double, c: String)
+    extends SomeBaseClass
+    with SomeTrait

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11326,3 +11326,37 @@ def stop(step: Double, ndir: Double, nx: Double): Boolean =
     ||
     (ndir < 1e-32) // gradient absolutely too small; numerical issues may lurk
   )
+<<< #4542 narrow
+maxColumn = 40
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(
+    a: Int,
+    b: Double,
+    c: String
+) extends SomeBaseClass
+    with SomeTrait
+<<< #4542 medium
+maxColumn = 50
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(a: Int, b: Double, c: String)
+    extends SomeBaseClass
+    with SomeTrait
+<<< #4542 wide
+maxColumn = 100
+binPack.parentConstructors = source
+===
+class SomeClass(a: Int, b: Double, c: String)
+extends SomeBaseClass
+with SomeTrait
+>>>
+class SomeClass(a: Int, b: Double, c: String) extends SomeBaseClass with SomeTrait

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1116453, "total explored")
+      assertEquals(explored, 1117062, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
While it works, it might appear as if only `keep` is supported. Helps with #4542.