### PR TITLE
FormatOps: use `exemptScope = notAssign`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -901,6 +901,10 @@ to be exempted from the default indentation rule:
     [scala-js coding style](https://github.com/scala-js/scala-js/blob/main/CODINGSTYLE.md#long-expressions-with-binary-operators).
 - `all`: all infix operators
   - this value replaced deprecated `indentOperator.topLevelOnly=false`
+- `notAssign` (since v3.8.4): any non-assignment operator
+  - this value expanded upon deprecated `verticalAlignMultilineOperators`
+    which now simply maps to `{ exemptScope = notAssign, excludeRegex = ".*" }`
+- `notWithinAssign` (since v3.8.4): any infix not part of a larger assignment expression
 
 ```scala mdoc:scalafmt
 indent.infix.exemptScope = oldTopLevel
@@ -1025,11 +1029,6 @@ renamed from `indentOperator.include`.
 ```scala mdoc:defaults
 indent.infix.includeRegex
 ```
-
-#### `indent.infix.assignmentOnly`
-
-Indents only after an assignment operator. Prior to v3.8.4, was called
-`verticalAlignMultilineOperators`.
 
 #### `indent.infix.preset`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -90,8 +90,16 @@ object IndentOperator {
     case object oldTopLevel extends Exempt
     case object aloneEnclosed extends Exempt
     case object aloneArgOrBody extends Exempt
+    case object notAssign extends Exempt
+    case object notWithinAssign extends Exempt
 
-    implicit val reader: ConfCodecEx[Exempt] = ReaderUtil
-      .oneOf[Exempt](all, oldTopLevel, aloneEnclosed, aloneArgOrBody)
+    implicit val reader: ConfCodecEx[Exempt] = ReaderUtil.oneOf[Exempt](
+      all,
+      oldTopLevel,
+      aloneEnclosed,
+      aloneArgOrBody,
+      notAssign,
+      notWithinAssign,
+    )
   }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -56,7 +56,6 @@ case class IndentOperator(
     includeRegex: String = ".*",
     @annotation.ExtraName("exclude")
     excludeRegex: String = "^(&&|\\|\\|)$",
-    assignmentOnly: Boolean = false,
 ) {
   private val includeRegexp = includeRegex.r.pattern
   private val excludeRegexp = excludeRegex.r.pattern
@@ -101,5 +100,13 @@ object IndentOperator {
       notAssign,
       notWithinAssign,
     )
+  }
+
+  val boolToAssign: PartialFunction[Conf, Conf] = { case Conf.Bool(value) =>
+    if (value) Conf.Obj(
+      "exemptScope" -> Conf.Str("notAssign"),
+      "excludeRegex" -> Conf.Str(".*"),
+    )
+    else Conf.Obj.empty
   }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -86,7 +86,7 @@ import metaconfig._
 @annotation.SectionRename("poorMansTrailingCommasInConfigStyle", "newlines.configStyle.beforeComma") // v3.8.4
 @annotation.SectionRename("optIn.forceBlankLineBeforeDocstring", "docstrings.forceBlankLineBefore") // v3.4.0
 @annotation.SectionRename("indentOperator", "indent.infix") // v3.8.4
-@annotation.SectionRename("verticalAlignMultilineOperators", "indent.infix.assignmentOnly") // v3.8.4
+@annotation.SectionRename("verticalAlignMultilineOperators", "indent.infix", IndentOperator.boolToAssign) // v3.8.4
 @annotation.SectionRename("indentYieldKeyword", "indent.yieldKeyword") // v3.8.4
 @annotation.SectionRename("rewriteTokens", "rewrite.tokens") // v3.8.4
 @annotation.SectionRename("importSelectors", "binPack.importSelectors") // v3.8.4

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -575,10 +575,16 @@ class FormatOps(
         case IndentOperator.Exempt.oldTopLevel => isOldTopLevel(getChild)
         case IndentOperator.Exempt.aloneEnclosed => isAloneEnclosed(getChild)
         case IndentOperator.Exempt.aloneArgOrBody => isAloneArgOrBody(getChild)
-        case _ => true
+        case IndentOperator.Exempt.notAssign => isAfterAssignmentOp(false)
+        case IndentOperator.Exempt.notWithinAssign => !app.isAssignment &&
+          // fullInfix itself is never an assignment
+          fullInfix.parent.exists {
+            case _: Member.Infix => false
+            case p: Member.ArgClause => !p.parent.is[Member.Infix]
+            case _ => true
+          }
       }
-      if (cfg.assignmentOnly) isAfterAssignmentOp(false)
-      else if (beforeLhs) assignBodyExpire.isEmpty
+      if (beforeLhs) assignBodyExpire.isEmpty
       else app.is[Pat] || allowNoIndent && cfg.noindent(app.op.value)
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -575,6 +575,7 @@ class FormatOps(
         case IndentOperator.Exempt.oldTopLevel => isOldTopLevel(getChild)
         case IndentOperator.Exempt.aloneEnclosed => isAloneEnclosed(getChild)
         case IndentOperator.Exempt.aloneArgOrBody => isAloneArgOrBody(getChild)
+        case _ => true
       }
       if (cfg.assignmentOnly) isAfterAssignmentOp(false)
       else if (beforeLhs) assignBodyExpire.isEmpty

--- a/scalafmt-tests/shared/src/test/resources/vertical-multiline/verticalAlignMultilineOperators.stat
+++ b/scalafmt-tests/shared/src/test/resources/vertical-multiline/verticalAlignMultilineOperators.stat
@@ -37,3 +37,167 @@ object Foo3 {
   a +
   b
 }
+<<< #4681 verticalAlignMultilineOperators
+maxColumn = 16
+===
+object a {
+  val foo1 = a +
+    b
+  foo1 = aaaa -
+    bbbb
+  foo1 =
+    aaaabbbb
+  foo1 += aaaa -
+    bbbb
+  foo1 +=
+    aaaabbbb
+  foo1 == aaaa -
+    bbbb
+  foo1 ==
+    aaaabbbb
+  foo1 := aaaa -
+    bbbb
+  foo1 :=
+    aaaabbbb
+  foo1 >= aaaa -
+    bbbb
+  foo1 >=
+    aaaabbbb
+}
+>>>
+object a {
+  val foo1 = a +
+    b
+  foo1 = aaaa -
+    bbbb
+  foo1 =
+    aaaabbbb
+  foo1 += aaaa -
+  bbbb
+  foo1 +=
+    aaaabbbb
+  foo1 == aaaa -
+  bbbb
+  foo1 ==
+  aaaabbbb
+  foo1 := aaaa -
+  bbbb
+  foo1 :=
+    aaaabbbb
+  foo1 >= aaaa -
+  bbbb
+  foo1 >=
+  aaaabbbb
+}
+<<< #4681 notAssign
+maxColumn = 16
+indent.infix {
+  exemptScope = notAssign
+  excludeRegex = ".*"
+}
+===
+object a {
+  val foo1 = a +
+    b
+  foo1 = aaaa -
+    bbbb
+  foo1 =
+    aaaabbbb
+  foo1 += aaaa -
+    bbbb
+  foo1 +=
+    aaaabbbb
+  foo1 == aaaa -
+    bbbb
+  foo1 ==
+    aaaabbbb
+  foo1 := aaaa -
+    bbbb
+  foo1 :=
+    aaaabbbb
+  foo1 >= aaaa -
+    bbbb
+  foo1 >=
+    aaaabbbb
+}
+>>>
+object a {
+  val foo1 = a +
+    b
+  foo1 = aaaa -
+    bbbb
+  foo1 =
+    aaaabbbb
+  foo1 += aaaa -
+  bbbb
+  foo1 +=
+    aaaabbbb
+  foo1 == aaaa -
+  bbbb
+  foo1 ==
+  aaaabbbb
+  foo1 := aaaa -
+  bbbb
+  foo1 :=
+    aaaabbbb
+  foo1 >= aaaa -
+  bbbb
+  foo1 >=
+  aaaabbbb
+}
+<<< #4681 notWithinAssign
+maxColumn = 16
+indent.infix {
+  exemptScope = notWithinAssign
+  excludeRegex = ".*"
+}
+===
+object a {
+  val foo1 = a +
+    b
+  foo1 = aaaa -
+    bbbb
+  foo1 =
+    aaaabbbb
+  foo1 += aaaa -
+    bbbb
+  foo1 +=
+    aaaabbbb
+  foo1 == aaaa -
+    bbbb
+  foo1 ==
+    aaaabbbb
+  foo1 := aaaa -
+    bbbb
+  foo1 :=
+    aaaabbbb
+  foo1 >= aaaa -
+    bbbb
+  foo1 >=
+    aaaabbbb
+}
+>>>
+object a {
+  val foo1 = a +
+    b
+  foo1 = aaaa -
+    bbbb
+  foo1 =
+    aaaabbbb
+  foo1 += aaaa -
+  bbbb
+  foo1 +=
+    aaaabbbb
+  foo1 == aaaa -
+  bbbb
+  foo1 ==
+  aaaabbbb
+  foo1 := aaaa -
+  bbbb
+  foo1 :=
+    aaaabbbb
+  foo1 >= aaaa -
+  bbbb
+  foo1 >=
+  aaaabbbb
+}

--- a/scalafmt-tests/shared/src/test/resources/vertical-multiline/verticalAlignMultilineOperators.stat
+++ b/scalafmt-tests/shared/src/test/resources/vertical-multiline/verticalAlignMultilineOperators.stat
@@ -91,6 +91,7 @@ object a {
 }
 <<< #4681 notAssign
 maxColumn = 16
+verticalAlignMultilineOperators = false
 indent.infix {
   exemptScope = notAssign
   excludeRegex = ".*"
@@ -147,6 +148,7 @@ object a {
 }
 <<< #4681 notWithinAssign
 maxColumn = 16
+verticalAlignMultilineOperators = false
 indent.infix {
   exemptScope = notWithinAssign
   excludeRegex = ".*"
@@ -185,7 +187,7 @@ object a {
   foo1 =
     aaaabbbb
   foo1 += aaaa -
-  bbbb
+    bbbb
   foo1 +=
     aaaabbbb
   foo1 == aaaa -
@@ -193,7 +195,7 @@ object a {
   foo1 ==
   aaaabbbb
   foo1 := aaaa -
-  bbbb
+    bbbb
   foo1 :=
     aaaabbbb
   foo1 >= aaaa -

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1241608, "total explored")
+      assertEquals(explored, 1241926, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Also, remove assignmentOnly field and use notAssign scope. Follow-on to #4681.
