### PR TITLE
GranularPlatformAsyncOps: modify read/write async

### DIFF
--- a/scalafmt-sysops/jvm/src/main/scala/org/scalafmt/sysops/GranularPlatformAsyncOps.scala
+++ b/scalafmt-sysops/jvm/src/main/scala/org/scalafmt/sysops/GranularPlatformAsyncOps.scala
@@ -11,84 +11,96 @@ import java.{util => ju}
 import scala.concurrent.Future
 import scala.concurrent.Promise
 import scala.io.Codec
-import scala.util.Try
 
 private[sysops] object GranularPlatformAsyncOps {
 
   def readFileAsync(path: Path)(implicit codec: Codec): Future[String] = {
-    val promise = Promise[String]()
-
-    val buf = new Array[Byte](1024)
-    val bbuf = ByteBuffer.wrap(buf)
-    val os = new ByteArrayOutputStream()
-
-    Try {
-      val channel = AsynchronousFileChannel.open(
-        path,
-        new ju.HashSet(ju.Arrays.asList(StandardOpenOption.READ)),
-        PlatformRunOps.inputExecutionContext,
-      )
-      val handler = new CompletionHandler[Integer, AnyRef] {
-        override def completed(result: Integer, unused: AnyRef): Unit = {
-          val count = result.intValue()
-          if (count < 0) {
-            promise.trySuccess(os.toString(codec.charSet.name()))
-            channel.close()
-          } else {
-            if (count > 0) {
-              os.write(buf, 0, count)
-              bbuf.clear()
-            }
-            channel.read(bbuf, os.size(), null, this)
-          }
-        }
-        override def failed(exc: Throwable, unused: AnyRef): Unit = {
-          promise.tryFailure(exc)
-          channel.close()
-        }
-      }
-
-      channel.read(bbuf, 0, null, handler)
-    }.failed.foreach(promise.tryFailure)
-
-    promise.future
+    val ec = PlatformRunOps.inputExecutionContext
+    Future {
+      val opts = new ju.HashSet(ju.Arrays.asList(StandardOpenOption.READ))
+      AsynchronousFileChannel.open(path, opts, ec)
+    }(ec).flatMap { channel =>
+      val promise = Promise[String]()
+      new ReadContext(promise, channel).read(0)
+      promise.future
+    }(PlatformRunOps.parasiticExecutionContext)
   }
 
   def writeFileAsync(path: Path, content: String)(implicit
       codec: Codec,
   ): Future[Unit] = {
-    val promise = Promise[Unit]()
-    val buf = ByteBuffer.wrap(content.getBytes(codec.charSet))
+    val ec = PlatformRunOps.outputExecutionContext
+    Future {
+      val opts = new ju.HashSet(ju.Arrays.asList(
+        StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+      ))
+      AsynchronousFileChannel.open(path, opts, ec)
+    }(ec).flatMap { channel =>
+      val promise = Promise[Unit]()
+      val buf = ByteBuffer.wrap(content.getBytes(codec.charSet))
+      new WriteContext(promise, channel, buf).write()
+      promise.future
+    }(PlatformRunOps.parasiticExecutionContext)
+  }
 
-    Try {
-      val channel = AsynchronousFileChannel.open(
-        path,
-        new ju.HashSet(ju.Arrays.asList(
-          StandardOpenOption.CREATE,
-          StandardOpenOption.WRITE,
-          StandardOpenOption.TRUNCATE_EXISTING,
-        )),
-        PlatformRunOps.outputExecutionContext,
-      )
+  private abstract class Handler[A <: Context[_]]
+      extends CompletionHandler[Integer, A] {
+    override def failed(exc: Throwable, obj: A): Unit = obj.failed(exc)
+  }
 
-      val handler = new CompletionHandler[Integer, AnyRef] {
-        override def completed(result: Integer, attachment: AnyRef): Unit =
-          if (buf.hasRemaining) channel.write(buf, buf.position(), null, this)
-          else {
-            promise.trySuccess(())
-            channel.close()
-          }
+  private object ReadHandler extends Handler[ReadContext] {
+    override def completed(res: Integer, obj: ReadContext): Unit = obj
+      .read(res.intValue())
+  }
 
-        override def failed(exc: Throwable, attachment: AnyRef): Unit = {
-          promise.tryFailure(exc)
-          channel.close()
-        }
+  private object WriteHandler extends Handler[WriteContext] {
+    override def completed(res: Integer, obj: WriteContext): Unit = obj.write()
+  }
+
+  private abstract class Context[A] {
+    val promise: Promise[A]
+    val channel: AsynchronousFileChannel
+    def failed(exc: Throwable): Unit = {
+      promise.tryFailure(exc)
+      channel.close()
+    }
+  }
+
+  private class ReadContext(
+      val promise: Promise[String],
+      val channel: AsynchronousFileChannel,
+  )(implicit codec: Codec)
+      extends Context[String] {
+    private val arr = new Array[Byte](1024)
+    private val buf = ByteBuffer.wrap(arr)
+    private val os = new ByteArrayOutputStream()
+
+    def read(count: Int): Unit =
+      if (count < 0) {
+        promise.trySuccess(os.toString(codec.charSet.name()))
+        channel.close()
+      } else {
+        if (count > 0) { os.write(arr, 0, count); buf.clear() }
+        try channel.read(buf, os.size(), this, ReadHandler)
+        catch { case exc: Throwable => failed(exc) }
       }
+  }
 
-      channel.write(buf, 0L, null, handler)
-    }.failed.foreach(promise.tryFailure)
-
-    promise.future
+  private class WriteContext(
+      val promise: Promise[Unit],
+      val channel: AsynchronousFileChannel,
+      buf: ByteBuffer,
+  ) extends Context[Unit] {
+    def write(): Unit =
+      if (buf.hasRemaining)
+        try channel.write(buf, buf.position(), this, WriteHandler)
+        catch { case exc: Throwable => failed(exc) }
+      else {
+        promise.trySuccess(())
+        channel.close()
+      }
   }
 
 }


### PR DESCRIPTION
Instead of creating an async channel in current thread, schedule it as a future, which moves execution to a worker and captures exceptions as well.

Also, use attachable contexts in handler methods.