### PR TITLE
Splits: handle poly function after `{` and `=>`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -303,7 +303,7 @@ object SplitsAfterLeftBrace extends Splits {
           case _ => None
         }
         (arrow, 0, nlOnly)
-      case (t: Term.FunctionTerm) :: Nil =>
+      case (t: Term.FunctionLike) :: Nil =>
         val arrow = lastLambda(t).flatMap(getFuncArrow).getOrElse(getLast(t))
         val nlOnly = cfg.newlines.beforeCurlyLambdaParams match {
           case Newlines.BeforeCurlyLambdaParams.always => Some(true)
@@ -821,10 +821,10 @@ object SplitsAfterFunctionArrow extends Splits {
   ): Seq[Split] = {
     import fo._, ft._
     leftOwner match {
-      case leftFunc: Term.FunctionTerm
-          if !right.is[T.Comment] && !tokens.isEmpty(leftFunc.body) &&
-            isBlockFunction(leftFunc) => blockFunctionTerm(leftFunc)
-      case _: Term.FunctionTerm | _: Term.PolyFunction => functionOrSelf
+      case leftFunc: Term.FunctionLike =>
+        val isBlockFunc = !right.is[T.Comment] &&
+          !tokens.isEmpty(leftFunc.body) && isBlockFunction(leftFunc)
+        if (isBlockFunc) blockFunctionTerm(leftFunc) else functionOrSelf
       case t: Self if t.ancestor(2).is[Term.NewAnonymous] => functionOrSelf
       case _ => Seq.empty
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -73,7 +73,7 @@ object TreeOps {
   @tailrec
   def isBlockFunction(fun: Term)(implicit ftoks: FormatTokens): Boolean =
     fun.parent match {
-      case Some(p: Term.FunctionTerm) => isBlockFunction(p)
+      case Some(p: Term.FunctionLike) => isBlockFunction(p)
       case Some(p @ Term.Block(`fun` :: Nil)) => ftoks.getHead(p).left
           .is[T.LeftBrace] || isBlockFunction(p)
       case Some(SingleArgInBraces(_, `fun`, _)) => true

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8547,3 +8547,43 @@ def foldStep(
       ({ type l[a] = B })#l
     ]
 ): B = ???
+<<< functions: context within polymorphic function
+newlines.beforeCurlyLambdaParams = never
+===
+object a {
+    def tupled[O1[_], O2[_]](
+          f1: ChildFunction0[O1],
+          f2: ChildFunction0[O2],
+      ): ChildFunction0.Tupled[O1, O2] = {
+        [b : Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+      }
+}
+>>>
+object a {
+  def tupled[O1[_], O2[_]](
+      f1: ChildFunction0[O1],
+      f2: ChildFunction0[O2]
+  ): ChildFunction0.Tupled[O1, O2] = {
+    [b: Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+  }
+}
+<<< functions: context within regular function
+newlines.beforeCurlyLambdaParams = never
+===
+object a {
+    def tupled[O1[_], O2[_]](
+          f1: ChildFunction0[O1],
+          f2: ChildFunction0[O2],
+      ): ChildFunction0.Tupled[O1, O2] = {
+        (b: Bound) => _ => (child: Child[b]) => (f1[b](child), f2[b](child))
+      }
+}
+>>>
+object a {
+  def tupled[O1[_], O2[_]](
+      f1: ChildFunction0[O1],
+      f2: ChildFunction0[O2]
+  ): ChildFunction0.Tupled[O1, O2] = { (b: Bound) => _ => (child: Child[b]) =>
+    (f1[b](child), f2[b](child))
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8563,8 +8563,8 @@ object a {
   def tupled[O1[_], O2[_]](
       f1: ChildFunction0[O1],
       f2: ChildFunction0[O2]
-  ): ChildFunction0.Tupled[O1, O2] = {
-    [b: Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+  ): ChildFunction0.Tupled[O1, O2] = { [b: Bound] => _ ?=> (child: Child[b]) =>
+    (f1[b](child), f2[b](child))
   }
 }
 <<< functions: context within regular function

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8226,8 +8226,8 @@ object a {
   def tupled[O1[_], O2[_]](
       f1: ChildFunction0[O1],
       f2: ChildFunction0[O2]
-  ): ChildFunction0.Tupled[O1, O2] = {
-    [b: Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+  ): ChildFunction0.Tupled[O1, O2] = { [b: Bound] => _ ?=> (child: Child[b]) =>
+    (f1[b](child), f2[b](child))
   }
 }
 <<< functions: context within regular function

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8210,3 +8210,43 @@ def foldStep(
       ({ type l[a] = B })#l
     ]
 ): B = ???
+<<< functions: context within polymorphic function
+newlines.beforeCurlyLambdaParams = never
+===
+object a {
+    def tupled[O1[_], O2[_]](
+          f1: ChildFunction0[O1],
+          f2: ChildFunction0[O2],
+      ): ChildFunction0.Tupled[O1, O2] = {
+        [b : Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+      }
+}
+>>>
+object a {
+  def tupled[O1[_], O2[_]](
+      f1: ChildFunction0[O1],
+      f2: ChildFunction0[O2]
+  ): ChildFunction0.Tupled[O1, O2] = {
+    [b: Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+  }
+}
+<<< functions: context within regular function
+newlines.beforeCurlyLambdaParams = never
+===
+object a {
+    def tupled[O1[_], O2[_]](
+          f1: ChildFunction0[O1],
+          f2: ChildFunction0[O2],
+      ): ChildFunction0.Tupled[O1, O2] = {
+        (b: Bound) => _ => (child: Child[b]) => (f1[b](child), f2[b](child))
+      }
+}
+>>>
+object a {
+  def tupled[O1[_], O2[_]](
+      f1: ChildFunction0[O1],
+      f2: ChildFunction0[O2]
+  ): ChildFunction0.Tupled[O1, O2] = { (b: Bound) => _ => (child: Child[b]) =>
+    (f1[b](child), f2[b](child))
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8570,3 +8570,43 @@ def foldStep(
       ({ type l[a] = B })#l
     ]
 ): B = ???
+<<< functions: context within polymorphic function
+newlines.beforeCurlyLambdaParams = never
+===
+object a {
+    def tupled[O1[_], O2[_]](
+          f1: ChildFunction0[O1],
+          f2: ChildFunction0[O2],
+      ): ChildFunction0.Tupled[O1, O2] = {
+        [b : Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+      }
+}
+>>>
+object a {
+  def tupled[O1[_], O2[_]](
+      f1: ChildFunction0[O1],
+      f2: ChildFunction0[O2]
+  ): ChildFunction0.Tupled[O1, O2] = {
+    [b: Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+  }
+}
+<<< functions: context within regular function
+newlines.beforeCurlyLambdaParams = never
+===
+object a {
+    def tupled[O1[_], O2[_]](
+          f1: ChildFunction0[O1],
+          f2: ChildFunction0[O2],
+      ): ChildFunction0.Tupled[O1, O2] = {
+        (b: Bound) => _ => (child: Child[b]) => (f1[b](child), f2[b](child))
+      }
+}
+>>>
+object a {
+  def tupled[O1[_], O2[_]](
+      f1: ChildFunction0[O1],
+      f2: ChildFunction0[O2]
+  ): ChildFunction0.Tupled[O1, O2] = {
+    (b: Bound) => _ => (child: Child[b]) => (f1[b](child), f2[b](child))
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8902,3 +8902,43 @@ def foldStep(
       })#l
     ]
 ): B = ???
+<<< functions: context within polymorphic function
+newlines.beforeCurlyLambdaParams = never
+===
+object a {
+    def tupled[O1[_], O2[_]](
+          f1: ChildFunction0[O1],
+          f2: ChildFunction0[O2],
+      ): ChildFunction0.Tupled[O1, O2] = {
+        [b : Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+      }
+}
+>>>
+object a {
+  def tupled[O1[_], O2[_]](
+      f1: ChildFunction0[O1],
+      f2: ChildFunction0[O2]
+  ): ChildFunction0.Tupled[O1, O2] = {
+    [b: Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+  }
+}
+<<< functions: context within regular function
+newlines.beforeCurlyLambdaParams = never
+===
+object a {
+    def tupled[O1[_], O2[_]](
+          f1: ChildFunction0[O1],
+          f2: ChildFunction0[O2],
+      ): ChildFunction0.Tupled[O1, O2] = {
+        (b: Bound) => _ => (child: Child[b]) => (f1[b](child), f2[b](child))
+      }
+}
+>>>
+object a {
+  def tupled[O1[_], O2[_]](
+      f1: ChildFunction0[O1],
+      f2: ChildFunction0[O2]
+  ): ChildFunction0.Tupled[O1, O2] = { (b: Bound) => _ => (child: Child[b]) =>
+    (f1[b](child), f2[b](child))
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -8918,8 +8918,8 @@ object a {
   def tupled[O1[_], O2[_]](
       f1: ChildFunction0[O1],
       f2: ChildFunction0[O2]
-  ): ChildFunction0.Tupled[O1, O2] = {
-    [b: Bound] => _ ?=> (child: Child[b]) => (f1[b](child), f2[b](child))
+  ): ChildFunction0.Tupled[O1, O2] = { [b: Bound] => _ ?=> (child: Child[b]) =>
+    (f1[b](child), f2[b](child))
   }
 }
 <<< functions: context within regular function

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2565660, "total explored")
+      assertEquals(explored, 2568684, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2568684, "total explored")
+      assertEquals(explored, 2568616, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
In those contexts, replace Term.FunctionTerm with Term.FunctionLike.