### PR TITLE
Update readme.md to add JDK compatibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,12 @@ Head over to [the user docs][docs] for instructions on how to install scalafmt.
   `browser-sync start --server --files "target/*.html"`.
   See [Browsersync](https://www.browsersync.io/).
 
+### JDK compatibility
+| JDK  | Release         |
+| ---- | ----------------|
+| 8    | Up to `v3.7.16` |
+| 11+  | _latest_        |
+
 ### Team
 The current maintainers (people who can merge pull requests) are:
 


### PR DESCRIPTION
Similar to https://github.com/scalameta/sbt-scalafmt/pull/341 (here the section is h3 title because there is not `installation` section).

The second badge (CI appveyor) is broken. It seems the project does not use this building service anymore.