### PR TITLE
improvement: Pin image versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
           - '11'
           - '21'
         os:
-          - windows-latest
-          - ubuntu-latest
+          - windows-2022
+          - ubuntu-22.04
         scala:
           - '2.12.20'
           - '2.13.16'

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -25,9 +25,9 @@ jobs:
         deploy: [
           { os: macOS-13, name: scalafmt-x86_64-apple-darwin.zip },
           { os: macOS-14, name: scalafmt-aarch64-apple-darwin.zip },
-          { os: ubuntu-latest, name: scalafmt-x86_64-pc-linux.zip },
+          { os: ubuntu-22.04, name: scalafmt-x86_64-pc-linux.zip },
           { os: ubuntu-24.04-arm, name: scalafmt-aarch64-pc-linux.zip },
-          { os: windows-latest, name: scalafmt-x86_64-pc-win32.zip }
+          { os: windows-2022, name: scalafmt-x86_64-pc-win32.zip }
         ]
     runs-on: ${{ matrix.deploy.os }}
     steps:


### PR DESCRIPTION
Without the change it seems it's not possible to use scalafmt on older ubuntu images due to older gcc version. This should not be an issue normally as users can just update. For windows it's just a precaution since that is also the latest image and windows-2019 seems way too old.