### PR TITLE
InfixSplits: include `fullInfixEnclosedIn` flag

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -347,7 +347,7 @@ class FormatOps(
         case t: Defn.Var => t.body eq fullInfix
         case _ => true
       }
-      if (ok) InfixSplits(app, ft, fullInfix)
+      if (ok) InfixSplits(app, ft, fullInfix, fullInfixEnclosedIn)
         .getBeforeLhsOrRhs(afterInfix, spaceMod = spaceMod)
       else spaceSplits
     }
@@ -371,7 +371,7 @@ class FormatOps(
     def modNL = Newline2x(fullInfixEnclosedInParens && ft.hasBlankLine)
     def nl(cost: Int)(implicit fl: FileLine) = Split(modNL, cost)
     def withIndent(split: Split) =
-      Seq(InfixSplits.withNLIndent(split, app, fullInfix))
+      Seq(InfixSplits.withNLIndent(split, app, (fullInfix, fullInfixEnclosedIn)))
 
     if (isBeforeOp)
       if (ft.noBreak) withIndent(spc) // !sourceIgnored


### PR DESCRIPTION
We always obtain it anyway while determining fullInfix.