### PR TITLE
RedundantBraces: remove in if-guard sometimes

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -717,6 +717,8 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
             case _ => true
           }
 
+        case _: Case => !RewriteCtx.isPostfixExpr(stat)
+
         // can't do it for try until 2.13.3
         case _ if RewriteCtx.isPrefixExpr(stat) => false
 

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces-case.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces-case.stat
@@ -101,3 +101,31 @@ object a {
     case a if a =>
   }
 }
+<<< if with infix
+a match {
+  case a if {a > b} =>
+}
+>>>
+a match {
+  case a if { a > b } =>
+}
+<<< if with match, scala2
+runner.dialect = scala213
+===
+a match {
+  case a if {a match { case b => true } } =>
+}
+>>>
+a match {
+  case a if { a match { case b => true } } =>
+}
+<<< if with match, scala3
+runner.dialect = scala3
+===
+a match {
+  case a if {a match { case b => true } } =>
+}
+>>>
+a match {
+  case a if { a match { case b => true } } =>
+}

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces-case.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantBraces-case.stat
@@ -107,7 +107,7 @@ a match {
 }
 >>>
 a match {
-  case a if { a > b } =>
+  case a if a > b =>
 }
 <<< if with match, scala2
 runner.dialect = scala213
@@ -127,5 +127,5 @@ a match {
 }
 >>>
 a match {
-  case a if { a match { case b => true } } =>
+  case a if a match { case b => true } =>
 }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2597808, "total explored")
+      assertEquals(explored, 2597792, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2597580, "total explored")
+      assertEquals(explored, 2597808, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Match the logic applied in RedundantParens, allow postfix expressions.