### PR TITLE
RedundantBraces: remove inner braces in argclause

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -515,13 +515,13 @@ object TreeOps {
   }
 
   @tailrec
-  def getTreeSingleExpr(tree: Tree): Option[Tree] = tree match {
+  def getTreeSingleExpr(tree: Tree): Option[Term] = tree match {
     case t: Term.Block => t.stats match {
         case stat :: Nil => getTreeSingleExpr(stat)
         case _ => None
       }
-    case _: Defn => None
-    case t => Some(t)
+    case t: Term => Some(t)
+    case _ => None
   }
 
   def isTreeSingleExpr(tree: Tree): Boolean = getTreeSingleExpr(tree).isDefined

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -1135,12 +1135,24 @@ object a {
 }
 >>>
 object a {
-  val foo = bar { case x => y }
-  val foo = bar { case x => y }
-  val foo = bar { case x => y }
-  val foo = bar.baz { case x => y }
-  val foo = bar.baz { case x => y }
-  val foo = bar.baz { case x => y }
+  val foo = bar { case x =>
+    y
+  }
+  val foo = bar { case x =>
+    y
+  }
+  val foo = bar { case x =>
+    y
+  }
+  val foo = bar.baz { case x =>
+    y
+  }
+  val foo = bar.baz { case x =>
+    y
+  }
+  val foo = bar.baz { case x =>
+    y
+  }
 }
 <<< single-block partial function with block one-arg apply, with comments
 object a {
@@ -1210,14 +1222,14 @@ object a {
     // c6
   }
   val foo = bar { // c1
-    { // c2
-      // c3
-      { // c4
-        case x => y
-        // c5
-      } // c6
-      // c7
-    } // c8
+    // c2
+    // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    // c7
+    // c8
   }
   val foo = bar.baz { // c1
     { // c2
@@ -1234,14 +1246,14 @@ object a {
     // c6
   }
   val foo = bar.baz { // c1
-    { // c2
-      // c3
-      { // c4
-        case x => y
-        // c5
-      } // c6
-      // c7
-    } // c8
+    // c2
+    // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    // c7
+    // c8
   }
 }
 <<< single-block partial function with block one-arg apply, with comments and parens
@@ -1309,16 +1321,15 @@ object a {
       // c4
     } // c5
   } // c6
-  val foo = bar( // c1
-    { // c2
-      // c3
-      { // c4
-        case x => y
-        // c5
-      } // c6
-      // c7
-    } // c8
-  )
+  val foo = bar { // c1
+    // c2
+    // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    // c7
+  } // c8
   val foo = bar.baz { // c1
     // c2
     case x => y
@@ -1331,16 +1342,15 @@ object a {
       // c4
     } // c5
   } // c6
-  val foo = bar.baz( // c1
-    { // c2
-      // c3
-      { // c4
-        case x => y
-        // c5
-      } // c6
-      // c7
-    } // c8
-  )
+  val foo = bar.baz { // c1
+    // c2
+    // c3
+    { // c4
+      case x => y
+      // c5
+    } // c6
+    // c7
+  } // c8
 }
 <<< init-only secondary ctors
 class a(vi: Int, vs: String) {

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1202529, "total explored")
+      assertEquals(explored, 1202551, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Instead of removing outer braces after checking that an inner expression will provide own, let's keep outer braces and remove them in the inner if appropriate.