### PR TITLE
sysops: refactor platform-specific code

### DIFF
--- a/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/MicroBenchmark.scala
+++ b/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/MicroBenchmark.scala
@@ -2,6 +2,7 @@ package org.scalafmt.benchmarks
 
 import org.scalafmt.Scalafmt
 import org.scalafmt.sysops.FileOps
+import org.scalafmt.sysops.PlatformFileOps
 
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
@@ -27,13 +28,13 @@ abstract class MicroBenchmark(path: String*) extends FormatBenchmark {
   var code: String = _
 
   @Setup
-  def setup(): Unit = code = FileOps.readFile(getPath)
+  def setup(): Unit = code = PlatformFileOps.readFile(getPath)
 
   def getPath: Path = {
     val filename = FileOps.getFile(Seq("src", "resources") ++ path)
     // jmh runs from benchmarks directory while tests run from from root.
     // Can't bother to find more generic solution
-    if (FileOps.isRegularFile(filename)) filename
+    if (PlatformFileOps.isRegularFile(filename)) filename
     else FileOps.getFile(Seq("scalafmt-benchmarks", "src", "resources") ++ path)
   }
 

--- a/scalafmt-cli/jvm/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
+++ b/scalafmt-cli/jvm/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
@@ -4,7 +4,7 @@ import org.scalafmt.Error
 import org.scalafmt.dynamic.ScalafmtDynamicError
 import org.scalafmt.interfaces.Scalafmt
 import org.scalafmt.interfaces.ScalafmtSession
-import org.scalafmt.sysops.FileOps
+import org.scalafmt.sysops.PlatformFileOps
 
 import java.nio.file.Path
 
@@ -34,7 +34,7 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
     val inputMethods = getInputMethods(options, filterMatcher)
     if (inputMethods.isEmpty) ExitCode.Ok
     else runInputs(options, inputMethods, termDisplayMessage) { inputMethod =>
-      import org.scalafmt.sysops.PlatformCompat.executionContext
+      import org.scalafmt.sysops.PlatformRunOps.executionContext
       Future(handleFile(inputMethod, session, options)).recover {
         case x: Error.MisformattedFile => reporter.fail(x)(x.file)
       }.map(ExitCode.merge(_, reporter.getExitCode))
@@ -56,7 +56,7 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
     val dirBuilder = Seq.newBuilder[Path]
     val fileBuilder = Set.newBuilder[Path]
     paths.foreach(path =>
-      if (FileOps.isRegularFile(path)) fileBuilder += path
+      if (PlatformFileOps.isRegularFile(path)) fileBuilder += path
       else dirBuilder += path,
     )
     val dirs = dirBuilder.result()

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -76,13 +76,8 @@ object InputMethod {
     override protected def overwrite(text: String, options: CliOptions): Unit =
       file.writeFile(text)(options.encoding)
 
-    override protected def list(options: CliOptions): Unit = {
-      val usePath = PlatformCompat.isNativeOnWindows
-      options.common.out.println(
-        if (usePath) options.cwd.path.relativize(file.path)
-        else options.cwd.toUri.relativize(file.toUri),
-      )
-    }
+    override protected def list(options: CliOptions): Unit = options.common.out
+      .println(PlatformCompat.relativize(options.cwd, file))
   }
 
   def unifiedDiff(filename: String, original: String, revised: String): String = {

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -39,7 +39,7 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
       }.fold(scalafmtConf)(scalafmtConf.withGitAutoCRLF)
 
       runInputs(options, inputMethods, termDisplayMessage) { inputMethod =>
-        import org.scalafmt.sysops.PlatformCompat.executionContext
+        import org.scalafmt.sysops.PlatformRunOps.executionContext
         Future(handleFile(inputMethod, options, adjustedScalafmtConf)).recover {
           case e: Error.MisformattedFile =>
             options.common.err.println(e.customMessage)

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -1,17 +1,11 @@
 package org.scalafmt.cli
 
 import org.scalafmt.Error
-import org.scalafmt.sysops.AbsoluteFile
-import org.scalafmt.sysops.BatchPathFinder
-import org.scalafmt.sysops.PlatformCompat
+import org.scalafmt.sysops._
 
 import java.nio.file.Path
 
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.concurrent.duration
+import scala.concurrent._
 
 trait ScalafmtRunner {
   private[cli] def run(
@@ -84,7 +78,7 @@ trait ScalafmtRunner {
     val termDisplay = newTermDisplay(options, inputMethods, termDisplayMessage)
 
     implicit val executionContext: ExecutionContext =
-      PlatformCompat.executionContext
+      PlatformRunOps.executionContext
     val completed = Promise[ExitCode]()
 
     val tasks = List.newBuilder[Future[ExitCode]]

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -4,13 +4,12 @@ import org.scalafmt.CompatCollections.JavaConverters._
 import org.scalafmt.Error.NoMatchingFiles
 import org.scalafmt.Versions.{stable => stableVersion}
 import org.scalafmt.cli.FileTestOps._
-import org.scalafmt.config.PlatformConfig
 import org.scalafmt.config.ProjectFiles
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.sysops.AbsoluteFile
-import org.scalafmt.sysops.FileOps
 import org.scalafmt.sysops.OsSpecific._
 import org.scalafmt.sysops.PlatformCompat
+import org.scalafmt.sysops.PlatformFileOps
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -139,8 +138,8 @@ trait CliTestBehavior {
         originalTmpFile.toFile.getPath,
         originalTmpFile2.toFile.getPath,
       )
-      val obtained = FileOps.readFile(originalTmpFile)
-      val obtained2 = FileOps.readFile(originalTmpFile2)
+      val obtained = PlatformFileOps.readFile(originalTmpFile)
+      val obtained2 = PlatformFileOps.readFile(originalTmpFile2)
       assertNoDiff(obtained, expected10)
       assertNoDiff(obtained2, expected10)
     }
@@ -197,7 +196,7 @@ trait CliTestBehavior {
         "--config-str",
         s"""{version="$version",style=IntelliJ}""",
       )
-      val str = FileOps.readFile(tmpFile)
+      val str = PlatformFileOps.readFile(tmpFile)
       assertNoDiff(str, unformatted)
     }
     test(s"scalafmt --test fails with non zero exit code $label") {
@@ -220,7 +219,7 @@ trait CliTestBehavior {
         tmpFile.toFile.getAbsolutePath,
       )
       assertEquals(Cli.mainWithOptions(baseCliOptions, args: _*), ExitCode.Ok)
-      val obtained = FileOps.readFile(tmpFile)
+      val obtained = PlatformFileOps.readFile(tmpFile)
       // TODO: We need to pass customFiles information to ProjectFiles
       assertNoDiff(obtained, formatted)
     }
@@ -541,9 +540,9 @@ trait CliTestBehavior {
         "-f",
         fileStr(file1, file2, file3),
       )
-      val obtained = FileOps.readFile(file1)
-      val obtained2 = FileOps.readFile(file2)
-      val obtained3 = FileOps.readFile(file3)
+      val obtained = PlatformFileOps.readFile(file1)
+      val obtained2 = PlatformFileOps.readFile(file2)
+      val obtained3 = PlatformFileOps.readFile(file3)
       assertNoDiff(obtained, formatted)
       assertNoDiff(obtained2, formatted)
       assertNoDiff(obtained3, formatted)
@@ -736,7 +735,7 @@ trait CliTestBehavior {
 }
 
 class CliTest extends AbstractCliTest with CliTestBehavior {
-  if (!PlatformConfig.isScalaNative) testCli("1.6.0-RC4") // test for runDynamic, incompatible with Scala Native
+  if (PlatformCompat.isJVM) testCli("1.6.0-RC4") // test for runDynamic, incompatible with Scala Native
   testCli(stableVersion) // test for runScalafmt
 
   test(s"path-error") {

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/FileTestOps.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/FileTestOps.scala
@@ -2,12 +2,10 @@ package org.scalafmt.cli
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.RegexCompat
-import org.scalafmt.sysops.AbsoluteFile
-import org.scalafmt.sysops.FileOps
+import org.scalafmt.sysops._
 
 import java.io.File
 import java.io.PrintStream
-import java.nio.file.Files
 
 object FileTestOps {
 
@@ -15,7 +13,7 @@ object FileTestOps {
     * necessary files/directories with respective file contents.
     */
   def string2dir(layout: String): AbsoluteFile = {
-    val root = AbsoluteFile(Files.createTempDirectory("root"))
+    val root = AbsoluteFile(PlatformFileOps.mkdtemp("root"))
     RegexCompat.splitByBeforeTextMatching(layout, "\n/").foreach { row =>
       val path :: contents :: Nil = row.stripPrefix("\n").split("\n", 2).toList
       val file = root / path.stripPrefix("/")
@@ -40,7 +38,7 @@ object FileTestOps {
     val prefix = rootPath.toString
     FileOps.listFiles(rootPath).sortBy(_.toString).map(path =>
       s"""|${path.toString.stripPrefix(prefix)}
-          |${FileOps.readFile(path)}""".stripMargin,
+          |${PlatformFileOps.readFile(path)}""".stripMargin,
     ).mkString("\n").replace(File.separator, "/") // ensure original separators
   }
 
@@ -59,5 +57,5 @@ object FileTestOps {
   )
 
   val baseCliOptions: CliOptions =
-    getMockOptions(AbsoluteFile(Files.createTempDirectory("base-dir")))
+    getMockOptions(AbsoluteFile(PlatformFileOps.mkdtemp("base-dir")))
 }

--- a/scalafmt-sysops/jvm/src/main/scala/org/scalafmt/sysops/PlatformCompat.scala
+++ b/scalafmt-sysops/jvm/src/main/scala/org/scalafmt/sysops/PlatformCompat.scala
@@ -1,11 +1,10 @@
 package org.scalafmt.sysops
 
-import scala.concurrent.ExecutionContext
-
 private[scalafmt] object PlatformCompat {
+  def isJVM = true
   def isScalaNative = false
   def isNativeOnWindows = false
 
-  implicit def executionContext: ExecutionContext = ExecutionContext.global
-
+  def relativize(cwd: AbsoluteFile, file: AbsoluteFile): String = cwd.toUri
+    .relativize(file.toUri).toString
 }

--- a/scalafmt-sysops/native/src/main/scala/org/scalafmt/sysops/PlatformCompat.scala
+++ b/scalafmt-sysops/native/src/main/scala/org/scalafmt/sysops/PlatformCompat.scala
@@ -1,12 +1,16 @@
 package org.scalafmt.sysops
 
-import scala.concurrent.ExecutionContext
 import scala.scalanative.runtime.Platform
 
 private[scalafmt] object PlatformCompat {
+  def isJVM = false
   def isScalaNative = true
   def isNativeOnWindows = Platform.isWindows()
 
-  implicit def executionContext: ExecutionContext = ExecutionContext.global
+  def relativize(cwd: AbsoluteFile, file: AbsoluteFile): String = {
+    val usePath = PlatformCompat.isNativeOnWindows
+    if (usePath) cwd.path.relativize(file.path).toString
+    else cwd.toUri.relativize(file.toUri).toString
+  }
 
 }

--- a/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/AbsoluteFile.scala
+++ b/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/AbsoluteFile.scala
@@ -2,15 +2,13 @@ package org.scalafmt.sysops
 
 import java.io.File
 import java.net.URI
-import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.attribute.BasicFileAttributes
 
 import scala.io.Codec
 
 /** Wrapper around java.io.File with an absolute path. */
 final class AbsoluteFile(val path: Path) extends AnyVal {
-  def exists: Boolean = Files.exists(path)
+  def exists: Boolean = PlatformFileOps.exists(path)
   def /(other: Path) = join(other)
   def /(other: String) = join(other)
 
@@ -24,30 +22,28 @@ final class AbsoluteFile(val path: Path) extends AnyVal {
   def jfile: File = path.toFile
 
   @inline
-  def isDirectory: Boolean = FileOps.isDirectory(path)
+  def isDirectory: Boolean = PlatformFileOps.isDirectory(path)
   @inline
-  def isRegularFile: Boolean = FileOps.isRegularFile(path)
+  def isRegularFile: Boolean = PlatformFileOps.isRegularFile(path)
   @inline
-  def isRegularFileNoLinks: Boolean = FileOps.isRegularFileNoLinks(path)
-  @inline
-  def attributes: BasicFileAttributes = FileOps.getAttributes(path)
+  def isRegularFileNoLinks: Boolean = PlatformFileOps.isRegularFileNoLinks(path)
 
   @inline
   def listFiles: Seq[AbsoluteFile] = join(FileOps.listFiles(path))
   @inline
-  def readFile(implicit codec: Codec): String = FileOps.readFile(path)
+  def readFile(implicit codec: Codec): String = PlatformFileOps.readFile(path)
   @inline
-  def writeFile(content: String)(implicit codec: Codec): Unit = FileOps
+  def writeFile(content: String)(implicit codec: Codec): Unit = PlatformFileOps
     .writeFile(path, content)
 
   @inline
   def parent: AbsoluteFile = new AbsoluteFile(path.getParent)
   @inline
-  def delete(): Unit = Files.delete(path)
+  def delete(): Unit = PlatformFileOps.delete(path)
   @inline
-  def mkdir(): Unit = Files.createDirectory(path)
+  def mkdir(): Unit = PlatformFileOps.mkdir(path)
   @inline
-  def mkdirs(): Unit = Files.createDirectories(path)
+  def mkdirs(): Unit = PlatformFileOps.mkdirs(path)
 
   override def toString: String = path.toString
   @inline
@@ -66,9 +62,9 @@ object AbsoluteFile {
     apply(FileOps.getPath(head, tail: _*))
 
   def fromPathIfAbsolute(path: String): Option[AbsoluteFile] = {
-    val file = FileOps.getFile(path)
+    val file = FileOps.getPath(path)
     if (file.isAbsolute) Some(new AbsoluteFile(file)) else None
   }
 
-  def userDir = AbsoluteFile(System.getProperty("user.dir"))
+  def userDir = AbsoluteFile(PlatformFileOps.cwd())
 }

--- a/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/BatchPathFinder.scala
+++ b/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/BatchPathFinder.scala
@@ -1,7 +1,6 @@
 package org.scalafmt.sysops
 
 import java.nio.file.Path
-import java.nio.file.attribute.BasicFileAttributes
 
 trait BatchPathFinder {
 
@@ -34,11 +33,11 @@ object BatchPathFinder {
 
   final class DirFiles(val cwd: AbsoluteFile)(val matches: Path => Boolean)
       extends BatchPathFinder {
-    private def filter(path: Path, attrs: BasicFileAttributes): Boolean =
+    private def filter(path: Path, attrs: FileStat): Boolean =
       attrs.isRegularFile && matches(path)
     override def findFiles(dir: AbsoluteFile*): Seq[AbsoluteFile] = {
       val dirs = if (dir.isEmpty) Seq(cwd.path) else dir.map(_.path)
-      dirs.flatMap(FileOps.listFiles(_, filter)).map(new AbsoluteFile(_))
+      dirs.flatMap(FileOps.listFiles(filter)).map(new AbsoluteFile(_))
     }
   }
 

--- a/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/FileStat.scala
+++ b/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/FileStat.scala
@@ -1,0 +1,9 @@
+package org.scalafmt.sysops
+
+trait FileStat {
+
+  def isDirectory: Boolean
+  def isRegularFile: Boolean
+  def isSymlink: Boolean
+
+}

--- a/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/PlatformFileOps.scala
+++ b/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/PlatformFileOps.scala
@@ -1,0 +1,62 @@
+package org.scalafmt.sysops
+
+import org.scalafmt.CompatCollections.JavaConverters._
+
+import java.nio.file._
+
+import scala.io.Codec
+import scala.util.Try
+
+object PlatformFileOps {
+
+  private class NioFileStat(obj: attribute.BasicFileAttributes) extends FileStat {
+    def isDirectory: Boolean = obj.isDirectory
+    def isRegularFile: Boolean = obj.isRegularFile
+    def isSymlink: Boolean = obj.isSymbolicLink
+  }
+
+  def exists(file: Path): Boolean = Files.exists(file)
+
+  def symlink(link: Path, file: Path): Unit = Files
+    .createSymbolicLink(link, file)
+
+  def mkdir(file: Path): Unit = Files.createDirectory(file)
+  def mkdirs(file: Path): Unit = Files.createDirectories(file)
+  def mkdtemp(prefix: String): Path = Files.createTempDirectory(prefix)
+
+  def move(src: Path, dst: Path): Unit = Files
+    .move(src, dst, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+
+  def delete(file: Path): Unit = Files.delete(file)
+
+  def isDirectory(file: Path): Boolean = Files.isDirectory(file)
+  def isRegularFile(file: Path): Boolean = Files.isRegularFile(file)
+  def isRegularFileNoLinks(file: Path): Boolean = Files
+    .isRegularFile(file, LinkOption.NOFOLLOW_LINKS)
+
+  def getFileStat(file: Path, followLinks: Boolean): Option[FileStat] = {
+    val linkOpts = if (followLinks) Nil else Seq(LinkOption.NOFOLLOW_LINKS)
+    Try(Files.readAttributes(
+      file,
+      classOf[attribute.BasicFileAttributes],
+      linkOpts: _*,
+    )).toOption.map(new NioFileStat(_))
+  }
+
+  def listFiles(file: Path, matches: (Path, FileStat) => Boolean): Seq[Path] = {
+    val iter = Files
+      .find(file, Integer.MAX_VALUE, (p, a) => matches(p, new NioFileStat(a)))
+    try iter.iterator().asScala.toList
+    finally iter.close()
+  }
+
+  def readFile(file: Path)(implicit codec: Codec): String =
+    new String(Files.readAllBytes(file), codec.charSet)
+
+  def writeFile(path: Path, content: String)(implicit codec: Codec): Unit = {
+    val bytes = content.getBytes(codec.charSet)
+    Files.write(path, bytes)
+  }
+
+  def cwd() = System.getProperty("user.dir")
+}

--- a/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/PlatformRunOps.scala
+++ b/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/PlatformRunOps.scala
@@ -1,0 +1,34 @@
+package org.scalafmt.sysops
+
+import java.nio.file.Path
+import java.util.concurrent.Executors
+
+import scala.concurrent.ExecutionContext
+import scala.sys.process.ProcessLogger
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+private[scalafmt] object PlatformRunOps {
+
+  implicit def executionContext: ExecutionContext = ExecutionContext.global
+
+  def getSingleThreadExecutionContext: ExecutionContext = ExecutionContext
+    .fromExecutor(Executors.newSingleThreadExecutor())
+
+  def runArgv(cmd: Seq[String], cwd: Option[Path]): Try[String] = {
+    val err = new StringBuilder()
+    val logger = ProcessLogger(_ => (), x => err.append("\n> ").append(x))
+    val argv =
+      if (PlatformCompat.isNativeOnWindows) cmd.map(arg => '"' + arg + '"')
+      else cmd
+    Try(sys.process.Process(argv, cwd.map(_.toFile)).!!(logger)) match {
+      case Failure(e) =>
+        val msg =
+          s"Failed to run '${cmd.mkString(" ")}'. Error:${err.result()}\n"
+        Failure(new IllegalStateException(msg, e))
+      case Success(x) => Success(x.trim)
+    }
+  }
+
+}

--- a/scalafmt-sysops/shared/src/test/scala/org/scalafmt/sysops/DeleteTree.scala
+++ b/scalafmt-sysops/shared/src/test/scala/org/scalafmt/sysops/DeleteTree.scala
@@ -1,11 +1,7 @@
 package org.scalafmt.sysops
 
 import java.io.IOException
-import java.nio.file.FileVisitResult
-import java.nio.file.FileVisitor
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file._
 
 object DeleteTree {
   def apply(path: Path): Unit = {
@@ -17,12 +13,12 @@ object DeleteTree {
 class DeleteTree extends FileVisitor[Path] {
   override def preVisitDirectory(
       dir: Path,
-      attrs: BasicFileAttributes,
+      attrs: attribute.BasicFileAttributes,
   ): FileVisitResult = FileVisitResult.CONTINUE
 
   override def visitFile(
       file: Path,
-      attrs: BasicFileAttributes,
+      attrs: attribute.BasicFileAttributes,
   ): FileVisitResult = {
     Files.delete(file)
     FileVisitResult.CONTINUE

--- a/scalafmt-sysops/shared/src/test/scala/org/scalafmt/sysops/FileOpsTest.scala
+++ b/scalafmt-sysops/shared/src/test/scala/org/scalafmt/sysops/FileOpsTest.scala
@@ -1,7 +1,6 @@
 package org.scalafmt.sysops
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 import java.nio.file.Path
 
 import scala.util.Random
@@ -13,13 +12,13 @@ class FileOpsTest extends munit.FunSuite {
   private var path: Path = _
 
   override def beforeEach(context: BeforeEach): Unit =
-    path = Files.createTempDirectory("FileOpsTestDir")
+    path = PlatformFileOps.mkdtemp("FileOpsTestDir")
 
   override def afterEach(context: AfterEach): Unit =
     try DeleteTree(path)
     catch {
       case e: Throwable =>
-        println("Unable to delete test files")
+        println(s"Unable to delete test files: $path")
         e.printStackTrace()
     }
 
@@ -27,17 +26,17 @@ class FileOpsTest extends munit.FunSuite {
     assertEquals(FileOps.listFiles(path), Nil)
 
     val subfile = subpath(path)
-    Files.write(subfile, "file".getBytes(StandardCharsets.UTF_8))
+    PlatformFileOps.writeFile(subfile, "file")(StandardCharsets.UTF_8)
     assertEquals(FileOps.listFiles(path), Seq(subfile))
     assertEquals(FileOps.listFiles(subfile), Seq(subfile))
 
     val subdir = subpath(path)
-    Files.createDirectory(subdir)
+    PlatformFileOps.mkdir(subdir)
     assertEquals(FileOps.listFiles(path), Seq(subfile))
     assertEquals(FileOps.listFiles(subdir), Nil)
 
     val subsubfile = subpath(subdir)
-    Files.write(subsubfile, "file".getBytes(StandardCharsets.UTF_8))
+    PlatformFileOps.writeFile(subsubfile, "file")(StandardCharsets.UTF_8)
     assertEquals(FileOps.listFiles(path).toSet, Set(subfile, subsubfile))
     assertEquals(FileOps.listFiles(subdir), Seq(subsubfile))
     assertEquals(FileOps.listFiles(subsubfile), Seq(subsubfile))

--- a/scalafmt-tests-community/common/shared/src/test/scala/org/scalafmt/community/common/TestHelpers.scala
+++ b/scalafmt-tests-community/common/shared/src/test/scala/org/scalafmt/community/common/TestHelpers.scala
@@ -4,6 +4,7 @@ import org.scalafmt.CompatCollections.JavaConverters._
 import org.scalafmt.Formatted
 import org.scalafmt.Scalafmt
 import org.scalafmt.config._
+import org.scalafmt.sysops.PlatformRunOps
 
 import scala.meta._
 
@@ -20,7 +21,8 @@ import munit.diff.console.AnsiColors
 
 object TestHelpers {
 
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
+  implicit val executionContext: ExecutionContext =
+    PlatformRunOps.executionContext
 
   private[common] val communityProjectsDirectory = Paths
     .get("scalafmt-tests-community/target/community-projects")

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -2,6 +2,7 @@ package org.scalafmt
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.sysops.FileOps
+import org.scalafmt.sysops.PlatformFileOps
 import org.scalafmt.util.FormatAssertions
 
 import scala.meta.dialects.Scala213
@@ -33,7 +34,7 @@ class FidelityTest extends FunSuite with FormatAssertions {
     FileOps.listFiles(".").filter { x =>
       val filename = x.toString
       filename.endsWith(".scala") && !denyList.exists(filename.contains)
-    }.map(x => TestCase(x, FileOps.readFile(x)))
+    }.map(x => TestCase(x, PlatformFileOps.readFile(x)))
   }
 
   examples.foreach(example =>

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -5,11 +5,10 @@ import org.scalafmt.Error.SearchStateExploded
 import org.scalafmt.config.LineEndings
 import org.scalafmt.rewrite.FormatTokensRewrite
 import org.scalafmt.sysops.FileOps
+import org.scalafmt.sysops.PlatformFileOps
 import org.scalafmt.util._
 
 import scala.meta.parsers.ParseException
-
-import java.io.File
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -155,13 +154,12 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
       assertEquals(explored, 2520110, "total explored")
-    val results = debugResults.result()
     // TODO(olafur) don't block printing out test results.
     // I don't want to deal with scalaz's Tasks :'(
     val k = for {
-      _ <- Future(FileOps.writeFile(
-        s"target${File.separator}index.html",
-        Report.heatmap(results),
+      _ <- Future(PlatformFileOps.writeFile(
+        FileOps.getPath("target", "index.html"),
+        Report.heatmap(debugResults.result()),
       ))
     } yield ()
     // Travis exits right after running tests.

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/ManualTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/ManualTests.scala
@@ -2,6 +2,7 @@ package org.scalafmt
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.sysops.FileOps
+import org.scalafmt.sysops.PlatformFileOps
 import org.scalafmt.util.DiffTest
 import org.scalafmt.util.HasTests
 
@@ -12,15 +13,14 @@ import munit.Location
 
 object ManualTests extends HasTests {
   lazy val tests: Seq[DiffTest] = {
-    import FileOps._
     val testPrefix = testDir + File.separator
-    val testFiles = listFiles(testDir).map(x => (x, x.toString))
+    val testFiles = FileOps.listFiles(testDir).map(x => (x, x.toString))
     val manualFiles = for {
       (path, filename) <- testFiles if filename.endsWith(manual)
-      test <- readFile(path).linesIterator
+      test <- PlatformFileOps.readFile(path).linesIterator
         .withFilter(_.startsWith(HasTests.onlyPrefix)).map { name =>
           val testPath = stripPrefix(name)
-          val original = readFile(Paths.get(testPath))
+          val original = PlatformFileOps.readFile(Paths.get(testPath))
           val testFile = testPath.stripPrefix(testPrefix)
           DiffTest(
             testFile,
@@ -37,7 +37,7 @@ object ManualTests extends HasTests {
     val scalaFiles = for {
       (path, filename) <- testFiles if filename.endsWith(".scala")
     } yield {
-      val content = readFile(path)
+      val content = PlatformFileOps.readFile(path)
       DiffTest(
         filename,
         filename,

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/UnitTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/UnitTests.scala
@@ -22,7 +22,7 @@ object UnitTests extends HasTests {
   override lazy val tests: Seq[DiffTest] = {
     def checkPath(p: Path) = filename2parse(p.toString).isDefined
     for {
-      filename <- listFiles(testDir, (p, a) => checkPath(p) && a.isRegularFile)
+      filename <- listFiles((p, a) => checkPath(p) && a.isRegularFile)(testDir)
       test <- parseDiffTests(filename, notOnly = sys.env.contains("CI"))
     } yield test
   }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -11,7 +11,7 @@ import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.config.ScalafmtOptimizer
 import org.scalafmt.config.ScalafmtParser
 import org.scalafmt.config.ScalafmtRunner
-import org.scalafmt.sysops.FileOps
+import org.scalafmt.sysops.PlatformFileOps
 import org.scalafmt.tests.BuildInfo
 
 import java.nio.file.Path
@@ -57,7 +57,7 @@ trait HasTests extends FormatAssertions {
 
   def parseDiffTests(path: Path, notOnly: Boolean): Seq[DiffTest] = {
     val filename = path.toString
-    val content = FileOps.readFile(path)
+    val content = PlatformFileOps.readFile(path)
     val moduleOnly = isOnly(content)
     val moduleSkip = isSkip(content)
     val sep =


### PR DESCRIPTION
Put some shared code in `jvm-native/` and some in `jvm/` or `native/`.