### PR TITLE
FormatWriter: again fix infix align owner

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1473,8 +1473,11 @@ was disabled since the parameter's introduction in v2.5.0.
 
 ### `align.multiline`
 
-If this flag is set, when alignment is applied, multiline statements will not be
-excluded from search of tokens to align.
+This flag controls whether to include multiline statements in the search for
+tokens to align, with the following values:
+
+- `false`: align tokens only on adjacent lines
+- `true`: align consecutive statements even if tokens to align are not on adjacent lines
 
 > Since v2.5.0.
 

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -2158,3 +2158,89 @@ object a {
         val quux = Quux()
     }
 }
+<<< mixed single- and multi-line infix, !multiline
+align.multiline = false
+align.tokens."+" = [
+  { code = "+:", owners = [{ regex = "Term\\.ApplyInfix" }] },
+  { code = "++:", owners = [{ regex = "Term\\.ApplyInfix" }] },
+  { code = "+++:", owners = [{ regex = "Term\\.ApplyInfix" }] },
+]
+===
+object a {
+  a ++: aaa +: aa
+  bbb ++: bb +++:
+  cccccc ++: c ++: cc {
+    3
+  } +: cc +++:
+  ddd ++: dd ++: d
+  e +++: eeeeee +: eee
+
+  a %% aaa % aa
+  bbb %% bb %%%
+  cccccc %% c %% cc {
+    3
+  } % cc %%%
+  ddd %% dd %% d
+  e %%% eeeeee % eee
+}
+>>>
+object a {
+  a ++: aaa +: aa
+  bbb ++: bb +++:
+    cccccc ++: c ++: cc {
+      3
+    }    +: cc   +++:
+    ddd ++: dd    ++: d
+  e    +++: eeeeee +: eee
+
+  a %% aaa % aa
+  bbb %% bb %%%
+    cccccc %% c %% cc {
+      3
+    }    % cc   %%%
+    ddd %% dd    %% d
+  e    %%% eeeeee % eee
+}
+<<< mixed single- and multi-line infix, multiline
+align.multiline = true
+align.tokens."+" = [
+  { code = "+:", owners = [{ regex = "Term\\.ApplyInfix" }] },
+  { code = "++:", owners = [{ regex = "Term\\.ApplyInfix" }] },
+  { code = "+++:", owners = [{ regex = "Term\\.ApplyInfix" }] },
+]
+===
+object a {
+  a ++: aaa +: aa
+  bbb ++: bb +++:
+  cccccc ++: c ++: cc {
+    3
+  } +: cc +++:
+  ddd ++: dd ++: d
+  e +++: eeeeee +: eee
+
+  a %% aaa % aa
+  bbb %% bb %%%
+  cccccc %% c %% cc {
+    3
+  } % cc %%%
+  ddd %% dd %% d
+  e %%% eeeeee % eee
+}
+>>>
+object a {
+  a        ++: aaa    +: aa
+  bbb      ++: bb   +++:
+    cccccc ++: c     ++: cc {
+      3
+    }       +: cc   +++:
+    ddd    ++: dd    ++: d
+  e       +++: eeeeee +: eee
+
+  a        %% aaa    % aa
+  bbb      %% bb   %%%
+    cccccc %% c     %% cc {
+      3
+    }       % cc   %%%
+    ddd    %% dd    %% d
+  e       %%% eeeeee % eee
+}

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -392,7 +392,7 @@ Ok(
   Json.obj(
     "api" -> Json.obj(
       "current" -> api.currentVersion,
-      "olds" -> api.oldVersions.map { old =>
+      "olds"    -> api.oldVersions.map { old =>
         Json.obj(
           "version"       -> old.version,
           "deprecatedAt"  -> old.deprecatedAt,
@@ -1868,13 +1868,13 @@ foo ++= Seq(
 )
 >>>
 foo ++= Seq(
-  foo    % bar, // c2
-  fooo  %% barr % baz  % "test",
-  foooo %% bar  % bazz % "test",
-  fooooo % barrr %
-    baz  % "test",
+  foo     % bar, // c2
+  fooo   %% barr   % baz  % "test",
+  foooo  %% bar    % bazz % "test",
+  fooooo  % barrr  %
+    baz   % "test",
   foooooo % barrrr %
-    bazz %
+    bazz  %
     "test",
   foo %%% bar % baz % "test"
 )
@@ -2185,17 +2185,17 @@ object a {
 }
 >>>
 object a {
-  a ++: aaa +: aa
-  bbb ++: bb +++:
-    cccccc ++: c ++: cc {
+  a        ++: aaa  +: aa
+  bbb      ++: bb +++:
+    cccccc ++: c   ++: cc {
       3
     }    +: cc   +++:
     ddd ++: dd    ++: d
   e    +++: eeeeee +: eee
 
-  a %% aaa % aa
-  bbb %% bb %%%
-    cccccc %% c %% cc {
+  a        %% aaa  % aa
+  bbb      %% bb %%%
+    cccccc %% c   %% cc {
       3
     }    % cc   %%%
     ddd %% dd    %% d

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2564648, "total explored")
+      assertEquals(explored, 2565168, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Keep the owner unchanged but apply this special logic mapping operator (Term.Name) to parent infix tree (Term.ApplyInfix) only when checking if the operator token is to be aligned using configured matchers.

If an infix expression starts with a multiline subexpression but ends with a single line of tokens to be aligned, then subsequent single-line statements are properly aligned with it.

However, in the opposite case, when an infix expression starts with a single line of tokens to be aligned and continues with a multiline part, then it was not aligned with previous statements.

By keeping the owner, we fix this inconsistency.

Includes undo of #4904.
