### PR TITLE
Workflow: run CI only native-image upon release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-    tags:
+    tags_ignore:
       - '*'
   pull_request:
   release:
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   test:
+    if: github.event_name != 'release'
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +40,7 @@ jobs:
       - run: TEST="2.13" sbt ci-test-jvm
         shell: bash
   test-scala-native:
+    if: github.event_name != 'release'
     strategy:
       fail-fast: false
       matrix:
@@ -63,6 +65,7 @@ jobs:
       - run: TEST="2.13" sbt ci-test-native
         shell: bash
   community-test:
+    if: github.event_name != 'release'
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +86,7 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - run: sbt communityTests${{ matrix.group }}/test
   formatting:
+    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Also, do not run CI when tagging; when the final commit of a release is merged, currently CI is invoked 3 times:
- upon commit merge into main (triggered by push to branch main)
- upon release (triggered by release published)
- upon tagging along with release (triggered by push to tag `vX.Y.Z`)

Let's remove the last trigger and run only native-image (which uploads release artifacts) on release trigger, as all the rest of the checks would have been run on the same commit when it had been originally pushed to main.