### PR TITLE
ScalafmtConfig: also convert `fileOverride` field

### DIFF
--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ScalafmtConfigTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ScalafmtConfigTest.scala
@@ -127,8 +127,8 @@ class ScalafmtConfigTest extends FunSuite {
           """|binPack.callSite = Never
              |binPack.importSelectors = unfold
              |fileOverride.pat1 = "scala213"
-             |fileOverride.pat2.binPack.unsafeCallSite = true
-             |fileOverride.pat3.importSelectors = true
+             |fileOverride.pat2.binPack.callSite = Always
+             |fileOverride.pat3.binPack.importSelectors = fold
              |indent.infix.exemptScope = oldTopLevel
              |newlines.forceBeforeMultilineAssign = def""".stripMargin,
         )


### PR DESCRIPTION
These are nested custom configurations. Helps with #4884.
