### PR TITLE
InputMethod: handle misformatted file, don't throw

### DIFF
--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -1,6 +1,5 @@
 package org.scalafmt.cli
 
-import org.scalafmt.Error.MisformattedFile
 import org.scalafmt.sysops.AbsoluteFile
 import org.scalafmt.sysops.FileOps
 import org.scalafmt.sysops.PlatformCompat
@@ -43,7 +42,8 @@ sealed abstract class InputMethod {
         val msg =
           if (diff.nonEmpty) diff
           else s"--- +$pathStr\n    => modified line endings only"
-        Future.failed(MisformattedFile(path, msg))
+        options.common.err.println(msg)
+        ExitCode.TestError.future
       case _ => options.exitCodeOnChange.future
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Error.scala
@@ -7,8 +7,6 @@ import scala.meta.Tree
 import scala.meta.inputs.Position
 import scala.meta.internal.inputs._
 
-import java.nio.file.Path
-
 import scala.reflect.ClassTag
 import scala.reflect.classTag
 import scala.util.control.NoStackTrace
@@ -51,9 +49,6 @@ object Error {
         s"""|Expected: ${classTag[Expected].runtimeClass.getName}
             |Obtained: ${log(obtained)}""".stripMargin,
       )
-
-  case class MisformattedFile(file: Path, customMessage: String)
-      extends Error(s"$file is mis-formatted. $customMessage")
 
   case class SearchStateExploded private (
       deepestState: State,


### PR DESCRIPTION
Now that we don't need to `recover` this error in ScalafmtRunner, adjust that logic as well.