### PR TITLE
FormatWriter: fix inconsistent multiline alignment

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -363,7 +363,7 @@ object Cleaver {
     def join(x: A -> B): R  = f(x._1, x._2)
   }
 }
-<<< only align single-line statements
+<<< only align single-line statements, break before multiline
 {
 val a = function(1, b)
 val aaaaa = function(1, b)
@@ -375,6 +375,24 @@ val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbb
   val aaaaa = function(1, b)
   val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
     function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+}
+<<< only align single-line statements, break within multiline
+{
+val a = function(1, b)
+val aaaaa = function(1, b)
+val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
+  1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+)
+}
+>>>
+{
+  val a     = function(1, b)
+  val aaaaa = function(1, b)
+  val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
+    1,
+    b,
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  )
 }
 <<< infix owner
    Ok(Json.obj(
@@ -713,6 +731,52 @@ object a {
         s"Not sure at all what kinda class this is: ${unknown.getClass}"
       )
   }
+}
+<<< #1811 1 with break within rhs, !multiline
+align.multiline = false
+===
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd <- Option(4)
+  } yield ()
+}
+>>>
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd <- Option(4)
+  } yield ()
+}
+<<< #1811 1 with break before rhs, !multiline
+align.multiline = false
+===
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <-
+     Option(3)
+    dd <- Option(4)
+  } yield ()
+}
+>>>
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <-
+      Option(3)
+    dd <- Option(4)
+  } yield ()
 }
 <<< #1811 1 no blanks
 align.multiline = true

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -371,8 +371,8 @@ val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbb
 }
 >>>
 {
-  val a     = function(1, b)
-  val aaaaa = function(1, b)
+  val a                                = function(1, b)
+  val aaaaa                            = function(1, b)
   val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
     function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
 }
@@ -386,8 +386,8 @@ val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
 }
 >>>
 {
-  val a     = function(1, b)
-  val aaaaa = function(1, b)
+  val a                                = function(1, b)
+  val aaaaa                            = function(1, b)
   val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
     1,
     b,
@@ -748,8 +748,8 @@ object a {
 >>>
 object a {
   for {
-    a   <- Option(1)
-    bbb <- Option(2)
+    a      <- Option(1)
+    bbb    <- Option(2)
     cccccc <- Option {
       3
     }
@@ -771,8 +771,8 @@ object a {
 >>>
 object a {
   for {
-    a   <- Option(1)
-    bbb <- Option(2)
+    a      <- Option(1)
+    bbb    <- Option(2)
     cccccc <-
       Option(3)
     dd <- Option(4)
@@ -1111,7 +1111,7 @@ class ThisIsMyClass(a: Long, b: Long) {
   val myClass                                          = new ThisIsMyClass(init, end)
   val thisIsMyListOfClasses: ListBuffer[ThisIsMyClass] = ListBuffer()
   val abcdefghijklmnopqrstuvwxyz                       = new ThisIsMyClass(init, end)
-  val abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst =
+  val abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst   =
     new ThisIsMyClass(init, end)
 }
 <<< #2449, !allowOverflow

--- a/scalafmt-tests/shared/src/test/resources/newlines/afterCurlyLambdaNever.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/afterCurlyLambdaNever.stat
@@ -68,7 +68,7 @@ class Bar {
       .flatMap { campaigns =>
         request match {
           case Nil => connection.pure(Right(toResponse(campaigns, Map.empty)))
-          case _ =>
+          case _   =>
             getProfileEmails(request.securityContext, profileIds).to[ConnectionIO].map {
               profileEmails =>
                 Right(toResponse(campaigns, profileEmails))

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -692,7 +692,7 @@ object a:
 object a:
    (xs match
         case xs: TupleXXL => xs
-        case xs =>
+        case xs           =>
           TupleXXL.fromIArray(
             xs
           ) // TODO use Iterator.toIArray

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -671,7 +671,7 @@ object a:
 object a:
    (xs match
         case xs: TupleXXL => xs
-        case xs => TupleXXL
+        case xs           => TupleXXL
             .fromIArray(
               xs
             ) // TODO use Iterator.toIArray

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -697,7 +697,7 @@ object a:
 object a:
    (xs match
         case xs: TupleXXL => xs
-        case xs =>
+        case xs           =>
           TupleXXL.fromIArray(xs) // TODO use Iterator.toIArray
    ).asInstanceOf[Tuple]
 <<< try/finally, single

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2565168, "total explored")
+      assertEquals(explored, 2565660, "total explored")
     // TODO(olafur) don't block printing out test results.
     TestPlatformCompat.executeAndWait(PlatformFileOps.writeFile(
       FileOps.getPath("target", "index.html"),


### PR DESCRIPTION
Remove EOL owner position check in `isMatchPossible` and simply rely on reference row being before current row. For multiline statements, that would not hold true.