### PR TITLE
CI: enable `dockerize` on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,9 +181,9 @@ jobs:
           asset_name: ${{ matrix.deploy.name }}
           asset_content_type: application/zip
   dockerize:
-    needs: [scala-native,test]
+    needs: [scala-native]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && github.event_name != 'release'
+    if: github.event_name == 'release'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -192,8 +192,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: scalameta/scalafmt
-          tags: type=semver,pattern={{raw}}
-      - name: Downloading scalafmt-linux-musl for Docker Build
+          tags: type=raw,value=${{ github.event.release.tag_name }}
+      - name: Downloading scalafmt for Docker Build
         uses: actions/download-artifact@v4
         with:
           name: scalafmt-x86_64-pc-linux


### PR DESCRIPTION
dockerize used to run on tag push but we have disabled this trigger; also, since it downloads an artifact, we simply need to run it after the artifact is uploaded, i.e. on release.

Hopefully, the change to "metadata-action" to extract tags works exactly as chatgpt promised.

Possibly fixes #4761.