### PR TITLE
Config: use new features of ConfDecoderXxx

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -53,17 +53,16 @@ object RewriteScala3Settings {
     implicit val encoder: ConfEncoder[RemoveOptionalBraces] = generic
       .deriveEncoder[RemoveOptionalBraces]
 
-    implicit final val decoder: ConfDecoderEx[RemoveOptionalBraces] = {
-      val baseDecoder = generic.deriveDecoderEx[RemoveOptionalBraces](no)
-      (stateOpt, conf) =>
-        conf match {
-          case Conf.Bool(true) | Conf.Str("yes") => Configured.Ok(yes)
-          case Conf.Bool(false) | Conf.Str("no") => Configured.Ok(no)
-          case Conf.Str("oldSyntaxToo") => Configured
-              .Ok(RemoveOptionalBraces(oldSyntaxToo = true))
-          case _ => baseDecoder.read(stateOpt, conf)
-        }
-    }
+    implicit final val decoder: ConfDecoderEx[RemoveOptionalBraces] = generic
+      .deriveDecoderEx[RemoveOptionalBraces](no).contramap {
+        case Conf.Bool(true) | Conf.Str("yes") => Conf
+            .Obj("enabled" -> Conf(true))
+        case Conf.Bool(false) | Conf.Str("no") => Conf
+            .Obj("enabled" -> Conf(false))
+        case Conf.Str("oldSyntaxToo") => Conf
+            .Obj("enabled" -> Conf(true), "oldSyntaxToo" -> Conf(true))
+        case conf => conf
+      }
   }
 
   case class EndMarker(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfDecoders.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfDecoders.scala
@@ -10,7 +10,7 @@ object ScalafmtConfDecoders extends ScalafmtConfDecoders
 
 trait ScalafmtConfDecoders {
   implicit def eventReaderFor[A <: FormatEvent]: ConfDecoderEx[A => Unit] =
-    ConfDecoderEx.from[A => Unit] { case _ => Configured.Ok((_: A) => ()) }
+    ConfDecoderEx.from[A => Unit]((_, _) => Configured.Ok((_: A) => ()))
 
   implicit lazy val parseReader: ConfCodecEx[MetaParser] = ConfCodecEx
     .oneOf[MetaParser](parseSource, parseStat, parseCase)


### PR DESCRIPTION
To be able to apply Conf modifications and inspect them, we need to make sure we implement decoders correctly. Helps with #4884.