### PR TITLE
Policy: add methods `asAfter` and `asUntil`

### DIFF
--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59357916)
+  override protected def totalStatesVisited: Option[Int] = Some(59229705)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -52,7 +52,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59575073)
+  override protected def totalStatesVisited: Option[Int] = Some(59444243)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42584993)
+  override protected def totalStatesVisited: Option[Int] = Some(42553269)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(53251209)
+  override protected def totalStatesVisited: Option[Int] = Some(53284169)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39245552)
+  override protected def totalStatesVisited: Option[Int] = Some(39174786)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42432284)
+  override protected def totalStatesVisited: Option[Int] = Some(42300103)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(86405215)
+  override protected def totalStatesVisited: Option[Int] = Some(86100614)
 
   override protected def builds = Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
 
@@ -17,7 +17,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(91405983)
+  override protected def totalStatesVisited: Option[Int] = Some(91102086)
 
   override protected def builds = Seq(getBuild("v3.5.3", dialects.Scala213, 2756))
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11323,3 +11323,19 @@ topLevelStatementBlankLines.filter(x => x.minNest <= x.maxNest).sortBy {
   x =>
     (x.minBreaks, x.maxNest, -x.minNest, x.regex.fold(0)(-_.length))
 }
+<<< complex infix with final rhs an apply with multiline block
+maxColumn = 80
+===
+object a {
+  def memberRef(description: String) = u2 ~ u2 ^^ add1 {
+    case classRef ~ nameAndTypeRef => pool => description + ": " + pool(classRe
+f) + ", " + pool(nameAndTypeRef)
+  }
+}
+>>>
+object a {
+  def memberRef(description: String) = u2 ~ u2 ^^ add1 {
+    case classRef ~ nameAndTypeRef =>
+      pool => description + ": " + pool(classRe f) + ", " + pool(nameAndTypeRef)
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -1940,8 +1940,9 @@ val strings = Seq(
   s"  $bestEPStr",
   "Metrics:",
   s"  $metricHeader: ${bestScore.score}"
-) ++ otherMetricHeaders.zip(bestScore.otherScores)
-  .map { case (h, s) => s"  $h: $s" } ++ outputPath.toSeq.map { p =>
+) ++ otherMetricHeaders.zip(bestScore.otherScores).map { case (h, s) =>
+  s"  $h: $s"
+} ++ outputPath.toSeq.map { p =>
   s"The best variant params can be found in $p"
 }
 <<< 8.6: assignment with short expression
@@ -6723,9 +6724,9 @@ if (
 }
 >>>
 if (
-  settings.fuzzingMode &&
-  !system.settings.config
-    .hasPath("akka.stream.secret-test-fuzzing-warning-disable")
+  settings.fuzzingMode && !system.settings.config.hasPath(
+    "akka.stream.secret-test-fuzzing-warning-disable"
+  )
 ) {
   //
 }
@@ -6821,7 +6822,7 @@ object a {
     }
   ))
 }
