### PR TITLE
FormatTokens: add a third way to compute offset

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -244,7 +244,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
               if (tok.is[T.Whitespace]) None else Some(tok)
           }
           tokOpt.foreach { tok =>
-            span += tok.end - tok.start
+            span += tok.len
             if (span > maxStats) return false // RETURNING!!!
           }
         }


### PR DESCRIPTION
This one doesn't count opening or closing delimiters and is helpful in rewrite rules manipulating parens and braces.