### PR TITLE
Policy: add terminal, use in BestFirstSearch

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -751,7 +751,7 @@ class FormatOps(
   }
 
   def getSingleLineInfixPolicy(end: FT) = Policy
-    .onLeft(end, prefix = "INFSLB") {
+    .onLeft(end, prefix = "INFSLB", terminal = true) {
       case Decision(t: FT, s) if isInfixOp(t.meta.leftOwner) =>
         SplitTag.InfixChainNoNL.activateOnly(s)
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -401,7 +401,9 @@ class Router(formatOps: FormatOps) {
           val slbPolicy =
             if (exclude.isEmpty) slbParensPolicy
             else Policy.RelayOnSplit((s, _) => s.isNL)(slbParensPolicy)(
-              Policy.onLeft(close, "BracesToParensFailed") { case _ => Nil },
+              Policy.onLeft(close, "BracesToParensFailed", terminal = true) {
+                case _ => Nil
+              },
             )
           val sldPolicy = ownerIfNeedBreakAfterClose.map { p =>
             if (style.newlines.fold) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -55,8 +55,7 @@ final class State(
   def hasSlbUntil(ft: FT): Boolean = policy
     .exists(_.appliesUntil(ft)(_.isInstanceOf[PolicyOps.SingleLineBlock]))
 
-  def hasSlb(): Boolean = policy
-    .exists(_.exists(_.isInstanceOf[PolicyOps.SingleLineBlock]))
+  def terminal(): Boolean = policy.exists(_.exists(_.terminal))
 
   /** Calculates next State given split at tok.
     */

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -19,6 +19,7 @@ object PolicyOps {
   )(implicit fileLine: FileLine, style: ScalafmtConfig)
       extends Policy.Clause {
     override val noDequeue: Boolean = false
+    override def terminal: Boolean = false
     private val checkSyntax = noSyntaxNL || !style.newlines.ignoreInSyntax
     override val f: Policy.Pf = {
       case Decision(ft, s) if penalizeLambdas || !ft.left.is[T.RightArrow] =>
@@ -71,6 +72,7 @@ object PolicyOps {
       extends Policy.Clause {
     import TokenOps.isLeftCommentThenBreak
     override val noDequeue: Boolean = true
+    override def terminal: Boolean = true
     override val prefix: String = "SLB"
     private val checkSyntax = noSyntaxNL || !style.newlines.ignoreInSyntax
     override val f: Policy.Pf = {
@@ -106,6 +108,7 @@ object PolicyOps {
   )(implicit fileLine: FileLine)
       extends Policy.Clause {
     override val noDequeue: Boolean = false
+    override def terminal: Boolean = false
     override val prefix: String = "NB"
     override val f: Policy.Pf = split match {
       case Some(s) => {
@@ -141,6 +144,7 @@ object PolicyOps {
   )(implicit fileLine: FileLine)
       extends Policy.Clause {
     override val noDequeue: Boolean = false
+    override def terminal: Boolean = false
     override val prefix: String = "NA"
     override val f: Policy.Pf = split match {
       case Some(s) => {


### PR DESCRIPTION
Not just SingleLineBlock policy can lead to an impossible solution, so add this explicit field and use it in additional policies.