### PR TITLE
 FormatOps: `{` of refined type is optimal for defn

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -196,12 +196,12 @@ class FormatOps(
     result
   }
 
-  // invoked on closing paren, part of ParamClause
+  // invoked on opening paren, part of ParamClause
   @tailrec
-  final def defnSiteLastToken(t: Tree): Option[FT] = t match {
+  final def defnSiteOptimalToken(t: Tree): Option[FT] = t match {
     case _: Member.SyntaxValuesClause | _: Member.ParamClauseGroup |
         _: Type.ParamFunctionType => t.parent match {
-        case Some(p) => defnSiteLastToken(p)
+        case Some(p) => defnSiteOptimalToken(p)
         case _ => None
       }
     case t: Defn.Macro => tokenBeforeOpt(t.body).map(prevNonCommentBefore)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -204,6 +204,11 @@ class FormatOps(
         case Some(p) => defnSiteOptimalToken(p)
         case _ => None
       }
+    case Tree.WithDeclTpe(tpe: Type.Refine) if tpe.body.nonEmpty =>
+      getHeadOpt(tpe.body)
+    case Tree.WithDeclTpeOpt(Some(tpe: Type.Refine)) if tpe.body.nonEmpty =>
+      getHeadOpt(tpe.body)
+    // macro body comes after KwMacro, not directly after Equals
     case t: Defn.Macro => tokenBeforeOpt(t.body).map(prevNonCommentBefore)
     case t: Tree.WithBody => tokenBeforeOpt(t.body)
     case t: Stat.WithTemplate => tokenBeforeOpt(t.templ)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -1079,7 +1079,7 @@ class Router(formatOps: FormatOps) {
           else style.newlines.isBeforeOpenParenCallSite
         val optimalOpt =
           if (isBeforeOpenParen || !defnSite || isBracket) None
-          else defnSiteLastToken(leftOwner)
+          else defnSiteOptimalToken(leftOwner)
         val optimal: FT = getSlbEndOnLeft(optimalOpt.getOrElse(close))
 
         val wouldDangle = onlyConfigStyle || mustDangleForTrailingCommas ||

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42514702)
+  override protected def totalStatesVisited: Option[Int] = Some(42512477)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(52982463)
+  override protected def totalStatesVisited: Option[Int] = Some(52980238)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39189546)
+  override protected def totalStatesVisited: Option[Int] = Some(39189350)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42296092)
+  override protected def totalStatesVisited: Option[Int] = Some(42295896)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11623,9 +11623,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   }
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
@@ -11645,9 +11643,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   } = foo
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
@@ -11667,9 +11663,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   } = macro foo
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11610,3 +11610,69 @@ val bypasser = Flow.fromGraph {
       FlowShape(broadcast.in, merge.out)
   }
 }
+<<< #4704 Decl.Def with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+}
+<<< #4704 Defn.Def with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+}
+<<< #4704 Defn.DefMacro with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10835,3 +10835,63 @@ val bypasser = Flow.fromGraph {
       FlowShape(broadcast.in, merge.out)
   }
 }
+<<< #4704 Decl.Def with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] { type TypeClassType = ConsK[F] }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(
+      implicit_tc: ConsK[F]
+  ): AllOps[F, A] { type TypeClassType = ConsK[F] }
+}
+<<< #4704 Defn.Def with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] { type TypeClassType = ConsK[F] } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(
+      implicit_tc: ConsK[F]
+  ): AllOps[F, A] { type TypeClassType = ConsK[F] } = foo
+}
+<<< #4704 Defn.DefMacro with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] { type TypeClassType = ConsK[F] } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(
+      implicit_tc: ConsK[F]
+  ): AllOps[F, A] { type TypeClassType = ConsK[F] } = macro foo
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10848,12 +10848,12 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] { type TypeClassType = ConsK[F] }
-  implicit def toAllConsKOps[F[_], A](target: F[A])(
-      implicit_tc: ConsK[F]
-  ): AllOps[F, A] { type TypeClassType = ConsK[F] }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
 }
 <<< #4704 Defn.Def with refined decltpe
 maxColumn = 90
@@ -10868,12 +10868,12 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] { type TypeClassType = ConsK[F] } = foo
-  implicit def toAllConsKOps[F[_], A](target: F[A])(
-      implicit_tc: ConsK[F]
-  ): AllOps[F, A] { type TypeClassType = ConsK[F] } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
 }
 <<< #4704 Defn.DefMacro with refined decltpe
 maxColumn = 90
@@ -10888,10 +10888,10 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] { type TypeClassType = ConsK[F] } = macro foo
-  implicit def toAllConsKOps[F[_], A](target: F[A])(
-      implicit_tc: ConsK[F]
-  ): AllOps[F, A] { type TypeClassType = ConsK[F] } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11384,9 +11384,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   }
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
@@ -11406,9 +11404,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   } = foo
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
@@ -11428,9 +11424,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   } = macro foo
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11371,3 +11371,69 @@ val bypasser = Flow.fromGraph {
       FlowShape(broadcast.in, merge.out)
   }
 }
+<<< #4704 Decl.Def with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+}
+<<< #4704 Defn.Def with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+}
+<<< #4704 Defn.DefMacro with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11814,3 +11814,69 @@ val bypasser = Flow.fromGraph {
       FlowShape(broadcast.in, merge.out)
   }
 }
+<<< #4704 Decl.Def with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  }
+}
+<<< #4704 Defn.Def with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = foo
+}
+<<< #4704 Defn.DefMacro with refined decltpe
+maxColumn = 90
+===
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+}
+>>>
+object ops {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
+      tc: ConsK[F]
+  ): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
+    type TypeClassType = ConsK[F]
+  } = macro foo
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11827,9 +11827,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   }
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
@@ -11849,9 +11847,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   } = foo
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {
@@ -11871,9 +11867,7 @@ object ops {
 }
 >>>
 object ops {
-  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit
-      tc: ConsK[F]
-  ): AllOps[F, A] {
+  implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
     type TypeClassType = ConsK[F]
   } = macro foo
   implicit def toAllConsKOps[F[_], A](target: F[A])(implicit_tc: ConsK[F]): AllOps[F, A] {

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1241926, "total explored")
+      assertEquals(explored, 1246977, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1246977, "total explored")
+      assertEquals(explored, 1244442, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Fixes #4704.