### PR TITLE
Newlines: split `afterInfix` into `infix.{term,type,pat}Site`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2431,6 +2431,12 @@ around infix expressions. It contains the following parameter groups:
 
 - `termSite`
   - primarily applies to ordinary infix expressions (`Term.ApplyInfix`)
+- `typeSite`:
+  - applies to infix expressions within types (`Type.ApplyInfix`) only
+  - defaults to `termSite` if _no fields_ are specified
+- `patSite`:
+  - applies to infix expressions within patterns (`Pat.ExtractInfix`) only
+  - defaults to `termSite` if _no fields_ are specified
 
 Each of these groups has several parameters of its own (replacing deprecated
 `newlines.afterInfixXxx`, originally added in v2.5.0, which moved to `termSite`):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2424,25 +2424,37 @@ parameters require keeping this keyword attached to the opening brace.
 Therefore, any of the parameters described in this section will take precedence
 even when `newlines.configStyle.defnSite.prefer = true` is used.
 
-### `newlines.afterInfix`
+### `newlines.infix`
 
-> Since v2.5.0.
+Introduced in v3.8.4, this parameter (and its companions) controls formatting
+around infix expressions. It contains the following parameter groups:
 
-This parameter (and its companions) controls formatting around infix
-expressions.
+- `termSite`
+  - primarily applies to ordinary infix expressions (`Term.ApplyInfix`)
 
-> The default value depends on `newlines.source` (see below).
+Each of these groups has several parameters of its own (replacing deprecated
+`newlines.afterInfixXxx`, originally added in v2.5.0, which moved to `termSite`):
 
-#### `newlines.afterInfix=keep`
+- `style`:
+- `maxCountPerFile`
+- `maxCountPerExprForSome`
+- `breakOnNested`
+
+#### `newlines.infix: style=keep`
 
 This approach preserves line breaks in the input. This is the original
 behaviour, and default for `newlines.source=classic,keep`.
 
