### PR TITLE
InfixSplits: refactor intermediate expires

### DIFF
--- a/scalafmt-tests/shared/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/ApplyInfix.stat
@@ -573,7 +573,8 @@ require(
 >>>
 require(fraction >=
           0.0 - RandomSampler.roundingEpsilon
-          && fraction <=
+          &&
+          fraction <=
           1.0 + RandomSampler.roundingEpsilon,
         s"Sampling fraction ($fraction) must be on interval [0, 1]")
 <<< infix style=keepNL no break before op but after brace, no arg clause, RedundantBraces
@@ -588,11 +589,7 @@ fraction >= {
   1.0 + RandomSampler.roundingEpsilon
 }
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,3 +1,4 @@
- fraction >=
--  0.0 - RandomSampler.roundingEpsilon && fraction <=
-+  0.0 - RandomSampler.roundingEpsilon &&
-+  fraction <=
-   1.0 + RandomSampler.roundingEpsilon
+fraction >=
+  0.0 - RandomSampler.roundingEpsilon &&
+  fraction <=
+  1.0 + RandomSampler.roundingEpsilon

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -146,7 +146,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2695610, "total explored")
+      assertEquals(explored, 2695580, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Rather than iterating through all infixes twice, once to obtain their maximum precedence and then to collect the infixes themselves, let's do it only once.

Also, instead of computing the cost immediately, let's simply track the maximum precedence encountered.

In addition, let's keep only the last three expires while building the resulting buffer so that we don't need to trim it later.