### PR TITLE
SBT: remove buildInfoSettings from macros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,6 @@ lazy val coreJVM = core.jvm
 lazy val macros = crossProject(JVMPlatform, NativePlatform)
   .in(file("scalafmt-macros")).settings(
     moduleName := "scalafmt-macros",
-    buildInfoSettings,
     scalacOptions ++= scalacJvmOptions.value,
     libraryDependencies ++= Seq(
       scalameta.value,


### PR DESCRIPTION
Addresses build warning stipulating that these are not used.