### PR TITLE
CoursierDependencyDownloader: support credentials

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val dynamic = crossProject(JVMPlatform) // don't build for NativePlatform
     description := "Implementation of scalafmt-interfaces",
     buildInfoSettings("org.scalafmt.dynamic", "BuildInfo"),
     libraryDependencies ++= List(
-      "io.get-coursier" % "interface" % "1.0.28",
+      "io.get-coursier" %% "coursier" % coursier,
       "com.typesafe" % "config" % "1.4.4",
     ),
     sharedTestSettings,

--- a/scalafmt-dynamic/jvm/src/main/scala/org/scalafmt/dynamic/CoursierDependencyDownloader.scala
+++ b/scalafmt-dynamic/jvm/src/main/scala/org/scalafmt/dynamic/CoursierDependencyDownloader.scala
@@ -1,14 +1,12 @@
 package org.scalafmt.dynamic
 
-import org.scalafmt.CompatCollections.JavaConverters._
-
 import java.io.OutputStreamWriter
 import java.net.URI
 import java.net.URL
 
 import scala.util.Try
 
-import coursierapi.{Dependency => CoursierDependency, _}
+import coursier.{Dependency => _, MavenRepository => Repository, _}
 
 private class CoursierDependencyDownloader(
     downloadProgressWriter: OutputStreamWriter,
@@ -16,15 +14,12 @@ private class CoursierDependencyDownloader(
 ) extends DependencyDownloader {
 
   override def download(dependencies: Seq[Dependency]): Try[Seq[URL]] = Try {
-    val coursierDependencies = dependencies
-      .map(x => CoursierDependency.of(x.group, x.artifact, x.version))
-    // TODO: ttl is unavailable, see https://github.com/coursier/interface/issues/57
-    val cache = Cache.create()
-      .withLogger(Logger.progressBars(downloadProgressWriter))
-    val settings = Fetch.create().withCache(cache)
-      .addRepositories(repositories: _*)
-      .withDependencies(coursierDependencies: _*)
-    settings.fetch().asScala.map(_.toURI.toURL).toList
+    val fileCache = cache.FileCache() // this ctor preserves COURSIER_CREDENTIALS
+      .withLogger(cache.loggers.RefreshLogger.create(downloadProgressWriter))
+    Fetch(fileCache).addDependencies(dependencies.map { dep =>
+      val mod = Module(Organization(dep.group), ModuleName(dep.artifact))
+      core.Dependency(mod, dep.version)
+    }: _*).addRepositories(repositories: _*).run().map(_.toURI.toURL).toList
   }
 
 }
@@ -35,9 +30,11 @@ object CoursierDependencyDownloader extends DependencyDownloaderFactory {
     val writer = properties.reporter.downloadOutputStreamWriter()
     val repositories = properties.repositories.map { x =>
       val host = new URI(x).getHost
-      val repo = MavenRepository.of(x)
+      val repo = Repository(x)
       properties.repositoryCredentials.find(_.host == host).fold(repo)(cred =>
-        repo.withCredentials(Credentials.of(cred.username, cred.password)),
+        repo.withAuthentication(Some(
+          core.Authentication(cred.username, cred.password),
+        )),
       )
     }
     new CoursierDependencyDownloader(writer, repositories)


### PR DESCRIPTION
This requires using the full coursier library as it loads credentials from COURSIER_CREDENTIALS env var, just like any default repositories have been loaded from COURSIER_REPOSITORIES.