-#### `newlines.afterInfix=many,some`
+One caveat is: for `classic` type infixes with Scala3 (or if the dialect
+[enables](#runnerdialectoverride) the `useInfixTypePrecedence` flag),
+`some` is the default.
+
+#### `newlines.infix: style=many,some`
 
 These approaches _completely ignore_ existing newlines around infix, always use
 a space before an infix operator and occasionally break after it. `some` is
-default for `newlines.source=fold`, and `many` for `newlines.source=unfold`.
+default for `newlines.source=fold` (also see caveat under `keep` aboce), and
+`many` for `newlines.source=unfold`.
 
 > Might require increasing
 > [optimizer limits](#route-search-optimizations-giving-up),
@@ -2454,31 +2466,31 @@ after
 and both will _always_ break before an expression enclosed in matching
 parentheses.
 
-#### `newlines.afterInfixMaxCountPerFile`
+#### `newlines.infix: maxCountPerFile`
 
 ```scala mdoc:defaults
-newlines.afterInfixMaxCountPerFile
+newlines.infix.termSite.maxCountPerFile
 ```
 
-If the total number of infix operations in the _entire file_ exceeds
-`newlines.afterInfixMaxCountPerFile`, the formatter automatically switches to
-`newlines.afterInfix=keep` for this file.
+If the total number of matching infix operations in the _entire file_ exceeds
+`newlines.infix.xxxSite.maxCountPerFile`, the formatter automatically switches to
+`newlines.infix.xxxSite.style=keep` for this file.
 
-#### `newlines.afterInfixMaxCountPerExprForSome`
+#### `newlines.infix: maxCountPerExprForSome`
 
 ```scala mdoc:defaults
-newlines.afterInfixMaxCountPerExprForSome
+newlines.infix.termSite.maxCountPerExprForSome
 ```
 
-If `newlines.afterInfix` is set to `some` and the number of infix operations in
+If `newlines.infix.xxxSite.style` is set to `some` and the number of infix operations in
 a _given expression sequence_ (top-level or enclosed in parens/braces) exceeds
-`newlines.afterInfixMaxCountPerExprForSome`, the formatter switches to `many`
+`newlines.infix.xxxSite.maxCountPerExprForSome`, the formatter switches to `many`
 for that sequence only.
 
-#### `newlines.afterInfixBreakOnNested`
+#### `newlines.infix: breakOnNested`
 
 ```scala mdoc:defaults
-newlines.afterInfixBreakOnNested
+newlines.infix.termSite.breakOnNested
 ```
 
 If enabled, will force line breaks around a nested parenthesized sub-expression
@@ -3312,7 +3324,7 @@ xs.map( // should rewrite this, contains an infix with a break after operator
   x +
   1
 )
-// scalafmt: { newlines.afterInfix = some }
+// scalafmt: { newlines.infix.termSite.style = some }
 xs.map( // should rewrite this, allows formatting infix
   x
   + 1
@@ -3990,7 +4002,7 @@ The section contains the following settings (available since v3.8.1):
 - (since v3.8.4) `fewerBracesParensToo`
   - will apply the rule just above to an argument in parentheses as well,
     if the one of following is also satisfied:
-    - [`newlines.afterInfix`](#newlinesafterinfix) is NOT `keep`; or
+    - [`newlines.infix.xxxSite.style`](#newlinesinfix-stylekeep) is NOT `keep`; or
     - current dialect supports `allowInfixOperatorAfterNL`
 
 Prior to v3.8.1, `rewrite.scala3.removeOptionalBraces` was a flag which

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -253,16 +253,6 @@ case class ScalafmtConfig(
     rewrite = rewrite.withoutRewrites,
   )
 
-  def breakAfterInfix(tree: => Tree): Newlines.AfterInfix = newlines.afterInfix
-    .getOrElse {
-      val useSome = newlines.source == Newlines.classic &&
-        tree.is[Type.ApplyInfix] && dialect.useInfixTypePrecedence
-      if (useSome) Newlines.AfterInfix.some else newlines.breakAfterInfix
-    }
-
-  def formatInfix(tree: => Tree): Boolean = breakAfterInfix(tree) ne
-    Newlines.AfterInfix.keep
-
   def getFewerBraces(): Indents.FewerBraces =
     if (indent.getSignificant < 2) Indents.FewerBraces.never
     else indent.fewerBraces

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -181,7 +181,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
         def useDelim = settings.oneStatApply.changeDelim(lp, ftoks.getLast(ta))
         def shouldReplaceWithBrace(s: Stat): Boolean = s match {
           case x: Term.ApplyInfix
-              if !style.newlines.formatInfix &&
+              if style.newlines.infix.keep(x) &&
                 !style.dialect.allowInfixOperatorAfterNL &&
                 RedundantParens.breaksBeforeOp(x) => false
           case _ => useDelim eq T.LeftBrace
@@ -578,7 +578,8 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       val rft = ftoks.matchingRight(ft)
       def checkAfterRight(wasNonComment: => Boolean) = {
         val nrft = ftoks.nextNonComment(rft)
-        !nrft.right.is[T.Ident] || wasNonComment && style.formatInfix(p) ||
+        !nrft.right.is[T.Ident] ||
+        wasNonComment && !style.newlines.infix.keep(p) ||
         findTreeWithParent(p) { // check if infix is in parens
           case pp: Member.ArgClause => ftoks.getClosingIfWithinParensOrBraces(pp)
               .map(_.isRight)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -30,10 +30,10 @@ object RedundantParens extends Rewrite with FormatTokensRewrite.RuleFactory {
   def breaksBeforeOp(
       ia: Member.Infix,
   )(implicit style: ScalafmtConfig, ftoks: FormatTokens): Boolean = {
-    val formatInfix = style.formatInfix(ia)
+    val keepInfix = style.newlines.infix.keep(ia)
     def impl(ia: Member.Infix): Boolean = {
       val beforeOp = ftoks.prevNonCommentSameLine(ftoks.tokenJustBefore(ia.op))
-      beforeOp.hasBreak && (!formatInfix || beforeOp.left.is[T.Comment]) ||
+      beforeOp.hasBreak && (keepInfix || beforeOp.left.is[T.Comment]) ||
       ia.nestedInfixApps.exists(x => !ftoks.isEnclosedWithinParens(x) && impl(x))
     }
     impl(ia)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -192,7 +192,8 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
   )(implicit ft: FT, style: ScalafmtConfig): Replacement = {
     def okLeftDelim = ft.right.is[T.LeftBrace] ||
       style.rewrite.scala3.removeOptionalBraces.fewerBracesParensToo &&
-      (style.dialect.allowInfixOperatorAfterNL || style.newlines.formatInfix)
+      (style.dialect.allowInfixOperatorAfterNL ||
+        !style.newlines.infix.keep(tree))
     val ok = style.dialect.allowFewerBraces && okLeftDelim &&
       style.rewrite.scala3.removeOptionalBraces.fewerBracesMaxSpan > 0 &&
       isSeqSingle(tree.values)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -418,6 +418,7 @@ object TreeOps {
   final def isInfixOp(tree: Tree): Boolean = AsInfixOp.unapply(tree).isDefined
 
   object AsInfixOp {
+    def apply(tree: Tree) = unapply(tree)
     def unapply(tree: Tree): Option[Member.Infix] = tree.parent
       .collect { case ia: Member.Infix if ia.op eq tree => ia }
   }
@@ -884,7 +885,8 @@ object TreeOps {
 
     treeAt(0, topSourceTree, allTokens.head, allTokens.last, 0)
 
-    val checkedNewlines = baseStyle.newlines.checkInfixConfig(infixCount)
+    val checkedNewlines = baseStyle.newlines
+      .checkInfixConfig(infixCount)(baseStyle)
     val initStyle =
       if (checkedNewlines eq baseStyle.newlines) baseStyle
       else baseStyle.copy(newlines = checkedNewlines)

--- a/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42512477)
+  override protected def totalStatesVisited: Option[Int] = Some(42520687)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(52980238)
+  override protected def totalStatesVisited: Option[Int] = Some(52986574)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39189350)
+  override protected def totalStatesVisited: Option[Int] = Some(39189914)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42295896)
+  override protected def totalStatesVisited: Option[Int] = Some(42296538)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11671,49 +11671,7 @@ object ops {
   } = macro foo
 }
 <<< #4705 term=src, type=many
-object Foo {
-  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
-    ???
-
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
-    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
-}
->>>
-object Foo {
-  def oldStyle: Traverse[Option]
-    with MonadError[Option, Unit]
-    with Alternative[Option]
-    with CommutativeMonad[Option]
-    with CoflatMap[Option]
-    with Align[Option] =
-    ???
-
-  def newStyle: Traverse[
-    Option
-  ] & MonadError[
-    Option,
-    Unit
-  ] & Alternative[
-    Option
-  ] & CommutativeMonad[
-    Option
-  ] & CoflatMap[Option] & Align[
-    Option
-  ] =
-    Traverse[Option] & MonadError[
-      Option,
-      Unit
-    ] & Alternative[
-      Option
-    ] & CommutativeMonad[
-      Option
-    ] & CoflatMap[Option] & Align[
-      Option
-    ]
-}
-<<< #4705 term=some, type=keep
-maxColumn = 80
-newlines.infix.termSite.style = some
+newlines.infix.typeSite.style = many
 ===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
@@ -11732,15 +11690,26 @@ object Foo {
     with Align[Option] =
     ???
 
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
-    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
-    Align[Option] =
-    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
-      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+  def newStyle: Traverse[Option] &
+    MonadError[Option, Unit] &
+    Alternative[Option] &
+    CommutativeMonad[Option] &
+    CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[
+      Option,
+      Unit
+    ] & Alternative[
+      Option
+    ] & CommutativeMonad[
+      Option
+    ] & CoflatMap[Option] & Align[
+      Option
+    ]
 }
-<<< #4705 term=keep, type=some
+<<< #4705 term=some, type=keep
 maxColumn = 80
-newlines.infix.termSite.style = keep
+newlines.infix.termSite.style = some
+newlines.infix.typeSite.style = keep
 ===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
@@ -11762,6 +11731,34 @@ object Foo {
   def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
     Option
   ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
+      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=keep, type=some
+maxColumn = 80
+newlines.infix.termSite.style = keep
+newlines.infix.typeSite.style = some
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
     Traverse[Option] & MonadError[Option, Unit] & Alternative[
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11670,3 +11670,99 @@ object ops {
     type TypeClassType = ConsK[F]
   } = macro foo
 }
+<<< #4705 term=src, type=many
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle: Traverse[
+    Option
+  ] & MonadError[
+    Option,
+    Unit
+  ] & Alternative[
+    Option
+  ] & CommutativeMonad[
+    Option
+  ] & CoflatMap[Option] & Align[
+    Option
+  ] =
+    Traverse[Option] & MonadError[
+      Option,
+      Unit
+    ] & Alternative[
+      Option
+    ] & CommutativeMonad[
+      Option
+    ] & CoflatMap[Option] & Align[
+      Option
+    ]
+}
+<<< #4705 term=some, type=keep
+maxColumn = 80
+newlines.infix.termSite.style = some
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
+      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=keep, type=some
+maxColumn = 80
+newlines.infix.termSite.style = keep
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
+    Option
+  ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[
+      Option
+    ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10895,3 +10895,84 @@ object ops {
     type TypeClassType = ConsK[F]
   } = macro foo
 }
+<<< #4705 term=src, type=many
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] &
+    MonadError[Option, Unit] &
+    Alternative[Option] &
+    CommutativeMonad[Option] &
+    CoflatMap[Option] & Align[Option] =
+    Traverse[Option] &
+      MonadError[Option, Unit] &
+      Alternative[Option] &
+      CommutativeMonad[Option] &
+      CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=some, type=keep
+maxColumn = 80
+newlines.infix.termSite.style = some
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] = Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option]
+}
+<<< #4705 term=keep, type=some
+maxColumn = 80
+newlines.infix.termSite.style = keep
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
+    Option
+  ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[
+      Option
+    ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10896,6 +10896,8 @@ object ops {
   } = macro foo
 }
 <<< #4705 term=src, type=many
+newlines.infix.typeSite.style = many
+===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
     ???
@@ -10926,32 +10928,7 @@ object Foo {
 <<< #4705 term=some, type=keep
 maxColumn = 80
 newlines.infix.termSite.style = some
-===
-object Foo {
-  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
-    ???
-
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
-    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
-}
->>>
-object Foo {
-  def oldStyle: Traverse[Option]
-    with MonadError[Option, Unit]
-    with Alternative[Option]
-    with CommutativeMonad[Option]
-    with CoflatMap[Option]
-    with Align[Option] = ???
-
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
-    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
-    Align[Option] = Traverse[Option] & MonadError[Option, Unit] &
-    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
-    Align[Option]
-}
-<<< #4705 term=keep, type=some
-maxColumn = 80
-newlines.infix.termSite.style = keep
+newlines.infix.typeSite.style = keep
 ===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
@@ -10972,7 +10949,33 @@ object Foo {
   def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
     Option
   ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
-    Traverse[Option] & MonadError[Option, Unit] & Alternative[
-      Option
-    ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
+      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=keep, type=some
+maxColumn = 80
+newlines.infix.termSite.style = keep
+newlines.infix.typeSite.style = some
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] = Traverse[Option] & MonadError[Option, Unit] & Alternative[
+    Option
+  ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11431,3 +11431,96 @@ object ops {
     type TypeClassType = ConsK[F]
   } = macro foo
 }
+<<< #4705 term=src, type=many
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle
+      : Traverse[Option] & MonadError[
+        Option,
+        Unit
+      ] & Alternative[
+        Option
+      ] & CommutativeMonad[
+        Option
+      ] & CoflatMap[Option] & Align[
+        Option
+      ] =
+    Traverse[Option] & MonadError[
+      Option,
+      Unit
+    ] & Alternative[
+      Option
+    ] & CommutativeMonad[
+      Option
+    ] & CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=some, type=keep
+maxColumn = 80
+newlines.infix.termSite.style = some
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
+      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=keep, type=some
+maxColumn = 80
+newlines.infix.termSite.style = keep
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
+    Option
+  ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[
+      Option
+    ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11432,46 +11432,7 @@ object ops {
   } = macro foo
 }
 <<< #4705 term=src, type=many
-object Foo {
-  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
-    ???
-
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
-    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
-}
->>>
-object Foo {
-  def oldStyle: Traverse[Option]
-    with MonadError[Option, Unit]
-    with Alternative[Option]
-    with CommutativeMonad[Option]
-    with CoflatMap[Option]
-    with Align[Option] =
-    ???
-
-  def newStyle
-      : Traverse[Option] & MonadError[
-        Option,
-        Unit
-      ] & Alternative[
-        Option
-      ] & CommutativeMonad[
-        Option
-      ] & CoflatMap[Option] & Align[
-        Option
-      ] =
-    Traverse[Option] & MonadError[
-      Option,
-      Unit
-    ] & Alternative[
-      Option
-    ] & CommutativeMonad[
-      Option
-    ] & CoflatMap[Option] & Align[Option]
-}
-<<< #4705 term=some, type=keep
-maxColumn = 80
-newlines.infix.termSite.style = some
+newlines.infix.typeSite.style = many
 ===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
@@ -11490,15 +11451,24 @@ object Foo {
     with Align[Option] =
     ???
 
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
-    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
-    Align[Option] =
-    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
-      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+  def newStyle: Traverse[Option] &
+    MonadError[Option, Unit] &
+    Alternative[Option] &
+    CommutativeMonad[Option] &
+    CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[
+      Option,
+      Unit
+    ] & Alternative[
+      Option
+    ] & CommutativeMonad[
+      Option
+    ] & CoflatMap[Option] & Align[Option]
 }
-<<< #4705 term=keep, type=some
+<<< #4705 term=some, type=keep
 maxColumn = 80
-newlines.infix.termSite.style = keep
+newlines.infix.termSite.style = some
+newlines.infix.typeSite.style = keep
 ===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
@@ -11520,6 +11490,34 @@ object Foo {
   def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
     Option
   ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
+      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=keep, type=some
+maxColumn = 80
+newlines.infix.termSite.style = keep
+newlines.infix.typeSite.style = some
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
     Traverse[Option] & MonadError[Option, Unit] & Alternative[
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11874,3 +11874,84 @@ object ops {
     type TypeClassType = ConsK[F]
   } = macro foo
 }
+<<< #4705 term=src, type=many
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] &
+    MonadError[Option, Unit] &
+    Alternative[Option] &
+    CommutativeMonad[Option] &
+    CoflatMap[Option] & Align[Option] =
+    Traverse[Option] &
+      MonadError[Option, Unit] &
+      Alternative[Option] &
+      CommutativeMonad[Option] &
+      CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=some, type=keep
+maxColumn = 80
+newlines.infix.termSite.style = some
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
+      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=keep, type=some
+maxColumn = 80
+newlines.infix.termSite.style = keep
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
+    Option
+  ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[
+      Option
+    ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11875,6 +11875,8 @@ object ops {
   } = macro foo
 }
 <<< #4705 term=src, type=many
+newlines.infix.typeSite.style = many
+===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
     ???
@@ -11905,32 +11907,7 @@ object Foo {
 <<< #4705 term=some, type=keep
 maxColumn = 80
 newlines.infix.termSite.style = some
-===
-object Foo {
-  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
-    ???
-
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
-    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
-}
->>>
-object Foo {
-  def oldStyle: Traverse[Option]
-    with MonadError[Option, Unit]
-    with Alternative[Option]
-    with CommutativeMonad[Option]
-    with CoflatMap[Option]
-    with Align[Option] = ???
-
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
-    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
-    Align[Option] =
-    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
-      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
-}
-<<< #4705 term=keep, type=some
-maxColumn = 80
-newlines.infix.termSite.style = keep
+newlines.infix.typeSite.style = keep
 ===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
@@ -11951,6 +11928,33 @@ object Foo {
   def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
     Option
   ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
+      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+<<< #4705 term=keep, type=some
+maxColumn = 80
+newlines.infix.termSite.style = keep
+newlines.infix.typeSite.style = some
+===
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
     Traverse[Option] & MonadError[Option, Unit] & Alternative[
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8368,3 +8368,28 @@ object a:
             _.enteredAfter(explicitOuterPhase.asInstanceOf[DenotTransformer])
           )
      )
+<<< #4705
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[
+      Option
+    ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8369,6 +8369,8 @@ object a:
           )
      )
 <<< #4705
+newlines.infix.typeSite.style = many
+===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
     ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8033,3 +8033,26 @@ object a:
           explicitOuterPhase.asInstanceOf[DenotTransformer]
         ))
    )
+<<< #4705
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] = Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option]
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8034,6 +8034,8 @@ object a:
         ))
    )
 <<< #4705
