### PR TITLE
RedundantBraces: remove braces in block in parens

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -342,7 +342,7 @@ object a {
 }
 >>>
 object a {
-  b.c({ d => e + f })
+  b.c(d => e + f)
 }
 <<< #1027 3.1: with align
 align.preset = more

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
@@ -327,3 +327,42 @@ object a {
   )
     sb.delete(sb.length - 2, sb.length())
 }
+<<< block within parens: single-stat apply
+object a {
+  val switchVersion: Command = Command.args("+~", "<version> <args>")({
+    foo(bar)
+  })
+}
+>>>
+object a {
+  val switchVersion: Command = Command.args("+~", "<version> <args>")({
+    foo(bar)
+  })
+}
+<<< block within parens: single-stat infix
+object a {
+  val switchVersion: Command = Command.args("+~", "<version> <args>")({
+    foo + bar
+  })
+}
+>>>
+object a {
+  val switchVersion: Command = Command.args("+~", "<version> <args>")({
+    foo + bar
+  })
+}
+<<< block within parens: single-stat func with single-stat body (term)
+object a {
+  val switchVersion: Command = Command.args("+~", "<version> <args>")({ (initialState: State, args: Seq[String]) =>
+    {
+      foo + bar
+    }
+  })
+}
+>>>
+object a {
+  val switchVersion: Command = Command.args("+~", "<version> <args>")({
+    (initialState: State, args: Seq[String]) =>
+      foo + bar
+  })
+}

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
@@ -335,9 +335,9 @@ object a {
 }
 >>>
 object a {
-  val switchVersion: Command = Command.args("+~", "<version> <args>")({
+  val switchVersion: Command = Command.args("+~", "<version> <args>")(
     foo(bar)
-  })
+  )
 }
 <<< block within parens: single-stat infix
 object a {
@@ -347,9 +347,9 @@ object a {
 }
 >>>
 object a {
-  val switchVersion: Command = Command.args("+~", "<version> <args>")({
+  val switchVersion: Command = Command.args("+~", "<version> <args>")(
     foo + bar
-  })
+  )
 }
 <<< block within parens: single-stat func with single-stat body (term)
 object a {
@@ -361,8 +361,7 @@ object a {
 }
 >>>
 object a {
-  val switchVersion: Command = Command.args("+~", "<version> <args>")({
-    (initialState: State, args: Seq[String]) =>
-      foo + bar
-  })
+  val switchVersion: Command = Command.args("+~", "<version> <args>")(
+    (initialState: State, args: Seq[String]) => foo + bar
+  )
 }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1202551, "total explored")
+      assertEquals(explored, 1202871, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1202871, "total explored")
+      assertEquals(explored, 1202845, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Previously, we only allowed the braces to replace the parens on their immediate left, but now will also remove them if the block contains a simple expression.