### PR TITLE
IndentOperator: make default exemptScope explicit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -946,7 +946,7 @@ continuation indentation. Since 3.10.4, it takes multiple values, and expects ea
 If you have only one value, you may choose to specify `exemptScope = <value>`
 instead of `exemptScope = [ <value> ]`.
 If the list is empty, this constraint is satisfied, and any otherwise eligible infix operator
-is exempted.
+is exempted (this replaced deprecated `indentOperator.topLevelOnly=false`).
 
 It accepts the following values, to determine the context in which infix operators are eligible
 to be exempted from the default indentation rule:
@@ -968,8 +968,6 @@ to be exempted from the default indentation rule:
   only statement in a block; entire body of an assignment, case clause, control statement, etc;
   - it is intended to help implement a requirement of the
     [scala-js coding style](https://github.com/scala-js/scala-js/blob/main/CODINGSTYLE.md#long-expressions-with-binary-operators).
-- `all`: all infix operators
-  - this value replaced deprecated `indentOperator.topLevelOnly=false`
 - `notAssign` (since v3.8.4): any non-assignment operator
   - this value expanded upon deprecated `verticalAlignMultilineOperators`
     which now simply maps to `{ exemptScope = notAssign, excludeRegex = ".*" }`
@@ -1001,7 +999,7 @@ function {
 ```
 
 ```scala mdoc:scalafmt
-indent.infix = [{ exemptScope = [all] }]
+indent.infix = [{ exemptScope = [] }]
 ---
 function(
   a &&

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/IndentOperator.scala
@@ -81,18 +81,17 @@ object IndentOperator {
     case Conf.Str("akka") => akka
     case Conf.Str("default") => default
   }.withSectionRenames(
+    annotation.SectionRename.partial { // converted to Seq in v3.10.4
+      case x: Conf.Str => if (x.value == "all") Conf.Lst(Nil) else Conf.Lst(x)
+    }(exemptScopeName, exemptScopeName),
     // deprecated since v3.4.0
     annotation.SectionRename { case Conf.Bool(value) =>
-      if (value) Conf.nameOf(Exempt.oldTopLevel) else Conf.nameOf(Exempt.all)
+      if (value) Conf.Lst(Conf.nameOf(Exempt.oldTopLevel)) else Conf.Lst(Nil)
     }("topLevelOnly", exemptScopeName),
-    annotation.SectionRename.partial { // converted to Seq in v3.10.4
-      case x: Conf.Str => Conf.Lst(x)
-    }(exemptScopeName, exemptScopeName),
   )
 
   sealed abstract class Exempt
   object Exempt {
-    case object all extends Exempt
     case object oldTopLevel extends Exempt
     case object aloneEnclosed extends Exempt
     case object aloneArgOrBody extends Exempt
@@ -100,7 +99,6 @@ object IndentOperator {
     case object notWithinAssign extends Exempt
 
     implicit val reader: ConfCodecEx[Exempt] = ConfCodecEx.oneOf[Exempt](
-      all,
       oldTopLevel,
       aloneEnclosed,
       aloneArgOrBody,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/InfixSplits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/InfixSplits.scala
@@ -279,7 +279,6 @@ class InfixSplits(
       case t => t
     }
     def allowNoIndent(cfg: IndentOperator) = cfg.exemptScope.forall {
-      case Exempt.all => true
       case Exempt.oldTopLevel => isOldTopLevel(full)
       case Exempt.aloneEnclosed => isAloneEnclosed(full)
       case Exempt.aloneArgOrBody => isAloneArgOrBody(full)


### PR DESCRIPTION
Also, emphasize in documentation what an empty exemptScope does.