### PR TITLE
FileOps: implement walkFiles with granular control

### DIFF
--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -1,13 +1,13 @@
 package org.scalafmt
 
 import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.sysops.FileOps
-import org.scalafmt.sysops.PlatformFileOps
+import org.scalafmt.sysops._
 import org.scalafmt.util.FormatAssertions
 
 import scala.meta.dialects.Scala213
 
 import java.io.File
+import java.nio.file.Path
 
 import munit.FunSuite
 
@@ -26,11 +26,41 @@ class FidelityTest extends FunSuite with FormatAssertions {
     "/gh-pages/",
   ).map(_.replace("/", File.separator))
 
-  FileOps.listFiles(".").foreach { x =>
-    val filename = x.toString
-    val ok = filename.endsWith(".scala") && !denyList.exists(filename.contains)
+  override def munitTests(): Seq[Test] = {
+    var cnt = 0
+    val visitor = new FileOps.WalkVisitor {
+      override def onTree(dir: Path, fileStat: FileStat): FileOps.WalkVisit = {
+        val name = dir.getFileName.toString
+        val skip = name.length > 1 && (name(0) == '.' || name == "target")
+        if (skip) FileOps.WalkVisit.Skip else FileOps.WalkVisit.Good
+      }
+      override def onFile(file: Path, fileStat: FileStat): FileOps.WalkVisit = {
+        if (fileStat.isRegularFile && testForFidelity(file)) cnt += 1
+        FileOps.WalkVisit.Good
+      }
+      override def onFailStop(file: Path, exc: Throwable): Boolean = {
+        test(s"init failure: $file")(
+          fail(s"Failed to init test: ${exc.getMessage}", exc),
+        )
+        false
+      }
+    }
+    FileOps.walkFiles(visitor)(FileOps.getPath("."))
+
+    test("count of files") {
+      val expected = 271
+      assertEquals(cnt, expected, s"Expected $expected files to test, got $cnt")
+    }
+
+    super.munitTests()
+  }
+
+  private def testForFidelity(path: Path): Boolean = path.getFileName.toString
+    .endsWith(".scala") && {
+    val filename = path.toString
+    val ok = !denyList.exists(filename.contains)
     if (ok) test(filename)(
-      PlatformFileOps.readFileAsync(x).map { code =>
+      PlatformFileOps.readFileAsync(path).map { code =>
         val formatted = Scalafmt
           .formatCode(code, ScalafmtConfig.default, filename = filename)
         assertFormatPreservesAst(filename, code, formatted.get)(
@@ -39,6 +69,7 @@ class FidelityTest extends FunSuite with FormatAssertions {
         )
       }(munitExecutionContext),
     )
+    ok
   }
 
 }


### PR DESCRIPTION
Unfortunately, Files.find has no way to handle exceptions during tree traversal, including those it generates itself (such as when reading the file attributes).

Instead, let's add ability to use Files.walk, with a more fine-grained visitor handler.