### PR TITLE
Imports: process each importee comments separately

### DIFF
--- a/scalafmt-core/shared/src/main/scala-2.12/org/scalafmt/util/package.scala
+++ b/scalafmt-core/shared/src/main/scala-2.12/org/scalafmt/util/package.scala
@@ -1,0 +1,10 @@
+package org.scalafmt
+
+package object util {
+
+  implicit class ImplicitIterator[A](private val obj: Iterator[A])
+      extends AnyVal {
+    def nextOption(): Option[A] = if (obj.hasNext) Some(obj.next()) else None
+  }
+
+}

--- a/scalafmt-tests/shared/src/test/resources/rewrite/Imports.source
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/Imports.source
@@ -564,6 +564,7 @@ package a
 
 // c1
 import a.b // c2
+// c4
 import a.c // c3
 
 import d.e
@@ -1075,22 +1076,24 @@ package a
 >>>
 package a
 
-import a.{f, g} // a0
 import a.{
 // a1
   b, // a2
-  c // a3
-}
-import h.{f, g} // h0
+  c, // a3
+  f,
+  g
+} // a0
 import h.{
 // h1
   k,
   l, // h2
+  f,
+  g,
   a,
   b
-}
-import d.e.{f, g} // d0
+} // h0
 import d.e.{a, b, d, f => g, g => _, _}
+import d.e.{f, g} // d0
 import x.{y, _}
 import z._
 <<< folding, sort ascii, no groups, lots of comments
@@ -1126,19 +1129,21 @@ package a
 import a.{
 // a1
   b, // a2
-  c // a3
-}
-import a.{f, g} // a0
+  c, // a3
+  f,
+  g
+} // a0
 import d.e.{a, b, d, f => g, g => _, _}
 import d.e.{f, g} // d0
 import h.{
   a,
   b,
+  f,
+  g,
 // h1
   k,
   l // h2
-}
-import h.{f, g} // h0
+} // h0
 import x.{y, _}
 import z._
 <<< folding, sort ascii, no groups

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -17,7 +17,7 @@ import munit.FunSuite
   */
 class FidelityTest extends FunSuite with FormatAssertions {
 
-  private val numFiles = 272
+  private val numFiles = 273
 
   private val denyList = Set(
     "ConfigReader.scala",

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -146,7 +146,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2616660, "total explored")
+      assertEquals(explored, 2616616, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Handles trailing comments more widely, including on folding. If multiple trailing comments are encountered, moves them to before the import.