### PR TITLE
ScalafmtReflect: add dynamic version to exception

### DIFF
--- a/scalafmt-dynamic/jvm/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic/jvm/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -130,7 +130,7 @@ case class ScalafmtReflect(classLoader: ClassLoader, version: ScalafmtVersion)
           fileOpt.orNull,
           code,
           shortMessage,
-          e.getMessage,
+          s"[$version] ${e.getMessage}",
           range,
           e,
         )

--- a/scalafmt-dynamic/jvm/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-dynamic/jvm/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -194,7 +194,7 @@ class DynamicSuite extends FunSuite {
       val where = if (version >= "3.0.0") s"$name.scala" else "<input>"
       f.assertError(
         code,
-        s"""|$where:1: error:$dialectError ${bq}identifier$bq expected but ${bq}object$bq found
+        s"""|[$version] $where:1: error:$dialectError ${bq}identifier$bq expected but ${bq}object$bq found
             |$code
             |       ^""".stripMargin,
       )
@@ -346,7 +346,7 @@ class DynamicSuite extends FunSuite {
           .assertFormat("lazy   val   x =  project", "lazy val x = project\n")
         else f.assertError(
           "lazy   val   x =  project",
-          s"""|<input>:1: error:$dialectError classes cannot be lazy
+          s"""|[$version] <input>:1: error:$dialectError classes cannot be lazy
               |lazy   val   x =  project
               |^""".stripMargin,
         )
@@ -360,7 +360,7 @@ class DynamicSuite extends FunSuite {
           val where = if (usefilename) filename else "<input>"
           f.assertError(
             wrappedLiteral,
-            s"""|$where:1: error:$dialectError ${bq}identifier$bq expected but ${bq}integer constant$bq found
+            s"""|[$version] $where:1: error:$dialectError ${bq}identifier$bq expected but ${bq}integer constant$bq found
                 |$wrappedLiteral
                 |                           ^""".stripMargin,
             path,


### PR DESCRIPTION
This might alert some people to the actual version of scalafmt that is being used, if the one they expect is based on the version of the binary.