### PR TITLE
Router: handle braces around context bounds

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4716,6 +4716,50 @@ def method[A: Bound: Bound2]: B
 def method[A <: Bound: Bound2]: B
 ```
 
+### `spaces.withinContextBoundBraces`
+
+This parameter controls if a space should be used within braces which surround
+type context bounds and takes the same values as
+[`beforeContextBoundColon`](#spacesbeforecontextboundcolon) above.
+
+```scala mdoc:defaults
+spaces.withinContextBoundBraces
+```
+
+```scala mdoc:scalafmt
+runner.dialect = scala3
+spaces.withinContextBoundBraces=Never
+---
+def method[A: {Bound}]: B
+def method[A: {Bound, Bound2}]: B
+```
+
+```scala mdoc:scalafmt
+runner.dialect = scala3
+spaces.withinContextBoundBraces=Always
+---
+def method[A: {Bound}]: B
+def method[A: {Bound, Bound2}]: B
+```
+
+```scala mdoc:scalafmt
+runner.dialect = scala3
+spaces.withinContextBoundBraces=IfMultipleBounds
+---
+def method[A: {Bound}]: B
+def method[A <: Bound : {Bound2}]: B
+def method[A: {Bound, Bound2}]: B
+```
+
+```scala mdoc:scalafmt
+runner.dialect = scala3
+spaces.withinContextBoundBraces=IfMultipleContextBounds
+---
+def method[A: {Bound}]: B
+def method[A <: Bound : {Bound2}]: B
+def method[A: {Bound, Bound2}]: B
+```
+
 ### `spaces.inImportCurlyBraces`
 
 ```scala mdoc:defaults

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Spaces.scala
@@ -50,6 +50,8 @@ import metaconfig._
 case class Spaces(
     beforeContextBoundColon: Spaces.BeforeContextBound =
       Spaces.BeforeContextBound.Never,
+    withinContextBoundBraces: Spaces.BeforeContextBound =
+      Spaces.BeforeContextBound.Never,
     beforeApplyArgInParens: Spaces.BeforeArgInParens =
       Spaces.BeforeArgInParens.Never,
     beforeInfixArgInParens: Spaces.BeforeArgInParens =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -249,6 +249,14 @@ class Router(formatOps: FormatOps) {
         val close = matchingLeft(ft)
         Seq(Split(NoSplit, 0).withIndent(style.indent.main, close, Before))
 
+      // context bounds
+      case FT(_: T.LeftBrace, _, FT.LeftOwner(tb: Type.Bounds)) =>
+        val close = matchingLeft(ft)
+        val mod = Space(style.spaces.withinContextBoundBraces(tb))
+        Seq(Split(mod, 0).withIndent(style.indent.main, close, Before))
+      case FT(_, _: T.RightBrace, FT.RightOwner(tb: Type.Bounds)) =>
+        Seq(Split(Space(style.spaces.withinContextBoundBraces(tb)), 0))
+
       case FT(_: T.LeftBrace, right, _) =>
         val close = matchingLeft(ft)
         val isSelfAnnotationNL = style.newlines.selfAnnotation &&

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8409,3 +8409,93 @@ object Foo {
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
 }
+<<< grouped context bounds: before = always, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = always, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = always, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8447,8 +8447,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A : { Foo }] => A = ???
-given [B : { Bar, Baz }] => B = ???
+given [A : {Foo}] => A = ???
+given [B : {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = never, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = never
@@ -8457,8 +8457,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
-given [B: { Bar, Baz }] => B = ???
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = IfMultipleContextBounds
@@ -8467,8 +8467,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
-given [B : { Bar, Baz }] => B = ???
+given [A: {Foo}] => A = ???
+given [B : {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = always, within = IfMultipleContextBounds
 runner.parser = source
 spaces.beforeContextBoundColon = always
@@ -8477,7 +8477,7 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A : { Foo }] => A = ???
+given [A : {Foo}] => A = ???
 given [B : { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = never, within = IfMultipleContextBounds
 runner.parser = source
@@ -8487,7 +8487,7 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
+given [A: {Foo}] => A = ???
 given [B: { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = IfMultipleContextBounds
 runner.parser = source
@@ -8497,5 +8497,5 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
+given [A: {Foo}] => A = ???
 given [B : { Bar, Baz }] => B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8110,8 +8110,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A : { Foo }] => A = ???
-given [B : { Bar, Baz }] => B = ???
+given [A : {Foo}] => A = ???
+given [B : {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = never, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = never
@@ -8120,8 +8120,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
-given [B: { Bar, Baz }] => B = ???
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = IfMultipleContextBounds
@@ -8130,8 +8130,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
-given [B : { Bar, Baz }] => B = ???
+given [A: {Foo}] => A = ???
+given [B : {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = always, within = IfMultipleContextBounds
 runner.parser = source
 spaces.beforeContextBoundColon = always
@@ -8140,7 +8140,7 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A : { Foo }] => A = ???
+given [A : {Foo}] => A = ???
 given [B : { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = never, within = IfMultipleContextBounds
 runner.parser = source
@@ -8150,7 +8150,7 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
+given [A: {Foo}] => A = ???
 given [B: { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = IfMultipleContextBounds
 runner.parser = source
@@ -8160,5 +8160,5 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
+given [A: {Foo}] => A = ???
 given [B : { Bar, Baz }] => B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8072,3 +8072,93 @@ object Foo {
     Alternative[Option] & CommutativeMonad[Option] & CoflatMap[Option] &
     Align[Option]
 }
+<<< grouped context bounds: before = always, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = always, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = always, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8467,8 +8467,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A : { Foo }] => A = ???
-given [B : { Bar, Baz }] => B = ???
+given [A : {Foo}] => A = ???
+given [B : {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = never, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = never
@@ -8477,8 +8477,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
-given [B: { Bar, Baz }] => B = ???
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = IfMultipleContextBounds
@@ -8487,8 +8487,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
-given [B : { Bar, Baz }] => B = ???
+given [A: {Foo}] => A = ???
+given [B : {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = always, within = IfMultipleContextBounds
 runner.parser = source
 spaces.beforeContextBoundColon = always
@@ -8497,7 +8497,7 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A : { Foo }] => A = ???
+given [A : {Foo}] => A = ???
 given [B : { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = never, within = IfMultipleContextBounds
 runner.parser = source
@@ -8507,7 +8507,7 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
+given [A: {Foo}] => A = ???
 given [B: { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = IfMultipleContextBounds
 runner.parser = source
@@ -8517,5 +8517,5 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [A: { Foo }] => A = ???
+given [A: {Foo}] => A = ???
 given [B : { Bar, Baz }] => B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8429,3 +8429,93 @@ object Foo {
       Option
     ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
 }
+<<< grouped context bounds: before = always, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = always, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = always, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = never, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8760,3 +8760,183 @@ object Foo {
     Traverse[Option] & MonadError[Option, Unit] & Alternative[Option] &
       CommutativeMonad[Option] & CoflatMap[Option] & Align[Option]
 }
+<<< grouped context bounds: before = always, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A : {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B : {
+      Bar, Baz
+    }
+]
+  => B = ???
+<<< grouped context bounds: before = never, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A: {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B: {
+      Bar, Baz
+    }
+]
+  => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = always
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = always
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A: {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B : {
+      Bar, Baz
+    }
+]
+  => B = ???
+<<< grouped context bounds: before = always, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A : {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B : {
+      Bar, Baz
+    }
+]
+  => B = ???
+<<< grouped context bounds: before = never, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A: {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B: {
+      Bar, Baz
+    }
+]
+  => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = never
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = never
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A: {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B : {
+      Bar, Baz
+    }
+]
+  => B = ???
+<<< grouped context bounds: before = always, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = always
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A : {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B : {
+      Bar, Baz
+    }
+]
+  => B = ???
+<<< grouped context bounds: before = never, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = never
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A: {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B: {
+      Bar, Baz
+    }
+]
+  => B = ???
+<<< grouped context bounds: before = IfMultipleContextBounds, within = IfMultipleContextBounds
+runner.parser = source
+spaces.beforeContextBoundColon = IfMultipleContextBounds
+spaces.withinContextBoundBraces = IfMultipleContextBounds
+===
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
+>>>
+given [
+    A: {
+      Foo
+    }
+]
+  => A = ???
+given [
+    B : {
+      Bar, Baz
+    }
+]
+  => B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8768,18 +8768,8 @@ spaces.withinContextBoundBraces = always
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A : {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B : {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A : { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = never, within = always
 runner.parser = source
 spaces.beforeContextBoundColon = never
@@ -8788,18 +8778,8 @@ spaces.withinContextBoundBraces = always
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A: {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B: {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A: { Foo }] => A = ???
+given [B: { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = always
 runner.parser = source
 spaces.beforeContextBoundColon = IfMultipleContextBounds
@@ -8808,18 +8788,8 @@ spaces.withinContextBoundBraces = always
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A: {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B : {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A: { Foo }] => A = ???
+given [B : { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = always, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = always
@@ -8828,18 +8798,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A : {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B : {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A : {Foo}] => A = ???
+given [B : {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = never, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = never
@@ -8848,18 +8808,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A: {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B: {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A: {Foo}] => A = ???
+given [B: {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = never
 runner.parser = source
 spaces.beforeContextBoundColon = IfMultipleContextBounds
@@ -8868,18 +8818,8 @@ spaces.withinContextBoundBraces = never
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A: {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B : {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A: {Foo}] => A = ???
+given [B : {Bar, Baz}] => B = ???
 <<< grouped context bounds: before = always, within = IfMultipleContextBounds
 runner.parser = source
 spaces.beforeContextBoundColon = always
@@ -8888,18 +8828,8 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A : {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B : {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A : {Foo}] => A = ???
+given [B : { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = never, within = IfMultipleContextBounds
 runner.parser = source
 spaces.beforeContextBoundColon = never
@@ -8908,18 +8838,8 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A: {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B: {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A: {Foo}] => A = ???
+given [B: { Bar, Baz }] => B = ???
 <<< grouped context bounds: before = IfMultipleContextBounds, within = IfMultipleContextBounds
 runner.parser = source
 spaces.beforeContextBoundColon = IfMultipleContextBounds
@@ -8928,15 +8848,5 @@ spaces.withinContextBoundBraces = IfMultipleContextBounds
 given [A: {Foo}] => A = ???
 given [B: {Bar, Baz}] => B = ???
 >>>
-given [
-    A: {
-      Foo
-    }
-]
-  => A = ???
-given [
-    B : {
-      Bar, Baz
-    }
-]
-  => B = ???
+given [A: {Foo}] => A = ???
+given [B : { Bar, Baz }] => B = ???

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1256300, "total explored")
+      assertEquals(explored, 1258820, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -144,7 +144,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 1258820, "total explored")
+      assertEquals(explored, 1258568, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
Previously, they were treated as a regular block instead.