### PR TITLE
RedundantParens: keep parens in `given` infix type

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -59,6 +59,14 @@ object RedundantParens extends Rewrite with FormatTokensRewrite.RuleFactory {
     }
   }
 
+  private def okToReplaceDeclTpe(p: Tree.WithDeclTpe, t: Tree): Boolean =
+    (t, p) match {
+      // https://dotty.epfl.ch/docs/reference/syntax.html#declarations-and-definitions-1
+      // given requires AnnotType, not any Type
+      case (_: Type.ApplyInfix, _: Stat.GivenLike) => false
+      case _ => true
+    }
+
 }
 
 class RedundantParens(implicit val ftoks: FormatTokens)
@@ -126,7 +134,7 @@ class RedundantParens(implicit val ftoks: FormatTokens)
             case _ => true
           }
         case pia: Member.Infix => okToReplaceInfix(pia, t)
-        case p: Tree.WithDeclTpe if p.decltpe eq t => true
+        case p: Tree.WithDeclTpe if p.decltpe eq t => okToReplaceDeclTpe(p, t)
         case p: Tree.WithDeclTpeOpt if p.decltpe.contains(t) => true
         case _ => okToReplaceOther(t)
       }

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantParens.stat
@@ -1787,3 +1787,9 @@ object a {
     )
   }
 }
+<<< #4645
+runner.dialect = scala3
+===
+given fooBar: (Foo & Bar) = new Foo with Bar {}
+>>>
+given fooBar: Foo & Bar = new Foo with Bar {}

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantParens.stat
@@ -1792,4 +1792,4 @@ runner.dialect = scala3
 ===
 given fooBar: (Foo & Bar) = new Foo with Bar {}
 >>>
-given fooBar: Foo & Bar = new Foo with Bar {}
+given fooBar: (Foo & Bar) = new Foo with Bar {}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1208548, "total explored")
+      assertEquals(explored, 1208552, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1208516, "total explored")
+      assertEquals(explored, 1208548, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Fixes #4645.