### PR TITLE
FormatOps: allow blank around infix if in parens

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantParens.stat
@@ -1793,3 +1793,76 @@ runner.dialect = scala3
 given fooBar: (Foo & Bar) = new Foo with Bar {}
 >>>
 given fooBar: (Foo & Bar) = new Foo with Bar {}
+
+<<< remove parens but also remove blank line within infix [scala213]
+maxColumn = 80
+runner.dialect = scala213
+newlines.source = keep
+===
+val foo = (
+  defineFunction0(VarField.throwNullPointerException) {
+    Throw(maybeWrapInUBE(nullPointers, {
+      genScalaClassNew(NullPointerExceptionClass, NoArgConstructorName)
+    }))
+  } :::
+
+  // "checkNotNull", but with a very short name
+  defineFunction1(VarField.n) { x =>
+    Block(
+      If(x === Null(), genCallHelper(VarField.throwNullPointerException)),
+      Return(x)
+    )
+  }
+)
+>>>
+val foo =
+  defineFunction0(VarField.throwNullPointerException) {
+    Throw(maybeWrapInUBE(
+      nullPointers, {
+        genScalaClassNew(NullPointerExceptionClass, NoArgConstructorName)
+      }
+    ))
+  } :::
+    // "checkNotNull", but with a very short name
+    defineFunction1(VarField.n) { x =>
+      Block(
+        If(x === Null(), genCallHelper(VarField.throwNullPointerException)),
+        Return(x)
+      )
+    }
+<<< remove parens but also remove blank line within infix [scala3]
+maxColumn = 80
+runner.dialect = scala3
+newlines.source = keep
+===
+val foo = (
+  defineFunction0(VarField.throwNullPointerException) {
+    Throw(maybeWrapInUBE(nullPointers, {
+      genScalaClassNew(NullPointerExceptionClass, NoArgConstructorName)
+    }))
+  } :::
+
+  // "checkNotNull", but with a very short name
+  defineFunction1(VarField.n) { x =>
+    Block(
+      If(x === Null(), genCallHelper(VarField.throwNullPointerException)),
+      Return(x)
+    )
+  }
+)
+>>>
+val foo =
+  defineFunction0(VarField.throwNullPointerException) {
+    Throw(maybeWrapInUBE(
+      nullPointers, {
+        genScalaClassNew(NullPointerExceptionClass, NoArgConstructorName)
+      }
+    ))
+  } :::
+    // "checkNotNull", but with a very short name
+    defineFunction1(VarField.n) { x =>
+      Block(
+        If(x === Null(), genCallHelper(VarField.throwNullPointerException)),
+        Return(x)
+      )
+    }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1204337, "total explored")
+      assertEquals(explored, 1204611, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Check now that it's not enclosed in braces instead.