### PR TITLE
DynamicSuite: compare versions correctly

### DIFF
--- a/scalafmt-dynamic/jvm/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-dynamic/jvm/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -163,7 +163,8 @@ class DynamicSuite extends FunSuite {
   )(fn: (Format, String) => Unit): Unit = testedVersions.foreach(version =>
     test(s"$name [v=$version]") {
       val format = new Format(name, identity)
-      val dialect = if (version < "3.0.0") null else "scala213"
+      val ver = ScalafmtVersion.parse(version).get
+      val dialect = if (ver.cmp(3, 0, 0) < 0) null else "scala213"
       try {
         format.setVersion(version, dialect, config(version))
         fn(format, version)
@@ -187,10 +188,11 @@ class DynamicSuite extends FunSuite {
     val name = s"parse-error-$version-$dialect"
     check(name) { f =>
       f.setVersion(version, dialect)
-      val dialectError = getDialectError(version, dialect)
+      val ver = ScalafmtVersion.parse(version).get
+      val dialectError = getDialectError(ver, dialect)
       val code = s"""object object A { val version = "$version" }"""
-      val bq = getBackQuote(version)
-      val where = if (version >= "3.0.0") s"$name.scala" else "<input>"
+      val bq = getBackQuote(ver)
+      val where = if (ver.cmp(3, 0, 0) >= 0) s"$name.scala" else "<input>"
       f.assertError(
         code,
         s"""|[$version] $where:1: error:$dialectError ${bq}identifier$bq expected but ${bq}object$bq found
@@ -331,8 +333,9 @@ class DynamicSuite extends FunSuite {
       val name = s"sbt-$version-$dialect-$filename"
       check(name) { f =>
         f.setVersion(version, dialect, """project.includeFilters = [ ".*" ]""")
-        val isSbt = sbtTreatedDifferently(version) && filename.endsWith(".sbt")
-        val dialectError = getDialectError(version, dialect, isSbt)
+        val ver = ScalafmtVersion.parse(version).get
+        val isSbt = sbtTreatedDifferently(ver) && filename.endsWith(".sbt")
+        val dialectError = getDialectError(ver, dialect, isSbt)
         val path = Paths.get(filename)
         // test sbt allows top-level terms
         f.assertFormat(
@@ -341,7 +344,7 @@ class DynamicSuite extends FunSuite {
           path,
         )
         // test scala doesn't allow top-level terms (not passing path here)
-        if (version >= "3.0.0" || scalaVersion >= "213") f
+        if (ver.cmp(3, 0, 0) >= 0 || scalaVersion >= "213") f
           .assertFormat("lazy   val   x =  project", "lazy val x = project\n")
         else f.assertError(
           "lazy   val   x =  project",
@@ -352,10 +355,10 @@ class DynamicSuite extends FunSuite {
         // check wrapped literals, supported in sbt using scala 2.13+
         val wrappedLiteral = "object a { val  x:  Option[0]  =  Some(0) }"
         def assertIsWrappedLiteralFailure(): Unit = {
-          val bq = getBackQuote(version)
+          val bq = getBackQuote(ver)
           val usefilename = scalaVersion >= "213" ||
-            sbtTreatedDifferently(version) ||
-            version > "3.0.0" && filename.endsWith(".sbt")
+            sbtTreatedDifferently(ver) ||
+            ver.cmp(3, 0, 0) > 0 && filename.endsWith(".sbt")
           val where = if (usefilename) filename else "<input>"
           f.assertError(
             wrappedLiteral,
@@ -615,8 +618,13 @@ private object DynamicSuite {
     ).getOrElse(latest)
   }
 
-  def getDialectError(version: String, dialect: String, sbt: Boolean = false) =
-    if (version < "3.1.0") "" else s" [dialect ${if (sbt) "sbt" else dialect}]"
+  def getDialectError(
+      version: ScalafmtVersion,
+      dialect: String,
+      sbt: Boolean = false,
+  ) =
+    if (version.cmp(3, 1, 0) < 0) ""
+    else s" [dialect ${if (sbt) "sbt" else dialect}]"
 
   // in tests, let's not try to download current version
   def getModuleLoader = new ScalafmtModuleLoader {
@@ -632,8 +640,10 @@ private object DynamicSuite {
     override def close(): Unit = downloader.close()
   }
 
-  def getBackQuote(version: String): String = if (version > "3.8.0") "`" else ""
+  def getBackQuote(version: ScalafmtVersion): String =
+    if (version.cmp(3, 8, 0) > 0) "`" else ""
 
-  def sbtTreatedDifferently(version: String): Boolean = version > "3.8.0"
+  def sbtTreatedDifferently(version: ScalafmtVersion): Boolean = version
+    .cmp(3, 8, 0) > 0
 
 }

--- a/scalafmt-dynamic/shared/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
+++ b/scalafmt-dynamic/shared/src/main/scala/org/scalafmt/dynamic/ScalafmtVersion.scala
@@ -16,8 +16,10 @@ case class ScalafmtVersion(
   }
 
   def <(other: ScalafmtVersion): Boolean = compareTo(other) < 0
+  def <=(other: ScalafmtVersion): Boolean = !(other < this)
 
   def >(other: ScalafmtVersion): Boolean = other < this
+  def >=(other: ScalafmtVersion): Boolean = !(this < other)
 
   override def toString: String = s"$major.$minor.$patch" +
     (if (rc > 0) s"-RC$rc" else "") + snapshot
@@ -26,6 +28,9 @@ case class ScalafmtVersion(
     val cmp = Integer.compare(integerRepr, o.integerRepr)
     if (cmp != 0) cmp else snapshot.compareTo(o.snapshot)
   }
+
+  def cmp(major: Int, minor: Int, patch: Int, rc: Int = 0): Int =
+    compareTo(ScalafmtVersion(major, minor, patch, rc))
 }
 
 object ScalafmtVersion {


### PR DESCRIPTION
With current version reaching "3.10.", a string comparison is no longer accurate.