### PR TITLE
SyntacticGroupOps: fix for patterns, scala3 types

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -238,7 +238,7 @@ case class ScalafmtConfig(
     .wrapMaxColumn.getOrElse(maxColumn)
 
   @inline
-  private[scalafmt] def dialect = runner.getDialectForParser
+  private[scalafmt] implicit def dialect: Dialect = runner.getDialectForParser
 
   private[scalafmt] def getTrailingCommas = rewrite.trailingCommas.style
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SyntacticGroupOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SyntacticGroupOps.scala
@@ -3,7 +3,7 @@ package org.scalafmt.internal
 import org.scalafmt.internal.{SyntacticGroup => g}
 
 import scala.meta.internal.trees._
-import scala.meta.{Lit, Term, Tree}
+import scala.meta.{Dialect, Lit, Term, Tree}
 
 import scala.annotation.tailrec
 
@@ -14,10 +14,10 @@ object SyntacticGroupOps {
       innerOp: String,
       side: Side,
       what: AnyRef,
-  ): Boolean = {
+  )(implicit dialect: Dialect): Boolean = {
     val outerIsLeftAssoc = outerOp.isLeftAssoc
     if (outerIsLeftAssoc != innerOp.isLeftAssoc) true
-    else if (what ne g.Type) {
+    else if ((what ne g.Type) || dialect.useInfixTypePrecedence) {
       val diffPrecedence = outerOp.precedence - innerOp.precedence
       diffPrecedence > 0 ||
       diffPrecedence == 0 && outerIsLeftAssoc != side.isLeft
@@ -36,7 +36,7 @@ object SyntacticGroupOps {
       outerGroup: SyntacticGroup,
       innerGroup: SyntacticGroup,
       side: Side,
-  ): Boolean = (outerGroup, innerGroup) match {
+  )(implicit dialect: Dialect): Boolean = (outerGroup, innerGroup) match {
     case (g.Term.InfixExpr(outerOp), g.Term.InfixExpr(innerOp)) =>
       operatorNeedsParenthesis(outerOp, innerOp, side, what = g.Term)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -696,6 +696,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       b: Term.Block,
   )(implicit ft: FT, style: ScalafmtConfig, session: Session): Boolean =
     getSingleStatIfLineSpanOk(b).exists { stat =>
+      import style.dialect
       @tailrec
       def keepForParent(tree: Tree): Boolean = tree match {
         case t: Term.ArgClause => t.parent match {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -19,7 +19,10 @@ object RedundantParens extends Rewrite with FormatTokensRewrite.RuleFactory {
   override def create(implicit ftoks: FormatTokens): FormatTokensRewrite.Rule =
     new RedundantParens
 
-  private def infixNeedsParens(outer: Member.Infix, inner: Tree): Boolean = {
+  private def infixNeedsParens(outer: Member.Infix, inner: Tree)(implicit
+      style: ScalafmtConfig,
+  ): Boolean = {
+    import style.dialect
     val sgOuter = TreeSyntacticGroup(outer)
     val sgInner = TreeSyntacticGroup(inner)
     val side = if (outer.lhs eq inner) Side.Left else Side.Right

--- a/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(52759813)
+  override protected def totalStatesVisited: Option[Int] = Some(52759797)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests/shared/src/test/resources/rewrite/RedundantParens.stat
+++ b/scalafmt-tests/shared/src/test/resources/rewrite/RedundantParens.stat
@@ -2152,9 +2152,9 @@ object a {
   type T = foo - bar + baz
 
   type T = foo * (bar - baz)
-  type T = foo + bar * baz
+  type T = (foo + bar) * baz
 
-  type T = foo - (bar * baz)
+  type T = foo - bar * baz
   type T = foo * bar - baz
 }
 <<< various-precedence type infixes, right-assoc, scala3
@@ -2176,11 +2176,11 @@ object a {
   type T = foo -: bar +: baz
   type T = (foo -: bar) +: baz
 
-  type T = foo *: bar -: baz
+  type T = foo *: (bar -: baz)
   type T = (foo +: bar) *: baz
 
   type T = foo -: bar *: baz
-  type T = (foo *: bar) -: baz
+  type T = foo *: bar -: baz
 }
 <<< various-precedence type infixes, mixed-assoc, scala3
 runner.dialect = scala3
@@ -2311,9 +2311,9 @@ object a {
   func[foo - bar + baz]
 
   func[foo * (bar - baz)]
-  func[foo + bar * baz]
+  func[(foo + bar) * baz]
 
-  func[foo - (bar * baz)]
+  func[foo - bar * baz]
   func[foo * bar - baz]
 }
 <<< various-precedence generic-type infixes, right-assoc, scala3
@@ -2335,11 +2335,11 @@ object a {
   func[foo -: bar +: baz]
   func[(foo -: bar) +: baz]
 
-  func[foo *: bar -: baz]
+  func[foo *: (bar -: baz)]
   func[(foo +: bar) *: baz]
 
   func[foo -: bar *: baz]
-  func[(foo *: bar) -: baz]
+  func[foo *: bar -: baz]
 }
 <<< various-precedence generic-type infixes, mixed-assoc, scala3
 runner.dialect = scala3

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2749594, "total explored")
+      assertEquals(explored, 2749592, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Bring this implementation (hopefully) in sync with how scalameta parser handles precedence and associativity (which hopefully does it correctly itself), and improve handling of types which in scala3 don't follow old special-case rules anymore.