### PR TITLE
SBT: get mdoc version from its plugin

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val scalacheckV = "1.18.1"
   val coursier    = "2.1.10"
   val munitV      = "1.0.2"
-  val mdocV       = "2.6.1"
+  val mdocV       = mdoc.BuildInfo.version
 
   val scalapb = Def.setting {
     ExclusionRule(


### PR DESCRIPTION
Otherwise, it was necessary manually to keep `Dependencies.scala` and `plugins.sbt` in sync.