### PR TITLE
Bump release workflows to `macos-15`/`macos-15-intel` runners

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         deploy: [
-          { os: macOS-13, name: scalafmt-x86_64-apple-darwin.zip },
-          { os: macOS-14, name: scalafmt-aarch64-apple-darwin.zip },
+          { os: macOS-15-intel, name: scalafmt-x86_64-apple-darwin.zip },
+          { os: macOS-15, name: scalafmt-aarch64-apple-darwin.zip },
           { os: ubuntu-22.04, name: scalafmt-x86_64-pc-linux.zip },
           { os: ubuntu-24.04-arm, name: scalafmt-aarch64-pc-linux.zip },
           { os: windows-2025, name: scalafmt-x86_64-pc-win32.zip }


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
`macos-13` was retired 04.12.2025 (last month), which I'm guessing is why we are missing the `scalafmt-x86_64-apple-darwin.zip` artifact in `scalafmt` 3.10.3: https://github.com/scalameta/scalafmt/releases/tag/v3.10.3
Hopefully this would fix it.
cc @tgodzik 