### PR TITLE
RedundantBraces: remove func body braces in parens

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
@@ -47,7 +47,7 @@ case class RewriteSettings(
     .forTestOpt.map(x => copy(avoidInfix = x))
 
   def bracesToParensForOneLineApply = redundantBraces.parensForOneLineApply &&
-    rules.contains(RedundantBraces)
+    RedundantBraces.usedIn(this)
 
 }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -426,7 +426,7 @@ object ScalafmtConfig {
         addIf(rewrite.scala3.removeEndMarkerMaxLines >= rewrite.scala3.insertEndMarkerMinLines)
       addIf(rewrite.insertBraces.minLines != 0 && rewrite.scala3.insertEndMarkerMinLines != 0)
       addIf(rewrite.insertBraces.minLines != 0 && rewrite.scala3.removeOptionalBraces.oldSyntaxToo)
-      if (rewrite.insertBraces.minLines != 0 && rewrite.rules.contains(RedundantBraces))
+      if (rewrite.insertBraces.minLines != 0 && RedundantBraces.usedIn(rewrite))
         addIf(rewrite.insertBraces.minLines < rewrite.redundantBraces.maxBreaks)
       addIf(align.beforeOpenParenDefnSite && !align.closeParenSite)
       addIf(align.beforeOpenParenCallSite && !align.closeParenSite)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -1,7 +1,6 @@
 package org.scalafmt.rewrite
 
-import org.scalafmt.config.RedundantBracesSettings
-import org.scalafmt.config.ScalafmtConfig
+import org.scalafmt.config._
 import org.scalafmt.internal._
 import org.scalafmt.util.TreeOps._
 
@@ -15,6 +14,9 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
   import FormatTokensRewrite._
 
   override def enabled(implicit style: ScalafmtConfig): Boolean = true
+
+  def usedIn(rewrite: RewriteSettings): Boolean = rewrite.rules.contains(this)
+  def used(implicit style: ScalafmtConfig): Boolean = usedIn(style.rewrite)
 
   override def create(implicit ftoks: FormatTokens): Rule = new RedundantBraces
 
@@ -203,7 +205,9 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
             }
           case f: Term.FunctionTerm =>
             getBlockToReplaceAsFuncBodyInSingleArgApply(ta, f) match {
-              case Some((_, xlb)) => replaceWithBrace(claim = xlb.idx - 1 :: Nil)
+              case Some((xb, xlb)) =>
+                if (canRewriteStatWithParens(xb) && okLineSpan(xb)) null
+                else replaceWithBrace(claim = xlb.idx - 1 :: Nil)
               case _ => null
             }
           case _ => null

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -151,13 +151,15 @@ class RedundantParens(implicit val ftoks: FormatTokens)
   }
 
   private def okToReplaceArgClause(
-      t: Member.ArgClause,
-  )(implicit style: ScalafmtConfig): Boolean = t.values match {
+      ac: Member.ArgClause,
+  )(implicit style: ScalafmtConfig): Boolean = ac.values match {
     case arg :: Nil => arg match {
-        case _: Term.Block | _: Term.PartialFunction => !t.parent.isOpt[Init]
+        case b: Term.Block => !(ac.parent.isOpt[Init] ||
+            RedundantBraces.used && RedundantBraces.canRewriteStatWithParens(b))
+        case _: Term.PartialFunction => !ac.parent.isOpt[Init]
         case _: Lit.Unit | _: Member.Tuple => false
         case _: Term.SelectPostfix => false
-        case _ => t.parent.exists {
+        case _ => ac.parent.exists {
             case pia: Member.Infix => okToReplaceInfix(pia, arg)
             case _ => false
           }

--- a/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59229705)
+  override protected def totalStatesVisited: Option[Int] = Some(59238466)
 
   override protected def builds = Seq(getBuild(
     "2024.2.28",
@@ -52,7 +52,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59444243)
+  override protected def totalStatesVisited: Option[Int] = Some(59452507)
 
   override protected def builds = Seq(getBuild(
     "2024.3.4",

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42553269)
+  override protected def totalStatesVisited: Option[Int] = Some(42555134)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(53284169)
+  override protected def totalStatesVisited: Option[Int] = Some(53285820)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39174786)
+  override protected def totalStatesVisited: Option[Int] = Some(39175046)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42300103)
+  override protected def totalStatesVisited: Option[Int] = Some(42300467)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(86100614)
+  override protected def totalStatesVisited: Option[Int] = Some(86105937)
 
   override protected def builds = Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
 
@@ -17,7 +17,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(91102086)
+  override protected def totalStatesVisited: Option[Int] = Some(91105917)
 
   override protected def builds = Seq(getBuild("v3.5.3", dialects.Scala213, 2756))
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11027,6 +11027,27 @@ repeatTakeMapAndFold = fuse(
 <<< #4133 parens to braces, with function as argument
 maxColumn = 72
 rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.maxBreaks = 3 
+===
+val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
+  if (!isRep) Ident(param)
+  else {
+    val parTp = elementType(ArrayClass, param.tpe)
+    val wrap = gen.mkWrapArray(Ident(param), parTp)
+  }
+})
+>>>
+val seqArgs =
+  map3(newPs, oldPs, isRepeated) { (param, oldParam, isRep) =>
+    if (!isRep) Ident(param)
+    else {
+      val parTp = elementType(ArrayClass, param.tpe)
+      val wrap = gen.mkWrapArray(Ident(param), parTp)
+    }
+  }
+<<< #4133 keep parens, remove braces, with function as argument
+maxColumn = 72
+rewrite.rules = [RedundantBraces]
 ===
 val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
   if (!isRep) Ident(param)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11057,14 +11057,13 @@ val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
   }
 })
 >>>
