### PR TITLE
Splits: don't indent enclosed cond in if/while

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -326,9 +326,9 @@ object Split {
       fileLineStack: FileLineStack,
   ): Split = if (ignore) ignored else Split(modExt, cost)
 
-  def opt(mod: Modification, cost: Int)(implicit
-      fileLineStack: FileLineStack,
-  ): Split = if (mod eq null) ignored else Split(mod, cost)
+  def opt(mod: Modification, cost: Int, policy: Policy = Policy.NoPolicy)(
+      implicit fileLineStack: FileLineStack,
+  ): Split = if (mod eq null) ignored else Split(mod, cost, policy = policy)
 
   implicit class ImplicitSeqSplit(private val obj: Seq[Split]) extends AnyVal {
     def penalize(penalty: Int): Seq[Split] = obj.map(_.withPenalty(penalty))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -1999,7 +1999,7 @@ object SplitsAfterLeftParen extends Splits {
         val nlPolicy = penalizeNewlines & decideNewlinesOnlyBeforeClose(close)
         Seq(noSplit, Split(Newline, 1, policy = nlPolicy).withIndent(indent))
       } else Seq(baseNoSplit(penalizeNewlines, Newline).withIndents(
-        if (noAlign) Seq(indent) // TODO: check if enclosed
+        if (noAlign) if (enclosedInBraces) Seq.empty else Seq(indent)
         else alignIndents,
       ))
     }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -12296,9 +12296,9 @@ if ({
 }) baos.write(buffer, 0, nread)
 >>>
 if ({
-    nread = is.read(buffer, 0, buffer.length)
-    nread != -1
-  }) baos.write(buffer, 0, nread)
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
 <<< while cond in braces, danglingParentheses.ctrlSite
 maxColumn = 80
 danglingParentheses.ctrlSite = true
@@ -12322,6 +12322,6 @@ while ({
 }) baos.write(buffer, 0, nread)
 >>>
 while ({
-    nread = is.read(buffer, 0, buffer.length)
-    nread != -1
-  }) baos.write(buffer, 0, nread)
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -12273,3 +12273,55 @@ Zone.acquire { implicit z: Zone =>
   import scalanative.libc.string
   assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }
+<<< if cond in braces, danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = true
+===
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+<<< if cond in braces, !danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = false
+===
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+if ({
+    nread = is.read(buffer, 0, buffer.length)
+    nread != -1
+  }) baos.write(buffer, 0, nread)
+<<< while cond in braces, danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = true
+===
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+<<< while cond in braces, !danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = false
+===
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+while ({
+    nread = is.read(buffer, 0, buffer.length)
+    nread != -1
+  }) baos.write(buffer, 0, nread)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -11497,3 +11497,55 @@ Zone.acquire { implicit z: Zone =>
   import scalanative.libc.string
   assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }
+<<< if cond in braces, danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = true
+===
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+<<< if cond in braces, !danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = false
+===
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+if ({
+    nread = is.read(buffer, 0, buffer.length)
+    nread != -1
+  }) baos.write(buffer, 0, nread)
+<<< while cond in braces, danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = true
+===
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+<<< while cond in braces, !danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = false
+===
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+while ({
+    nread = is.read(buffer, 0, buffer.length)
+    nread != -1
+  }) baos.write(buffer, 0, nread)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -11520,9 +11520,9 @@ if ({
 }) baos.write(buffer, 0, nread)
 >>>
 if ({
-    nread = is.read(buffer, 0, buffer.length)
-    nread != -1
-  }) baos.write(buffer, 0, nread)
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
 <<< while cond in braces, danglingParentheses.ctrlSite
 maxColumn = 80
 danglingParentheses.ctrlSite = true
@@ -11546,6 +11546,6 @@ while ({
 }) baos.write(buffer, 0, nread)
 >>>
 while ({
-    nread = is.read(buffer, 0, buffer.length)
-    nread != -1
-  }) baos.write(buffer, 0, nread)
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -12066,9 +12066,9 @@ if ({
 }) baos.write(buffer, 0, nread)
 >>>
 if ({
-    nread = is.read(buffer, 0, buffer.length)
-    nread != -1
-  }) baos.write(buffer, 0, nread)
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
 <<< while cond in braces, danglingParentheses.ctrlSite
 maxColumn = 80
 danglingParentheses.ctrlSite = true
@@ -12092,6 +12092,6 @@ while ({
 }) baos.write(buffer, 0, nread)
 >>>
 while ({
-    nread = is.read(buffer, 0, buffer.length)
-    nread != -1
-  }) baos.write(buffer, 0, nread)
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -12043,3 +12043,55 @@ Zone.acquire { implicit z: Zone =>
   import scalanative.libc.string
   assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }
+<<< if cond in braces, danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = true
+===
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+<<< if cond in braces, !danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = false
+===
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+if ({
+    nread = is.read(buffer, 0, buffer.length)
+    nread != -1
+  }) baos.write(buffer, 0, nread)
+<<< while cond in braces, danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = true
+===
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+<<< while cond in braces, !danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = false
+===
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+while ({
+    nread = is.read(buffer, 0, buffer.length)
+    nread != -1
+  }) baos.write(buffer, 0, nread)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -12536,3 +12536,59 @@ Zone.acquire { implicit z: Zone =>
   import scalanative.libc.string
   assertEquals("case 2", 0, string.strcmp(buf2, c"1"))
 }
+<<< if cond in braces, danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = true
+===
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+})
+  baos.write(buffer, 0, nread)
+<<< if cond in braces, !danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = false
+===
+if ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+if ({
+    nread = is.read(buffer, 0, buffer.length)
+    nread != -1
+  })
+  baos.write(buffer, 0, nread)
+<<< while cond in braces, danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = true
+===
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+})
+  baos.write(buffer, 0, nread)
+<<< while cond in braces, !danglingParentheses.ctrlSite
+maxColumn = 80
+danglingParentheses.ctrlSite = false
+===
+while ({
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+}) baos.write(buffer, 0, nread)
+>>>
+while ({
+    nread = is.read(buffer, 0, buffer.length)
+    nread != -1
+  })
+  baos.write(buffer, 0, nread)

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -12560,9 +12560,9 @@ if ({
 }) baos.write(buffer, 0, nread)
 >>>
 if ({
-    nread = is.read(buffer, 0, buffer.length)
-    nread != -1
-  })
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+})
   baos.write(buffer, 0, nread)
 <<< while cond in braces, danglingParentheses.ctrlSite
 maxColumn = 80
@@ -12588,7 +12588,7 @@ while ({
 }) baos.write(buffer, 0, nread)
 >>>
 while ({
-    nread = is.read(buffer, 0, buffer.length)
-    nread != -1
-  })
+  nread = is.read(buffer, 0, buffer.length)
+  nread != -1
+})
   baos.write(buffer, 0, nread)

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2546848, "total explored")
+      assertEquals(explored, 2549280, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
We already do that for `danglingParentheses.ctrlSite = true` but now fix also the other case.