### PR TITLE
FormatOps: expand use of afterCurlyLambdaParams

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -822,7 +822,7 @@ object SplitsAfterFunctionArrow extends Splits {
     import fo._, ft._
     leftOwner match {
       case leftFunc: Term.FunctionLike =>
-        val isBlockFunc = !right.is[T.Comment] &&
+        val isBlockFunc = (!right.is[T.Comment] || ft.hasBreak) &&
           !tokens.isEmpty(leftFunc.body) && isBlockFunction(leftFunc)
         if (isBlockFunc) blockFunctionTerm(leftFunc) else functionOrSelf
       case t: Self if t.ancestor(2).is[Term.NewAnonymous] => functionOrSelf

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -12652,6 +12652,7 @@ object a {
 >>>
 object a {
   foo { implicit z =>
+
     /* Requirement:
      */
     bar

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -11866,6 +11866,7 @@ object a {
 >>>
 object a {
   foo { implicit z =>
+
     /* Requirement:
      */
     bar

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -12439,6 +12439,7 @@ object a {
 >>>
 object a {
   foo { implicit z =>
+
     /* Requirement:
      */
     bar

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -12916,6 +12916,7 @@ object a {
 >>>
 object a {
   foo { implicit z =>
+
     /* Requirement:
      */
     bar

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces.stat
@@ -3319,7 +3319,6 @@ object a {
 >>>
 object a {
   Foo.foo: z =>
-
      /* Requirement:
       */
      bar
@@ -3339,7 +3338,6 @@ object a {
 >>>
 object a {
   Foo.foo: z =>
-
      /* Requirement:
       */
      bar

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_fold.stat
@@ -3042,7 +3042,6 @@ object a {
 >>>
 object a {
   Foo.foo: z =>
-
      /* Requirement:
       */
      bar
@@ -3062,7 +3061,6 @@ object a {
 >>>
 object a {
   Foo.foo: z =>
-
      /* Requirement:
       */
      bar

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_keep.stat
@@ -3332,7 +3332,6 @@ object a {
 >>>
 object a {
   Foo.foo: z =>
-
      /* Requirement:
       */
      bar
@@ -3352,7 +3351,6 @@ object a {
 >>>
 object a {
   Foo.foo: z =>
-
      /* Requirement:
       */
      bar

--- a/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/FewerBraces_unfold.stat
@@ -3367,7 +3367,6 @@ object a {
 >>>
 object a {
   Foo.foo: z =>
-
      /* Requirement:
       */
      bar
@@ -3387,7 +3386,6 @@ object a {
 >>>
 object a {
   Foo.foo: z =>
-
      /* Requirement:
       */
      bar

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -8928,6 +8928,7 @@ object a {
 >>>
 object a {
   foo { implicit z =>
+
     /* Requirement:
      */
     bar

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8579,6 +8579,7 @@ object a {
 >>>
 object a {
   foo { implicit z =>
+
     /* Requirement:
      */
     bar

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -8946,6 +8946,7 @@ object a {
 >>>
 object a {
   foo { implicit z =>
+
     /* Requirement:
      */
     bar

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -9293,6 +9293,7 @@ object a {
 >>>
 object a {
   foo { implicit z =>
+
     /* Requirement:
      */
     bar

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2607784, "total explored")
+      assertEquals(explored, 2607772, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Apply it in scala3 and before a comment.