### PR TITLE
RegexCompat: keep multiline-string trailing spaces

### DIFF
--- a/scalafmt-core/js/src/main/scala/org/scalafmt/internal/RegexCompat.scala
+++ b/scalafmt-core/js/src/main/scala/org/scalafmt/internal/RegexCompat.scala
@@ -38,7 +38,7 @@ private[scalafmt] object RegexCompat {
   val docstringLeadingSpace = pat("^\\h+")
 
   @inline
-  def compileStripMarginPattern(pipe: Char) = pat(s"\\h*\\r*\\n(\\h*\\$pipe)?")
+  def compileStripMarginPattern(pipe: Char) = pat(s"\\r*\\n(\\h*\\$pipe)?")
 
   @inline
   def compileStripMarginPatternWithLineContent(pipe: Char) =

--- a/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/RegexCompat.scala
+++ b/scalafmt-core/jvm/src/main/scala/org/scalafmt/internal/RegexCompat.scala
@@ -36,7 +36,7 @@ private[scalafmt] object RegexCompat {
 
   @inline
   private def compileStripMarginPattern(pipe: Char) = Pattern
-    .compile(s"\\h*\\r*\\n(\\h*+\\$pipe)?")
+    .compile(s"\\r*\\n(\\h*+\\$pipe)?")
 
   @inline
   def compileStripMarginPatternWithLineContent(pipe: Char) = Pattern

--- a/scalafmt-core/native/src/main/scala/org/scalafmt/internal/RegexCompat.scala
+++ b/scalafmt-core/native/src/main/scala/org/scalafmt/internal/RegexCompat.scala
@@ -82,7 +82,7 @@ object RegexCompat {
   val docstringLeadingSpace = pat("^\\h+")
 
   @inline
-  def compileStripMarginPattern(pipe: Char) = pat(s"\\h*\\r*\\n(\\h*\\$pipe)?")
+  def compileStripMarginPattern(pipe: Char) = pat(s"\\r*\\n(\\h*\\$pipe)?")
 
   @inline
   def compileStripMarginPatternWithLineContent(pipe: Char) =

--- a/scalafmt-tests/shared/src/test/resources/default/String.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/String.stat
@@ -812,7 +812,7 @@ object a {
 }
 >>>
 object a {
-  """|foo
+  """|foo  
      |bar""".stripMargin
 }
 <<< #4825 keep trailing spaces, !assumeStandardLibraryStripMargin

--- a/scalafmt-tests/shared/src/test/resources/default/String.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/String.stat
@@ -803,3 +803,27 @@ object a {
     s"Can't create a new SpecialThingamer when forwarding without specialUserId/specialDetails. SpecialUserID: ${x.maybeSpecialUserId}, Special details count: ${maybeSpecialDetails.map(_.length).getOrElse(0)}"
   )
 }
+<<< #4825 keep trailing spaces, assumeStandardLibraryStripMargin
+assumeStandardLibraryStripMargin = true
+===
+object a {
+  """|foo  
+     |bar""".stripMargin
+}
+>>>
+object a {
+  """|foo
+     |bar""".stripMargin
+}
+<<< #4825 keep trailing spaces, !assumeStandardLibraryStripMargin
+assumeStandardLibraryStripMargin = false
+===
+object a {
+  """|foo  
+     |bar""".stripMargin
+}
+>>>
+object a {
+  """|foo  
+     |bar""".stripMargin
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2520110, "total explored")
+      assertEquals(explored, 2520174, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Fixes #4825.