### PR TITLE
ParConverts: remove as unused

### DIFF
--- a/scalafmt-sysops/jvm/src/main/scala-2.12/org/scalafmt/CompatCollections.scala
+++ b/scalafmt-sysops/jvm/src/main/scala-2.12/org/scalafmt/CompatCollections.scala
@@ -2,9 +2,4 @@ package org.scalafmt
 
 private[scalafmt] object CompatCollections {
   val JavaConverters = scala.collection.JavaConverters
-  object ParConverters {
-    implicit class XtensionIterable[T](val col: Iterable[T]) extends AnyVal {
-      def compatPar = col.par
-    }
-  }
 }

--- a/scalafmt-sysops/jvm/src/main/scala-2.13/org/scalafmt/CompatCollections.scala
+++ b/scalafmt-sysops/jvm/src/main/scala-2.13/org/scalafmt/CompatCollections.scala
@@ -1,12 +1,5 @@
 package org.scalafmt
 
-import scala.collection.parallel.CollectionConverters._
-
 private[scalafmt] object CompatCollections {
   val JavaConverters = scala.jdk.CollectionConverters
-  object ParConverters {
-    implicit class XtensionIterable[T](val col: Iterable[T]) extends AnyVal {
-      def compatPar = col.par
-    }
-  }
 }

--- a/scalafmt-sysops/native/src/main/scala-2.12/org/scalafmt/CompatCollections.scala
+++ b/scalafmt-sysops/native/src/main/scala-2.12/org/scalafmt/CompatCollections.scala
@@ -2,10 +2,4 @@ package org.scalafmt
 
 object CompatCollections {
   val JavaConverters = scala.collection.JavaConverters
-
-  object ParConverters {
-    implicit class XtensionIterable[T](val col: Iterable[T]) extends AnyVal {
-      def compatPar = col.par
-    }
-  }
 }

--- a/scalafmt-sysops/native/src/main/scala-2.13/org/scalafmt/CompatCollections.scala
+++ b/scalafmt-sysops/native/src/main/scala-2.13/org/scalafmt/CompatCollections.scala
@@ -2,13 +2,4 @@ package org.scalafmt
 
 object CompatCollections {
   val JavaConverters = scala.jdk.CollectionConverters
-
-  // Parallel collections are not released yet for Scala Native:
-  // https://github.com/scala/scala-parallel-collections/issues/262
-  // Once that releases, this should be able to be removed
-  object ParConverters {
-    implicit class XtensionIterable[T](val col: Iterable[T]) extends AnyVal {
-      def compatPar = col
-    }
-  }
 }

--- a/scalafmt-tests/jvm/src/test/scala/org/scalafmt/ScalafmtProps.scala
+++ b/scalafmt-tests/jvm/src/test/scala/org/scalafmt/ScalafmtProps.scala
@@ -1,6 +1,5 @@
 package org.scalafmt
 
-import org.scalafmt.CompatCollections.ParConverters._
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.sysops.AbsoluteFile
 import org.scalafmt.util.FormatAssertions
@@ -10,6 +9,7 @@ import scala.meta._
 import scala.meta.testkit._
 
 import scala.collection.mutable
+import scala.collection.parallel.CollectionConverters._
 
 import munit.FailException
 import munit.FunSuite
@@ -23,7 +23,7 @@ class ScalafmtProps extends FunSuite with FormatAssertions {
     val corpus = Corpus.files(
       // TODO(olafur) remove once testkit 1.7 is out
       Corpus.fastparse.copy(Corpus.fastparse.url.replace("olafurpg", "scalameta")),
-    ).take(count).toBuffer.compatPar
+    ).take(count).toBuffer.par
     SyntaxAnalysis.run[Observation[Bug]](corpus) { file =>
       val code = file.read
       try Scalafmt.format(code, config) match {


### PR DESCRIPTION
In the only remaining JVM test, use `.par` explicitly.