### PR TITLE
FormatWriter: insert/remove end markers using gaps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4312,6 +4312,22 @@ is used to calculate the span for the purposes of applying
 
 Prior to v3.10.3, this setting was named `scala3.countEndMarkerLines`.
 
+### `rewrite.scala3.endMarker.spanIs`
+
+```scala mdoc:defaults
+rewrite.scala3.endMarker.spanIs
+```
+
+> Since v3.10.3.
+
+This parameter defines what "span" refers to when applying
+[`insertMinSpan`](#rewritescala3endmarkerinsertminspan) and
+[`removeMaxSpan`](#rewritescala3endmarkerremovemaxspan).
+It takes the following values:
+
+- `lines`: span counts the number of lines
+- `blankGaps`: span counts the number of blank gaps instead
+
 ## Vertical Multiline
 
 Since: v1.6.0.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -67,6 +67,7 @@ object RewriteScala3Settings {
   }
 
   case class EndMarker(
+      spanIs: EndMarker.SpanIs = EndMarker.SpanIs.lines,
       spanHas: EndMarker.SpanHas = EndMarker.SpanHas.all,
       removeMaxSpan: Int = 0,
       insertMinSpan: Int = 0,
@@ -78,6 +79,14 @@ object RewriteScala3Settings {
     implicit val surface: generic.Surface[EndMarker] = generic.deriveSurface
     implicit val codec: ConfCodecEx[EndMarker] = generic.deriveCodecEx(default)
       .noTypos
+
+    sealed abstract class SpanIs
+    object SpanIs {
+      implicit val codec: ConfCodecEx[SpanIs] = ReaderUtil
+        .oneOf(lines, blankGaps)
+      case object lines extends SpanIs
+      case object blankGaps extends SpanIs
+    }
 
     sealed abstract class SpanHas
     object SpanHas {

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -9110,3 +9110,123 @@ type Bar[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R] = Foo[SECURITY_INPUT, 
 >>>
 type Bar[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R] =
   Foo[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, R]
+<<< #5064 insert/remove end markers using blank gaps
+rewrite.scala3.endMarker {
+  spanIs = blankGaps
+  insertMinSpan = 3
+  removeMaxSpan = 2
+}
+===
+object a:
+  def foo1before2between1after() =
+
+    line1
+
+    line2
+
+    line3
+
+  def foo1before2between0after() =
+
+    line1
+
+    line2
+
+    line3
+  def foo0before2between0after() =
+    line1
+
+    line2
+
+    line3
+  def foo0before2between1after() =
+    line1
+
+    line2
+
+    line3
+
+  def foo0before3between0after() =
+    line1
+
+    line2
+
+    line3
+
+    line4
+  def foo1before1between1after() =
+
+    line1
+
+    line2
+
+  end foo
+
+  def foo0before1between1after() =
+    line1
+
+    line2
+
+  end foo
+
+  def foo0before1between0after() =
+    line1
+
+    line2
+  end foo
+>>>
+object a:
+   def foo1before2between1after() =
+
+      line1
+
+      line2
+
+      line3
+   end foo1before2between1after
+
+   def foo1before2between0after() =
+
+      line1
+
+      line2
+
+      line3
+   end foo1before2between0after
+   def foo0before2between0after() =
+      line1
+
+      line2
+
+      line3
+   def foo0before2between1after() =
+      line1
+
+      line2
+
+      line3
+
+   def foo0before3between0after() =
+      line1
+
+      line2
+
+      line3
+
+      line4
+   end foo0before3between0after
+   def foo1before1between1after() =
+
+      line1
+
+      line2
+
+   def foo0before1between1after() =
+      line1
+
+      line2
+
+   def foo0before1between0after() =
+      line1
+
+      line2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -8734,3 +8734,123 @@ type Bar[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R] = Foo[SECURITY_INPUT, 
 >>>
 type Bar[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R] =
   Foo[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, R]
+<<< #5064 insert/remove end markers using blank gaps
+rewrite.scala3.endMarker {
+  spanIs = blankGaps
+  insertMinSpan = 3
+  removeMaxSpan = 2
+}
+===
+object a:
+  def foo1before2between1after() =
+
+    line1
+
+    line2
+
+    line3
+
+  def foo1before2between0after() =
+
+    line1
+
+    line2
+
+    line3
+  def foo0before2between0after() =
+    line1
+
+    line2
+
+    line3
+  def foo0before2between1after() =
+    line1
+
+    line2
+
+    line3
+
+  def foo0before3between0after() =
+    line1
+
+    line2
+
+    line3
+
+    line4
+  def foo1before1between1after() =
+
+    line1
+
+    line2
+
+  end foo
+
+  def foo0before1between1after() =
+    line1
+
+    line2
+
+  end foo
+
+  def foo0before1between0after() =
+    line1
+
+    line2
+  end foo
+>>>
+object a:
+   def foo1before2between1after() =
+
+      line1
+
+      line2
+
+      line3
+   end foo1before2between1after
+
+   def foo1before2between0after() =
+
+      line1
+
+      line2
+
+      line3
+   end foo1before2between0after
+   def foo0before2between0after() =
+      line1
+
+      line2
+
+      line3
+   def foo0before2between1after() =
+      line1
+
+      line2
+
+      line3
+
+   def foo0before3between0after() =
+      line1
+
+      line2
+
+      line3
+
+      line4
+   end foo0before3between0after
+   def foo1before1between1after() =
+
+      line1
+
+      line2
+
+   def foo0before1between1after() =
+      line1
+
+      line2
+
+   def foo0before1between0after() =
+      line1
+
+      line2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -9129,3 +9129,123 @@ type Bar[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R] = Foo[SECURITY_INPUT, 
 >>>
 type Bar[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R] =
   Foo[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, R]
+<<< #5064 insert/remove end markers using blank gaps
+rewrite.scala3.endMarker {
+  spanIs = blankGaps
+  insertMinSpan = 3
+  removeMaxSpan = 2
+}
+===
+object a:
+  def foo1before2between1after() =
+
+    line1
+
+    line2
+
+    line3
+
+  def foo1before2between0after() =
+
+    line1
+
+    line2
+
+    line3
+  def foo0before2between0after() =
+    line1
+
+    line2
+
+    line3
+  def foo0before2between1after() =
+    line1
+
+    line2
+
+    line3
+
+  def foo0before3between0after() =
+    line1
+
+    line2
+
+    line3
+
+    line4
+  def foo1before1between1after() =
+
+    line1
+
+    line2
+
+  end foo
+
+  def foo0before1between1after() =
+    line1
+
+    line2
+
+  end foo
+
+  def foo0before1between0after() =
+    line1
+
+    line2
+  end foo
+>>>
+object a:
+   def foo1before2between1after() =
+
+      line1
+
+      line2
+
+      line3
+   end foo1before2between1after
+
+   def foo1before2between0after() =
+
+      line1
+
+      line2
+
+      line3
+   end foo1before2between0after
+   def foo0before2between0after() =
+      line1
+
+      line2
+
+      line3
+   def foo0before2between1after() =
+      line1
+
+      line2
+
+      line3
+
+   def foo0before3between0after() =
+      line1
+
+      line2
+
+      line3
+
+      line4
+   end foo0before3between0after
+   def foo1before1between1after() =
+
+      line1
+
+      line2
+
+   def foo0before1between1after() =
+      line1
+
+      line2
+
+   def foo0before1between0after() =
+      line1
+
+      line2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -9491,3 +9491,123 @@ type Bar[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, -R] = Foo[
   OUTPUT,
   R
 ]
+<<< #5064 insert/remove end markers using blank gaps
+rewrite.scala3.endMarker {
+  spanIs = blankGaps
+  insertMinSpan = 3
+  removeMaxSpan = 2
+}
+===
+object a:
+  def foo1before2between1after() =
+
+    line1
+
+    line2
+
+    line3
+
+  def foo1before2between0after() =
+
+    line1
+
+    line2
+
+    line3
+  def foo0before2between0after() =
+    line1
+
+    line2
+
+    line3
+  def foo0before2between1after() =
+    line1
+
+    line2
+
+    line3
+
+  def foo0before3between0after() =
+    line1
+
+    line2
+
+    line3
+
+    line4
+  def foo1before1between1after() =
+
+    line1
+
+    line2
+
+  end foo
+
+  def foo0before1between1after() =
+    line1
+
+    line2
+
+  end foo
+
+  def foo0before1between0after() =
+    line1
+
+    line2
+  end foo
+>>>
+object a:
+   def foo1before2between1after() =
+
+      line1
+
+      line2
+
+      line3
+   end foo1before2between1after
+
+   def foo1before2between0after() =
+
+      line1
+
+      line2
+
+      line3
+   end foo1before2between0after
+   def foo0before2between0after() =
+      line1
+
+      line2
+
+      line3
+   def foo0before2between1after() =
+      line1
+
+      line2
+
+      line3
+
+   def foo0before3between0after() =
+      line1
+
+      line2
+
+      line3
+
+      line4
+   end foo0before3between0after
+   def foo1before1between1after() =
+
+      line1
+
+      line2
+
+   def foo0before1between1after() =
+      line1
+
+      line2
+
+   def foo0before1between0after() =
+      line1
+
+      line2

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -146,7 +146,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2621792, "total explored")
+      assertEquals(explored, 2622944, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Instead of counting lines, we could instead count the number of blank gaps within a section. Fixes #5064.