### PR TITLE
SBT: handle more metadata in assemblyMergeStrategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         run: git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"
       - run: sbt ++${{ matrix.scala }} test-jvm
         if: ${{ (success() || failure()) && steps.gitconfig.outcome == 'success' }}
+        id: testjvm
       - run: sbt ++${{ matrix.scala }} test-js
         if: ${{ (success() || failure()) && steps.gitconfig.outcome == 'success' }}
       - run: sbt ++${{ matrix.scala }} test-native
@@ -50,6 +51,9 @@ jobs:
         if: ${{ (success() || failure()) && steps.gitconfig.outcome == 'success' }}
       - run: sbt ++${{ matrix.scala }} docs/run
         if: ${{ (success() || failure()) && steps.gitconfig.outcome == 'success' }}
+      # Build and sanity-check the fat jar
+      - run: sbt ++${{ matrix.scala }} "cli/assembly; cli/runAssembly --non-interactive"
+        if: ${{ (success() || failure()) && steps.testjvm.outcome == 'success' }}
   community-test:
     strategy:
       fail-fast: false


### PR DESCRIPTION
I tried to run `sbt "cli/assembly"` and it didn't work for me, these rules fix it.

The basic justification for the rules:
* `module-info.class` - discard - we don't need Java Module descriptors in a fat jar
* `javax.inject.Named` - concat - various plexus libraries need their metadata

Applied the rules to both `cli` and `dynamic`. I don't think it's really needed on `dynamic` but SBT seems to run assembly on it even when runing `cli / assembly` so it seems prudent to get rid of that error (better would be not running assembly on it).