### PR TITLE
Config: replace all `preserve` etc. with `keep`

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -85,7 +85,7 @@ object Scalafmt {
       range: Set[Range],
   ): Try[String] =
     if (FileOps.isMarkdown(file)) {
-      val mdocStyle = style.withLineEndings(LineEndings.preserve)
+      val mdocStyle = style.withLineEndings(LineEndings.keep)
       val res = MarkdownParser
         .transformMdoc(code)(doFormatOne(_, mdocStyle, file, range))
       style.lineEndings match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Docstrings.scala
@@ -49,7 +49,7 @@ case class Docstrings(
   import Docstrings._
 
   def withoutRewrites: Docstrings =
-    copy(removeEmpty = false, wrap = Wrap.keep, style = Preserve)
+    copy(removeEmpty = false, wrap = Wrap.keep, style = keep)
 
   def skipFirstLineIf(wasBlank: Boolean): Boolean = style
     .skipFirstLine(blankFirstLine).exists {
@@ -70,7 +70,7 @@ object Docstrings {
   sealed abstract class Style {
     def skipFirstLine(v: Option[BlankFirstLine]): Option[BlankFirstLine]
   }
-  case object Preserve extends Style {
+  case object keep extends Style {
     def skipFirstLine(v: Option[BlankFirstLine]): Option[BlankFirstLine] =
       Some(BlankFirstLine.keep)
   }
@@ -89,8 +89,9 @@ object Docstrings {
   }
 
   implicit val reader: ConfCodecEx[Style] = ReaderUtil
-    .oneOfCustom[Style](Preserve, Asterisk, SpaceAsterisk, AsteriskSpace) {
-      case Conf.Str("keep") => Configured.Ok(Preserve)
+    .oneOfCustom[Style](keep, Asterisk, SpaceAsterisk, AsteriskSpace) {
+      case Conf.Str(str) if str.equalsIgnoreCase("preserve") =>
+        Configured.Ok(keep)
     }
 
   sealed abstract class Oneline

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/LineEndings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/LineEndings.scala
@@ -6,12 +6,13 @@ sealed abstract class LineEndings
 
 object LineEndings {
   implicit val reader: ConfCodecEx[LineEndings] = ReaderUtil
-    .oneOfCustom[LineEndings](unix, windows, preserve) {
-      case Conf.Str("keep") => Configured.Ok(preserve)
+    .oneOfCustom[LineEndings](unix, windows, keep) {
+      case Conf.Str(str) if str.equalsIgnoreCase("preserve") =>
+        Configured.Ok(keep)
     }
   case object unix extends LineEndings
   case object windows extends LineEndings
-  case object preserve extends LineEndings
+  case object keep extends LineEndings
 
   def eol(isWin: Boolean): String = if (isWin) "\r\n" else "\n"
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Literals.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Literals.scala
@@ -24,12 +24,12 @@ object Literals {
   sealed abstract class Case {
     import Case._
     def process(str: String): String = this match {
-      case Unchanged => str
+      case Keep => str
       case Lower => str.toLowerCase()
       case Upper => str.toUpperCase()
     }
     def process(ch: Char): Char = this match {
-      case Unchanged => ch
+      case Keep => ch
       case Lower => Character.toLowerCase(ch)
       case Upper => Character.toUpperCase(ch)
     }
@@ -37,12 +37,13 @@ object Literals {
 
   object Case {
     implicit val codec: ConfCodecEx[Case] = ReaderUtil
-      .oneOfCustom[Case](Upper, Lower, Unchanged) { // aliases
-        case Conf.Str("keep") => Configured.Ok(Unchanged)
+      .oneOfCustom[Case](Upper, Lower, Keep) { // aliases
+        case Conf.Str(str) if str.equalsIgnoreCase("unchanged") =>
+          Configured.Ok(Keep)
       }
     case object Upper extends Case
     case object Lower extends Case
-    case object Unchanged extends Case
+    case object Keep extends Case
   }
 
   case class FloatingPoint(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -498,13 +498,14 @@ object Newlines {
 
   sealed abstract class AfterCurlyLambdaParams
   object AfterCurlyLambdaParams {
-    case object preserve extends AfterCurlyLambdaParams
+    case object keep extends AfterCurlyLambdaParams
     case object always extends AfterCurlyLambdaParams
     case object never extends AfterCurlyLambdaParams
     case object squash extends AfterCurlyLambdaParams
     implicit val codec: ConfCodecEx[AfterCurlyLambdaParams] = ReaderUtil
-      .oneOfCustom[AfterCurlyLambdaParams](preserve, always, never, squash) {
-        case Conf.Str("keep") => Configured.Ok(preserve)
+      .oneOfCustom[AfterCurlyLambdaParams](keep, always, never, squash) {
+        case Conf.Str(str) if str.equalsIgnoreCase("preserve") =>
+          Configured.Ok(keep)
       }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -45,7 +45,7 @@ import metaconfig._
   *   - If [[LineEndings.unix]], output will include only unix line endings
   *   - If [[LineEndings.windows]], output will include only windows line
   *     endings
-  *   - If [[LineEndings.preserve]], output will include endings included in
+  *   - If [[LineEndings.keep]], output will include endings included in
   *     original file (windows if there was at least one windows line ending,
   *     unix if there was zero occurrences of windows line endings)
   * @param includeCurlyBraceInSelectChains
@@ -163,7 +163,7 @@ case class ScalafmtConfig(
   def withGitAutoCRLF(value: String): ScalafmtConfig = value.toLowerCase match {
     case "input" => withLineEndings(LineEndings.unix)
     case "true" => withLineEndings(LineEndings.windows)
-    case "false" => withLineEndings(LineEndings.preserve)
+    case "false" => withLineEndings(LineEndings.keep)
     case _ => this
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -106,7 +106,7 @@ class FormatWriter(formatOps: FormatOps) {
     var useCRLF = initStyle.lineEndings.fold(-1) {
       case LineEndings.unix => -1
       case LineEndings.windows => 1
-      case LineEndings.preserve => 0
+      case LineEndings.keep => 0
     }
 
     @tailrec
@@ -624,7 +624,7 @@ class FormatWriter(formatOps: FormatOps) {
       private def formatDocstring(
           text: String,
       )(implicit sb: StringBuilder): Unit =
-        if (style.docstrings.style eq Docstrings.Preserve) sb.append(text)
+        if (style.docstrings.style eq Docstrings.keep) sb.append(text)
         else if (!formatOnelineDocstring(text)) new FormatMlDoc(text).format()
 
       private abstract class FormatCommentBase(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Modification.scala
@@ -86,7 +86,7 @@ object Modification {
     case Newlines.AfterCurlyLambdaParams.never =>
       (style.newlines.okSpaceForSource(newlines), Newline)
     case Newlines.AfterCurlyLambdaParams.always => (false, Newline2x)
-    case Newlines.AfterCurlyLambdaParams.preserve =>
+    case Newlines.AfterCurlyLambdaParams.keep =>
       val blanks = newlines >= 2
       (style.newlines.okSpaceForSource(newlines, !blanks), Newline2x(blanks))
   }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/EmptyFileTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/EmptyFileTest.scala
@@ -13,7 +13,7 @@ class EmptyFileTest extends FunSuite {
   private val cfgWithLineEndingsCRLF = ScalafmtConfig.default
     .withLineEndings(LineEndings.windows)
   private val cfgWithLineEndingsKeep = ScalafmtConfig.default
-    .withLineEndings(LineEndings.preserve)
+    .withLineEndings(LineEndings.keep)
 
   Seq(
     ("", "\n", "\r\n", "\n"),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/LineEndingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/LineEndingsTest.scala
@@ -11,7 +11,7 @@ class LineEndingsTest extends FunSuite {
     val original = "@ Singleton\r\nobject a {\r\nval y = 2\r\n}"
     val expected = "@Singleton\r\nobject a {\r\n  val y = 2\r\n}\r\n"
     val obtained = Scalafmt
-      .format(original, ScalafmtConfig.default.withLineEndings(preserve)).get
+      .format(original, ScalafmtConfig.default.withLineEndings(keep)).get
     assertNoDiff(obtained, expected)
   }
 
@@ -19,7 +19,7 @@ class LineEndingsTest extends FunSuite {
     val original = "@ Singleton\nobject a {\nval y = 2\n}"
     val expected = "@Singleton\nobject a {\n  val y = 2\n}\n"
     val obtained = Scalafmt
-      .format(original, ScalafmtConfig.default.withLineEndings(preserve)).get
+      .format(original, ScalafmtConfig.default.withLineEndings(keep)).get
     assertNoDiff(obtained, expected)
   }
 


### PR DESCRIPTION
Let's standardize on the canonical name of the enum.