### PR TITLE
Config: make `withDialect` a public method

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -68,7 +68,7 @@ object Scalafmt {
       if (isSbt) {
         val sbtStyle = style.forSbt
         if (sbtStyle.dialect ne baseStyle.dialect) sbtStyle
-        else sbtStyle.withDialect(NamedDialect(dialects.Sbt))
+        else sbtStyle.withDialect(dialects.Sbt, "sbt")
       } else style
     }
     val styleTry =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/NamedDialect.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/NamedDialect.scala
@@ -14,20 +14,16 @@ object NamedDialect {
     apply(name.toLowerCase, pair.value)
   }
 
-  val scala212 = Scala212.withAllowTrailingCommas(true) // SIP-27, 2.12.2
-  val scala213 = Scala213.withAllowTrailingCommas(true)
-  val scala3 = Scala3
-
   private[config] val known = Seq[sourcecode.Text[Dialect]](
     Scala211,
-    scala212,
+    Scala212,
     Scala212Source3,
-    scala213,
+    Scala213,
     Scala213Source3,
     Sbt0137,
     Sbt1,
     Scala3Future,
-    scala3,
+    Scala3,
     Scala30,
     Scala31,
     Scala32,
@@ -39,7 +35,7 @@ object NamedDialect {
 
   private[config] val defaultName = "default"
   // current default is 213
-  private[config] val default = apply(defaultName, scala213)
+  private[config] val default = apply(defaultName, Scala213)
 
   def getName(dialect: Dialect): Option[String] = known
     .find(_.dialect eq dialect).map(_.name)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -129,9 +129,9 @@ object ProjectFiles {
         Some(NamedDialect(text))
       private[config] val s210 = nd(dialects.Scala210)
       private[config] val s211 = nd(dialects.Scala211)
-      private[config] val s212 = nd(NamedDialect.scala212)
-      private[config] val s213 = nd(NamedDialect.scala213)
-      private[config] val s3 = nd(NamedDialect.scala3)
+      private[config] val s212 = nd(dialects.Scala212)
+      private[config] val s213 = nd(dialects.Scala213)
+      private[config] val s3 = nd(dialects.Scala3)
 
       override protected[config] def getDialectByLang(
           lang: String,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -125,13 +125,12 @@ object ProjectFiles {
         dialect.allowSignificantIndentation
 
       @inline
-      private[config] def nd(text: sourcecode.Text[Dialect]) =
-        Some(NamedDialect(text))
-      private[config] val s210 = nd(dialects.Scala210)
-      private[config] val s211 = nd(dialects.Scala211)
-      private[config] val s212 = nd(dialects.Scala212)
-      private[config] val s213 = nd(dialects.Scala213)
-      private[config] val s3 = nd(dialects.Scala3)
+      private[config] def opt(nd: NamedDialect) = Some(nd)
+      private[config] val s210 = opt(dialects.Scala210)
+      private[config] val s211 = opt(dialects.Scala211)
+      private[config] val s212 = opt(dialects.Scala212)
+      private[config] val s213 = opt(dialects.Scala213)
+      private[config] val s3 = opt(dialects.Scala3)
 
       override protected[config] def getDialectByLang(
           lang: String,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RunnerSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RunnerSettings.scala
@@ -44,12 +44,10 @@ case class RunnerSettings(
   private[scalafmt] def getParser = parser.parse
 
   @inline
-  private[scalafmt] def withDialect(dialect: NamedDialect) =
-    copy(dialect = dialect)
+  def withDialect(nd: NamedDialect): RunnerSettings = copy(dialect = nd)
 
   @inline
-  private[scalafmt] def withParser(parser: ScalafmtParser) =
-    copy(parser = parser)
+  def withParser(parser: ScalafmtParser): RunnerSettings = copy(parser = parser)
 
   private[scalafmt] def forCodeBlock =
     copy(debug = false, eventCallback = null, parser = ScalafmtParser.Source)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -134,12 +134,11 @@ case class ScalafmtConfig(
       k -> v.getMatcher
     }
 
-  private[scalafmt] def withDialect(dialect: NamedDialect): ScalafmtConfig =
-    copy(runner = runner.withDialect(dialect))
+  def withDialect(nd: NamedDialect): ScalafmtConfig =
+    copy(runner = runner.withDialect(nd))
 
-  private[scalafmt] def withDialect(
-      dialect: Option[NamedDialect],
-  ): ScalafmtConfig = dialect.fold(this)(withDialect)
+  def withDialect(nd: Option[NamedDialect]): ScalafmtConfig = nd
+    .fold(this)(withDialect)
 
   def withDialect(dialect: Dialect, name: String): ScalafmtConfig =
     withDialect(NamedDialect(name, dialect))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/package.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/package.scala
@@ -1,8 +1,19 @@
 package org.scalafmt
 
-import scala.meta.Tree
-import scala.meta.parsers.Parse
+import scala.meta._
+
+import scala.language.implicitConversions
 
 package object config extends ScalafmtConfDecoders {
-  type MetaParser = Parse[_ <: Tree]
+  type MetaParser = parsers.Parse[_ <: Tree]
+
+  type NamedDialect = sourcecode.Text[Dialect]
+
+  implicit def toDialect(nd: NamedDialect): Dialect = nd.value
+
+  implicit class ImplicitNamedDialect(private val nd: NamedDialect)
+      extends AnyVal {
+    def name: String = nd.source
+    def dialect: Dialect = nd.value
+  }
 }

--- a/scalafmt-docs/src/main/scala/docs/ScalafmtModifier.scala
+++ b/scalafmt-docs/src/main/scala/docs/ScalafmtModifier.scala
@@ -1,7 +1,6 @@
 package docs
 
 import org.scalafmt.Scalafmt
-import org.scalafmt.config.NamedDialect
 import org.scalafmt.config.ScalafmtConfig
 
 import scala.meta.inputs.Input
@@ -67,7 +66,7 @@ class ScalafmtModifier extends StringModifier {
 object ScalafmtModifier {
 
   private val defaultConfig = ScalafmtConfig.default.copy(maxColumn = 40)
-    .withDialect(NamedDialect.scala213, "scala213")
+    .withDialect(scala.meta.dialects.Scala213, "scala213")
 
   private val defaultSbtConfig = defaultConfig.forSbt
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/StandardProjectLayoutTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/StandardProjectLayoutTest.scala
@@ -83,7 +83,7 @@ class StandardProjectLayoutTest extends munit.FunSuite {
     (s3, "scala-2", s213),
     (s213, "scala-3", s3),
     (s3, "scala-3", None),
-    (nd(dialects.Scala3Future), "scala-3", None),
+    (opt(dialects.Scala3Future), "scala-3", None),
   ).foreach { case (curDialectOpt, lang, expDialectOpt) =>
     val curName = curDialectOpt.map(_.name).orNull
     val expName = expDialectOpt.map(_.name).orNull

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/HasTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/HasTests.scala
@@ -207,7 +207,9 @@ trait HasTests extends FormatAssertions {
 
 object HasTests {
 
-  private val defaultDialect = NamedDialect("scala213", NamedDialect.scala213)
+  import scala.meta.dialects
+
+  private val defaultDialect = NamedDialect("scala213", dialects.Scala213)
 
   private def withoutSlowStates(cfg: ScalafmtConfig): ScalafmtConfig = cfg
     .copy(runner =
@@ -219,8 +221,7 @@ object HasTests {
 
   private val defaultConfig =
     withoutSlowStates(ScalafmtConfig.default.withDialect(defaultDialect))
-  private val scala3Config = defaultConfig
-    .withDialect(NamedDialect.scala3, "scala3")
+  private val scala3Config = defaultConfig.withDialect(dialects.Scala3, "scala3")
   private val scalaJsConfig = defaultConfig.forScalaJs.copy(maxColumn = 79)
 
   private val testing = defaultConfig.copy(


### PR DESCRIPTION
Also:

- remove local copies of dialects: they are completely identical to the originals and they also convey the impression that their type is NamedDialect when it is just Dialect
- replace NamedDialect with sourcecode.Text[Dialect]: this will allow passing a properly named variable containing just a dialect to a method expecting a "named dialect"