### PR TITLE
Scalameta: update to v4.14.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 object Dependencies {
   val metaconfigV = "0.17.0"
-  val scalametaV  = "4.14.0"
+  val scalametaV  = "4.14.1"
   val scalacheckV = "1.18.1"
   val coursier    = "2.1.24"
   val munitV      = "1.2.1"

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/NamedDialect.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/NamedDialect.scala
@@ -29,6 +29,8 @@ object NamedDialect {
     Scala34,
     Scala35,
     Scala36,
+    Scala37,
+    Scala38,
   ).sortBy(_.source)
 
   private[config] val defaultName = "default"


### PR DESCRIPTION
That release includes the definition of scala38.