### PR TITLE
TreeExtractors: switch to scalameta precedence

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -185,12 +185,12 @@ class RedundantParens(implicit val ftoks: FormatTokens)
       case RedundantParensSettings.InfixSide.many
           if tia.op.value != pia.op.value =>
         val tiaPrecedence = tia.precedence
-        tiaPrecedence <= precedenceHigh ||
-        tiaPrecedence < precedenceLowest && pia.precedence >= precedenceLowest
+        tiaPrecedence >= precedenceHigh ||
+        tiaPrecedence > precedenceLowest && pia.precedence <= precedenceLowest
       case RedundantParensSettings.InfixSide.some =>
         val tiaPrecedence = tia.precedence
-        tiaPrecedence <= precedenceVeryHigh ||
-        tiaPrecedence <= precedenceMedium && pia.precedence >= precedenceLowest
+        tiaPrecedence >= precedenceVeryHigh ||
+        tiaPrecedence >= precedenceMedium && pia.precedence <= precedenceLowest
       case _ => true
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -30,33 +30,15 @@ object InfixApp {
   }
 
   // https://scala-lang.org/files/archive/spec/2.11/06-expressions.html#infix-operations
-  // The precedence of an assignment ... is lower than the precedence of any other ...
-  private val infixOpPrecedence: Map[Char, Int] = {
-    val builder = Map.newBuilder[Char, Int]
-    def add(precedence: Int, ops: Char*): Unit = addSeq(precedence, ops)
-    def addSeq(precedence: Int, ops: Iterable[Char]): Unit = ops
-      .foreach(builder += _ -> precedence)
-    // start with 1; all other special characters will get 0 by omission
-    add(1, '*', '/', '%')
-    add(2, '+', '-')
-    add(3, ':')
-    add(4, '<', '>')
-    add(5, '=', '!')
-    add(6, '&')
-    add(7, '^')
-    add(8, '|')
-    addSeq(9, 'a' to 'z')
-    addSeq(9, 'A' to 'Z')
-    builder.result()
-  }
-
-  // https://scala-lang.org/files/archive/spec/2.11/06-expressions.html#infix-operations
   // Operators ending in a colon `:' are right-associative. All other operators are left-associative.
   @inline
   def isLeftAssoc(op: String): Boolean = op.isLeftAssoc
 
   @inline
-  def getPrecedence(op: String): Int = infixOpPrecedence.getOrElse(op.head, 0)
+  def getPrecedence(op: String): Int = {
+    val idx = op.lastIndexWhere(_ != '=')
+    if (idx < 0) op else op.substring(0, idx + 1)
+  }.precedence
 
 }
 


### PR DESCRIPTION
The difference is, scalameta version of precedence assigns higher values to higher-priority operators (rather than lower values the way scalafmt used to do this).

Additional differences in scalameta are:
- correctly maps `_` and `$` into the same category as letters (with the precedence of 1)
- calls out assignment operators explicitly, using precedence 0, instead of whatever their first character would otherwise map to, which we'll temporarily disable.