-val seqArgs =
-  map3(newPs, oldPs, isRepeated) { (param, oldParam, isRep) =>
-    if (!isRep) Ident(param)
-    else {
-      val parTp = elementType(ArrayClass, param.tpe)
-      val wrap = gen.mkWrapArray(Ident(param), parTp)
-    }
+val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) =>
+  if (!isRep) Ident(param)
+  else {
+    val parTp = elementType(ArrayClass, param.tpe)
+    val wrap = gen.mkWrapArray(Ident(param), parTp)
   }
+)
 <<< #4133 nested apply followed by select
 maxColumn = 80
 newlines.avoidForSimpleOverflow = all

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10312,13 +10312,13 @@ val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
   }
 })
 >>>
-val seqArgs = map3(newPs, oldPs, isRepeated) { (param, oldParam, isRep) =>
+val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) =>
   if (!isRep) Ident(param)
   else {
     val parTp = elementType(ArrayClass, param.tpe)
     val wrap = gen.mkWrapArray(Ident(param), parTp)
   }
-}
+)
 <<< #4133 nested apply followed by select
 maxColumn = 80
 newlines.avoidForSimpleOverflow = all

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10283,6 +10283,26 @@ repeatTakeMapAndFold = fuse(
 <<< #4133 parens to braces, with function as argument
 maxColumn = 72
 rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.maxBreaks = 3 
+===
+val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
+  if (!isRep) Ident(param)
+  else {
+    val parTp = elementType(ArrayClass, param.tpe)
+    val wrap = gen.mkWrapArray(Ident(param), parTp)
+  }
+})
+>>>
+val seqArgs = map3(newPs, oldPs, isRepeated) { (param, oldParam, isRep) =>
+  if (!isRep) Ident(param)
+  else {
+    val parTp = elementType(ArrayClass, param.tpe)
+    val wrap = gen.mkWrapArray(Ident(param), parTp)
+  }
+}
+<<< #4133 keep parens, remove braces, with function as argument
+maxColumn = 72
+rewrite.rules = [RedundantBraces]
 ===
 val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
   if (!isRep) Ident(param)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -10782,6 +10782,27 @@ repeatTakeMapAndFold = fuse(
 <<< #4133 parens to braces, with function as argument
 maxColumn = 72
 rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.maxBreaks = 3 
+===
+val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
+  if (!isRep) Ident(param)
+  else {
+    val parTp = elementType(ArrayClass, param.tpe)
+    val wrap = gen.mkWrapArray(Ident(param), parTp)
+  }
+})
+>>>
+val seqArgs = map3(newPs, oldPs, isRepeated) {
+  (param, oldParam, isRep) =>
+    if (!isRep) Ident(param)
+    else {
+      val parTp = elementType(ArrayClass, param.tpe)
+      val wrap = gen.mkWrapArray(Ident(param), parTp)
+    }
+}
+<<< #4133 keep parens, remove braces, with function as argument
+maxColumn = 72
+rewrite.rules = [RedundantBraces]
 ===
 val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
   if (!isRep) Ident(param)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -8538,8 +8538,12 @@ object a {
 >>>
 object a {
   foo := bar {
-    val baz = qux(x => plugh => xyzzy)
-    val baz = qux(x => quux => fred)
+    val baz = qux(x =>
+      plugh => xyzzy
+    )
+    val baz = qux(x =>
+      quux => fred
+    )
   }
 }
 <<< no braces around nested lambda, braces around outer
@@ -10812,14 +10816,13 @@ val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
   }
 })
 >>>
