### PR TITLE
FormatWriter: processLineEnd after processLine

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1184,8 +1184,43 @@ class FormatWriter(formatOps: FormatOps) {
         while (idx < locations.length) {
           var alignContainer: Tree = null
           val columnCandidates = IndexedSeq.newBuilder[AlignStop]
+
+          def processLineEnd(implicit floc: FormatLocation): Unit = {
+            val isBlankLine = floc.state.mod.isBlankLine
+            if (alignContainer ne null) {
+              val candidates = columnCandidates.result()
+              val block = getOrCreateBlock(alignContainer)
+              val blockWasEmpty = block.isEmpty
+              if (!blockWasEmpty || !isBlankLine) {
+                val alignLine = new AlignLine(
+                  candidates,
+                  floc.state.prev.column + columnShift,
+                  floc.style,
+                )
+                val appendToEmptyBlock = blockWasEmpty || {
+                  val sameOwner = wasSameContainer(alignContainer)
+                  val notAdded = !block.tryAppendToBlock(alignLine, sameOwner)
+
+                  (isBlankLine || notAdded && shouldFlush(alignContainer)) && {
+                    flushAlignBlock(block)
+                    !isBlankLine
+                  }
+                }
+
+                if (appendToEmptyBlock) block.appendToEmptyBlock(alignLine)
+              }
+
+              prevAlignContainer = alignContainer
+              prevBlock = block
+            }
+            if (isBlankLine || alignContainer.eq(null)) getBlockToFlush(
+              getAlignContainer(floc.formatToken.rightOwner)._1,
+              isBlankLine,
+            ).foreach(flushAlignBlock)
+          }
+
           @tailrec
-          def processLine: FormatLocation = {
+          def processLine: Unit = {
             if (idx > 0) {
               val prevFloc = locations(idx - 1)
               if (prevFloc.hasBreakAfter || prevFloc.formatToken.leftHasNewline)
@@ -1197,7 +1232,7 @@ class FormatWriter(formatOps: FormatOps) {
             columnShift += floc.shift
             if (
               floc.hasBreakAfter || ft.leftHasNewline || idx >= locations.length
-            ) floc
+            ) processLineEnd
             else {
               getAlignIsSlc(ft, locations(idx)).foreach { isSlc =>
                 val (container, depth) =
@@ -1225,42 +1260,11 @@ class FormatWriter(formatOps: FormatOps) {
                 }
                 if (alignContainer eq container) appendCandidate()
               }
-              if (idx < locations.length) processLine else floc
+              processLine
             }
           }
 
-          implicit val floc: FormatLocation = processLine
-          val isBlankLine = floc.state.mod.isBlankLine
-          if (alignContainer ne null) {
-            val candidates = columnCandidates.result()
-            val block = getOrCreateBlock(alignContainer)
-            val blockWasEmpty = block.isEmpty
-            if (!blockWasEmpty || !isBlankLine) {
-              val alignLine = new AlignLine(
-                candidates,
-                floc.state.prev.column + columnShift,
-                floc.style,
-              )
-              val appendToEmptyBlock = blockWasEmpty || {
-                val sameOwner = wasSameContainer(alignContainer)
-                val notAdded = !block.tryAppendToBlock(alignLine, sameOwner)
-
-                (isBlankLine || notAdded && shouldFlush(alignContainer)) && {
-                  flushAlignBlock(block)
-                  !isBlankLine
-                }
-              }
-
-              if (appendToEmptyBlock) block.appendToEmptyBlock(alignLine)
-            }
-
-            prevAlignContainer = alignContainer
-            prevBlock = block
-          }
-          if (isBlankLine || alignContainer.eq(null)) getBlockToFlush(
-            getAlignContainer(floc.formatToken.meta.rightOwner)._1,
-            isBlankLine,
-          ).foreach(flushAlignBlock)
+          processLine
         }
         blocks.valuesIterator.foreach(flushAlignBlock)
         finalResult.result()


### PR DESCRIPTION
Cosmetic: simply wrap the logic right after `processLine` in its own function, move it before `processLine` and call when `processLine` is done. Helps with #5040.