### PR TITLE
RedundantBraces: keep quote unless within splice

### DIFF
--- a/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39499346)
+  override protected def totalStatesVisited: Option[Int] = Some(39499418)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42639613)
+  override protected def totalStatesVisited: Option[Int] = Some(42639685)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests/shared/src/test/resources/scala3/Macro.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/Macro.stat
@@ -176,12 +176,12 @@ ${{{ foo }}} bar ${{{ baz }}}
 '{ ${ foo } bar ${ baz } }
 '{{{ ${{ foo }} bar ${{ baz }} }}}
 >>>
-'foo
-'foo
-'foo == 'baz
-'foo == 'baz
-'foo bar 'baz
-'foo bar 'baz
+'{ foo }
+'{ foo }
+'{ foo } == '{ baz }
+'{ foo } == '{ baz }
+'{ foo } bar '{ baz }
+'{ foo } bar '{ baz }
 
 ${ 'foo }
 ${ 'foo }
@@ -219,10 +219,16 @@ ${{{ foo /* c */ }}}
 '{ ${ /* c */ foo } }
 '{{{ ${{ foo /* c */ }} }}}
 >>>
-'/* c */ foo
-'foo /* c */
+'{ /* c */
+  foo
+}
+'{ foo /* c */ }
 
-${ '/* c */ foo }
+${
+  '{ /* c */
+    foo
+  }
+}
 ${ 'foo /* c */ }
 
 ${ /* c */
@@ -230,7 +236,11 @@ ${ /* c */
 }
 ${ foo /* c */ }
 
-'{ $/* c */ foo }
+'{
+  ${ /* c */
+    foo
+  }
+}
 '{ $foo /* c */ }
 <<< quoted and spliced patterns, RedundantBraces
 runner.parser = source

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2763004, "total explored")
+      assertEquals(explored, 2763180, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Also, protect with `generalExpressions` flag and skip if there's an intervening comment. Fixes #5202.