->>> { stateVisits = 2039, stateVisits2 = 2039 }
+>>> { stateVisits = 2070, stateVisits2 = 2070 }
 object a {
   buffer.append((
     if (!fetchContent) {
@@ -9068,13 +9069,14 @@ val stats = Profiler.getStatistics().asScala.toSeq.map {
   case (trace, count) => MethodCallTrace(trace.className, trace.methodName, trace.methodDescriptor) -> count.intValue
 }
 >>>
-val stats = Profiler.getStatistics().asScala.toSeq.map {
-  case (trace, count) => MethodCallTrace(
+val stats = Profiler.getStatistics().asScala.toSeq
+  .map { case (trace, count) =>
+    MethodCallTrace(
       trace.className,
       trace.methodName,
       trace.methodDescriptor
     ) -> count.intValue
-}
+  }
 <<< #4133 partial function within apply, short
 rdd.map(
     {case (id, count) => (count, id)})
@@ -10061,7 +10063,7 @@ system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil).recoverWith {
             }
       }
 }
->>> { stateVisits = 6655, stateVisits2 = 6655 }
+>>> { stateVisits = 3689, stateVisits2 = 3689 }
 system.dynamicAccess.createInstanceFor[Serializer](fqn, Nil).recoverWith {
   case _: NoSuchMethodException => system.dynamicAccess
       .createInstanceFor[Serializer](
@@ -10568,10 +10570,10 @@ object a {
 f) + ", " + pool(nameAndTypeRef)
   }
 }
->>> { stateVisits = 194, stateVisits2 = 194 }
+>>> { stateVisits = 161, stateVisits2 = 161 }
 object a {
-  def memberRef(description: String) = u2 ~ u2 ^^
-    add1 { case classRef ~ nameAndTypeRef =>
+  def memberRef(description: String) = u2 ~ u2 ^^ add1 {
+    case classRef ~ nameAndTypeRef =>
       pool => description + ": " + pool(classRe f) + ", " + pool(nameAndTypeRef)
-    }
+  }
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10559,3 +10559,19 @@ rewrite.redundantBraces.parensForOneLineApply = true
 topLevelStatementBlankLines.filter(x => x.minNest <= x.maxNest).sortBy {
   x => (x.minBreaks, x.maxNest, -x.minNest, x.regex.fold(0)(-_.length))
 }
+<<< complex infix with final rhs an apply with multiline block
+maxColumn = 80
+===
+object a {
+  def memberRef(description: String) = u2 ~ u2 ^^ add1 {
+    case classRef ~ nameAndTypeRef => pool => description + ": " + pool(classRe
+f) + ", " + pool(nameAndTypeRef)
+  }
+}
+>>> { stateVisits = 194, stateVisits2 = 194 }
+object a {
+  def memberRef(description: String) = u2 ~ u2 ^^
+    add1 { case classRef ~ nameAndTypeRef =>
+      pool => description + ": " + pool(classRe f) + ", " + pool(nameAndTypeRef)
+    }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11077,3 +11077,19 @@ topLevelStatementBlankLines.filter(x => x.minNest <= x.maxNest).sortBy {
   x =>
     (x.minBreaks, x.maxNest, -x.minNest, x.regex.fold(0)(-_.length))
 }
+<<< complex infix with final rhs an apply with multiline block
+maxColumn = 80
+===
+object a {
+  def memberRef(description: String) = u2 ~ u2 ^^ add1 {
+    case classRef ~ nameAndTypeRef => pool => description + ": " + pool(classRe
+f) + ", " + pool(nameAndTypeRef)
+  }
+}
+>>>
+object a {
+  def memberRef(description: String) = u2 ~ u2 ^^ add1 {
+    case classRef ~ nameAndTypeRef =>
+      pool => description + ": " + pool(classRe f) + ", " + pool(nameAndTypeRef)
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11507,3 +11507,21 @@ topLevelStatementBlankLines
   .sortBy { x =>
     (x.minBreaks, x.maxNest, -x.minNest, x.regex.fold(0)(-_.length))
   }
+<<< complex infix with final rhs an apply with multiline block
+maxColumn = 80
+===
+object a {
+  def memberRef(description: String) = u2 ~ u2 ^^ add1 {
+    case classRef ~ nameAndTypeRef => pool => description + ": " + pool(classRe
+f) + ", " + pool(nameAndTypeRef)
+  }
+}
+>>>
+object a {
+  def memberRef(description: String) =
+    u2 ~ u2 ^^
+      add1 { case classRef ~ nameAndTypeRef =>
+        pool =>
+          description + ": " + pool(classRe f) + ", " + pool(nameAndTypeRef)
+      }
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1210389, "total explored")
+      assertEquals(explored, 1202529, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1209520, "total explored")
+      assertEquals(explored, 1210389, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
They assume the policy is enclosed in a Delay or Expire and simplify itself by removing redundant components.

This also potentially leads to checks such as `terminal` and `maxEndPos` returning a different value and possibly leading to a different format.