### PR TITLE
ScalafmtConfig: make format-on/off configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4412,6 +4412,16 @@ val identity = Array(1, 0, 0,
 // format: on
 ```
 
+Since v3.8.4, these format on-off tags can be configured:
+
+- `formatOff`: tags to turn formatting off
+- `formatOn`: tags to turn formatting back on
+
+```scala mdoc:defaults
+formatOff
+formatOn
+```
+
 ### Project
 
 Configure which source files should be formatted in this project.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -433,11 +433,11 @@ object FormatTokens {
     var fmtWasOff = false
     def process(right: T, tokIdx: Int): Unit = if (!right.is[T.Whitespace]) {
       val rmeta = FT.TokenMeta(owners(hash(right)), right.text)
-      if (left eq null) fmtWasOff = isFormatOff(right)
+      if (left eq null) fmtWasOff = style.isFormatOff(right)
       else {
         val between = tokens.arraySlice(prevNonWsIdx + 1, tokIdx)
-        val fmtIsOff = fmtWasOff || isFormatOff(right)
-        fmtWasOff = if (fmtWasOff) !isFormatOn(right) else fmtIsOff
+        val fmtIsOff = fmtWasOff || style.isFormatOff(right)
+        fmtWasOff = if (fmtWasOff) !style.isFormatOn(right) else fmtIsOff
         val meta = FT.Meta(between, ftIdx, fmtIsOff, lmeta, rmeta)
         result += FT(left, right, meta)
         ftIdx += 1

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -23,7 +23,7 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
   private val patchBuilder = mutable.Map.empty[(Int, Int), TokenPatch]
 
   val tokens = tree.tokens
-  val tokenTraverser = new TokenTraverser(tokens, input)
+  val tokenTraverser = new TokenTraverser(tokens, input)(style)
   val matchingParens = TreeOps
     .getMatchingParentheses(tokens)(TokenOps.hash)(identity)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -95,27 +95,6 @@ object TokenOps {
   @inline
   def getMod(ft: FT): Modification = Space.orNL(ft.newlinesBetween)
 
-  val formatOnCode = Set(
-    "@formatter:on", // IntelliJ
-    "format: on", // scalariform
-  )
-
-  val formatOffCode = Set(
-    "@formatter:off", // IntelliJ
-    "format: off", // scalariform
-  )
-
-  @inline
-  def isFormatOn(token: T): Boolean = isFormatIn(token, formatOnCode)
-
-  @inline
-  def isFormatOff(token: T): Boolean = isFormatIn(token, formatOffCode)
-
-  private def isFormatIn(token: T, set: Set[String]): Boolean = token match {
-    case t: Comment => set.contains(t.value.trim.toLowerCase)
-    case _ => false
-  }
-
   def endsWithSymbolIdent(tok: T): Boolean = tok match {
     case Ident(name) => !name.last.isLetterOrDigit && !tok.isBackquoted
     case _ => false

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -1,20 +1,24 @@
 package org.scalafmt.util
 
+import org.scalafmt.config.ScalafmtConfig
+
 import scala.meta.Input
 import scala.meta.tokens.Tokens
 import scala.meta.tokens.{Token => T}
 
 import scala.annotation.tailrec
 
-class TokenTraverser(tokens: Tokens, input: Input) {
+class TokenTraverser(tokens: Tokens, input: Input)(implicit
+    style: ScalafmtConfig,
+) {
   private[this] val (tok2idx, excludedTokens) = {
     val map = Map.newBuilder[T, Int]
     val excluded = Set.newBuilder[TokenOps.TokenHash]
     var formatOff = false
     var i = 0
     tokens.foreach { tok =>
-      if (!formatOff) { if (TokenOps.isFormatOff(tok)) formatOff = true }
-      else if (TokenOps.isFormatOn(tok)) formatOff = false
+      if (!formatOff) { if (style.isFormatOff(tok)) formatOff = true }
+      else if (style.isFormatOn(tok)) formatOff = false
       else excluded += TokenOps.hash(tok)
       map += tok -> i
       i += 1


### PR DESCRIPTION
Also, construct the default values without explicitly using the full string, as otherwise Intellij seems to detect it in the source file which contains it, despite it not being in a comment.