### PR TITLE
Router: handle Lit.Unit and empty ArgClause

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -950,9 +950,15 @@ class Router(formatOps: FormatOps) {
           )
         }
 
-      case FT(T.LeftParen(), T.RightParen(), _) =>
+      case FT(_: T.LeftParen, _: T.RightParen, _) =>
         val noNL = style.newlines.sourceIgnored || noBreak()
         Seq(Split(NoSplit.orNL(noNL), 0))
+
+      case FT(_: T.LeftParen, _: T.Comment, _) if (leftOwner match {
+            case _: Lit.Unit => true
+            case t: Member.ArgClause => t.values.isEmpty
+            case _ => false
+          }) && !hasBreakBeforeNonComment(ft) => Seq(Split(Space, 0))
 
       case FT(open @ LeftParenOrBracket(), right, _) if {
             if (isArgClauseSite(leftOwner)) style.binPack.callSiteFor(open) ==

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -137,7 +137,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1082952, "total explored")
+      assertEquals(explored, 1082944, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Depending on the dialect, `a + ()` might parse the argument as an empty ArgClause or a single-arg Lit.Unit, which might lead to differences in formatting rules considered.