### PR TITLE
InfixSplits: handle assignment operators better

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -35,10 +35,7 @@ object InfixApp {
   def isLeftAssoc(op: String): Boolean = op.isLeftAssoc
 
   @inline
-  def getPrecedence(op: String): Int = {
-    val idx = op.lastIndexWhere(_ != '=')
-    if (idx < 0) op else op.substring(0, idx + 1)
-  }.precedence
+  def getPrecedence(op: String): Int = op.precedence
 
 }
 

--- a/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59743964)
+  override protected def totalStatesVisited: Option[Int] = Some(59751190)
 
   override protected def builds = Seq {
     getBuild(
@@ -54,7 +54,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59959629)
+  override protected def totalStatesVisited: Option[Int] = Some(59966568)
 
   override protected def builds = Seq {
     getBuild(

--- a/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42964825)
+  override protected def totalStatesVisited: Option[Int] = Some(42966645)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(52757074)
+  override protected def totalStatesVisited: Option[Int] = Some(52762093)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39488958)
+  override protected def totalStatesVisited: Option[Int] = Some(39509843)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42628076)
+  override protected def totalStatesVisited: Option[Int] = Some(42649989)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/shared/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/shared/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(86404492)
+  override protected def totalStatesVisited: Option[Int] = Some(86408565)
 
   override protected def builds = Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
 
@@ -17,7 +17,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(91396210)
+  override protected def totalStatesVisited: Option[Int] = Some(91400337)
 
   override protected def builds = Seq(getBuild("v3.5.3", dialects.Scala213, 2756))
 

--- a/scalafmt-tests/shared/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/ApplyInfix.stat
@@ -718,8 +718,8 @@ lazy val sharedSettings = Def.settings(
     foo / bar += "baz" -> "foo / bar += baz",
     foo / bar / baz +=
       "qux' -> 'foo / bar / baz += qux",
-    foo / bar / baz += "qux" ->
-      "foo / bar / baz += qux",
+    foo / bar / baz +=
+      "qux" -> "foo / bar / baz += qux",
     foo / bar / baz +=
       "qux' -> 'foo / bar / baz += foo / bar / baz",
     foo / bar / baz += "qux" ->

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -10136,8 +10136,8 @@ rewrite.rules = [RedundantBraces]
 if (buf.nonEmpty || privateWithin != "")
   buf += {"TypeName(\"" + privateWithin + "\")"}
 >>>
-if (buf.nonEmpty || privateWithin != "") buf += "TypeName(\"" +
-  privateWithin + "\")"
+if (buf.nonEmpty || privateWithin != "") buf +=
+  "TypeName(\"" + privateWithin + "\")"
 <<< #4133 redundant braces around inner infix with overflow
 maxColumn = 78
 runner.dialect = scala3

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -7342,10 +7342,9 @@ private[this] def __computeSerializedSize(): _root_.scala.Int =
    var __size = 0
    if sealedValue.nullConstant.isDefined then
       val __value = sealedValue.nullConstant.get
-      __size += 1 +
-        SemanticdbOutputStream
-          .computeUInt32SizeNoTag(__value.serializedSize) +
-        __value.serializedSize;
+      __size += 1 + SemanticdbOutputStream.computeUInt32SizeNoTag(
+        __value.serializedSize
+      ) + __value.serializedSize;
    end if
    __size
 <<< expression with long `then` block and multi-line `else` block

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -148,7 +148,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2708842, "total explored")
+      assertEquals(explored, 2709702, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Allow a single-line newline split and possibly more options with shorter-span space splits (considering closer next infixes).