-val seqArgs = map3(newPs, oldPs, isRepeated) {
-  (param, oldParam, isRep) =>
-    if (!isRep) Ident(param)
-    else {
-      val parTp = elementType(ArrayClass, param.tpe)
-      val wrap = gen.mkWrapArray(Ident(param), parTp)
-    }
-}
+val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) =>
+  if (!isRep) Ident(param)
+  else {
+    val parTp = elementType(ArrayClass, param.tpe)
+    val wrap = gen.mkWrapArray(Ident(param), parTp)
+  }
+)
 <<< #4133 nested apply followed by select
 maxColumn = 80
 newlines.avoidForSimpleOverflow = all

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -8779,12 +8779,8 @@ object a {
 object a {
   foo :=
     bar {
-      val baz = qux { x => plugh =>
-        xyzzy
-      }
-      val baz = qux { x => quux =>
-        fred
-      }
+      val baz = qux(x => plugh => xyzzy)
+      val baz = qux(x => quux => fred)
     }
 }
 <<< no braces around nested lambda, braces around outer
@@ -11210,14 +11206,14 @@ val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
 })
 >>>
 val seqArgs =
-  map3(newPs, oldPs, isRepeated) { (param, oldParam, isRep) =>
+  map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) =>
     if (!isRep)
       Ident(param)
     else {
       val parTp = elementType(ArrayClass, param.tpe)
       val wrap = gen.mkWrapArray(Ident(param), parTp)
     }
-  }
+  )
 <<< #4133 nested apply followed by select
 maxColumn = 80
 newlines.avoidForSimpleOverflow = all

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11178,6 +11178,28 @@ repeatTakeMapAndFold = fuse(
 <<< #4133 parens to braces, with function as argument
 maxColumn = 72
 rewrite.rules = [RedundantBraces]
+rewrite.redundantBraces.maxBreaks = 3 
+===
+val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
+  if (!isRep) Ident(param)
+  else {
+    val parTp = elementType(ArrayClass, param.tpe)
+    val wrap = gen.mkWrapArray(Ident(param), parTp)
+  }
+})
+>>>
+val seqArgs =
+  map3(newPs, oldPs, isRepeated) { (param, oldParam, isRep) =>
+    if (!isRep)
+      Ident(param)
+    else {
+      val parTp = elementType(ArrayClass, param.tpe)
+      val wrap = gen.mkWrapArray(Ident(param), parTp)
+    }
+  }
+<<< #4133 keep parens, remove braces, with function as argument
+maxColumn = 72
+rewrite.rules = [RedundantBraces]
 ===
 val seqArgs = map3(newPs, oldPs, isRepeated)((param, oldParam, isRep) => {
   if (!isRep) Ident(param)

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces.stat
@@ -698,8 +698,10 @@ object a {
 }
 >>>
 object a {
-  val b = c(d => e) // comment1
-  /* comment2 */
+  val b = c(d =>
+    e // comment1
+    /* comment2 */
+  )
   /* comment3 */
 }
 <<< #1633 5.2: keep config style
@@ -1593,11 +1595,11 @@ object A {
 >>>
 object A:
   implicit def map: Array[Any] => List[String] = a =>
-    a.map { ae =>
+    a.map(ae =>
       ae match
         case s: String => s
         case _         => ae.toString
-    }.toList
+    ).toList
 <<< #3540
 object Bar extends Foo[(Int, String)]({ case (i, s) => () })
 >>>

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
@@ -1897,9 +1897,7 @@ foo
   )
 >>>
 foo
-  .mtd1 { x =>
-    x + 1
-  }
+  .mtd1(x => x + 1)
   .mtd2: x =>
      x + 1
      x + 2
@@ -1939,9 +1937,7 @@ foo
   )
 >>>
 foo
-  .mtd1 { x =>
-    x + 1
-  }
+  .mtd1(x => x + 1)
   .mtd2: x =>
      x + 1
      x + 2
@@ -1981,9 +1977,9 @@ foo
   )
 >>>
 foo
