### PR TITLE
Fix wrong config name and outdated path in doc

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3985,7 +3985,7 @@ This section describes rules which are applied if the appropriate dialect (e.g.,
 ### `rewrite.scala3.convertToNewSyntax`
 
 If this flag is enabled, the following new syntax will be applied (also,
-**since 3.8.0**, if an appropriate flag under `rewrite.scala.newSyntax` is not
+**since 3.8.0**, if an appropriate flag under `rewrite.scala3.newSyntax` is not
 set to `false`, see below):
 
 - [control syntax](https://dotty.epfl.ch/docs/reference/other-new-features/control-syntax.html)

--- a/docs/contributing-scalafmt.md
+++ b/docs/contributing-scalafmt.md
@@ -27,7 +27,7 @@ Take a look at https://github.com/scalameta/scalafmt/blob/master/scalafmt-tests/
   from the project root directory.
 - **PRs for features should generally come with _something_ added to the
   [Documentation](https://scalameta.org/scalafmt)**, so people can discover that
-  it exists. The docs are written in `readme/Readme.scalatex`.
+  it exists. The docs are written in `docs/configuration.md`.
 - **Be prepared to discuss/argue-for your changes if you want them merged**! You
   will probably need to refactor so your changes fit into the larger codebase -
   **If your code is hard to unit test, and you don't want to unit test it,


### PR DESCRIPTION
- readme/Readme.scalatex is removed in a105e65926b04e8d5179826e837bab4baa1cd39c
- configuration should be `rewrite.scala3.newSyntax` instead of `rewrite.scala.newSyntax`, referring to test case https://github.com/scalameta/scalafmt/blob/831b891411022deaab0081a20f0965ec4bc96dea/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat#L1540