### PR TITLE
Scalafmt: expand Error.WithCode in external format

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
@@ -120,6 +120,7 @@ object Error {
 
   case object MegaTestFailed extends Error("Mega test failed.")
 
-  case class WithCode(error: Throwable, code: String) extends Exception(error)
+  case class WithCode(error: Throwable, code: String)
+      extends Exception(error.getMessage, error)
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -57,7 +57,10 @@ object Scalafmt {
       style: ScalafmtConfig,
       range: Set[Range],
       filename: String,
-  ): Formatted = formatCode(code, style, range, filename).formatted
+  ): Formatted = formatCode(code, style, range, filename).formatted match {
+    case Formatted.Failure(Error.WithCode(ex, _)) => Formatted.Failure(ex)
+    case x => x
+  }
 
   private[scalafmt] def formatCode(
       code: String,
@@ -137,7 +140,7 @@ object Scalafmt {
       code: String,
       style: ScalafmtConfig = ScalafmtConfig.default,
       range: Set[Range] = Set.empty[Range],
-  ): Formatted = formatCode(code, style, range).formatted
+  ): Formatted = format(code, style, range, defaultFilename)
 
   // used by ScalafmtReflect.parseConfig
   def parseHoconConfigFile(configPath: Path): Configured[ScalafmtConfig] =


### PR DESCRIPTION
- Error: use nested error message in WithCode
- DynamicSuite: use non-RC version for `latest`