### PR TITLE
Scalameta: upgrade to v4.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,9 @@ inThisBuild {
     crossScalaVersions := List(scala213, scala212),
     resolvers ++= Resolver.sonatypeOssRepos("releases"),
     resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
+    resolvers +=
+      "Sonatype Releases"
+        .at("https://oss.sonatype.org/content/repositories/releases"),
     testFrameworks += new TestFramework("munit.Framework"),
     // causes native image issues
     dependencyOverrides += "org.jline" % "jline" % "3.29.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.15.0"
-  val scalametaV  = "4.13.0"
+  val scalametaV  = "4.13.1.1"
   val scalacheckV = "1.18.1"
   val coursier    = "2.1.24"
   val munitV      = "1.1.0"

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ScalafmtConfigTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ScalafmtConfigTest.scala
@@ -1,14 +1,8 @@
 package org.scalafmt.config
 
-import org.scalafmt.sysops._
-
 import munit.FunSuite
 
 class ScalafmtConfigTest extends FunSuite {
-
-  override def munitIgnore: Boolean =
-    // TODO: remove when scala.meta.internal.io.NodeNIOPath works on Windows
-    PlatformCompat.isJS && OsSpecific.isWindows
 
   test("project.matcher") {
     val config = ScalafmtConfig.fromHoconString(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/StandardProjectLayoutTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/StandardProjectLayoutTest.scala
@@ -6,10 +6,6 @@ import scala.meta.dialects
 
 class StandardProjectLayoutTest extends munit.FunSuite {
 
-  override def munitIgnore: Boolean =
-    // TODO: remove when scala.meta.internal.io.NodeNIOPath works on Windows
-    PlatformCompat.isJS && OsSpecific.isWindows
-
   import ProjectFiles.Layout.StandardConvention._
 
   Seq(


### PR DESCRIPTION
Now that JS NodeNIOPath works on Windows, re-enable the tests.