-  .mtd1 { x =>
-    x + 1
-  }
+  .mtd1(
+    x => x + 1,
+  )
   .mtd2: x =>
      x + 1
      x + 2
@@ -2020,10 +2016,7 @@ object a {
 }
 >>>
 object a:
-   mtd1 { x =>
-     x + 1
-   }
-   + mtd2: x =>
+   mtd1(x => x + 1) + mtd2: x =>
       x + 1
       x + 2
    + mtd3 { x =>

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
@@ -1739,7 +1739,9 @@ foo
     },
   )
 >>>
-foo.mtd1 { x => x + 1 }.mtd2: x =>
+foo.mtd1(
+  x => x + 1,
+).mtd2: x =>
    x + 1
    x + 2
 .mtd3 { x =>

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_keep.stat
@@ -1865,10 +1865,9 @@ foo
   )
 >>>
 foo
-  .mtd1 {
-    x =>
-      x + 1
-  }
+  .mtd1(x =>
+    x + 1
+  )
   .mtd2: x =>
      x + 1
      x + 2
@@ -1909,10 +1908,9 @@ foo
   )
 >>>
 foo
-  .mtd1 {
-    x =>
-      x + 1
-  }
+  .mtd1(x =>
+    x + 1,
+  )
   .mtd2: x =>
      x + 1
      x + 2
@@ -1953,10 +1951,10 @@ foo
   )
 >>>
 foo
-  .mtd1 {
+  .mtd1(
     x =>
-      x + 1
-  }
+      x + 1,
+  )
   .mtd2: x =>
      x + 1
      x + 2
@@ -1994,11 +1992,9 @@ object a {
 }
 >>>
 object a:
-   mtd1 {
-     x =>
-       x + 1
-   }
-   + mtd2: x =>
+   mtd1(x =>
+     x + 1
+   ) + mtd2: x =>
       x + 1
       x + 2
    + mtd3 {

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_unfold.stat
@@ -1888,9 +1888,7 @@ foo
   )
 >>>
 foo
-  .mtd1 { x =>
-    x + 1
-  }
+  .mtd1(x => x + 1)
   .mtd2: x =>
      x + 1
      x + 2
@@ -1930,9 +1928,7 @@ foo
   )
 >>>
 foo
-  .mtd1 { x =>
-    x + 1
-  }
+  .mtd1(x => x + 1)
   .mtd2: x =>
      x + 1
      x + 2
@@ -1972,9 +1968,9 @@ foo
   )
 >>>
 foo
-  .mtd1 { x =>
-    x + 1
-  }
+  .mtd1(
+    x => x + 1,
+  )
   .mtd2: x =>
      x + 1
      x + 2
@@ -2011,9 +2007,7 @@ object a {
 }
 >>>
 object a:
-   mtd1 { x =>
-     x + 1
-   } +
+   mtd1(x => x + 1) +
      mtd2: x =>
         x + 1
         x + 2

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1204040, "total explored")
+      assertEquals(explored, 1204255, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1203082, "total explored")
+      assertEquals(explored, 1204040, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
If the body is single-stat, instead of moving them to replace parens, just remove them.