### PR TITLE
Splits: prefer before-dot over after-arrow rule

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -935,7 +935,8 @@ object SplitsAfterRightArrow extends Splits {
   ): Seq[Split] = {
     import ft._
     leftOwner match {
-      case t: CaseTree if !right.isAny[T.KwCatch, T.KwFinally] => caseTree(t) // Case arrow
+      case t: CaseTree if !right.isAny[T.KwCatch, T.KwFinally, T.Dot] => // Case arrow
+        caseTree(t)
       case _: Type.ByNameType => Seq(Split(Space(cfg.spaces.inByNameTypes), 0))
       case _ => Seq.empty
     }

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
@@ -2737,3 +2737,36 @@ indent.fewerBraces = beforeSelect
      .map(_ * 2)
      .last
    println(first)
+<<< SKIP empty case body
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ =>
+    .qux
+>>>
+BestFirstSearch:317 Failed to format
+UNABLE TO FORMAT,
+tok #14/17: [14] => . >>> RightArrow [59..61) | Dot [66..67) >>> Case.CaseImpl [52..61) [Term.PartialFunction] | Term.Select [12..70) [Template.Body] <<<[LF]>>>
+policies:
+  REL?:[Splits:3283](CASESLB>ARROW:[Splits:3276]d <== >=RightArrow[14] ??? <=RightArrow[14] ==> NA:[Splits:3239]d <== >=RightArrow[14])
+  NA:[FormatOps:2000]d <== >=RightArrow[14]
+  (NEXTSEL2NL[14]:[Splits:2523]d <== >=RightArrow[14] & PNL+2:[Splits:2579]d <== <Ident(qux)[16])
+  <=Ident(qux)[16] ==> NA:[FormatOps:1929]d <== >=Ident(qux)[16]
+splits (before policy):
+  c=1[0] NL:[Splits:973->Splits:55](NoPolicy)
+splits (after policy):
+<<< non-empty case body
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ => two
+    .qux
+>>>
+object a:
+   foo
+     .bar:
+        case 1 => one
+        case _ => two
+     .qux

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
@@ -2737,7 +2737,7 @@ indent.fewerBraces = beforeSelect
      .map(_ * 2)
      .last
    println(first)
-<<< SKIP empty case body
+<<< empty case body
 object a:
   foo
     .bar:
@@ -2745,17 +2745,12 @@ object a:
       case _ =>
     .qux
 >>>
-BestFirstSearch:317 Failed to format
-UNABLE TO FORMAT,
-tok #14/17: [14] => . >>> RightArrow [59..61) | Dot [66..67) >>> Case.CaseImpl [52..61) [Term.PartialFunction] | Term.Select [12..70) [Template.Body] <<<[LF]>>>
-policies:
-  REL?:[Splits:3283](CASESLB>ARROW:[Splits:3276]d <== >=RightArrow[14] ??? <=RightArrow[14] ==> NA:[Splits:3239]d <== >=RightArrow[14])
-  NA:[FormatOps:2000]d <== >=RightArrow[14]
-  (NEXTSEL2NL[14]:[Splits:2523]d <== >=RightArrow[14] & PNL+2:[Splits:2579]d <== <Ident(qux)[16])
-  <=Ident(qux)[16] ==> NA:[FormatOps:1929]d <== >=Ident(qux)[16]
-splits (before policy):
-  c=1[0] NL:[Splits:973->Splits:55](NoPolicy)
-splits (after policy):
+object a:
+   foo
+     .bar:
+        case 1 => one
+        case _ =>
+     .qux
 <<< non-empty case body
 object a:
   foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
@@ -2479,3 +2479,36 @@ def main() =
         foo bar
      .map(_ * 2).last
    println(first)
+<<< SKIP empty case body
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ =>
+    .qux
+>>>
+BestFirstSearch:317 Failed to format
+UNABLE TO FORMAT,
+tok #14/17: [14] => . >>> RightArrow [59..61) | Dot [66..67) >>> Case.CaseImpl [52..61) [Term.PartialFunction] | Term.Select [12..70) [Template.Body] <<<[LF]>>>
+policies:
+  REL?:[Splits:3283](CASESLB>ARROW:[Splits:3276]d <== >=RightArrow[14] ??? NoPolicy)
+  NA:[FormatOps:2000]d <== >=RightArrow[14]
+  (NEXTSEL1NL:[Splits:2712]d <== <Ident(qux)[16] & NA:[Splits:2701]d <== >=RightArrow[14])
+  <=Ident(qux)[16] ==> NA:[FormatOps:1929]d <== >=Ident(qux)[16]
+splits (before policy):
+  c=1[0] NL:[Splits:977->Splits:55](NoPolicy)
+splits (after policy):
+  [!SelectChainFirstNL]c=1[0] NL:[Splits:977->Splits:55](NoPolicy)
+<<< non-empty case body
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ => two
+    .qux
+>>>
+object a:
+   foo.bar:
+      case 1 => one
+      case _ => two
+   .qux

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
@@ -2479,7 +2479,7 @@ def main() =
         foo bar
      .map(_ * 2).last
    println(first)
-<<< SKIP empty case body
+<<< empty case body
 object a:
   foo
     .bar:
@@ -2487,18 +2487,11 @@ object a:
       case _ =>
     .qux
 >>>
-BestFirstSearch:317 Failed to format
-UNABLE TO FORMAT,
-tok #14/17: [14] => . >>> RightArrow [59..61) | Dot [66..67) >>> Case.CaseImpl [52..61) [Term.PartialFunction] | Term.Select [12..70) [Template.Body] <<<[LF]>>>
-policies:
-  REL?:[Splits:3283](CASESLB>ARROW:[Splits:3276]d <== >=RightArrow[14] ??? NoPolicy)
-  NA:[FormatOps:2000]d <== >=RightArrow[14]
-  (NEXTSEL1NL:[Splits:2712]d <== <Ident(qux)[16] & NA:[Splits:2701]d <== >=RightArrow[14])
-  <=Ident(qux)[16] ==> NA:[FormatOps:1929]d <== >=Ident(qux)[16]
-splits (before policy):
-  c=1[0] NL:[Splits:977->Splits:55](NoPolicy)
-splits (after policy):
-  [!SelectChainFirstNL]c=1[0] NL:[Splits:977->Splits:55](NoPolicy)
+object a:
+   foo.bar:
+      case 1 => one
+      case _ =>
+   .qux
 <<< non-empty case body
 object a:
   foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_keep.stat
@@ -2720,3 +2720,31 @@ indent.fewerBraces = beforeSelect
      .map(_ * 2)
      .last
    println(first)
+<<< empty case body
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ =>
+    .qux
+>>>
+object a:
+   foo
+     .bar:
+        case 1 => one
+        case _ =>
+     .qux
+<<< non-empty case body
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ => two
+    .qux
+>>>
+object a:
+   foo
+     .bar:
+        case 1 => one
+        case _ => two
+     .qux

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_unfold.stat
@@ -2765,3 +2765,34 @@ def main() =
      .map(_ * 2)
      .last
    println(first)
+<<< empty case body
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ =>
+    .qux
+>>>
+object a:
+   foo
+     .bar:
+        case 1 =>
+          one
+        case _ =>
+     .qux
+<<< non-empty case body
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ => two
+    .qux
+>>>
+object a:
+   foo
+     .bar:
+        case 1 =>
+          one
+        case _ =>
+          two
+     .qux

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2562756, "total explored")
+      assertEquals(explored, 2562900, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2562268, "total explored")
+      assertEquals(explored, 2562756, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Helps with #4897.