+newlines.infix.typeSite.style = many
+===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
     ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8392,6 +8392,8 @@ object a:
           )
      )
 <<< #4705
+newlines.infix.typeSite.style = many
+===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
     ???
@@ -8406,9 +8408,9 @@ object Foo {
     with CoflatMap[Option] with Align[Option] =
     ???
 
-  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
-    Option
-  ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
     Traverse[Option] & MonadError[Option, Unit] & Alternative[
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8391,3 +8391,25 @@ object a:
             _.enteredAfter(explicitOuterPhase.asInstanceOf[DenotTransformer])
           )
      )
+<<< #4705
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit]
+    with Alternative[Option] with CommutativeMonad[Option]
+    with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[
+    Option
+  ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[
+      Option
+    ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8716,6 +8716,8 @@ object a:
           )
      )
 <<< #4705
+newlines.infix.typeSite.style = many
+===
 object Foo {
   def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
     ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8715,3 +8715,26 @@ object a:
             _.enteredAfter(explicitOuterPhase.asInstanceOf[DenotTransformer])
           )
      )
+<<< #4705
+object Foo {
+  def oldStyle: Traverse[Option] with MonadError[Option, Unit] with Alternative[Option] with CommutativeMonad[Option] with CoflatMap[Option] with Align[Option] =
+    ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}
+>>>
+object Foo {
+  def oldStyle: Traverse[Option]
+    with MonadError[Option, Unit]
+    with Alternative[Option]
+    with CommutativeMonad[Option]
+    with CoflatMap[Option]
+    with Align[Option] = ???
+
+  def newStyle: Traverse[Option] & MonadError[Option, Unit] &
+    Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
+    Align[Option] =
+    Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
+      CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1252915, "total explored")
+      assertEquals(explored, 1252783, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1245280, "total explored")
+      assertEquals(explored, 1252915, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Fixes #4705.