### PR TITLE
ScalafmtConfig: rename continuationIndent->indent

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -85,9 +85,6 @@ import metaconfig._
 @annotation.SectionRename("trailingCommas", "rewrite.trailingCommas.style") // v3.0.5
 @annotation.SectionRename("poorMansTrailingCommasInConfigStyle", "newlines.configStyle.beforeComma") // v3.8.4
 @annotation.SectionRename("optIn.forceBlankLineBeforeDocstring", "docstrings.forceBlankLineBefore") // v3.4.0
-@annotation.SectionRename("indentOperator", "indent.infix") // v3.8.4
-@annotation.SectionRename("verticalAlignMultilineOperators", "indent.infix", IndentOperator.boolToAssign) // v3.8.4
-@annotation.SectionRename("indentYieldKeyword", "indent.yieldKeyword") // v3.8.4
 @annotation.SectionRename("rewriteTokens", "rewrite.tokens") // v3.8.4
 @annotation.SectionRename("importSelectors", "binPack.importSelectors") // v3.8.4
 @annotation.SectionRename("binPackImportSelectors", "binPack.importSelectors") // v3.8.4
@@ -100,6 +97,11 @@ import metaconfig._
 // annotations
 @annotation.SectionRename("optIn.annotationNewlines", "newlines.annotation") // v3.8.4
 @annotation.SectionRename("optIn.selfAnnotationNewline", "newlines.selfAnnotation") // v3.8.4
+// indent
+@annotation.SectionRename("continuationIndent", "indent") // v3.8.5
+@annotation.SectionRename("indentOperator", "indent.infix") // v3.8.4
+@annotation.SectionRename("verticalAlignMultilineOperators", "indent.infix", IndentOperator.boolToAssign) // v3.8.4
+@annotation.SectionRename("indentYieldKeyword", "indent.yieldKeyword") // v3.8.4
 // scalafmt: { maxColumn = 80 }
 case class ScalafmtConfig(
     version: String = org.scalafmt.Versions.stable,
@@ -107,7 +109,6 @@ case class ScalafmtConfig(
     docstrings: Docstrings = Docstrings(),
     comments: Comments = Comments(),
     binPack: BinPack = BinPack(),
-    @annotation.ExtraName("continuationIndent")
     indent: Indents = Indents(),
     align: Align = Align(),
     spaces: Spaces = Spaces(),

--- a/scalafmt-tests/shared/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/shared/src/test/resources/test/IndentOperator.stat
@@ -4082,6 +4082,6 @@ final case class Appends(
 ) extends Batch_4_1_0
 >>>
 final case class Appends(
-    offset: Offset,
-    records: NonEmptyList[ActionRecord[Action.Append]]
+  offset: Offset,
+  records: NonEmptyList[ActionRecord[Action.Append]]
 ) extends Batch_4_1_0

--- a/scalafmt-tests/shared/src/test/resources/test/IndentOperator.stat
+++ b/scalafmt-tests/shared/src/test/resources/test/IndentOperator.stat
@@ -4068,3 +4068,20 @@ object A {
 
   /* Some comment */
 }
+<<< #4717 interplay between indentOperator and continuationIndent
+maxColumn = 80
+indentOperator.topLevelOnly = true
+continuationIndent {
+  callSite = 2
+  defnSite = 2
+}
+===
+final case class Appends(
+    offset: Offset,
+    records: NonEmptyList[ActionRecord[Action.Append]],
+) extends Batch_4_1_0
+>>>
+final case class Appends(
+    offset: Offset,
+    records: NonEmptyList[ActionRecord[Action.Append]]
+) extends Batch_4_1_0

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1252791, "total explored")
+      assertEquals(explored, 1252841, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Don't use ExtraName as that will not take effect if other sections are moved to within `indent`. Fixes #4717.
