### PR TITLE
InfixSplits: enforce break around nested infix

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2521,6 +2521,22 @@ newlines.infix.termSite.breakOnNested
 If enabled, will force line breaks around a nested parenthesized sub-expression
 in a multi-line infix expression.
 
+This logic, however, will not apply if the precedence of the inner expression
+is lower than the outer; that is, we _had_ to put it in parentheses, not because
+we _chose_ to, for readability. This is to prevent breaking like this:
+
+```scala
+// original
+(a + b) * c
+(a + b) < c
+
+// formatted
+(a + b) *
+c // ok to force
+(a + b) <
+c // not ok by default
+```
+
 ### `newlines.avoidForSimpleOverflow`
 
 A list parameter (of comma-separated flags), with possible flags described

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -13094,8 +13094,8 @@ object a {
   a = foo > bar && bar.baz && baz > qux &&
     qux > xyz
   b =
-    (foo > bar &&
-      bar.baz && baz > qux && qux > xyz)
+    (foo > bar && bar.baz && baz > qux &&
+      qux > xyz)
   c = {
     foo > bar && bar.baz && baz > qux &&
     qux > xyz
@@ -13122,12 +13122,10 @@ object a {
   ) {}
   a =
     (foo > bar) &&
-      bar.baz &&
-      baz > qux && qux > xyz
+      bar.baz && baz > qux && qux > xyz
   b =
     ((foo > bar) &&
-      bar.baz &&
-      baz > qux && qux > xyz)
+      bar.baz && baz > qux && qux > xyz)
   c = {
     (foo > bar) &&
     bar.baz && baz > qux && qux > xyz
@@ -13149,18 +13147,17 @@ object a {
 >>>
 object a {
   if (
-    foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   ) {}
-  a = foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+  a = foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   b =
-    (foo > bar &&
-      (bar.baz) &&
-      baz > qux && qux > xyz)
+    (foo > bar && (bar.baz) && baz > qux &&
+      qux > xyz)
   c = {
-    foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   }
 }
 <<< mixed nested infixes, with breakOnNested 4
@@ -13179,17 +13176,20 @@ object a {
 >>>
 object a {
   if (
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   ) {}
-  a = foo > bar && bar.baz && (baz > qux) &&
+  a = foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   b =
-    (foo > bar &&
-      bar.baz && (baz > qux) &&
+    (foo > bar && bar.baz &&
+      (baz > qux) &&
       qux > xyz)
   c = {
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   }
 }
@@ -13215,8 +13215,8 @@ object a {
   a = foo > bar && bar.baz && baz > qux &&
     (qux > xyz)
   b =
-    (foo > bar &&
-      bar.baz && baz > qux && (qux > xyz))
+    (foo > bar && bar.baz && baz > qux &&
+      (qux > xyz))
   c = {
     foo > bar && bar.baz && baz > qux &&
     (qux > xyz)
@@ -13238,17 +13238,18 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+    (foo > bar) &&
+    (bar.baz) && baz > qux && qux > xyz
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+  a =
+    (foo > bar) &&
+      (bar.baz) && baz > qux && qux > xyz
   b =
-    ((foo > bar) && (bar.baz) &&
-      baz > qux && qux > xyz)
+    ((foo > bar) &&
+      (bar.baz) && baz > qux && qux > xyz)
   c = {
-    (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+    (foo > bar) &&
+    (bar.baz) && baz > qux && qux > xyz
   }
 }
 <<< mixed nested infixes, with breakOnNested 7
@@ -13267,17 +13268,22 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+    (foo > bar) &&
+    (bar.baz) && baz > qux &&
+    (qux > xyz)
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+  a =
+    (foo > bar) &&
+      (bar.baz) && baz > qux &&
+      (qux > xyz)
   b =
-    ((foo > bar) && (bar.baz) &&
-      baz > qux && (qux > xyz))
+    ((foo > bar) &&
+      (bar.baz) && baz > qux &&
+      (qux > xyz))
   c = {
-    (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+    (foo > bar) &&
+    (bar.baz) && baz > qux &&
+    (qux > xyz)
   }
 }
 <<< mixed nested infixes, with breakOnNested 8
@@ -13297,7 +13303,8 @@ object a {
 object a {
   if (
     (foo > bar) &&
-    bar.baz && (baz > qux) &&
+    bar.baz &&
+    (baz > qux) &&
     (qux > xyz)
   ) {}
   a =
@@ -13312,7 +13319,8 @@ object a {
       (qux > xyz))
   c = {
     (foo > bar) &&
-    bar.baz && (baz > qux) &&
+    bar.baz &&
+    (baz > qux) &&
     (qux > xyz)
   }
 }
@@ -13340,8 +13348,7 @@ object a {
     (baz > qux) &&
     (qux > xyz)
   b =
-    (foo > bar &&
-      (bar.baz) &&
+    (foo > bar && (bar.baz) &&
       (baz > qux) &&
       (qux > xyz))
   c = {
@@ -13366,19 +13373,24 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
+    (foo > bar) &&
+    (bar.baz) &&
     (baz > qux) &&
     (qux > xyz)
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    (baz > qux) &&
-    (qux > xyz)
+  a =
+    (foo > bar) &&
+      (bar.baz) &&
+      (baz > qux) &&
+      (qux > xyz)
   b =
-    ((foo > bar) && (bar.baz) &&
+    ((foo > bar) &&
+      (bar.baz) &&
       (baz > qux) &&
       (qux > xyz))
   c = {
-    (foo > bar) && (bar.baz) &&
+    (foo > bar) &&
+    (bar.baz) &&
     (baz > qux) &&
     (qux > xyz)
   }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -12279,8 +12279,8 @@ object a {
   a = foo > bar && bar.baz && baz > qux &&
     qux > xyz
   b =
-    (foo > bar &&
-      bar.baz && baz > qux && qux > xyz)
+    (foo > bar && bar.baz && baz > qux &&
+      qux > xyz)
   c = {
     foo > bar && bar.baz && baz > qux &&
     qux > xyz
@@ -12307,12 +12307,10 @@ object a {
   ) {}
   a =
     (foo > bar) &&
-      bar.baz &&
-      baz > qux && qux > xyz
+      bar.baz && baz > qux && qux > xyz
   b =
     ((foo > bar) &&
-      bar.baz &&
-      baz > qux && qux > xyz)
+      bar.baz && baz > qux && qux > xyz)
   c = {
     (foo > bar) &&
     bar.baz && baz > qux && qux > xyz
@@ -12334,18 +12332,17 @@ object a {
 >>>
 object a {
   if (
-    foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   ) {}
-  a = foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+  a = foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   b =
-    (foo > bar &&
-      (bar.baz) &&
-      baz > qux && qux > xyz)
+    (foo > bar && (bar.baz) && baz > qux &&
+      qux > xyz)
   c = {
-    foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   }
 }
 <<< mixed nested infixes, with breakOnNested 4
@@ -12364,17 +12361,20 @@ object a {
 >>>
 object a {
   if (
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   ) {}
-  a = foo > bar && bar.baz && (baz > qux) &&
+  a = foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   b =
-    (foo > bar &&
-      bar.baz && (baz > qux) &&
+    (foo > bar && bar.baz &&
+      (baz > qux) &&
       qux > xyz)
   c = {
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   }
 }
@@ -12400,8 +12400,8 @@ object a {
   a = foo > bar && bar.baz && baz > qux &&
     (qux > xyz)
   b =
-    (foo > bar &&
-      bar.baz && baz > qux && (qux > xyz))
+    (foo > bar && bar.baz && baz > qux &&
+      (qux > xyz))
   c = {
     foo > bar && bar.baz && baz > qux &&
     (qux > xyz)
@@ -12423,17 +12423,18 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+    (foo > bar) &&
+    (bar.baz) && baz > qux && qux > xyz
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+  a =
+    (foo > bar) &&
+      (bar.baz) && baz > qux && qux > xyz
   b =
-    ((foo > bar) && (bar.baz) &&
-      baz > qux && qux > xyz)
+    ((foo > bar) &&
+      (bar.baz) && baz > qux && qux > xyz)
   c = {
-    (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+    (foo > bar) &&
+    (bar.baz) && baz > qux && qux > xyz
   }
 }
 <<< mixed nested infixes, with breakOnNested 7
@@ -12452,17 +12453,22 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+    (foo > bar) &&
+    (bar.baz) && baz > qux &&
+    (qux > xyz)
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+  a =
+    (foo > bar) &&
+      (bar.baz) && baz > qux &&
+      (qux > xyz)
   b =
-    ((foo > bar) && (bar.baz) &&
-      baz > qux && (qux > xyz))
+    ((foo > bar) &&
+      (bar.baz) && baz > qux &&
+      (qux > xyz))
   c = {
-    (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+    (foo > bar) &&
+    (bar.baz) && baz > qux &&
+    (qux > xyz)
   }
 }
 <<< mixed nested infixes, with breakOnNested 8
@@ -12482,7 +12488,8 @@ object a {
 object a {
   if (
     (foo > bar) &&
-    bar.baz && (baz > qux) &&
+    bar.baz &&
+    (baz > qux) &&
     (qux > xyz)
   ) {}
   a =
@@ -12497,7 +12504,8 @@ object a {
       (qux > xyz))
   c = {
     (foo > bar) &&
-    bar.baz && (baz > qux) &&
+    bar.baz &&
+    (baz > qux) &&
     (qux > xyz)
   }
 }
@@ -12525,8 +12533,7 @@ object a {
     (baz > qux) &&
     (qux > xyz)
   b =
-    (foo > bar &&
-      (bar.baz) &&
+    (foo > bar && (bar.baz) &&
       (baz > qux) &&
       (qux > xyz))
   c = {
@@ -12551,19 +12558,24 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
+    (foo > bar) &&
+    (bar.baz) &&
     (baz > qux) &&
     (qux > xyz)
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    (baz > qux) &&
-    (qux > xyz)
+  a =
+    (foo > bar) &&
+      (bar.baz) &&
+      (baz > qux) &&
+      (qux > xyz)
   b =
-    ((foo > bar) && (bar.baz) &&
+    ((foo > bar) &&
+      (bar.baz) &&
       (baz > qux) &&
       (qux > xyz))
   c = {
-    (foo > bar) && (bar.baz) &&
+    (foo > bar) &&
+    (bar.baz) &&
     (baz > qux) &&
     (qux > xyz)
   }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -12864,8 +12864,8 @@ object a {
   a = foo > bar && bar.baz && baz > qux &&
     qux > xyz
   b =
-    (foo > bar &&
-      bar.baz && baz > qux && qux > xyz)
+    (foo > bar && bar.baz && baz > qux &&
+      qux > xyz)
   c = {
     foo > bar && bar.baz && baz > qux &&
     qux > xyz
@@ -12892,12 +12892,10 @@ object a {
   ) {}
   a =
     (foo > bar) &&
-      bar.baz &&
-      baz > qux && qux > xyz
+      bar.baz && baz > qux && qux > xyz
   b =
     ((foo > bar) &&
-      bar.baz &&
-      baz > qux && qux > xyz)
+      bar.baz && baz > qux && qux > xyz)
   c = {
     (foo > bar) &&
     bar.baz && baz > qux && qux > xyz
@@ -12919,18 +12917,17 @@ object a {
 >>>
 object a {
   if (
-    foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   ) {}
-  a = foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+  a = foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   b =
-    (foo > bar &&
-      (bar.baz) &&
-      baz > qux && qux > xyz)
+    (foo > bar && (bar.baz) && baz > qux &&
+      qux > xyz)
   c = {
-    foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   }
 }
 <<< mixed nested infixes, with breakOnNested 4
@@ -12949,17 +12946,20 @@ object a {
 >>>
 object a {
   if (
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   ) {}
-  a = foo > bar && bar.baz && (baz > qux) &&
+  a = foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   b =
-    (foo > bar &&
-      bar.baz && (baz > qux) &&
+    (foo > bar && bar.baz &&
+      (baz > qux) &&
       qux > xyz)
   c = {
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   }
 }
@@ -12985,8 +12985,8 @@ object a {
   a = foo > bar && bar.baz && baz > qux &&
     (qux > xyz)
   b =
-    (foo > bar &&
-      bar.baz && baz > qux && (qux > xyz))
+    (foo > bar && bar.baz && baz > qux &&
+      (qux > xyz))
   c = {
     foo > bar && bar.baz && baz > qux &&
     (qux > xyz)
@@ -13008,17 +13008,18 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+    (foo > bar) &&
+    (bar.baz) && baz > qux && qux > xyz
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+  a =
+    (foo > bar) &&
+      (bar.baz) && baz > qux && qux > xyz
   b =
-    ((foo > bar) && (bar.baz) &&
-      baz > qux && qux > xyz)
+    ((foo > bar) &&
+      (bar.baz) && baz > qux && qux > xyz)
   c = {
-    (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+    (foo > bar) &&
+    (bar.baz) && baz > qux && qux > xyz
   }
 }
 <<< mixed nested infixes, with breakOnNested 7
@@ -13037,17 +13038,22 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+    (foo > bar) &&
+    (bar.baz) && baz > qux &&
+    (qux > xyz)
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+  a =
+    (foo > bar) &&
+      (bar.baz) && baz > qux &&
+      (qux > xyz)
   b =
-    ((foo > bar) && (bar.baz) &&
-      baz > qux && (qux > xyz))
+    ((foo > bar) &&
+      (bar.baz) && baz > qux &&
+      (qux > xyz))
   c = {
-    (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+    (foo > bar) &&
+    (bar.baz) && baz > qux &&
+    (qux > xyz)
   }
 }
 <<< mixed nested infixes, with breakOnNested 8
@@ -13067,7 +13073,8 @@ object a {
 object a {
   if (
     (foo > bar) &&
-    bar.baz && (baz > qux) &&
+    bar.baz &&
+    (baz > qux) &&
     (qux > xyz)
   ) {}
   a =
@@ -13082,7 +13089,8 @@ object a {
       (qux > xyz))
   c = {
     (foo > bar) &&
-    bar.baz && (baz > qux) &&
+    bar.baz &&
+    (baz > qux) &&
     (qux > xyz)
   }
 }
@@ -13110,8 +13118,7 @@ object a {
     (baz > qux) &&
     (qux > xyz)
   b =
-    (foo > bar &&
-      (bar.baz) &&
+    (foo > bar && (bar.baz) &&
       (baz > qux) &&
       (qux > xyz))
   c = {
@@ -13136,19 +13143,24 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
+    (foo > bar) &&
+    (bar.baz) &&
     (baz > qux) &&
     (qux > xyz)
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    (baz > qux) &&
-    (qux > xyz)
+  a =
+    (foo > bar) &&
+      (bar.baz) &&
+      (baz > qux) &&
+      (qux > xyz)
   b =
-    ((foo > bar) && (bar.baz) &&
+    ((foo > bar) &&
+      (bar.baz) &&
       (baz > qux) &&
       (qux > xyz))
   c = {
-    (foo > bar) && (bar.baz) &&
+    (foo > bar) &&
+    (bar.baz) &&
     (baz > qux) &&
     (qux > xyz)
   }

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -13377,8 +13377,8 @@ object a {
       qux > xyz
   b =
     (
-      foo > bar &&
-        bar.baz && baz > qux && qux > xyz
+      foo > bar && bar.baz && baz > qux &&
+        qux > xyz
     )
   c = {
     foo > bar && bar.baz && baz > qux &&
@@ -13406,13 +13406,11 @@ object a {
   ) {}
   a =
     (foo > bar) &&
-      bar.baz &&
-      baz > qux && qux > xyz
+      bar.baz && baz > qux && qux > xyz
   b =
     (
       (foo > bar) &&
-        bar.baz &&
-        baz > qux && qux > xyz
+        bar.baz && baz > qux && qux > xyz
     )
   c = {
     (foo > bar) &&
@@ -13435,21 +13433,20 @@ object a {
 >>>
 object a {
   if (
-    foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   ) {}
   a =
-    foo > bar && (bar.baz) &&
-      baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+      qux > xyz
   b =
     (
-      foo > bar &&
-        (bar.baz) &&
-        baz > qux && qux > xyz
+      foo > bar && (bar.baz) && baz > qux &&
+        qux > xyz
     )
   c = {
-    foo > bar && (bar.baz) &&
-    baz > qux && qux > xyz
+    foo > bar && (bar.baz) && baz > qux &&
+    qux > xyz
   }
 }
 <<< mixed nested infixes, with breakOnNested 4
@@ -13468,20 +13465,23 @@ object a {
 >>>
 object a {
   if (
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   ) {}
   a =
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+      (baz > qux) &&
       qux > xyz
   b =
     (
-      foo > bar &&
-        bar.baz && (baz > qux) &&
+      foo > bar && bar.baz &&
+        (baz > qux) &&
         qux > xyz
     )
   c = {
-    foo > bar && bar.baz && (baz > qux) &&
+    foo > bar && bar.baz &&
+    (baz > qux) &&
     qux > xyz
   }
 }
@@ -13509,8 +13509,8 @@ object a {
       (qux > xyz)
   b =
     (
-      foo > bar &&
-        bar.baz && baz > qux && (qux > xyz)
+      foo > bar && bar.baz && baz > qux &&
+        (qux > xyz)
     )
   c = {
     foo > bar && bar.baz && baz > qux &&
@@ -13533,19 +13533,20 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+    (foo > bar) &&
+    (bar.baz) && baz > qux && qux > xyz
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+  a =
+    (foo > bar) &&
+      (bar.baz) && baz > qux && qux > xyz
   b =
     (
-      (foo > bar) && (bar.baz) &&
-        baz > qux && qux > xyz
+      (foo > bar) &&
+        (bar.baz) && baz > qux && qux > xyz
     )
   c = {
-    (foo > bar) && (bar.baz) &&
-    baz > qux && qux > xyz
+    (foo > bar) &&
+    (bar.baz) && baz > qux && qux > xyz
   }
 }
 <<< mixed nested infixes, with breakOnNested 7
@@ -13564,19 +13565,24 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+    (foo > bar) &&
+    (bar.baz) && baz > qux &&
+    (qux > xyz)
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+  a =
+    (foo > bar) &&
+      (bar.baz) && baz > qux &&
+      (qux > xyz)
   b =
     (
-      (foo > bar) && (bar.baz) &&
-        baz > qux && (qux > xyz)
+      (foo > bar) &&
+        (bar.baz) && baz > qux &&
+        (qux > xyz)
     )
   c = {
-    (foo > bar) && (bar.baz) &&
-    baz > qux && (qux > xyz)
+    (foo > bar) &&
+    (bar.baz) && baz > qux &&
+    (qux > xyz)
   }
 }
 <<< mixed nested infixes, with breakOnNested 8
@@ -13596,7 +13602,8 @@ object a {
 object a {
   if (
     (foo > bar) &&
-    bar.baz && (baz > qux) &&
+    bar.baz &&
+    (baz > qux) &&
     (qux > xyz)
   ) {}
   a =
@@ -13613,7 +13620,8 @@ object a {
     )
   c = {
     (foo > bar) &&
-    bar.baz && (baz > qux) &&
+    bar.baz &&
+    (baz > qux) &&
     (qux > xyz)
   }
 }
@@ -13643,8 +13651,7 @@ object a {
       (qux > xyz)
   b =
     (
-      foo > bar &&
-        (bar.baz) &&
+      foo > bar && (bar.baz) &&
         (baz > qux) &&
         (qux > xyz)
     )
@@ -13670,21 +13677,26 @@ object a {
 >>>
 object a {
   if (
-    (foo > bar) && (bar.baz) &&
+    (foo > bar) &&
+    (bar.baz) &&
     (baz > qux) &&
     (qux > xyz)
   ) {}
-  a = (foo > bar) && (bar.baz) &&
-    (baz > qux) &&
-    (qux > xyz)
+  a =
+    (foo > bar) &&
+      (bar.baz) &&
+      (baz > qux) &&
+      (qux > xyz)
   b =
     (
-      (foo > bar) && (bar.baz) &&
+      (foo > bar) &&
+        (bar.baz) &&
         (baz > qux) &&
         (qux > xyz)
     )
   c = {
-    (foo > bar) && (bar.baz) &&
+    (foo > bar) &&
+    (bar.baz) &&
     (baz > qux) &&
     (qux > xyz)
   }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -146,7 +146,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2685668, "total explored")
+      assertEquals(explored, 2691544, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Previously, we'd only apply it inconsistently.