### PR TITLE
ScalafmtRunner: use separate execution contexts

### DIFF
--- a/scalafmt-cli/jvm/src/main/scala/org/scalafmt/cli/CliUtils.scala
+++ b/scalafmt-cli/jvm/src/main/scala/org/scalafmt/cli/CliUtils.scala
@@ -1,7 +1,7 @@
 package org.scalafmt.cli
 
 import org.scalafmt.sysops.AbsoluteFile
-import org.scalafmt.sysops.PlatformRunOps.executionContext
+import org.scalafmt.sysops.PlatformRunOps
 
 import scala.io.Source
 
@@ -17,6 +17,7 @@ private[scalafmt] trait CliUtils {
                 .getWorkingDirectory}",
         ),
       )
+    import PlatformRunOps.parasiticExecutionContext
     Cli.mainWithOptions(
       CliOptions.default.copy(common =
         CliOptions.default.common.copy(

--- a/scalafmt-cli/jvm/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
+++ b/scalafmt-cli/jvm/src/main/scala/org/scalafmt/cli/ScalafmtDynamicRunner.scala
@@ -1,18 +1,15 @@
 package org.scalafmt.cli
 
-import org.scalafmt.Error
 import org.scalafmt.dynamic.ScalafmtDynamicError
 import org.scalafmt.interfaces.Scalafmt
 import org.scalafmt.interfaces.ScalafmtSession
 import org.scalafmt.sysops.PlatformFileOps
-import org.scalafmt.sysops.PlatformRunOps
 
 import java.nio.file.Path
 
 import scala.concurrent.Future
 
 object ScalafmtDynamicRunner extends ScalafmtRunner {
-  import org.scalafmt.sysops.PlatformRunOps.executionContext
 
   override private[cli] def run(
       options: CliOptions,
@@ -31,7 +28,7 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
 
   private def runWithSession(
       options: CliOptions,
-      termDisplayMessage: String,
+      displayMsg: String,
       reporter: ScalafmtCliReporter,
   )(session: ScalafmtSession): Future[ExitCode] = {
     val sessionMatcher = session.matchesProjectFilters _
@@ -42,22 +39,12 @@ object ScalafmtDynamicRunner extends ScalafmtRunner {
       }
     val inputMethods = getInputMethods(options, filterMatcher)
     if (inputMethods.isEmpty) ExitCode.Ok.future
-    else runInputs(options, inputMethods, termDisplayMessage)(inputMethod =>
-      handleFile(inputMethod, session, options).recover {
-        case x: Error.MisformattedFile => reporter.fail(x)(x.file)
-      }.map(ExitCode.merge(_, reporter.getExitCode)),
-    )
+    else runInputs(options, inputMethods, displayMsg) { case (code, path) =>
+      val formatted = session.format(path, code)
+      val exitCode = reporter.getExitCode(path)
+      if (exitCode eq null) Right(formatted) else Left(exitCode)
+    }
   }
-
-  private[this] def handleFile(
-      inputMethod: InputMethod,
-      session: ScalafmtSession,
-      options: CliOptions,
-  ): Future[ExitCode] = inputMethod.readInput(options)
-    .map(code => code -> session.format(inputMethod.path, code))
-    .flatMap { case (code, formattedCode) =>
-      inputMethod.write(formattedCode, code, options)
-    }(PlatformRunOps.ioExecutionContext)
 
   private def getFileMatcher(paths: Seq[Path]): Path => Boolean = {
     val dirBuilder = Seq.newBuilder[Path]

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 
 object Cli extends CliUtils {
 
-  import PlatformRunOps.executionContext
+  import PlatformRunOps.parasiticExecutionContext
 
   def main(args: Array[String]): Unit =
     mainWithOptions(CliOptions.default, args: _*)

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -34,8 +34,9 @@ sealed abstract class InputMethod {
       case WriteMode.Stdout => print(formatted, options); exitCode.future
       case _ if !codeChanged => ExitCode.Ok.future
       case WriteMode.List => list(options); options.exitCodeOnChange.future
-      case WriteMode.Override => overwrite(formatted, options)
-          .map(_ => options.exitCodeOnChange)(PlatformRunOps.ioExecutionContext)
+      case WriteMode.Override => overwrite(formatted, options).map(_ =>
+          options.exitCodeOnChange,
+        )(PlatformRunOps.parasiticExecutionContext)
       case WriteMode.Test =>
         val pathStr = path.toString
         val diff = InputMethod.unifiedDiff(pathStr, original, formatted)

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/TermDisplay.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/TermDisplay.scala
@@ -155,7 +155,7 @@ object TermDisplay extends TermUtils {
     private def shouldUpdate(): Boolean = shouldUpdateFlag
       .compareAndSet(true, false)
 
-    def end(): Unit = if (isStarted.get()) {
+    def end(): Unit = if (isStarted.compareAndSet(true, false)) {
       polling.cancel()
       if (fallbackMode) processStopFallback() else processStop()
     }
@@ -255,7 +255,7 @@ object TermDisplay extends TermUtils {
         -info.fraction.sum
       }
 
-    private def processStop(): Unit = {} // poison pill
+    private def processStop(): Unit = out.append("\n\n").flush() // poison pill
 
     private def processUpdate(): Unit = if (shouldUpdate()) {
       val (done0, downloads0) = downloads.synchronized {

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -26,8 +26,6 @@ import munit.FunSuite
 
 abstract class AbstractCliTest extends FunSuite {
 
-  import org.scalafmt.sysops.PlatformRunOps.executionContext
-
   def mkArgs(str: String): Array[String] = str.split(' ')
 
   def runWith(root: AbsoluteFile, argStr: String)(implicit

--- a/scalafmt-sysops/js/src/main/scala/org/scalafmt/sysops/PlatformRunOps.scala
+++ b/scalafmt-sysops/js/src/main/scala/org/scalafmt/sysops/PlatformRunOps.scala
@@ -15,9 +15,8 @@ private[scalafmt] object PlatformRunOps {
   implicit def executionContext: ExecutionContext =
     scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-  def ioExecutionContext: ExecutionContext = executionContext
-
-  def getSingleThreadExecutionContext: ExecutionContext = executionContext // same one
+  implicit def parasiticExecutionContext: ExecutionContext =
+    GranularDialectAsyncOps.parasiticExecutionContext
 
   def runArgv(cmd: Seq[String], cwd: Option[Path]): Try[String] = {
     val options = cwd.fold(js.Dictionary[js.Any]())(cwd =>

--- a/scalafmt-sysops/jvm-native/src/main/scala/org/scalafmt/sysops/PlatformRunOps.scala
+++ b/scalafmt-sysops/jvm-native/src/main/scala/org/scalafmt/sysops/PlatformRunOps.scala
@@ -4,6 +4,7 @@ import java.nio.file.Path
 import java.util.concurrent.Executors
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutorService
 import scala.sys.process.ProcessLogger
 import scala.util.Failure
 import scala.util.Success
@@ -13,11 +14,17 @@ private[scalafmt] object PlatformRunOps {
 
   implicit def executionContext: ExecutionContext = ExecutionContext.global
 
-  def ioExecutionContext: ExecutionContext =
-    GranularPlatformAsyncOps.ioExecutionContext
+  val inputExecutionContext: ExecutionContextExecutorService = ExecutionContext
+    .fromExecutorService(
+      Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors()),
+    )
+  val outputExecutionContext: ExecutionContextExecutorService = ExecutionContext
+    .fromExecutorService(
+      Executors.newFixedThreadPool(Runtime.getRuntime.availableProcessors()),
+    )
 
-  def getSingleThreadExecutionContext: ExecutionContext = ExecutionContext
-    .fromExecutor(Executors.newSingleThreadExecutor())
+  implicit def parasiticExecutionContext: ExecutionContext =
+    GranularDialectAsyncOps.parasiticExecutionContext
 
   def runArgv(cmd: Seq[String], cwd: Option[Path]): Try[String] = {
     val err = new StringBuilder()

--- a/scalafmt-sysops/native/src/main/scala/org/scalafmt/sysops/GranularPlatformAsyncOps.scala
+++ b/scalafmt-sysops/native/src/main/scala/org/scalafmt/sysops/GranularPlatformAsyncOps.scala
@@ -1,26 +1,19 @@
 package org.scalafmt.sysops
 
-import java.nio.file.Files
 import java.nio.file.Path
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.io.Codec
 
 private[sysops] object GranularPlatformAsyncOps {
 
-  import PlatformRunOps.executionContext
-
-  def ioExecutionContext: ExecutionContext = executionContext
-
   def readFileAsync(path: Path)(implicit codec: Codec): Future[String] =
-    Future(PlatformFileOps.readFile(path))
+    Future(PlatformFileOps.readFile(path))(PlatformRunOps.inputExecutionContext)
 
-  def writeFileAsync(path: Path, content: String)(implicit
+  def writeFileAsync(path: Path, data: String)(implicit
       codec: Codec,
-  ): Future[Unit] = Future {
-    val bytes = content.getBytes(codec.charSet)
-    Files.write(path, bytes)
-  }
+  ): Future[Unit] = Future(
+    PlatformFileOps.writeFile(path, data),
+  )(PlatformRunOps.outputExecutionContext)
 
 }

--- a/scalafmt-sysops/shared/src/main/scala-2.12/org/scalafmt/sysops/GranularDialectAsyncOps.scala
+++ b/scalafmt-sysops/shared/src/main/scala-2.12/org/scalafmt/sysops/GranularDialectAsyncOps.scala
@@ -1,0 +1,14 @@
+package org.scalafmt.sysops
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
+
+private[sysops] object GranularDialectAsyncOps {
+
+  object parasiticExecutionContext extends ExecutionContextExecutor {
+    override final def execute(runnable: Runnable): Unit = runnable.run()
+    override final def reportFailure(t: Throwable): Unit = ExecutionContext
+      .defaultReporter(t)
+  }
+
+}

--- a/scalafmt-sysops/shared/src/main/scala-2.13/org/scalafmt/sysops/GranularDialectAsyncOps.scala
+++ b/scalafmt-sysops/shared/src/main/scala-2.13/org/scalafmt/sysops/GranularDialectAsyncOps.scala
@@ -1,0 +1,10 @@
+package org.scalafmt.sysops
+
+import scala.concurrent.ExecutionContext
+
+private[sysops] object GranularDialectAsyncOps {
+
+  def parasiticExecutionContext: ExecutionContext.parasitic.type =
+    ExecutionContext.parasitic
+
+}

--- a/scalafmt-tests-community/common/shared/src/test/scala/org/scalafmt/community/common/CommunitySuite.scala
+++ b/scalafmt-tests-community/common/shared/src/test/scala/org/scalafmt/community/common/CommunitySuite.scala
@@ -57,8 +57,8 @@ abstract class CommunitySuite extends FunSuite {
     val stats =
       if (tasks.isEmpty) TestStats.init
       else {
-        val allTasks = Future
-          .reduceLeft(tasks)(TestStats.merge)(TestHelpers.executionContext)
+        import org.scalafmt.sysops.PlatformRunOps.executionContext
+        val allTasks = Future.reduceLeft(tasks)(TestStats.merge)
         Await.result(allTasks, duration.Duration.Inf)
       }
     val timePer1KLines = Math


### PR DESCRIPTION
- in both core and dynamic runners, reading and writing is done the same way, with the only difference being formatting; hence, let's move I/O to shared runner
- to avoid reading all files first and only then formatting and writing them, let's create separate input and output execution contexts and use the former for reading and formatting, and the latter for writing
- finally, let's define parasitic execution context (one which executes immediately, without putting the task in a queue), for short tasks such as triggering `.onComplete` or updating task progress