### PR TITLE
Splits: handle braces within if/for/while better

### DIFF
--- a/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59395995)
+  override protected def totalStatesVisited: Option[Int] = Some(59396121)
 
   override protected def builds = Seq {
     getBuild(
@@ -54,7 +54,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59610714)
+  override protected def totalStatesVisited: Option[Int] = Some(59610840)
 
   override protected def builds = Seq {
     getBuild(

--- a/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(52987012)
+  override protected def totalStatesVisited: Option[Int] = Some(52987016)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39188529)
+  override protected def totalStatesVisited: Option[Int] = Some(39188577)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42292843)
+  override protected def totalStatesVisited: Option[Int] = Some(42292891)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/shared/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/shared/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(85958083)
+  override protected def totalStatesVisited: Option[Int] = Some(85958174)
 
   override protected def builds = Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
 
@@ -17,7 +17,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(90961547)
+  override protected def totalStatesVisited: Option[Int] = Some(90961638)
 
   override protected def builds = Seq(getBuild("v3.5.3", dialects.Scala213, 2756))
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9246,6 +9246,24 @@ object a {
       map
     )
 }
+<<< single-line block as infix arg
+maxColumn = 80
+===
+object a {
+  if ({ rs = counterCells; rs } != null &&
+    { m = rs.length; m } > 0 && rs({ j = (m - 1) & h; j }
+  ) == null) {
+    rs(j) = r
+  }
+}
+>>>
+object a {
+  if ({ rs = counterCells; rs } != null && {
+    m = rs.length; m
+  } > 0 && rs({ j = (m - 1) & h; j }) == null) {
+    rs(j) = r
+  }
+}
 <<< #4133 case body enclosed, no break before lparen, no break after lparen
 object a {
   foo match {

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -9258,9 +9258,11 @@ object a {
 }
 >>>
 object a {
-  if ({ rs = counterCells; rs } != null && {
-    m = rs.length; m
-  } > 0 && rs({ j = (m - 1) & h; j }) == null) {
+  if (
+    { rs = counterCells; rs } != null && {
+      m = rs.length; m
+    } > 0 && rs({ j = (m - 1) & h; j }) == null
+  ) {
     rs(j) = r
   }
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -8675,9 +8675,10 @@ object a {
 }
 >>>
 object a {
-  if ({ rs = counterCells; rs } != null && { m = rs.length; m } > 0 && rs({
-    j = (m - 1) & h; j
-  }) == null) { rs(j) = r }
+  if (
+    { rs = counterCells; rs } != null && { m = rs.length; m } > 0 &&
+    rs({ j = (m - 1) & h; j }) == null
+  ) { rs(j) = r }
 }
 <<< #4133 case body enclosed, no break before lparen, no break after lparen
 object a {

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -8663,6 +8663,22 @@ object a {
     map
   )
 }
+<<< single-line block as infix arg
+maxColumn = 80
+===
+object a {
+  if ({ rs = counterCells; rs } != null &&
+    { m = rs.length; m } > 0 && rs({ j = (m - 1) & h; j }
+  ) == null) {
+    rs(j) = r
+  }
+}
+>>>
+object a {
+  if ({ rs = counterCells; rs } != null && { m = rs.length; m } > 0 && rs({
+    j = (m - 1) & h; j
+  }) == null) { rs(j) = r }
+}
 <<< #4133 case body enclosed, no break before lparen, no break after lparen
 object a {
   foo match {

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9063,9 +9063,11 @@ object a {
 }
 >>>
 object a {
-  if ({ rs = counterCells; rs } != null && { m = rs.length; m } > 0 && rs({
-    j = (m - 1) & h; j
-  }) == null) {
+  if (
+    { rs = counterCells; rs } != null && { m = rs.length; m } > 0 && rs({
+      j = (m - 1) & h; j
+    }) == null
+  ) {
     rs(j) = r
   }
 }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -9051,6 +9051,24 @@ object a {
       map
     )
 }
+<<< single-line block as infix arg
+maxColumn = 80
+===
+object a {
+  if ({ rs = counterCells; rs } != null &&
+    { m = rs.length; m } > 0 && rs({ j = (m - 1) & h; j }
+  ) == null) {
+    rs(j) = r
+  }
+}
+>>>
+object a {
+  if ({ rs = counterCells; rs } != null && { m = rs.length; m } > 0 && rs({
+    j = (m - 1) & h; j
+  }) == null) {
+    rs(j) = r
+  }
+}
 <<< #4133 case body enclosed, no break before lparen, no break after lparen
 object a {
   foo match {

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9363,6 +9363,32 @@ object a {
       map
     )
 }
+<<< single-line block as infix arg
+maxColumn = 80
+===
+object a {
+  if ({ rs = counterCells; rs } != null &&
+    { m = rs.length; m } > 0 && rs({ j = (m - 1) & h; j }
+  ) == null) {
+    rs(j) = r
+  }
+}
+>>>
+object a {
+  if ({
+    rs = counterCells;
+    rs
+  } != null && {
+    m = rs.length;
+    m
+  } > 0 &&
+  rs({
+    j = (m - 1) & h;
+    j
+  }) == null) {
+    rs(j) = r
+  }
+}
 <<< #4133 case body enclosed, no break before lparen, no break after lparen
 object a {
   foo match {

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -9375,17 +9375,19 @@ object a {
 }
 >>>
 object a {
-  if ({
-    rs = counterCells;
-    rs
-  } != null && {
-    m = rs.length;
-    m
-  } > 0 &&
-  rs({
-    j = (m - 1) & h;
-    j
-  }) == null) {
+  if (
+    {
+      rs = counterCells;
+      rs
+    } != null && {
+      m = rs.length;
+      m
+    } > 0 &&
+    rs({
+      j = (m - 1) & h;
+      j
+    }) == null
+  ) {
     rs(j) = r
   }
 }

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8536,3 +8536,14 @@ yield
 for foo <- Some(42)
 yield
    case Some(x) => foo
+<<< scalaz nested refined types
+def foldStep(
+  onGosub: ~>[({type l[a] = (S[a], a => Free[S, A])})#l, ({type l[a] = B})#l]
+): B = ???
+>>>
+def foldStep(
+    onGosub: ~>[
+      ({ type l[a] = (S[a], a => Free[S, A]) })#l,
+      ({ type l[a] = B })#l
+    ]
+): B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8199,3 +8199,14 @@ yield
 for foo <- Some(42)
 yield
    case Some(x) => foo
+<<< scalaz nested refined types
+def foldStep(
+  onGosub: ~>[({type l[a] = (S[a], a => Free[S, A])})#l, ({type l[a] = B})#l]
+): B = ???
+>>>
+def foldStep(
+    onGosub: ~>[
+      ({ type l[a] = (S[a], a => Free[S, A]) })#l,
+      ({ type l[a] = B })#l
+    ]
+): B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8559,3 +8559,14 @@ for
    foo <- Some(42)
 yield
    case Some(x) => foo
+<<< scalaz nested refined types
+def foldStep(
+  onGosub: ~>[({type l[a] = (S[a], a => Free[S, A])})#l, ({type l[a] = B})#l]
+): B = ???
+>>>
+def foldStep(
+    onGosub: ~>[
+      ({ type l[a] = (S[a], a => Free[S, A]) })#l,
+      ({ type l[a] = B })#l
+    ]
+): B = ???

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8887,3 +8887,18 @@ for foo <- Some(42)
 yield
    case Some(x) =>
      foo
+<<< scalaz nested refined types
+def foldStep(
+  onGosub: ~>[({type l[a] = (S[a], a => Free[S, A])})#l, ({type l[a] = B})#l]
+): B = ???
+>>>
+def foldStep(
+    onGosub: ~>[
+      ({
+        type l[a] = (S[a], a => Free[S, A])
+      })#l,
+      ({
+        type l[a] = B
+      })#l
+    ]
+): B = ???

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2540816, "total explored")
+      assertEquals(explored, 2541354, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2537916, "total explored")
+      assertEquals(explored, 2540816, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Previously, we'd assume that a brace within `if` or `while` contains the entire condition and let the brace rules handle it; however, this brace could enclose only a part of the condition and hence needs to be handled differently then.

Additionally, we ignored the danglingParentheses.ctrlSite parameter in these cases as well.

Helps with #4859.