### PR TITLE
TreeOps: no trailing commas for extended instance

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/shared/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -492,7 +492,7 @@ extension [
     A,
     B,
 ](
-    self: Int,
+    self: Int
 )(using
     a: A,
     b: B,
@@ -518,7 +518,7 @@ extension [
     A,
     B,
 ](
-    self: Int,
+    self: Int
 )(using
     a: A,
     b: B,

--- a/scalafmt-tests/shared/src/test/resources/trailing-commas/trailingCommasAlways.stat
+++ b/scalafmt-tests/shared/src/test/resources/trailing-commas/trailingCommasAlways.stat
@@ -473,3 +473,55 @@ f(
   else
     1234567890,
 )
+<<< #4869 has comma
+runner.dialect = scala3
+===
+extension [
+  A,
+  B
+](
+  self: Int,
+)(using
+  a: A,
+  b: B
+){
+  def foo = self.hashCode
+}
+>>>
+extension [
+    A,
+    B,
+](
+    self: Int,
+)(using
+    a: A,
+    b: B,
+) {
+  def foo = self.hashCode
+}
+<<< #4869 no comma
+runner.dialect = scala3
+===
+extension [
+  A,
+  B
+](
+  self: Int
+)(using
+  a: A,
+  b: B
+){
+  def foo = self.hashCode
+}
+>>>
+extension [
+    A,
+    B,
+](
+    self: Int,
+)(using
+    a: A,
+    b: B,
+) {
+  def foo = self.hashCode
+}

--- a/scalafmt-tests/shared/src/test/resources/trailing-commas/trailingCommasPreserve.stat
+++ b/scalafmt-tests/shared/src/test/resources/trailing-commas/trailingCommasPreserve.stat
@@ -540,3 +540,55 @@ object a {
     }),
   )
 }
+<<< #4869 has comma
+runner.dialect = scala3
+===
+extension [
+  A,
+  B
+](
+  self: Int,
+)(using
+  a: A,
+  b: B
+){
+  def foo = self.hashCode
+}
+>>>
+extension [
+    A,
+    B
+](
+    self: Int,
+)(using
+    a: A,
+    b: B
+) {
+  def foo = self.hashCode
+}
+<<< #4869 no comma
+runner.dialect = scala3
+===
+extension [
+  A,
+  B
+](
+  self: Int
+)(using
+  a: A,
+  b: B
+){
+  def foo = self.hashCode
+}
+>>>
+extension [
+    A,
+    B
+](
+    self: Int
+)(using
+    a: A,
+    b: B
+) {
+  def foo = self.hashCode
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2552242, "total explored")
+      assertEquals(explored, 2552742, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Fixes #4869.