### PR TITLE
RedundantBraces: fix removing blocks

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -661,8 +661,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       // can allow if: no ".foo", no "with B", or has braces
       !b.parent.is[Term.Select] || t.templ.inits.lengthCompare(1) <= 0 ||
       t.templ.body.stats.nonEmpty || t.tokens.last.is[T.RightBrace]
-    case _: Term => true
-    case _ => false
+    case _ => isTreeSingleExpr(s)
   }
 
   private def okToRemoveBlockWithinApply(b: Term.Block)(implicit

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
@@ -768,16 +768,10 @@ object a {
   }
 }
 >>>
-test does not parse: [dialect scala213] illegal start of simple expression
 object a {
-  def foo =
+  def foo = {
     val len = firstColumn + syntax.length; (len, len)
-    ^
-}
-====== full result: ======
-object a {
-  def foo =
-    val len = firstColumn + syntax.length; (len, len)
+  }
 }
 <<< def body as nested block 2
 object a {
@@ -786,16 +780,10 @@ object a {
   }
 }
 >>>
-test does not parse: [dialect scala213] illegal start of simple expression
 object a {
-  def foo =
+  def foo = {
     val len = firstColumn + syntax.length; (len, len)
-    ^
-}
-====== full result: ======
-object a {
-  def foo =
-    val len = firstColumn + syntax.length; (len, len)
+  }
 }
 <<< def body as nested block 3
 object a {
@@ -804,14 +792,8 @@ object a {
   }
 }
 >>>
-test does not parse: [dialect scala213] illegal start of simple expression
 object a {
-  def foo =
+  def foo = {
     val len = firstColumn + syntax.length; (len, len)
-    ^
-}
-====== full result: ======
-object a {
-  def foo =
-    val len = firstColumn + syntax.length; (len, len)
+  }
 }

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces2.stat
@@ -761,3 +761,57 @@ runner.dialect = scala3
     // Write here your test ....
     // don't forget to remove `pending`
 }
+<<< def body as nested block 1
+object a {
+  def foo = {
+    { val len = firstColumn + syntax.length; (len, len) }
+  }
+}
+>>>
+test does not parse: [dialect scala213] illegal start of simple expression
+object a {
+  def foo =
+    val len = firstColumn + syntax.length; (len, len)
+    ^
+}
+====== full result: ======
+object a {
+  def foo =
+    val len = firstColumn + syntax.length; (len, len)
+}
+<<< def body as nested block 2
+object a {
+  def foo = {
+    { { val len = firstColumn + syntax.length; (len, len) } }
+  }
+}
+>>>
+test does not parse: [dialect scala213] illegal start of simple expression
+object a {
+  def foo =
+    val len = firstColumn + syntax.length; (len, len)
+    ^
+}
+====== full result: ======
+object a {
+  def foo =
+    val len = firstColumn + syntax.length; (len, len)
+}
+<<< def body as nested block 3
+object a {
+  def foo = {
+    { { { val len = firstColumn + syntax.length; (len, len) } } }
+  }
+}
+>>>
+test does not parse: [dialect scala213] illegal start of simple expression
+object a {
+  def foo =
+    val len = firstColumn + syntax.length; (len, len)
+    ^
+}
+====== full result: ======
+object a {
+  def foo =
+    val len = firstColumn + syntax.length; (len, len)
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -154,7 +154,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2519892, "total explored")
+      assertEquals(explored, 2520060, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -154,7 +154,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2519748, "total explored")
+      assertEquals(explored, 2519892, "total explored")
     val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(


### PR DESCRIPTION
We continue removing blocks nested within another block, assuming that at least one outer block is preserved if necessary.

Therefore, before removing an outer block, make sure it doesn't contain a deeply nested multi-stat expression.