### PR TITLE
TreeOps: fix lambda param check a-la fewer-braces

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -373,13 +373,14 @@ object TreeOps {
       style: ScalafmtConfig,
   ): Boolean = !style.dialect.allowFewerBraces || {
     val params = func.paramClause
-    params.values match {
+    params.mod.nonEmpty ||
+    (params.values match {
       case param :: Nil => param.decltpe match {
           case Some(_: Type.Name) => ftoks.isEnclosedInMatching(params)
           case _ => true
         }
       case _ => true
-    }
+    })
   }
 
   @tailrec

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -12200,3 +12200,30 @@ object a {
       params += cpa
   else if (sym.isSynthetic && sym.isImplicit) return
 }
+<<< lambda with implicit parameter, scala213
+maxColumn = 80
+runner.dialect = scala213
+===
+Zone.acquire { implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+>>>
+Zone.acquire { implicit z: Zone =>
+  import scalanative.libc.string
+  assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+<<< lambda with implicit parameter, scala3
+maxColumn = 80
+runner.dialect = scala3
+===
+Zone.acquire { implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+>>>
+Zone.acquire {
+  implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -12222,8 +12222,7 @@ Zone.acquire { implicit z: Zone =>
     assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }
 >>>
-Zone.acquire {
-  implicit z: Zone =>
-    import scalanative.libc.string
-    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+Zone.acquire { implicit z: Zone =>
+  import scalanative.libc.string
+  assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -11431,3 +11431,30 @@ object a {
       params += cpa
   else if (sym.isSynthetic && sym.isImplicit) return
 }
+<<< lambda with implicit parameter, scala213
+maxColumn = 80
+runner.dialect = scala213
+===
+Zone.acquire { implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+>>>
+Zone.acquire { implicit z: Zone =>
+  import scalanative.libc.string
+  assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+<<< lambda with implicit parameter, scala3
+maxColumn = 80
+runner.dialect = scala3
+===
+Zone.acquire { implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+>>>
+Zone.acquire {
+  implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -11453,8 +11453,7 @@ Zone.acquire { implicit z: Zone =>
     assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }
 >>>
-Zone.acquire {
-  implicit z: Zone =>
-    import scalanative.libc.string
-    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+Zone.acquire { implicit z: Zone =>
+  import scalanative.libc.string
+  assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11992,8 +11992,7 @@ Zone.acquire { implicit z: Zone =>
     assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }
 >>>
-Zone.acquire {
-  implicit z: Zone =>
-    import scalanative.libc.string
-    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+Zone.acquire { implicit z: Zone =>
+  import scalanative.libc.string
+  assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -11970,3 +11970,30 @@ object a {
       params += cpa
   else if (sym.isSynthetic && sym.isImplicit) return
 }
+<<< lambda with implicit parameter, scala213
+maxColumn = 80
+runner.dialect = scala213
+===
+Zone.acquire { implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+>>>
+Zone.acquire { implicit z: Zone =>
+  import scalanative.libc.string
+  assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+<<< lambda with implicit parameter, scala3
+maxColumn = 80
+runner.dialect = scala3
+===
+Zone.acquire { implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+>>>
+Zone.acquire {
+  implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -12454,3 +12454,30 @@ object a {
   else if (sym.isSynthetic && sym.isImplicit)
     return
 }
+<<< lambda with implicit parameter, scala213
+maxColumn = 80
+runner.dialect = scala213
+===
+Zone.acquire { implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+>>>
+Zone.acquire { implicit z: Zone =>
+  import scalanative.libc.string
+  assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+<<< lambda with implicit parameter, scala3
+maxColumn = 80
+runner.dialect = scala3
+===
+Zone.acquire { implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}
+>>>
+Zone.acquire {
+  implicit z: Zone =>
+    import scalanative.libc.string
+    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -12476,8 +12476,7 @@ Zone.acquire { implicit z: Zone =>
     assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }
 >>>
-Zone.acquire {
-  implicit z: Zone =>
-    import scalanative.libc.string
-    assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
+Zone.acquire { implicit z: Zone =>
+  import scalanative.libc.string
+  assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2537686, "total explored")
+      assertEquals(explored, 2537604, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2536352, "total explored")
+      assertEquals(explored, 2537686, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
We don't allow break after `=>` in lambda when the parameter might look like a fewer-braces apply. However, if the parameter has an `implicit`, there's no danger of that.