### PR TITLE
feat: change default to `trailingCommas = always`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/TrailingCommas.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/TrailingCommas.scala
@@ -4,7 +4,7 @@ import metaconfig._
 
 case class TrailingCommas(
     allowFolding: Boolean = true,
-    style: TrailingCommas.Style = TrailingCommas.never,
+    style: TrailingCommas.Style = TrailingCommas.always,
 ) {
   def withoutRewrites: TrailingCommas = copy(style = TrailingCommas.keep)
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/ScalafmtTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/ScalafmtTest.scala
@@ -49,7 +49,7 @@ class ScalafmtTest extends FunSuite {
        |  function(
        |    aaaaaaaa,
        |    bbbbbbbbbb,
-       |    ddddd(eeeeeeeeee, fffffff, gggggggg)
+       |    ddddd(eeeeeeeeee, fffffff, gggggggg),
        |  )
        |}
        |""".stripMargin,


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/8dae1ef5-a764-489a-a625-7ea83d6bdc26)

7y after #1214, poll result have changed significantly in #1184, and outstanding amount of people **want** `trailingCommas = always` (40 thumbs up) and **hate** `trailingCommas = never` (15 thumbs up and 14 thumbs down).
 
however, this change causes following error when running `sbt tests/test` locally:
need help solving this failure.

```
==> X org.scalafmt.FormatTests.initializationError  0.0s java.lang.IllegalArgumentException: Failed to parse line=1 filename /run/media/home/scarf/repo/scala/scalafmt/scalafmt-tests/shared/src/test/resources/align/addSbtPlugin.source:
preset = defaultWithAlign
runner.dialect = Sbt0137
can't use: [
         (no support in Scala dialect sbt0137): getTrailingCommas eq TrailingCommas.always
]
    at org.scalafmt.util.HasTests.$anonfun$parseDiffTests$1(HasTests.scala:76)
    at metaconfig.Configured$ConfiguredImplicit.fold(Configured.scala:115)
    at metaconfig.Configured$ConfiguredImplicit.getOrRecover(Configured.scala:111)
    at org.scalafmt.util.HasTests.loadStyle$1(HasTests.scala:72)
    at org.scalafmt.util.HasTests.parseDiffTests(HasTests.scala:79)
    at org.scalafmt.util.HasTests.parseDiffTests$(HasTests.scala:50)
    at org.scalafmt.UnitTests$.parseDiffTests(UnitTests.scala:9)
    at org.scalafmt.UnitTests$.$anonfun$tests$2(UnitTests.scala:26)
    at scala.collection.immutable.List.flatMap(List.scala:294)
    at scala.collection.immutable.List.flatMap(List.scala:79)
    at org.scalafmt.UnitTests$.tests$lzycompute(UnitTests.scala:25)
    at org.scalafmt.UnitTests$.tests(UnitTests.scala:22)
    at org.scalafmt.FormatTests.onlyUnit$lzycompute(FormatTests.scala:20)
    at org.scalafmt.FormatTests.onlyUnit(FormatTests.scala:20)
    at org.scalafmt.FormatTests.onlyManual$lzycompute(FormatTests.scala:21)
    at org.scalafmt.FormatTests.onlyManual(FormatTests.scala:21)
    at org.scalafmt.FormatTests.<init>(FormatTests.scala:28)
```