### PR TITLE
FormatWriter: traverse align owner up infix chain

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1883,12 +1883,13 @@ object FormatWriter {
   private def getAlignNonSlcOwner(ft: FT, nextFloc: FormatLocation)(implicit
       floc: FormatLocation,
   ): Option[Option[Tree]] = {
-    def getNonSlcOwner = ft.meta.rightOwner match {
-      case name: Term.Name => name.parent match {
-          case Some(p: Term.ApplyInfix) => p
-          case _ => name
+    @tailrec
+    def getNonSlcOwner(x: Tree): Tree = x match {
+      case _: Term.Name | _: Term.ApplyInfix => x.parent match {
+          case Some(p: Term.ApplyInfix) => getNonSlcOwner(p)
+          case _ => x
         }
-      case x => x
+      case _ => x
     }
 
     val slc = ft.right.is[T.Comment] && nextFloc.hasBreakAfter &&
@@ -1896,7 +1897,7 @@ object FormatWriter {
     val code = if (slc) "//" else ft.meta.right.text
     floc.style.alignMap.get(code).flatMap { matchers =>
       // Corner case when line ends with comment
-      val nonSlcOwner = if (slc) None else Some(getNonSlcOwner)
+      val nonSlcOwner = if (slc) None else Some(getNonSlcOwner(ft.rightOwner))
       val owner = nonSlcOwner.getOrElse(ft.meta.leftOwner)
       val ok = matchers.isEmpty || matchers.exists(_.matches(owner))
       if (ok) Some(nonSlcOwner) else None

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -1868,11 +1868,11 @@ foo ++= Seq(
 )
 >>>
 foo ++= Seq(
-  foo     % bar, // c2
-  fooo   %% barr % baz  % "test",
-  foooo  %% bar  % bazz % "test",
-  fooooo  % barrr %
-    baz   % "test",
+  foo    % bar, // c2
+  fooo  %% barr % baz  % "test",
+  foooo %% bar  % bazz % "test",
+  fooooo % barrr %
+    baz  % "test",
   foooooo % barrrr %
     bazz %
     "test",

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -1852,7 +1852,9 @@ case class Foo() {
   def Bar(abc:        Int, deg:         String, xyz:        Boolean) = ???
   def Baz(hijk:       Int, lmnop:       String)                      = ???
 }
-<<< align infix with breaks
+<<< align infix with breaks, !multiline
+align.multiline = false
+===
 foo ++= Seq(
   foo % bar, // c2
   fooo %% barr % baz % "test",
@@ -1875,6 +1877,32 @@ foo ++= Seq(
     bazz %
     "test",
   foo %%% bar % baz % "test"
+)
+<<< align infix with breaks, multiline
+align.multiline = true
+===
+foo ++= Seq(
+  foo % bar, // c2
+  fooo %% barr % baz % "test",
+  foooo %% bar % bazz % "test",
+  fooooo % barrr %
+     baz % "test",
+  foooooo % barrrr %
+     bazz %
+     "test",
+  foo %%% bar % baz % "test"
+)
+>>>
+foo ++= Seq(
+  foo     % bar, // c2
+  fooo   %% barr   % baz  % "test",
+  foooo  %% bar    % bazz % "test",
+  fooooo  % barrr  %
+    baz   % "test",
+  foooooo % barrrr %
+    bazz  %
+    "test",
+  foo   %%% bar    % baz  % "test"
 )
 <<< curry params after
 align.tokens."+" = [{

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2564448, "total explored")
+      assertEquals(explored, 2564648, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Since an infix chain usually looks like one expression, especially when spanning multiple lines, let's get the outer one.