### PR TITLE
Cli: do not forget to exit on failure as well

### DIFF
--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -6,14 +6,20 @@ import org.scalafmt.sysops.PlatformFileOps
 import org.scalafmt.sysops.PlatformRunOps
 
 import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
 
 object Cli extends CliUtils {
 
   import PlatformRunOps.parasiticExecutionContext
 
   def main(args: Array[String]): Unit =
-    mainWithOptions(CliOptions.default, args: _*)
-      .map(exit => PlatformRunOps.exit(exit.code))
+    mainWithOptions(CliOptions.default, args: _*).onComplete {
+      case Failure(ex) =>
+        ex.printStackTrace()
+        PlatformRunOps.exit(ExitCode.UnexpectedError.code)
+      case Success(exit) => PlatformRunOps.exit(exit.code)
+    }
 
   def mainWithOptions(options: CliOptions, args: String*): Future[ExitCode] =
     getConfig(options, args: _*) match {


### PR DESCRIPTION
Since `main` is now async, it will not automatically exit the process on failure and will instead hang. Let's exit explicitly.