### PR TITLE
Cli: add option to diff config

### DIFF
--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/CliArgParser.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/CliArgParser.scala
@@ -137,6 +137,12 @@ object CliArgParser {
              |continuing after read completes, thus separating I/O-bound
              |input and CPU-bound formatting thread pools.""".stripMargin,
         )
+      opt[Unit]("diff-config")
+        .action((_, c) => writeMode(c, WriteMode.DiffConfig)).text(
+          """|Compare original configuration with the effective one
+             |(after resolving aliases or renaming deprecated parameters).
+             |""".stripMargin,
+        )
 
       note(
         s"""|Examples:

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/WriteMode.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/WriteMode.scala
@@ -27,4 +27,8 @@ object WriteMode {
   case object Test extends WriteMode {
     val usesOut: Boolean = false
   }
+
+  case object DiffConfig extends WriteMode {
+    val usesOut: Boolean = true
+  }
 }


### PR DESCRIPTION
As canonical configuration evolves, some sections or parameters are renamed or modified, resulting in a different configuration than what the user has specified.

This option will allow inspecting the new effective configuration. Fixes #4884.