### PR TITLE
Splits: ensure break between `yield` and `case`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -3381,6 +3381,12 @@ object SplitsAfterYield extends Splits {
       case t: Term.ForYield => Some(t.body)
       case _ => None
     }).fold(Seq.empty[Split]) {
+      case b: Term.PartialFunction
+          if dialect.allowSignificantIndentation &&
+            nextNonComment(ft).right.is[T.KwCase] =>
+        val split = Split(Newline, 0)
+          .withIndent(cfg.indent.getSignificant, getLast(b), ExpiresOn.After)
+        Seq(split)
       case b: Tree.Block
           if right.is[T.LeftBrace] &&
             matchingOptRight(ft).exists(_.idx >= getLast(b).idx) =>

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8533,10 +8533,6 @@ for
 yield
   case Some(x) => foo
 >>>
-test does not parse: [dialect scala3] illegal start of simple expression
 for foo <- Some(42)
-yield case Some(x) => foo
-      ^
-====== full result: ======
-for foo <- Some(42)
-yield case Some(x) => foo
+yield
+   case Some(x) => foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8527,3 +8527,16 @@ object a {
     x = "string"
   )
 }
+<<< #4857
+for
+  foo <- Some(42)
+yield
+  case Some(x) => foo
+>>>
+test does not parse: [dialect scala3] illegal start of simple expression
+for foo <- Some(42)
+yield case Some(x) => foo
+      ^
+====== full result: ======
+for foo <- Some(42)
+yield case Some(x) => foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8190,3 +8190,14 @@ object a {
     x = "string"
   )
 }
+<<< #4857
+for
+  foo <- Some(42)
+yield
+  case Some(x) => foo
+>>>
+test does not parse: [dialect scala3] illegal start of simple expression
+for foo <- Some(42) yield case Some(x) => foo
+                          ^
+====== full result: ======
+for foo <- Some(42) yield case Some(x) => foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8196,8 +8196,6 @@ for
 yield
   case Some(x) => foo
 >>>
-test does not parse: [dialect scala3] illegal start of simple expression
-for foo <- Some(42) yield case Some(x) => foo
-                          ^
-====== full result: ======
-for foo <- Some(42) yield case Some(x) => foo
+for foo <- Some(42)
+yield
+   case Some(x) => foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8549,3 +8549,18 @@ object a {
     x = "string"
   )
 }
+<<< #4857
+for
+  foo <- Some(42)
+yield
+  case Some(x) => foo
+>>>
+test does not parse: [dialect scala3] illegal start of simple expression
+for
+   foo <- Some(42)
+yield case Some(x) => foo
+      ^
+====== full result: ======
+for
+   foo <- Some(42)
+yield case Some(x) => foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8555,12 +8555,7 @@ for
 yield
   case Some(x) => foo
 >>>
-test does not parse: [dialect scala3] illegal start of simple expression
 for
    foo <- Some(42)
-yield case Some(x) => foo
-      ^
-====== full result: ======
-for
-   foo <- Some(42)
-yield case Some(x) => foo
+yield
+   case Some(x) => foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8883,12 +8883,7 @@ for
 yield
   case Some(x) => foo
 >>>
-test does not parse: [dialect scala3] illegal start of simple expression
 for foo <- Some(42)
-yield case Some(x) =>
-      ^
-  foo
-====== full result: ======
-for foo <- Some(42)
-yield case Some(x) =>
-  foo
+yield
+   case Some(x) =>
+     foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8877,3 +8877,18 @@ object a {
     x = "string"
   )
 }
+<<< #4857
+for
+  foo <- Some(42)
+yield
+  case Some(x) => foo
+>>>
+test does not parse: [dialect scala3] illegal start of simple expression
+for foo <- Some(42)
+yield case Some(x) =>
+      ^
+  foo
+====== full result: ======
+for foo <- Some(42)
+yield case Some(x) =>
+  foo

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2537756, "total explored")
+      assertEquals(explored, 2537916, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2537604, "total explored")
+      assertEquals(explored, 2537756, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Fixes #4857.