### PR TITLE
FormatOps: modify ctrl-body comment splits

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1644,14 +1644,11 @@ class FormatOps(
       else if (ft.hasBreak) Seq(nlSplitFunc(0).forThisLine)
       else {
         val nextFt = nextNonCommentSameLineAfter(ft)
-        val splits =
-          if (nextFt.noBreak) splitsFunc(nextFt)
-          else {
-            val split = nlSplitFunc(0).forThisLine
-            Seq(if (rhsIsCommentedOut(nextFt)) split.withNoIndent else split)
-          }
-        val policy = Policy.onlyFor(nextFt, "CBCMT")(_ => splits)
-        Seq(Split(Space, 0, policy = policy))
+        val nlPolicy = decideNewlinesOnlyAfterClose(nextFt)
+        if (nextFt.hasBreakOrEOF)
+          Seq(nlSplitFunc(1).forThisLine.withMod(Space).andPolicy(nlPolicy))
+        else splitsFunc(nextFt)
+          .map(s => s.withMod(Space).andPolicy(nlPolicy, !s.isNL))
       }
 
     def folded(

--- a/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59389474)
+  override protected def totalStatesVisited: Option[Int] = Some(59389297)
 
   override protected def builds = Seq {
     getBuild(
@@ -54,7 +54,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59604274)
+  override protected def totalStatesVisited: Option[Int] = Some(59604049)
 
   override protected def builds = Seq {
     getBuild(

--- a/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42547229)
+  override protected def totalStatesVisited: Option[Int] = Some(42546299)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(52668381)
+  override protected def totalStatesVisited: Option[Int] = Some(52667390)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39186783)
+  override protected def totalStatesVisited: Option[Int] = Some(39186772)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42290928)
+  override protected def totalStatesVisited: Option[Int] = Some(42290938)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/shared/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/shared/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(85924573)
+  override protected def totalStatesVisited: Option[Int] = Some(85923242)
 
   override protected def builds = Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
 
@@ -17,7 +17,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(90890767)
+  override protected def totalStatesVisited: Option[Int] = Some(90889429)
 
   override protected def builds = Seq(getBuild("v3.5.3", dialects.Scala213, 2756))
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -3503,10 +3503,11 @@ object a {
 }
 >>>
 object a {
-  def validate(d: DirectoryProxy, step: Int): Unit = if (step != 0) /* c1 */
-    { /* c2 */
-      d.name should be("dir" + step)
-    }
+  def validate(d: DirectoryProxy, step: Int): Unit = if (
+    step != 0
+  ) /* c1 */ { /* c2 */
+    d.name should be("dir" + step)
+  }
 }
 <<< #2113 case 1
 object a {

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10090,15 +10090,17 @@ def isNeverSubType(tp1: Type, tp2: Type): Boolean = /*logResult(s"isNeverSubType
   case _ => false
 })
 >>>
-def isNeverSubType(tp1: Type, tp2: Type): Boolean = /*logResult(s"isNeverSubType($tp1, $tp2)")*/
-  (tp1.dealias, tp2.dealias) match {
-    case (TypeRef(_, sym1, args1), TypeRef(_, sym2, args2)) =>
-      isNeverSubClass(sym1, sym2) || (sym1 isSubClass sym2) && {
-        val tp1seen = tp1 baseType sym2
-        isNeverSubArgs(tp1seen.typeArgs, args2, sym2.typeParams)
-      }
-    case _ => false
-  }
+def isNeverSubType(tp1: Type, tp2: Type): Boolean = /*logResult(s"isNeverSubType($tp1, $tp2)")*/ (
+  tp1.dealias,
+  tp2.dealias
+) match {
+  case (TypeRef(_, sym1, args1), TypeRef(_, sym2, args2)) =>
+    isNeverSubClass(sym1, sym2) || (sym1 isSubClass sym2) && {
+      val tp1seen = tp1 baseType sym2
+      isNeverSubArgs(tp1seen.typeArgs, args2, sym2.typeParams)
+    }
+  case _ => false
+}
 <<< #4133 redundant braces around assignment rhs infix
 maxColumn = 70
 rewrite.rules = [RedundantBraces]

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
@@ -2751,7 +2751,7 @@ object a:
         case 1 => one
         case _ =>
      .qux
-<<< SKIP empty case body, only a comment
+<<< empty case body, only a comment
 object a:
   foo
     .bar:
@@ -2759,21 +2759,12 @@ object a:
       case _ => // two
     .qux
 >>>
-BestFirstSearch:317 Failed to format
-UNABLE TO FORMAT,
-tok #15/18: [15] // two . >>> Comment( two) [62..68) | Dot [73..74) >>> Term.Select [12..77) [Template.Body] | Term.Select [12..77) [Template.Body] <<<[LF]>>>
-policies:
-  CBCMT[15]:[FormatOps:1653]d <== >=Comment( two)[15]
-  REL?:[Splits:3283](CASESLB>ARROW:[Splits:3276]d <== >=Comment( two)[15] ??? NoPolicy)
-  NA:[FormatOps:2000]d <== >=Comment( two)[15]
-  (NEXTSEL2NL[15]:[Splits:2523]d <== >=Comment( two)[15] & PNL+2:[Splits:2579]d <== <Ident(qux)[17])
-  <=Ident(qux)[17] ==> NA:[FormatOps:1929]d <== >=Ident(qux)[17]
-splits (before policy):
-  [SelectChainSecondNL]c=1[0] NL:[Splits:2627->Splits:2568](NoPolicy)
-  c=0[0] NL:[Splits:2629->Splits:2629](NoPolicy)
-  [SelectChainSecondNL,SelectChainFirstNL]c=1[0] NL:[Splits:2627->Splits:2568](NoPolicy)
-  [SelectChainFirstNL]c=0[0] NL:[Splits:2629->Splits:2629](NoPolicy)
-splits (after policy):
+object a:
+   foo
+     .bar:
+        case 1 => one
+        case _ => // two
+     .qux
 <<< non-empty case body
 object a:
   foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
@@ -2751,6 +2751,29 @@ object a:
         case 1 => one
         case _ =>
      .qux
+<<< SKIP empty case body, only a comment
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ => // two
+    .qux
+>>>
+BestFirstSearch:317 Failed to format
+UNABLE TO FORMAT,
+tok #15/18: [15] // two . >>> Comment( two) [62..68) | Dot [73..74) >>> Term.Select [12..77) [Template.Body] | Term.Select [12..77) [Template.Body] <<<[LF]>>>
+policies:
+  CBCMT[15]:[FormatOps:1653]d <== >=Comment( two)[15]
+  REL?:[Splits:3283](CASESLB>ARROW:[Splits:3276]d <== >=Comment( two)[15] ??? NoPolicy)
+  NA:[FormatOps:2000]d <== >=Comment( two)[15]
+  (NEXTSEL2NL[15]:[Splits:2523]d <== >=Comment( two)[15] & PNL+2:[Splits:2579]d <== <Ident(qux)[17])
+  <=Ident(qux)[17] ==> NA:[FormatOps:1929]d <== >=Ident(qux)[17]
+splits (before policy):
+  [SelectChainSecondNL]c=1[0] NL:[Splits:2627->Splits:2568](NoPolicy)
+  c=0[0] NL:[Splits:2629->Splits:2629](NoPolicy)
+  [SelectChainSecondNL,SelectChainFirstNL]c=1[0] NL:[Splits:2627->Splits:2568](NoPolicy)
+  [SelectChainFirstNL]c=0[0] NL:[Splits:2629->Splits:2629](NoPolicy)
+splits (after policy):
 <<< non-empty case body
 object a:
   foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
@@ -2492,7 +2492,7 @@ object a:
       case 1 => one
       case _ =>
    .qux
-<<< SKIP empty case body, only a comment
+<<< empty case body, only a comment
 object a:
   foo
     .bar:
@@ -2500,19 +2500,11 @@ object a:
       case _ => // two
     .qux
 >>>
-BestFirstSearch:317 Failed to format
-UNABLE TO FORMAT,
-tok #14/18: [14] => // two >>> RightArrow [59..61) | Comment( two) [62..68) >>> Case.CaseImpl [52..61) [Term.PartialFunction] | Term.Select [12..77) [Template.Body] <<<[ ]>>>
-policies:
-  REL?:[Splits:3283](CASESLB>ARROW:[Splits:3276]d <== >=Comment( two)[15] ??? NoPolicy)
-  <=Comment( two)[15] ==> NA:[FormatOps:2000]d <== >=Comment( two)[15]
-  (NEXTSEL1NL:[Splits:2712]d <== <Ident(qux)[17] & <=Comment( two)[15] ==> NA:[Splits:2701]d <== >=Comment( two)[15])
-  <=Ident(qux)[17] ==> NA:[FormatOps:1929]d <== >=Ident(qux)[17]
-splits (before policy):
-  c=0[0] SP:[FormatOps:1654->FormatOps:1654](<=Comment( two)[15] ==> CBCMT[15]:[FormatOps:1653]d <== >=Comment( two)[15])
-splits (after policy):
-  [!SelectChainFirstNL]c=0[0] SP:[FormatOps:1654->FormatOps:1654]((<=Comment( two)[15] ==> CBCMT[15]:[FormatOps:1653]d <== >=Comment( two)[15] & SLB:[Splits:3280]!d <== <=RightArrow[14]), opt==>![14])
-  [!SelectChainFirstNL]c=0[0] SP:[FormatOps:1654->FormatOps:1654](<=Comment( two)[15] ==> CBCMT[15]:[FormatOps:1653]d <== >=Comment( two)[15])
+object a:
+   foo.bar:
+      case 1 => one
+      case _ => // two
+   .qux
 <<< non-empty case body
 object a:
   foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
@@ -2492,6 +2492,27 @@ object a:
       case 1 => one
       case _ =>
    .qux
+<<< SKIP empty case body, only a comment
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ => // two
+    .qux
+>>>
+BestFirstSearch:317 Failed to format
+UNABLE TO FORMAT,
+tok #14/18: [14] => // two >>> RightArrow [59..61) | Comment( two) [62..68) >>> Case.CaseImpl [52..61) [Term.PartialFunction] | Term.Select [12..77) [Template.Body] <<<[ ]>>>
+policies:
+  REL?:[Splits:3283](CASESLB>ARROW:[Splits:3276]d <== >=Comment( two)[15] ??? NoPolicy)
+  <=Comment( two)[15] ==> NA:[FormatOps:2000]d <== >=Comment( two)[15]
+  (NEXTSEL1NL:[Splits:2712]d <== <Ident(qux)[17] & <=Comment( two)[15] ==> NA:[Splits:2701]d <== >=Comment( two)[15])
+  <=Ident(qux)[17] ==> NA:[FormatOps:1929]d <== >=Ident(qux)[17]
+splits (before policy):
+  c=0[0] SP:[FormatOps:1654->FormatOps:1654](<=Comment( two)[15] ==> CBCMT[15]:[FormatOps:1653]d <== >=Comment( two)[15])
+splits (after policy):
+  [!SelectChainFirstNL]c=0[0] SP:[FormatOps:1654->FormatOps:1654]((<=Comment( two)[15] ==> CBCMT[15]:[FormatOps:1653]d <== >=Comment( two)[15] & SLB:[Splits:3280]!d <== <=RightArrow[14]), opt==>![14])
+  [!SelectChainFirstNL]c=0[0] SP:[FormatOps:1654->FormatOps:1654](<=Comment( two)[15] ==> CBCMT[15]:[FormatOps:1653]d <== >=Comment( two)[15])
 <<< non-empty case body
 object a:
   foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_keep.stat
@@ -2734,6 +2734,20 @@ object a:
         case 1 => one
         case _ =>
      .qux
+<<< empty case body, only a comment
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ => // two
+    .qux
+>>>
+object a:
+   foo
+     .bar:
+        case 1 => one
+        case _ => // two
+     .qux
 <<< non-empty case body
 object a:
   foo

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_unfold.stat
@@ -2780,6 +2780,21 @@ object a:
           one
         case _ =>
      .qux
+<<< empty case body, only a comment
+object a:
+  foo
+    .bar:
+      case 1 => one
+      case _ => // two
+    .qux
+>>>
+object a:
+   foo
+     .bar:
+        case 1 =>
+          one
+        case _ => // two
+     .qux
 <<< non-empty case body
 object a:
   foo

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2563072, "total explored")
+      assertEquals(explored, 2564448, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2562900, "total explored")
+      assertEquals(explored, 2563072, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Instead of forcing possibly inconsistent before-comment splits after the comment, use the natural splits but slightly modify them. That will make sure that any policies they come with are correctly preserved.

Fixes #4897.
