### PR TITLE
Newlines: add a new infix style option, `keepNL`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2467,12 +2467,18 @@ Each of these groups has several parameters of its own (replacing deprecated
 
 #### `newlines.infix: style=keep`
 
-This approach preserves line breaks in the input. This is the original
-behaviour, and default for `newlines.source=classic,keep`.
+This approach preserves existence or absence of line breaks in the input. This
+is the original behaviour, and default for `newlines.source=classic,keep`.
 
 One caveat is: for `classic` type infixes with Scala3 (or if the dialect
 [enables](#runnerdialectoverride) the `useInfixTypePrecedence` flag),
 `some` is the default.
+
+#### `newlines.infix: style=keepNL`
+
+Added in v3.10.4, this approach preserves line breaks in the input, but doesn't
+necessarily preserve their absence (and thus could add additional line breaks
+after some infix operators).
 
 #### `newlines.infix: style=many,some`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -404,7 +404,9 @@ object Newlines {
       case _ => termSite
     }
 
-    def keep(tree: Tree): Boolean = get(tree).isKeep
+    def sourceIgnored(tree: Tree): Boolean = get(tree).sourceIgnored
+    def sourceIgnoredAt(ft: FT)(tree: Tree): Boolean = get(tree)
+      .sourceIgnoredAt(ft)
 
     private[config] def sourceIgnoredIfSet: Boolean =
       termSite.sourceIgnoredIfSet && typeSite.forall(_.sourceIgnoredIfSet) &&
@@ -423,6 +425,9 @@ object Newlines {
     case object keep extends Style {
       def sourceIgnored: Boolean = false
     }
+    case object keepNL extends Style {
+      def sourceIgnored: Boolean = false
+    }
     case object some extends Style {
       def sourceIgnored: Boolean = true
     }
@@ -430,7 +435,7 @@ object Newlines {
       def sourceIgnored: Boolean = true
     }
     implicit val styleReader: ConfCodecEx[Style] = ConfCodecEx
-      .oneOf[Style](keep, some, many)
+      .oneOf[Style](keep, some, many, keepNL)
 
     /** @param style
       *   Controls how line breaks around infix operations are handled
@@ -461,7 +466,8 @@ object Newlines {
           val opt = Infix.defaultStyle(cfg.newlines.source).orElse(orElseStyle)
           copy(style = opt.getOrElse(keep))
         } else this
-      def isKeep: Boolean = style eq keep
+      def sourceIgnoredAt(ft: FT): Boolean =
+        if (ft.noBreak) style ne keep else sourceIgnored
       def sourceIgnored: Boolean = style.sourceIgnored
       private[config] def sourceIgnoredIfSet: Boolean =
         (style eq null) || sourceIgnored

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -64,9 +64,9 @@ class FormatOps(
         if (start.rightOwner.is[Member.ParamClauseGroup]) start else null
       case _ if start.hasBlankLine => start
       case _
-          if AsInfixOp(start.rightOwner)
+          if !AsInfixOp(start.rightOwner)
             .orElse(AsInfixOp(prevNonComment(start).leftOwner))
-            .exists(style.newlines.infix.keep) =>
+            .forall(style.newlines.infix.sourceIgnored) =>
         if (start.hasBreak) start else null
       case _: T.LeftParen if (start.rightOwner match {
             case _: Member.ArgClause =>
@@ -333,7 +333,7 @@ class FormatOps(
       def spaceMod = Space(useSpaceAroundOp && (isBeforeOp || useSpaceBeforeArg))
 
       val afterInfix = style.newlines.infix.get(app)
-      if (!afterInfix.isKeep)
+      if (afterInfix.sourceIgnoredAt(ft))
         if (isBeforeOp) Seq(Split(spaceMod, 0))
         else {
           val (fullInfix, enclosedIn) = InfixSplits.findMaybeEnclosingInfix(app)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -188,8 +188,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
         def useDelim = settings.oneStatApply.changeDelim(lp, ftoks.getLast(ta))
         def shouldReplaceWithBrace(s: Stat): Boolean = s match {
           case x: Term.ApplyInfix
-              if style.newlines.infix.keep(x) &&
-                !style.dialect.allowInfixOperatorAfterNL &&
+              if !style.dialect.allowInfixOperatorAfterNL &&
                 RedundantParens.breaksBeforeOp(x) => false
           case _ => useDelim eq T.LeftBrace
         }
@@ -591,7 +590,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       def checkAfterRight(wasNonComment: => Boolean) = {
         val nrft = ftoks.nextNonComment(rft)
         !nrft.right.is[T.Ident] || !isInfixOp(nrft.rightOwner) ||
-        wasNonComment && !style.newlines.infix.keep(p) ||
+        wasNonComment && style.newlines.infix.sourceIgnoredAt(nrft)(p) ||
         findTreeWithParent(p) { // check if infix is in parens
           case pp: Member.ArgClause => ftoks.getClosingIfWithinParensOrBraces(pp)
               .map(_.isRight)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -29,7 +29,7 @@ object RedundantParens extends Rewrite with FormatTokensRewrite.RuleFactory {
   def breaksBeforeOp(
       ia: Member.Infix,
   )(implicit style: ScalafmtConfig, ftoks: FormatTokens): Boolean = {
-    val keepInfix = style.newlines.infix.keep(ia)
+    val keepInfix = !style.newlines.infix.sourceIgnored(ia)
     def impl(ia: Member.Infix): Boolean = {
       val beforeOp = ftoks.prevNonCommentSameLine(ftoks.tokenJustBefore(ia.op))
       beforeOp.hasBreak && (keepInfix || beforeOp.left.is[T.Comment]) ||

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -186,7 +186,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
     def okLeftDelim = ft.right.is[T.LeftBrace] ||
       style.rewrite.scala3.removeOptionalBraces.fewerBracesParensToo &&
       (style.dialect.allowInfixOperatorAfterNL ||
-        !style.newlines.infix.keep(tree))
+        style.newlines.infix.sourceIgnoredAt(ft)(tree))
     val ok = style.dialect.allowFewerBraces && okLeftDelim &&
       style.rewrite.scala3.removeOptionalBraces.fewerBracesMaxSpan > 0 &&
       isSeqSingle(tree.values)


### PR DESCRIPTION
This variant preserves only the presence of a newline but doesn't need to preserve its absence.