### PR TITLE
Format strings and interpolated strings consistently

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -75,10 +75,11 @@ object PolicyOps {
     override def terminal: Boolean = true
     override val prefix: String = "SLB"
     private val checkSyntax = noSyntaxNL || !style.newlines.ignoreInSyntax
+    def failsLeftSyntaxNL(ft: FT): Boolean = checkSyntax && ft.leftHasNewline
     override val f: Policy.Pf = {
       case Decision(ft, s)
           if !(ft.right.is[T.EOF] || okSLC && isLeftCommentThenBreak(ft)) =>
-        if (checkSyntax && ft.leftHasNewline) Seq.empty else s.filterNot(_.isNL)
+        if (failsLeftSyntaxNL(ft)) Seq.empty else s.filterNot(_.isNL)
     }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -21,10 +21,10 @@ object PolicyOps {
     override val noDequeue: Boolean = false
     override def terminal: Boolean = false
     private val checkSyntax = noSyntaxNL || !style.newlines.ignoreInSyntax
+    def failsSyntaxNL(ft: FT): Boolean = checkSyntax && ft.rightHasNewline
     override val f: Policy.Pf = {
       case Decision(ft, s) if penalizeLambdas || !ft.left.is[T.RightArrow] =>
-        if (checkSyntax && ft.leftHasNewline) s.penalize(penalty)
-        else s.penalizeNL(penalty)
+        if (failsSyntaxNL(ft)) s.penalize(penalty) else s.penalizeNL(penalty)
     }
     override def prefix: String = s"PNL+$penalty"
   }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -11763,3 +11763,227 @@ object Foo {
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
 }
+<<< consistency between string and interpolation: stripMargin, ignoreInSyntax
+maxColumn = 40
+align.stripMargin = true
+newlines.ignoreInSyntax = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+                 |baz
+                 |qux""".stripMargin
+  val foo2i = s"""|bar
+                  |baz
+                  |qux""".stripMargin
+  val foo3si =
+    """|bar
+       |baz
+       |qux""".stripMargin + s"""|bar
+                                |baz
+                                |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+        |baz
+        |qux""".stripMargin + """|bar
+                                |baz
+                                |qux""".stripMargin
+}
+<<< consistency between string and interpolation: stripMargin, !ignoreInSyntax
+maxColumn = 40
+align.stripMargin = true
+newlines.ignoreInSyntax = false
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+                 |baz
+                 |qux""".stripMargin
+  val foo2i = s"""|bar
+                  |baz
+                  |qux""".stripMargin
+  val foo3si =
+    """|bar
+       |baz
+       |qux""".stripMargin + s"""|bar
+                                |baz
+                                |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+        |baz
+        |qux""".stripMargin + """|bar
+                                |baz
+                                |qux""".stripMargin
+}
+<<< consistency between string and interpolation: !stripMargin, ignoreInSyntax
+maxColumn = 40
+align.stripMargin = false
+newlines.ignoreInSyntax = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+    |baz
+    |qux""".stripMargin
+  val foo2i = s"""|bar
+    |baz
+    |qux""".stripMargin
+  val foo3si = """|bar
+    |baz
+    |qux""".stripMargin + s"""|bar
+    |baz
+    |qux""".stripMargin
+  val foo3is = s"""|bar
+    |baz
+    |qux""".stripMargin + """|bar
+    |baz
+    |qux""".stripMargin
+}
+<<< consistency between string and interpolation: !stripMargin, !ignoreInSyntax
+maxColumn = 40
+align.stripMargin = false
+newlines.ignoreInSyntax = false
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+    |baz
+    |qux""".stripMargin
+  val foo2i = s"""|bar
+    |baz
+    |qux""".stripMargin
+  val foo3si = """|bar
+    |baz
+    |qux""".stripMargin + s"""|bar
+    |baz
+    |qux""".stripMargin
+  val foo3is = s"""|bar
+    |baz
+    |qux""".stripMargin + """|bar
+    |baz
+    |qux""".stripMargin
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -11079,8 +11079,7 @@ object a {
    qux"""
   val foo2s = """|bar
                  |baz
-                 |qux"""
-    .stripMargin
+                 |qux""".stripMargin
   val foo2i =
     s"""|bar
         |baz
@@ -11088,8 +11087,7 @@ object a {
   val foo3si =
     """|bar
        |baz
-       |qux"""
-      .stripMargin +
+       |qux""".stripMargin +
       s"""|bar
           |baz
           |qux""".stripMargin
@@ -11099,8 +11097,7 @@ object a {
         |qux""".stripMargin +
       """|bar
          |baz
-         |qux"""
-        .stripMargin
+         |qux""".stripMargin
 }
 <<< consistency between string and interpolation: !stripMargin, ignoreInSyntax
 maxColumn = 40
@@ -11200,8 +11197,7 @@ object a {
    qux"""
   val foo2s = """|bar
     |baz
-    |qux"""
-    .stripMargin
+    |qux""".stripMargin
   val foo2i =
     s"""|bar
       |baz
@@ -11209,8 +11205,7 @@ object a {
   val foo3si =
     """|bar
       |baz
-      |qux"""
-      .stripMargin +
+      |qux""".stripMargin +
       s"""|bar
         |baz
         |qux""".stripMargin
@@ -11220,6 +11215,5 @@ object a {
       |qux""".stripMargin +
       """|bar
         |baz
-        |qux"""
-        .stripMargin
+        |qux""".stripMargin
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10979,3 +10979,247 @@ object Foo {
     Option
   ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
 }
+<<< consistency between string and interpolation: stripMargin, ignoreInSyntax
+maxColumn = 40
+align.stripMargin = true
+newlines.ignoreInSyntax = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+                 |baz
+                 |qux""".stripMargin
+  val foo2i = s"""|bar
+                  |baz
+                  |qux""".stripMargin
+  val foo3si =
+    """|bar
+       |baz
+       |qux""".stripMargin +
+      s"""|bar
+          |baz
+          |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+        |baz
+        |qux""".stripMargin +
+      """|bar
+         |baz
+         |qux""".stripMargin
+}
+<<< consistency between string and interpolation: stripMargin, !ignoreInSyntax
+maxColumn = 40
+align.stripMargin = true
+newlines.ignoreInSyntax = false
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i =
+    s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+                 |baz
+                 |qux"""
+    .stripMargin
+  val foo2i =
+    s"""|bar
+        |baz
+        |qux""".stripMargin
+  val foo3si =
+    """|bar
+       |baz
+       |qux"""
+      .stripMargin +
+      s"""|bar
+          |baz
+          |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+        |baz
+        |qux""".stripMargin +
+      """|bar
+         |baz
+         |qux"""
+        .stripMargin
+}
+<<< consistency between string and interpolation: !stripMargin, ignoreInSyntax
+maxColumn = 40
+align.stripMargin = false
+newlines.ignoreInSyntax = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+    |baz
+    |qux""".stripMargin
+  val foo2i = s"""|bar
+    |baz
+    |qux""".stripMargin
+  val foo3si =
+    """|bar
+      |baz
+      |qux""".stripMargin + s"""|bar
+      |baz
+      |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+      |baz
+      |qux""".stripMargin + """|bar
+      |baz
+      |qux""".stripMargin
+}
+<<< consistency between string and interpolation: !stripMargin, !ignoreInSyntax
+maxColumn = 40
+align.stripMargin = false
+newlines.ignoreInSyntax = false
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i =
+    s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+    |baz
+    |qux"""
+    .stripMargin
+  val foo2i =
+    s"""|bar
+      |baz
+      |qux""".stripMargin
+  val foo3si =
+    """|bar
+      |baz
+      |qux"""
+      .stripMargin +
+      s"""|bar
+        |baz
+        |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+      |baz
+      |qux""".stripMargin +
+      """|bar
+        |baz
+        |qux"""
+        .stripMargin
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -11070,16 +11070,18 @@ object a {
 }
 >>>
 object a {
-  val foo1s = """bar
+  val foo1s =
+    """bar
    baz
    qux"""
   val foo1i =
     s"""bar
    baz
    qux"""
-  val foo2s = """|bar
-                 |baz
-                 |qux""".stripMargin
+  val foo2s =
+    """|bar
+       |baz
+       |qux""".stripMargin
   val foo2i =
     s"""|bar
         |baz
@@ -11188,16 +11190,18 @@ object a {
 }
 >>>
 object a {
-  val foo1s = """bar
+  val foo1s =
+    """bar
    baz
    qux"""
   val foo1i =
     s"""bar
    baz
    qux"""
-  val foo2s = """|bar
-    |baz
-    |qux""".stripMargin
+  val foo2s =
+    """|bar
+      |baz
+      |qux""".stripMargin
   val foo2i =
     s"""|bar
       |baz

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11522,3 +11522,237 @@ object Foo {
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
 }
+<<< consistency between string and interpolation: stripMargin, ignoreInSyntax
+maxColumn = 40
+align.stripMargin = true
+newlines.ignoreInSyntax = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+                 |baz
+                 |qux""".stripMargin
+  val foo2i = s"""|bar
+                  |baz
+                  |qux""".stripMargin
+  val foo3si =
+    """|bar
+       |baz
+       |qux""".stripMargin + s"""|bar
+                                |baz
+                                |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+        |baz
+        |qux""".stripMargin + """|bar
+                                |baz
+                                |qux""".stripMargin
+}
+<<< consistency between string and interpolation: stripMargin, !ignoreInSyntax
+maxColumn = 40
+align.stripMargin = true
+newlines.ignoreInSyntax = false
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i =
+    s"""bar
+   baz
+   qux"""
+  val foo2s =
+    """|bar
+       |baz
+       |qux""".stripMargin
+  val foo2i =
+    s"""|bar
+        |baz
+        |qux""".stripMargin
+  val foo3si =
+    """|bar
+       |baz
+       |qux""".stripMargin + s"""|bar
+                                |baz
+                                |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+        |baz
+        |qux""".stripMargin + """|bar
+                                |baz
+                                |qux""".stripMargin
+}
+<<< consistency between string and interpolation: !stripMargin, ignoreInSyntax
+maxColumn = 40
+align.stripMargin = false
+newlines.ignoreInSyntax = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+    |baz
+    |qux""".stripMargin
+  val foo2i = s"""|bar
+    |baz
+    |qux""".stripMargin
+  val foo3si =
+    """|bar
+      |baz
+      |qux""".stripMargin + s"""|bar
+      |baz
+      |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+      |baz
+      |qux""".stripMargin + """|bar
+      |baz
+      |qux""".stripMargin
+}
+<<< consistency between string and interpolation: !stripMargin, !ignoreInSyntax
+maxColumn = 40
+align.stripMargin = false
+newlines.ignoreInSyntax = false
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i =
+    s"""bar
+   baz
+   qux"""
+  val foo2s =
+    """|bar
+      |baz
+      |qux""".stripMargin
+  val foo2i =
+    s"""|bar
+      |baz
+      |qux""".stripMargin
+  val foo3si =
+    """|bar
+      |baz
+      |qux""".stripMargin + s"""|bar
+      |baz
+      |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+      |baz
+      |qux""".stripMargin + """|bar
+      |baz
+      |qux""".stripMargin
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11611,7 +11611,8 @@ object a {
 }
 >>>
 object a {
-  val foo1s = """bar
+  val foo1s =
+    """bar
    baz
    qux"""
   val foo1i =
@@ -11728,7 +11729,8 @@ object a {
 }
 >>>
 object a {
-  val foo1s = """bar
+  val foo1s =
+    """bar
    baz
    qux"""
   val foo1i =

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -11959,3 +11959,249 @@ object Foo {
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
 }
+<<< consistency between string and interpolation: stripMargin, ignoreInSyntax
+maxColumn = 40
+align.stripMargin = true
+newlines.ignoreInSyntax = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i =
+    s"""bar
+   baz
+   qux"""
+  val foo2s =
+    """|bar
+       |baz
+       |qux""".stripMargin
+  val foo2i =
+    s"""|bar
+        |baz
+        |qux""".stripMargin
+  val foo3si =
+    """|bar
+       |baz
+       |qux""".stripMargin +
+      s"""|bar
+          |baz
+          |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+        |baz
+        |qux""".stripMargin +
+      """|bar
+         |baz
+         |qux""".stripMargin
+}
+<<< consistency between string and interpolation: stripMargin, !ignoreInSyntax
+maxColumn = 40
+align.stripMargin = true
+newlines.ignoreInSyntax = false
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i =
+    s"""bar
+   baz
+   qux"""
+  val foo2s =
+    """|bar
+       |baz
+       |qux""".stripMargin
+  val foo2i =
+    s"""|bar
+        |baz
+        |qux""".stripMargin
+  val foo3si =
+    """|bar
+       |baz
+       |qux""".stripMargin +
+      s"""|bar
+          |baz
+          |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+        |baz
+        |qux""".stripMargin +
+      """|bar
+         |baz
+         |qux""".stripMargin
+}
+<<< consistency between string and interpolation: !stripMargin, ignoreInSyntax
+maxColumn = 40
+align.stripMargin = false
+newlines.ignoreInSyntax = true
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i =
+    s"""bar
+   baz
+   qux"""
+  val foo2s =
+    """|bar
+      |baz
+      |qux""".stripMargin
+  val foo2i =
+    s"""|bar
+      |baz
+      |qux""".stripMargin
+  val foo3si =
+    """|bar
+      |baz
+      |qux""".stripMargin + s"""|bar
+      |baz
+      |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+      |baz
+      |qux""".stripMargin + """|bar
+      |baz
+      |qux""".stripMargin
+}
+<<< consistency between string and interpolation: !stripMargin, !ignoreInSyntax
+maxColumn = 40
+align.stripMargin = false
+newlines.ignoreInSyntax = false
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i = s"""bar
+   baz
+   qux"""
+  val foo2s = """|bar
+   |baz
+   |qux""".stripMargin
+  val foo2i = s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3si = """|bar
+   |baz
+   |qux""".stripMargin + s"""|bar
+   |baz
+   |qux""".stripMargin
+  val foo3is = s"""|bar
+   |baz
+   |qux""".stripMargin + """|bar
+   |baz
+   |qux""".stripMargin
+}
+>>>
+object a {
+  val foo1s = """bar
+   baz
+   qux"""
+  val foo1i =
+    s"""bar
+   baz
+   qux"""
+  val foo2s =
+    """|bar
+      |baz
+      |qux""".stripMargin
+  val foo2i =
+    s"""|bar
+      |baz
+      |qux""".stripMargin
+  val foo3si =
+    """|bar
+      |baz
+      |qux""".stripMargin +
+      s"""|bar
+        |baz
+        |qux""".stripMargin
+  val foo3is =
+    s"""|bar
+      |baz
+      |qux""".stripMargin +
+      """|bar
+        |baz
+        |qux""".stripMargin
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1253916, "total explored")
+      assertEquals(explored, 1256178, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1256178, "total explored")
+      assertEquals(explored, 1256164, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
- Router: check noSyntaxNL at the end of RHS
- PolicyOps: check NL in syntax on the right
