### PR TITLE
ParConverters: move from sysops to tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,8 +113,7 @@ lazy val sysops = crossProject(JVMPlatform, NativePlatform, JSPlatform)
       else Seq("com.github.bigwheel" %% "util-backports" % "2.1")
     },
     sharedTestSettings,
-  ).platformsSettings(JVMPlatform, NativePlatform)(parallelCollections)
-  .jsEnablePlugins(ScalaJSPlugin).jsSettings(
+  ).jsEnablePlugins(ScalaJSPlugin).jsSettings(
     libraryDependencies += "org.scalameta" %%% "io" % scalametaV,
     scalaJsSettings,
   )
@@ -231,9 +230,9 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform, JSPlatform)
       (Test / resourceDirectories).value.find(_.toPath.startsWith(sharedTests))
         .get
     }),
-  ).enablePlugins(BuildInfoPlugin)
-  .jvmSettings(javaOptions += "-Dfile.encoding=UTF8").dependsOn(core)
-  .aggregate(core).jsSettings(scalaJsSettings).jsEnablePlugins(ScalaJSPlugin)
+  ).enablePlugins(BuildInfoPlugin).dependsOn(core).aggregate(core)
+  .jvmSettings(javaOptions += "-Dfile.encoding=UTF8", parallelCollections)
+  .jsSettings(scalaJsSettings).jsEnablePlugins(ScalaJSPlugin)
 
 lazy val sharedTestSettings = Seq(libraryDependencies += munit.value % Test)
 

--- a/scalafmt-sysops/shared/src/main/scala-2.12/org/scalafmt/CompatCollections.scala
+++ b/scalafmt-sysops/shared/src/main/scala-2.12/org/scalafmt/CompatCollections.scala
@@ -2,5 +2,4 @@ package org.scalafmt
 
 private[scalafmt] object CompatCollections {
   val JavaConverters = scala.collection.JavaConverters
-  object ParConverters
 }

--- a/scalafmt-sysops/shared/src/main/scala-2.13/org/scalafmt/CompatCollections.scala
+++ b/scalafmt-sysops/shared/src/main/scala-2.13/org/scalafmt/CompatCollections.scala
@@ -2,5 +2,4 @@ package org.scalafmt
 
 private[scalafmt] object CompatCollections {
   val JavaConverters = scala.jdk.CollectionConverters
-  val ParConverters = scala.collection.parallel.CollectionConverters
 }

--- a/scalafmt-tests/jvm/src/test/scala-2.12/org.scalafmt/TestCompatCollections.scala
+++ b/scalafmt-tests/jvm/src/test/scala-2.12/org.scalafmt/TestCompatCollections.scala
@@ -1,0 +1,5 @@
+package org.scalafmt
+
+private[scalafmt] object TestCompatCollections {
+  object ParConverters
+}

--- a/scalafmt-tests/jvm/src/test/scala-2.13/org/scalafmt/TestCompatCollections.scala
+++ b/scalafmt-tests/jvm/src/test/scala-2.13/org/scalafmt/TestCompatCollections.scala
@@ -1,0 +1,5 @@
+package org.scalafmt
+
+private[scalafmt] object TestCompatCollections {
+  val ParConverters = scala.collection.parallel.CollectionConverters
+}

--- a/scalafmt-tests/jvm/src/test/scala/org/scalafmt/ScalafmtProps.scala
+++ b/scalafmt-tests/jvm/src/test/scala/org/scalafmt/ScalafmtProps.scala
@@ -1,6 +1,6 @@
 package org.scalafmt
 
-import org.scalafmt.CompatCollections.ParConverters._
+import org.scalafmt.TestCompatCollections.ParConverters._
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.sysops.AbsoluteFile
 import org.scalafmt.util.FormatAssertions
@@ -20,10 +20,7 @@ class ScalafmtProps extends FunSuite with FormatAssertions {
       config: ScalafmtConfig = ScalafmtConfig.default,
       count: Int = Int.MaxValue,
   ): mutable.Seq[(CorpusFile, Observation[Bug])] = {
-    val corpus = Corpus.files(
-      // TODO(olafur) remove once testkit 1.7 is out
-      Corpus.fastparse.copy(Corpus.fastparse.url.replace("olafurpg", "scalameta")),
-    ).take(count).toBuffer.par
+    val corpus = Corpus.files(Corpus.fastparse).take(count).toBuffer.par
     SyntaxAnalysis.run[Observation[Bug]](corpus) { file =>
       val code = file.read
       try Scalafmt.format(code, config) match {


### PR DESCRIPTION
We use Futures everywhere, except ScalafmtProps test.