### PR TITLE
Add working "get started" example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ Here is an example `.scalafmt.conf`:
 version = @STABLE_VERSION@    // mandatory
 runner.dialect = scala213    // mandatory, see below for available dialects
 
+// here are some examples of optional settings
 align.preset = more    // For pretty alignment.
 maxColumn = 1234
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,9 @@ using [HOCON](https://github.com/lightbend/config) syntax.
 Here is an example `.scalafmt.conf`:
 
 ```scala config
+version = @STABLE_VERSION@    // mandatory
+runner.dialect = scala213    // mandatory, see below for available dialects
+
 align.preset = more    // For pretty alignment.
 maxColumn = 1234
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,12 @@ title: Installation
 
 You can use Scalafmt from your editor, build tool or terminal.
 
+## Configuration
+
+You'll need a `.scalafmt.conf` file to use Scalafmt.
+[The Configuration documentation](configuration.md) includes detailed
+documentation on the available options.
+
 ## IntelliJ
 
 The _Scala_ plugin compatible with recent versions of IntelliJ IDEA has


### PR DESCRIPTION
At the moment, the "Get started" button on the homepage links to the Installation documentation, but doesn't include instructions on setting Scalafmt up for a project. I have observed that this creates significant friction for engineers that are new to Scala.

It's tough to discover that there are two required pieces of configuration, and what the values of these should be. Even on the configuration page (which addresses more complex examples) there's no clear of example of a minimal working config definition that teams can start from. This means Scalafmt is only accessible to engineers that already know how it works, or that have somewhere else to copy a working config file from.

This change adds a note to the top of the Installation documentation, because:

1. this page is linked from "Get started" so it is the first thing people see
2. It's reasonable to interpret "Installing" to mean setting up Scalafmt on the project

We use the `@STABLE_VERSION@` reference so that these docs will always point to the correct version of Scalafmt. This is especially important because there are two different versions of Scalafmt (`scalafmt-core` / `sbt-scalafmt`), which is a detail that someone just setting up IDE formatting won't need to understand.

I think this proposal addresses the 99% use case of someone just wanting sensible auto-formatting in their IDE and needing to fill in the required pieces of configuration without any customisation. I'm open to the idea that something like this could go on the homepage (at https://scalameta.org/scalafmt/) instead and of course, if this isn't aligned with the documentation's goals then let's chat about that instead 🙏 
