### PR TITLE
InfixSplits: fix SLB indent length, expiration

### DIFF
--- a/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59751190)
+  override protected def totalStatesVisited: Option[Int] = Some(59751146)
 
   override protected def builds = Seq {
     getBuild(
@@ -54,7 +54,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59966568)
+  override protected def totalStatesVisited: Option[Int] = Some(59966524)
 
   override protected def builds = Seq {
     getBuild(

--- a/scalafmt-tests/shared/src/test/resources/default/ApplyInfix.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/ApplyInfix.stat
@@ -1220,7 +1220,7 @@ foo(
   foo1 / foo2 / foo3 / foo4 := foo5 / foo6 / foo7 / foo8 / foo9 / fooA / fooB / fooC / fooD / fooE,
   foo1 / foo2 / foo3 / foo4 := foo5 / foo6 / foo7 / foo8 / foo9 / fooA / fooB / fooC / fooD / fooE / fooF,
 )
->>> { stateVisits = 380, stateVisits2 = 294 }
+>>> { stateVisits = 326, stateVisits2 = 294 }
 foo(
     foo1 / foo2 / foo3 / foo4 := foo5,
     foo1 / foo2 / foo3 / foo4 := foo5 /
@@ -1288,31 +1288,32 @@ indent.infix {
   foo1 / foo2 / foo3 / foo4 := foo5 / foo6 / foo7 / foo8 / foo9 / fooA / fooB / fooC / fooD / fooE
   foo1 / foo2 / foo3 / foo4 := foo5 / foo6 / foo7 / foo8 / foo9 / fooA / fooB / fooC / fooD / fooE / fooF
 }
->>> { stateVisits = 371, stateVisits2 = 276 }
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,20 +1,20 @@
- {
-   foo1 / foo2 / foo3 / foo4 := foo5
-   foo1 / foo2 / foo3 / foo4 :=
--    foo5 / foo6
-+      foo5 / foo6
-   foo1 / foo2 / foo3 / foo4 :=
--    foo5 / foo6 / foo7
-+      foo5 / foo6 / foo7
-   foo1 / foo2 / foo3 / foo4 :=
--    foo5 / foo6 / foo7 / foo8
-+      foo5 / foo6 / foo7 / foo8
-   foo1 / foo2 / foo3 / foo4 :=
--    foo5 / foo6 / foo7 / foo8 / foo9
-+      foo5 / foo6 / foo7 / foo8 / foo9
-   foo1 / foo2 / foo3 / foo4 := foo5 /
-       foo6 / foo7 / foo8 / foo9 / fooA
-   foo1 / foo2 / foo3 / foo4 := foo5 /
-       foo6 / foo7 / foo8 / foo9 / fooA /
-       fooB
-   foo1 / foo2 / foo3 / foo4 := foo5 /
-       foo6 / foo7 / foo8 / foo9 / fooA /
-       fooB / fooC
-   foo1 / foo2 / foo3 / foo4 := foo5 /
-       foo6 / foo7 / foo8 / foo9 / fooA /
+>>> { stateVisits = 307, stateVisits2 = 276 }
+{
+  foo1 / foo2 / foo3 / foo4 := foo5
+  foo1 / foo2 / foo3 / foo4 :=
+      foo5 / foo6
+  foo1 / foo2 / foo3 / foo4 :=
+      foo5 / foo6 / foo7
+  foo1 / foo2 / foo3 / foo4 :=
+      foo5 / foo6 / foo7 / foo8
+  foo1 / foo2 / foo3 / foo4 :=
+      foo5 / foo6 / foo7 / foo8 / foo9
+  foo1 / foo2 / foo3 / foo4 := foo5 /
+      foo6 / foo7 / foo8 / foo9 / fooA
+  foo1 / foo2 / foo3 / foo4 := foo5 /
+      foo6 / foo7 / foo8 / foo9 / fooA /
+      fooB
+  foo1 / foo2 / foo3 / foo4 := foo5 /
+      foo6 / foo7 / foo8 / foo9 / fooA /
+      fooB / fooC
+  foo1 / foo2 / foo3 / foo4 := foo5 /
+      foo6 / foo7 / foo8 / foo9 / fooA /
+      fooB / fooC / fooD
+  foo1 / foo2 / foo3 / foo4 := foo5 /
+      foo6 / foo7 / foo8 / foo9 / fooA /
+      fooB / fooC / fooD / fooE
+  foo1 / foo2 / foo3 / foo4 := foo5 /
+      foo6 / foo7 / foo8 / foo9 / fooA /
+      fooB / fooC / fooD / fooE / fooF
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -8366,7 +8366,7 @@ object a {
     )
   )
 }
->>> { stateVisits = 4702, stateVisits2 = 4702 }
+>>> { stateVisits = 4702 }
 object a {
   div(cls := "cover")(
     div(cls := "doc")(bodyContents),
@@ -8453,7 +8453,7 @@ object a {
     )
   )
 }
->>> { stateVisits = 3882, stateVisits2 = 3882 }
+>>> { stateVisits = 3882 }
 object a {
   div(cls := "cover")(
     div(cls := "doc")(bodyContents),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2717612, "total explored")
+      assertEquals(explored, 2717194, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Previously, it was incorrectly using `main` rather than the more likely `afterInfix` indent configuration value.

Also, for assignment, let's use fullExpire rather than firstExpire.