### PR TITLE
Router: break before `=>` in new given

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -65,10 +65,12 @@ class FormatOps(
   final def getSlbEndOnLeft(start: FT)(implicit style: ScalafmtConfig): FT = {
     val nft = start.right match {
       case _: T.EOF => start
-      case _: T.Comma | _: T.Semicolon | _: T.RightArrow | _: T.Equals |
+      case _: T.Comma | _: T.Semicolon | _: T.Equals |
           _: T.Interpolation.Start | _: T.Interpolation.SpliceEnd |
           _: T.Interpolation.End | _: T.Interpolation.SpliceStart |
           _: T.Interpolation.Part => null
+      case _: T.RightArrow => // given breaks before `=>`
+        if (start.rightOwner.is[Member.ParamClauseGroup]) start else null
       case _ if start.hasBlankLine => start
       case _
           if AsInfixOp(start.rightOwner)

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -7967,29 +7967,43 @@ lazy val onlyImplicitOrTypeParams = paramss.forall(
 )
 <<< scala-3.6 given 1
 maxColumn = 40
+runner.parser = source
 ===
 given [A] =>
  Seq[A] = foo
+given [A]
+ => Seq[A] = foo
 >>>
 given [A] =>
   Seq[A] = foo
+given [A] => Seq[A] = foo
 <<< scala-3.6 given 2
 maxColumn = 40
+runner.parser = source
 ===
 given [A] => (Seq[A] =>
  List[A]) => List[A] = foo
+given [A] => (Seq[A]
+ => List[A]) => List[A] = foo
 >>>
+given [A] => (Seq[A] => List[A]) =>
+  List[A] = foo
 given [A] => (Seq[A] => List[A]) =>
   List[A] = foo
 <<< scala-3.6 given 3
 maxColumn = 40
+runner.parser = source
 ===
 given foo: (a: A) =>
  [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
+given foo: (a: A)
+ => [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
 >>>
 given foo: (a: A) =>
   [B, C <: AnyRef] => (b: B[A], C) =>
   List[A] = foo
+given foo: (a: A) => [B, C <: AnyRef] =>
+  (b: B[A], C) => List[A] = foo
 <<< don't rewrite complex infix to braces
 rewrite.redundantBraces.oneStatApply.bracesMinSpan = 1
 rewrite.rules = [RedundantBraces, RedundantParens]

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -7974,9 +7974,9 @@ given [A] =>
 given [A]
  => Seq[A] = foo
 >>>
-given [A] =>
-  Seq[A] = foo
 given [A] => Seq[A] = foo
+given [A]
+  => Seq[A] = foo
 <<< scala-3.6 given 2
 maxColumn = 40
 runner.parser = source
@@ -7986,10 +7986,10 @@ given [A] => (Seq[A] =>
 given [A] => (Seq[A]
  => List[A]) => List[A] = foo
 >>>
-given [A] => (Seq[A] => List[A]) =>
-  List[A] = foo
-given [A] => (Seq[A] => List[A]) =>
-  List[A] = foo
+given [A] => (Seq[A] => List[A])
+  => List[A] = foo
+given [A] => (Seq[A] => List[A])
+  => List[A] = foo
 <<< scala-3.6 given 3
 maxColumn = 40
 runner.parser = source
@@ -7999,11 +7999,11 @@ given foo: (a: A) =>
 given foo: (a: A)
  => [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
 >>>
-given foo: (a: A) =>
-  [B, C <: AnyRef] => (b: B[A], C) =>
-  List[A] = foo
-given foo: (a: A) => [B, C <: AnyRef] =>
-  (b: B[A], C) => List[A] = foo
+given foo: (a: A) => [B, C <: AnyRef]
+  => (b: B[A], C) => List[A] = foo
+given foo: (a: A)
+  => [B, C <: AnyRef] => (b: B[A], C)
+  => List[A] = foo
 <<< don't rewrite complex infix to braces
 rewrite.redundantBraces.oneStatApply.bracesMinSpan = 1
 rewrite.rules = [RedundantBraces, RedundantParens]

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7665,10 +7665,10 @@ given [A] => (Seq[A] =>
 given [A] => (Seq[A]
  => List[A]) => List[A] = foo
 >>>
-given [A] => (Seq[A] => List[A]) =>
-  List[A] = foo
-given [A] => (Seq[A] => List[A]) =>
-  List[A] = foo
+given [A] => (Seq[A] => List[A])
+  => List[A] = foo
+given [A] => (Seq[A] => List[A])
+  => List[A] = foo
 <<< scala-3.6 given 3
 maxColumn = 40
 runner.parser = source
@@ -7678,10 +7678,10 @@ given foo: (a: A) =>
 given foo: (a: A)
  => [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
 >>>
-given foo: (a: A) => [B, C <: AnyRef] =>
-  (b: B[A], C) => List[A] = foo
-given foo: (a: A) => [B, C <: AnyRef] =>
-  (b: B[A], C) => List[A] = foo
+given foo: (a: A) => [B, C <: AnyRef]
+  => (b: B[A], C) => List[A] = foo
+given foo: (a: A) => [B, C <: AnyRef]
+  => (b: B[A], C) => List[A] = foo
 <<< don't rewrite complex infix to braces
 rewrite.redundantBraces.oneStatApply.bracesMinSpan = 1
 rewrite.rules = [RedundantBraces, RedundantParens]

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7647,25 +7647,39 @@ lazy val onlyImplicitOrTypeParams = paramss.forall(_.exists { sym =>
 })
 <<< scala-3.6 given 1
 maxColumn = 40
+runner.parser = source
 ===
 given [A] =>
  Seq[A] = foo
+given [A]
+ => Seq[A] = foo
 >>>
+given [A] => Seq[A] = foo
 given [A] => Seq[A] = foo
 <<< scala-3.6 given 2
 maxColumn = 40
+runner.parser = source
 ===
 given [A] => (Seq[A] =>
  List[A]) => List[A] = foo
+given [A] => (Seq[A]
+ => List[A]) => List[A] = foo
 >>>
+given [A] => (Seq[A] => List[A]) =>
+  List[A] = foo
 given [A] => (Seq[A] => List[A]) =>
   List[A] = foo
 <<< scala-3.6 given 3
 maxColumn = 40
+runner.parser = source
 ===
 given foo: (a: A) =>
  [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
+given foo: (a: A)
+ => [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
 >>>
+given foo: (a: A) => [B, C <: AnyRef] =>
+  (b: B[A], C) => List[A] = foo
 given foo: (a: A) => [B, C <: AnyRef] =>
   (b: B[A], C) => List[A] = foo
 <<< don't rewrite complex infix to braces

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7990,29 +7990,43 @@ lazy val onlyImplicitOrTypeParams = paramss.forall(
 )
 <<< scala-3.6 given 1
 maxColumn = 40
+runner.parser = source
 ===
 given [A] =>
  Seq[A] = foo
+given [A]
+ => Seq[A] = foo
 >>>
 given [A] =>
   Seq[A] = foo
+given [A] => Seq[A] = foo
 <<< scala-3.6 given 2
 maxColumn = 40
+runner.parser = source
 ===
 given [A] => (Seq[A] =>
  List[A]) => List[A] = foo
+given [A] => (Seq[A]
+ => List[A]) => List[A] = foo
 >>>
+given [A] => (Seq[A] => List[A]) =>
+  List[A] = foo
 given [A] => (Seq[A] => List[A]) =>
   List[A] = foo
 <<< scala-3.6 given 3
 maxColumn = 40
+runner.parser = source
 ===
 given foo: (a: A) =>
  [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
+given foo: (a: A)
+ => [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
 >>>
 given foo: (a: A) =>
   [B, C <: AnyRef] => (b: B[A], C) =>
   List[A] = foo
+given foo: (a: A) => [B, C <: AnyRef] =>
+  (b: B[A], C) => List[A] = foo
 <<< don't rewrite complex infix to braces
 rewrite.redundantBraces.oneStatApply.bracesMinSpan = 1
 rewrite.rules = [RedundantBraces, RedundantParens]

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -7997,9 +7997,9 @@ given [A] =>
 given [A]
  => Seq[A] = foo
 >>>
-given [A] =>
-  Seq[A] = foo
 given [A] => Seq[A] = foo
+given [A]
+  => Seq[A] = foo
 <<< scala-3.6 given 2
 maxColumn = 40
 runner.parser = source
@@ -8009,10 +8009,10 @@ given [A] => (Seq[A] =>
 given [A] => (Seq[A]
  => List[A]) => List[A] = foo
 >>>
-given [A] => (Seq[A] => List[A]) =>
-  List[A] = foo
-given [A] => (Seq[A] => List[A]) =>
-  List[A] = foo
+given [A] => (Seq[A] => List[A])
+  => List[A] = foo
+given [A] => (Seq[A] => List[A])
+  => List[A] = foo
 <<< scala-3.6 given 3
 maxColumn = 40
 runner.parser = source
@@ -8022,11 +8022,11 @@ given foo: (a: A) =>
 given foo: (a: A)
  => [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
 >>>
-given foo: (a: A) =>
-  [B, C <: AnyRef] => (b: B[A], C) =>
-  List[A] = foo
-given foo: (a: A) => [B, C <: AnyRef] =>
-  (b: B[A], C) => List[A] = foo
+given foo: (a: A) => [B, C <: AnyRef]
+  => (b: B[A], C) => List[A] = foo
+given foo: (a: A)
+  => [B, C <: AnyRef] => (b: B[A], C)
+  => List[A] = foo
 <<< don't rewrite complex infix to braces
 rewrite.redundantBraces.oneStatApply.bracesMinSpan = 1
 rewrite.rules = [RedundantBraces, RedundantParens]

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8288,25 +8288,39 @@ lazy val onlyImplicitOrTypeParams = paramss.forall(
 )
 <<< scala-3.6 given 1
 maxColumn = 40
+runner.parser = source
 ===
 given [A] =>
  Seq[A] = foo
+given [A]
+ => Seq[A] = foo
 >>>
+given [A] => Seq[A] = foo
 given [A] => Seq[A] = foo
 <<< scala-3.6 given 2
 maxColumn = 40
+runner.parser = source
 ===
 given [A] => (Seq[A] =>
  List[A]) => List[A] = foo
+given [A] => (Seq[A]
+ => List[A]) => List[A] = foo
 >>>
+given [A] => (Seq[A] => List[A]) =>
+  List[A] = foo
 given [A] => (Seq[A] => List[A]) =>
   List[A] = foo
 <<< scala-3.6 given 3
 maxColumn = 40
+runner.parser = source
 ===
 given foo: (a: A) =>
  [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
+given foo: (a: A)
+ => [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
 >>>
+given foo: (a: A) => [B, C <: AnyRef] =>
+  (b: B[A], C) => List[A] = foo
 given foo: (a: A) => [B, C <: AnyRef] =>
   (b: B[A], C) => List[A] = foo
 <<< don't rewrite complex infix to braces

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8306,10 +8306,12 @@ given [A] => (Seq[A] =>
 given [A] => (Seq[A]
  => List[A]) => List[A] = foo
 >>>
-given [A] => (Seq[A] => List[A]) =>
-  List[A] = foo
-given [A] => (Seq[A] => List[A]) =>
-  List[A] = foo
+given [A]
+  => (Seq[A] => List[A])
+  => List[A] = foo
+given [A]
+  => (Seq[A] => List[A])
+  => List[A] = foo
 <<< scala-3.6 given 3
 maxColumn = 40
 runner.parser = source
@@ -8319,10 +8321,14 @@ given foo: (a: A) =>
 given foo: (a: A)
  => [B, C <: AnyRef] => (b: B[A], C) => List[A] = foo
 >>>
-given foo: (a: A) => [B, C <: AnyRef] =>
-  (b: B[A], C) => List[A] = foo
-given foo: (a: A) => [B, C <: AnyRef] =>
-  (b: B[A], C) => List[A] = foo
+given foo: (a: A)
+  => [B, C <: AnyRef]
+  => (b: B[A], C)
+  => List[A] = foo
+given foo: (a: A)
+  => [B, C <: AnyRef]
+  => (b: B[A], C)
+  => List[A] = foo
 <<< don't rewrite complex infix to braces
 rewrite.redundantBraces.oneStatApply.bracesMinSpan = 1
 rewrite.rules = [RedundantBraces, RedundantParens]

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1253729, "total explored")
+      assertEquals(explored, 1253916, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1252841, "total explored")
+      assertEquals(explored, 1253729, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Apparently, break after forces an indented region and fails to compile. Fixes scalacenter/scalafix#2174.