### PR TITLE
Add File Header Management (License / Copyright)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5172,6 +5172,237 @@ object Stuff {
 }
 ```
 
+## File Headers
+
+> Since v3.11.0.
+
+### `fileHeader`
+
+Inserts, replaces, or removes a file header (license notice, copyright line)
+at the top of each formatted file. Inactive by default.
+
+Three content sources, checked in order: `raw` (verbatim with delimiters),
+`text` (inner content, wrapped by `style`), `license` (SPDX identifier).
+First defined source wins. Setting a source to `""` activates **strip mode**
+(existing header removed).
+
+Shortcut forms: `fileHeader = none` (inactive), `fileHeader = "text"` (text
+shortcut).
+
+### `fileHeader.license`
+
+SPDX license identifier. Supported: `Apache-2.0`, `MIT`, `BSD-2-Clause`,
+`BSD-3-Clause`, `MPL-2.0`, `GPL-2.0-only`, `GPL-3.0-only`, `LGPL-2.1-only`,
+`LGPL-3.0-only`, `EPL-2.0`, `ISC`, `Unlicense`.
+
+```scala mdoc:scalafmt
+fileHeader.license = Apache-2.0
+fileHeader.copyrightHolder = "Org"
+fileHeader.since = 2020
+fileHeader.year = 2025
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.style`
+
+```scala mdoc:defaults
+fileHeader.style
+```
+
+#### `fileHeader.style = block`
+
+Default. Wraps content in `/* */`. Line prefix follows `docstrings.style`
+unless overridden by `fileHeader.comment.style`.
+
+#### `fileHeader.style = line`
+
+Wraps each line with `//`.
+
+```scala mdoc:scalafmt
+fileHeader.license = Apache-2.0
+fileHeader.copyrightHolder = "Org"
+fileHeader.since = 2020
+fileHeader.year = 2025
+fileHeader.style = line
+---
+package com.example
+
+object Main
+```
+
+#### `fileHeader.style = framed`
+
+Fixed-width bordered box. Width defaults to `maxColumn`; override with
+`fileHeader.comment.width`.
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.style = framed
+fileHeader.comment.width = 40
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.licenseStyle`
+
+```scala mdoc:defaults
+fileHeader.licenseStyle
+```
+
+`spdx` (default) emits a `SPDX-License-Identifier:` tag. `detailed` emits
+the full license text.
+
+```scala mdoc:scalafmt
+fileHeader.license = MIT
+fileHeader.licenseStyle = detailed
+fileHeader.copyrightHolder = "Org"
+fileHeader.year = 2025
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.text`
+
+Inner content string. Wrapped according to `style`.
+
+```scala mdoc:scalafmt
+fileHeader.text = "Proprietary.\nAll rights reserved."
+fileHeader.style = line
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.raw`
+
+Complete header including comment delimiters, inserted verbatim after
+`stripMargin.trim`. `style` and `comment` settings are ignored.
+
+```scala mdoc:scalafmt
+fileHeader.raw = "// Copyright (C) 2025 My Corp."
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.blankLineAfter`
+
+```scala mdoc:defaults
+fileHeader.blankLineAfter
+```
+
+Controls blank line between header and first code line.
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.style = line
+fileHeader.blankLineAfter = false
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.comment.blankFirstLine`
+
+Controls whether content starts on the `/*` line or the next line.
+
+- `unfold` (default): first line blank, content on next line
+- `fold`: content on the `/*` line
+
+For **block** style:
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.comment.blankFirstLine = fold
+---
+package com.example
+
+object Main
+```
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.comment.blankFirstLine = unfold
+---
+package com.example
+
+object Main
+```
+
+For **framed** style, controls whether a padding row appears after the top
+border:
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.style = framed
+fileHeader.comment.width = 40
+fileHeader.comment.blankFirstLine = fold
+---
+package com.example
+
+object Main
+```
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.style = framed
+fileHeader.comment.width = 40
+fileHeader.comment.blankFirstLine = unfold
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.comment.blankLastLine`
+
+```scala mdoc:defaults
+fileHeader.comment.blankLastLine
+```
+
+Adds a blank line before the closing `*/` (block) or bottom border (framed).
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.comment.blankLastLine = true
+---
+package com.example
+
+object Main
+```
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.style = framed
+fileHeader.comment.width = 40
+fileHeader.comment.blankLastLine = true
+---
+package com.example
+
+object Main
+```
+
+### Per-file overrides
+
+Use [`fileOverride`](#fileoverride) to vary header settings per file pattern.
+
+```conf
+fileOverride {
+  "glob:**.sbt" { fileHeader.style = line }
+  "glob:**/generated/**" { fileHeader = none }
+}
+```
+
 ## Disabling or customizing formatting
 
 ### `Search state exploded`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5206,6 +5206,63 @@ package com.example
 object Main
 ```
 
+### `fileHeader.copyrightHolder`
+
+Prepended as `Copyright <year> <holder>` before the license identifier or text.
+
+```scala mdoc:scalafmt
+fileHeader.license = MIT
+fileHeader.copyrightHolder = "My Organization"
+fileHeader.year = 2025
+---
+package com.example
+
+object Main
+```
+
+Without `copyrightHolder`, only the SPDX identifier line is emitted.
+
+```scala mdoc:scalafmt
+fileHeader.license = MIT
+fileHeader.year = 2025
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.since`
+
+Project inception year. When set, copyright year is rendered as a range
+`since-year`. When `since` equals `year`, a single year is used.
+
+```scala mdoc:scalafmt
+fileHeader.license = MIT
+fileHeader.copyrightHolder = "Org"
+fileHeader.since = 2020
+fileHeader.year = 2025
+---
+package com.example
+
+object Main
+```
+
+```scala mdoc:scalafmt
+fileHeader.license = MIT
+fileHeader.copyrightHolder = "Org"
+fileHeader.since = 2025
+fileHeader.year = 2025
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.year`
+
+Copyright end year. Defaults to the current calendar year when absent. Set
+explicitly to freeze for reproducible output.
+
 ### `fileHeader.style`
 
 ```scala mdoc:defaults
@@ -5216,6 +5273,14 @@ fileHeader.style
 
 Default. Wraps content in `/* */`. Line prefix follows `docstrings.style`
 unless overridden by `fileHeader.comment.style`.
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+---
+package com.example
+
+object Main
+```
 
 #### `fileHeader.style = line`
 
@@ -5386,6 +5451,46 @@ fileHeader.text = "My Header"
 fileHeader.style = framed
 fileHeader.comment.width = 40
 fileHeader.comment.blankLastLine = true
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.comment.style`
+
+Line prefix style for block comments. Defaults to `docstrings.style`.
+
+#### `fileHeader.comment.style = SpaceAsterisk`
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.comment.style = SpaceAsterisk
+---
+package com.example
+
+object Main
+```
+
+#### `fileHeader.comment.style = Asterisk`
+
+```scala mdoc:scalafmt
+fileHeader.text = "My Header"
+fileHeader.comment.style = Asterisk
+---
+package com.example
+
+object Main
+```
+
+### `fileHeader.comment.width`
+
+Frame width for `style = framed`. Defaults to `maxColumn`.
+
+```scala mdoc:scalafmt
+fileHeader.text = "Header"
+fileHeader.style = framed
+fileHeader.comment.width = 30
 ---
 package com.example
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -3,7 +3,7 @@ package org.scalafmt
 import org.scalafmt.Error.PreciseIncomplete
 import org.scalafmt.config._
 import org.scalafmt.internal._
-import org.scalafmt.rewrite.Rewrite
+import org.scalafmt.rewrite.{FileHeaderOps, Rewrite}
 import org.scalafmt.sysops.FileOps
 import org.scalafmt.util.{LoggerOps, MarkdownParser}
 
@@ -93,7 +93,10 @@ object Scalafmt {
         case Some(LineEndings.windows) => res.map(LoggerOps.crlf)
         case _ => res
       }
-    } else doFormatOne(code, style, file, range)
+    } else {
+      val withHeader = FileHeaderOps(code, style, range)
+      doFormatOne(withHeader, style, file, range)
+    }
 
   private[scalafmt] def toInput(code: String, file: String): Input = {
     val fileInput = Input.VirtualFile(file, code).withTokenizerOptions

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FileHeader.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FileHeader.scala
@@ -17,19 +17,6 @@ case class FileHeader(
     blankLineAfter: Boolean = true,
 ) {
   def isActive: Boolean = raw.isDefined || text.isDefined || license.isDefined
-
-  // Whether this config would produce a docstring-style comment that the
-  // formatter would try to reformat. Used by FormatWriter to bypass
-  // docstring handling for the file header.
-  def producesDocstringComment: Boolean =
-    if (!isActive) false
-    else raw match {
-      case Some(r) => r.stripMargin.trim.startsWith("/**")
-      case None =>
-        val hasContent = text.exists(_.stripMargin.trim.nonEmpty) ||
-          license.isDefined
-        hasContent && (style eq FileHeader.Style.framed)
-    }
 }
 
 object FileHeader {
@@ -38,8 +25,8 @@ object FileHeader {
   implicit lazy val surface: generic.Surface[FileHeader] = generic.deriveSurface
   implicit lazy val encoder: ConfEncoder[FileHeader] = generic.deriveEncoder
 
-  private val baseDecoder: ConfDecoderEx[FileHeader] =
-    generic.deriveDecoderEx(default).noTypos
+  private val baseDecoder: ConfDecoderEx[FileHeader] = generic
+    .deriveDecoderEx(default).noTypos
 
   implicit lazy val decoder: ConfDecoderEx[FileHeader] =
     new ConfDecoderEx[FileHeader] {
@@ -48,25 +35,24 @@ object FileHeader {
           conf: Conf,
       ): Configured[FileHeader] = conf match {
         case Conf.Str("none") | Conf.Bool(false) => Configured.ok(default)
-        case Conf.Str(value) =>
-          Configured.ok(default.copy(text = Some(value)))
+        case Conf.Str(value) => Configured.ok(default.copy(text = Some(value)))
         case _ => baseDecoder.read(state, conf).andThen(validate)
       }
     }
 
   private def validate(cfg: FileHeader): Configured[FileHeader] = {
     val errors = new mutable.ArrayBuffer[String]
-    cfg.since.foreach { y =>
-      if (y < 1900 || y > 2200) errors += s"fileHeader.since=$y is out of range"
-    }
-    cfg.year.foreach { y =>
-      if (y < 1900 || y > 2200) errors += s"fileHeader.year=$y is out of range"
-    }
-    for { s <- cfg.since; e <- cfg.year }
-      if (s > e) errors += "fileHeader.since must be <= fileHeader.year"
-    cfg.comment.width.foreach { w =>
-      if (w < 20) errors += "fileHeader.comment.width must be >= 20"
-    }
+    cfg.since.foreach(y =>
+      if (y < 1900 || y > 2200) errors += s"fileHeader.since=$y is out of range",
+    )
+    cfg.year.foreach(y =>
+      if (y < 1900 || y > 2200) errors += s"fileHeader.year=$y is out of range",
+    )
+    for { s <- cfg.since; e <- cfg.year } if (s > e) errors +=
+      "fileHeader.since must be <= fileHeader.year"
+    cfg.comment.width.foreach(w =>
+      if (w < 20) errors += "fileHeader.comment.width must be >= 20",
+    )
     if (errors.isEmpty) Configured.ok(cfg)
     else Configured.error(errors.mkString("; "))
   }
@@ -75,8 +61,8 @@ object FileHeader {
   object LicenseStyle {
     case object spdx extends LicenseStyle
     case object detailed extends LicenseStyle
-    implicit val codec: ConfCodecEx[LicenseStyle] =
-      ConfCodecEx.oneOf[LicenseStyle](spdx, detailed)
+    implicit val codec: ConfCodecEx[LicenseStyle] = ConfCodecEx
+      .oneOf[LicenseStyle](spdx, detailed)
   }
 
   sealed abstract class Style
@@ -84,8 +70,8 @@ object FileHeader {
     case object block extends Style
     case object line extends Style
     case object framed extends Style
-    implicit val codec: ConfCodecEx[Style] =
-      ConfCodecEx.oneOf[Style](block, line, framed)
+    implicit val codec: ConfCodecEx[Style] = ConfCodecEx
+      .oneOf[Style](block, line, framed)
   }
 
   case class Comment(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FileHeader.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FileHeader.scala
@@ -1,0 +1,105 @@
+package org.scalafmt.config
+
+import scala.collection.mutable
+
+import metaconfig._
+
+case class FileHeader(
+    raw: Option[String] = None,
+    text: Option[String] = None,
+    license: Option[License] = None,
+    licenseStyle: FileHeader.LicenseStyle = FileHeader.LicenseStyle.spdx,
+    copyrightHolder: Option[String] = None,
+    since: Option[Int] = None,
+    year: Option[Int] = None,
+    style: FileHeader.Style = FileHeader.Style.block,
+    comment: FileHeader.Comment = FileHeader.Comment(),
+    blankLineAfter: Boolean = true,
+) {
+  def isActive: Boolean = raw.isDefined || text.isDefined || license.isDefined
+
+  // Whether this config would produce a docstring-style comment that the
+  // formatter would try to reformat. Used by FormatWriter to bypass
+  // docstring handling for the file header.
+  def producesDocstringComment: Boolean =
+    if (!isActive) false
+    else raw match {
+      case Some(r) => r.stripMargin.trim.startsWith("/**")
+      case None =>
+        val hasContent = text.exists(_.stripMargin.trim.nonEmpty) ||
+          license.isDefined
+        hasContent && (style eq FileHeader.Style.framed)
+    }
+}
+
+object FileHeader {
+  val default: FileHeader = FileHeader()
+
+  implicit lazy val surface: generic.Surface[FileHeader] = generic.deriveSurface
+  implicit lazy val encoder: ConfEncoder[FileHeader] = generic.deriveEncoder
+
+  private val baseDecoder: ConfDecoderEx[FileHeader] =
+    generic.deriveDecoderEx(default).noTypos
+
+  implicit lazy val decoder: ConfDecoderEx[FileHeader] =
+    new ConfDecoderEx[FileHeader] {
+      override def read(
+          state: Option[FileHeader],
+          conf: Conf,
+      ): Configured[FileHeader] = conf match {
+        case Conf.Str("none") | Conf.Bool(false) => Configured.ok(default)
+        case Conf.Str(value) =>
+          Configured.ok(default.copy(text = Some(value)))
+        case _ => baseDecoder.read(state, conf).andThen(validate)
+      }
+    }
+
+  private def validate(cfg: FileHeader): Configured[FileHeader] = {
+    val errors = new mutable.ArrayBuffer[String]
+    cfg.since.foreach { y =>
+      if (y < 1900 || y > 2200) errors += s"fileHeader.since=$y is out of range"
+    }
+    cfg.year.foreach { y =>
+      if (y < 1900 || y > 2200) errors += s"fileHeader.year=$y is out of range"
+    }
+    for { s <- cfg.since; e <- cfg.year }
+      if (s > e) errors += "fileHeader.since must be <= fileHeader.year"
+    cfg.comment.width.foreach { w =>
+      if (w < 20) errors += "fileHeader.comment.width must be >= 20"
+    }
+    if (errors.isEmpty) Configured.ok(cfg)
+    else Configured.error(errors.mkString("; "))
+  }
+
+  sealed abstract class LicenseStyle
+  object LicenseStyle {
+    case object spdx extends LicenseStyle
+    case object detailed extends LicenseStyle
+    implicit val codec: ConfCodecEx[LicenseStyle] =
+      ConfCodecEx.oneOf[LicenseStyle](spdx, detailed)
+  }
+
+  sealed abstract class Style
+  object Style {
+    case object block extends Style
+    case object line extends Style
+    case object framed extends Style
+    implicit val codec: ConfCodecEx[Style] =
+      ConfCodecEx.oneOf[Style](block, line, framed)
+  }
+
+  case class Comment(
+      style: Option[Docstrings.Style] = None,
+      blankFirstLine: Option[Docstrings.BlankFirstLine] = None,
+      blankLastLine: Boolean = false,
+      width: Option[Int] = None,
+  )
+
+  object Comment {
+    val default: Comment = Comment()
+    implicit lazy val surface: generic.Surface[Comment] = generic.deriveSurface
+    implicit lazy val encoder: ConfEncoder[Comment] = generic.deriveEncoder
+    implicit lazy val decoder: ConfDecoderEx[Comment] = generic
+      .deriveDecoderEx(default).noTypos
+  }
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/LicenseTemplates.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/LicenseTemplates.scala
@@ -1,0 +1,209 @@
+package org.scalafmt.config
+
+import metaconfig._
+
+sealed abstract class License(val text: String)
+
+object License {
+  case object `Apache-2.0` extends License(
+    """Licensed under the Apache License, Version 2.0 (the "License");
+      |you may not use this file except in compliance with the License.
+      |You may obtain a copy of the License at
+      |
+      |    http://www.apache.org/licenses/LICENSE-2.0
+      |
+      |Unless required by applicable law or agreed to in writing, software
+      |distributed under the License is distributed on an "AS IS" BASIS,
+      |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      |See the License for the specific language governing permissions and
+      |limitations under the License.""".stripMargin,
+  )
+  case object MIT extends License(
+    """Permission is hereby granted, free of charge, to any person obtaining a copy
+      |of this software and associated documentation files (the "Software"), to deal
+      |in the Software without restriction, including without limitation the rights
+      |to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      |copies of the Software, and to permit persons to whom the Software is
+      |furnished to do so, subject to the following conditions:
+      |
+      |The above copyright notice and this permission notice shall be included in all
+      |copies or substantial portions of the Software.
+      |
+      |THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      |IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      |FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      |AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      |LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      |OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+      |SOFTWARE.""".stripMargin,
+  )
+  case object `BSD-2-Clause` extends License(
+    """Redistribution and use in source and binary forms, with or without
+      |modification, are permitted provided that the following conditions are met:
+      |
+      |1. Redistributions of source code must retain the above copyright notice, this
+      |   list of conditions and the following disclaimer.
+      |
+      |2. Redistributions in binary form must reproduce the above copyright notice,
+      |   this list of conditions and the following disclaimer in the documentation
+      |   and/or other materials provided with the distribution.
+      |
+      |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+      |AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+      |IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+      |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+      |FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+      |DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+      |SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+      |CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+      |OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+      |OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.""".stripMargin,
+  )
+  case object `BSD-3-Clause` extends License(
+    """Redistribution and use in source and binary forms, with or without
+      |modification, are permitted provided that the following conditions are met:
+      |
+      |1. Redistributions of source code must retain the above copyright notice, this
+      |   list of conditions and the following disclaimer.
+      |
+      |2. Redistributions in binary form must reproduce the above copyright notice,
+      |   this list of conditions and the following disclaimer in the documentation
+      |   and/or other materials provided with the distribution.
+      |
+      |3. Neither the name of the copyright holder nor the names of its
+      |   contributors may be used to endorse or promote products derived from
+      |   this software without specific prior written permission.
+      |
+      |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+      |AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+      |IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+      |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+      |FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+      |DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+      |SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+      |CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+      |OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+      |OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.""".stripMargin,
+  )
+  case object `MPL-2.0` extends License(
+    """This Source Code Form is subject to the terms of the Mozilla Public
+      |License, v. 2.0. If a copy of the MPL was not distributed with this
+      |file, You can obtain one at https://mozilla.org/MPL/2.0/.""".stripMargin,
+  )
+  case object `GPL-2.0-only` extends License(
+    """This program is free software; you can redistribute it and/or modify
+      |it under the terms of the GNU General Public License as published by
+      |the Free Software Foundation; version 2.
+      |
+      |This program is distributed in the hope that it will be useful,
+      |but WITHOUT ANY WARRANTY; without even the implied warranty of
+      |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+      |GNU General Public License for more details.
+      |
+      |You should have received a copy of the GNU General Public License along
+      |with this program; if not, write to the Free Software Foundation, Inc.,
+      |51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.""".stripMargin,
+  )
+  case object `GPL-3.0-only` extends License(
+    """This program is free software: you can redistribute it and/or modify
+      |it under the terms of the GNU General Public License as published by
+      |the Free Software Foundation, version 3.
+      |
+      |This program is distributed in the hope that it will be useful,
+      |but WITHOUT ANY WARRANTY; without even the implied warranty of
+      |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+      |GNU General Public License for more details.
+      |
+      |You should have received a copy of the GNU General Public License
+      |along with this program. If not, see <https://www.gnu.org/licenses/>.""".stripMargin,
+  )
+  case object `LGPL-2.1-only` extends License(
+    """This library is free software; you can redistribute it and/or modify
+      |it under the terms of the GNU Lesser General Public License as
+      |published by the Free Software Foundation; version 2.1.
+      |
+      |This library is distributed in the hope that it will be useful,
+      |but WITHOUT ANY WARRANTY; without even the implied warranty of
+      |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+      |GNU Lesser General Public License for more details.
+      |
+      |You should have received a copy of the GNU Lesser General Public
+      |License along with this library; if not, write to the Free Software
+      |Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.""".stripMargin,
+  )
+  case object `LGPL-3.0-only` extends License(
+    """This library is free software: you can redistribute it and/or modify
+      |it under the terms of the GNU Lesser General Public License as
+      |published by the Free Software Foundation, version 3.
+      |
+      |This library is distributed in the hope that it will be useful,
+      |but WITHOUT ANY WARRANTY; without even the implied warranty of
+      |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+      |GNU Lesser General Public License for more details.
+      |
+      |You should have received a copy of the GNU Lesser General Public
+      |License along with this library. If not, see
+      |<https://www.gnu.org/licenses/>.""".stripMargin,
+  )
+  case object `EPL-2.0` extends License(
+    """This program and the accompanying materials are made available under the
+      |terms of the Eclipse Public License v. 2.0 which is available at
+      |https://www.eclipse.org/legal/epl-2.0.
+      |
+      |This Source Code may also be made available under the following Secondary
+      |Licenses when the conditions for such availability set forth in the Eclipse
+      |Public License v. 2.0 are satisfied: GNU General Public License, version 2
+      |with the GNU Classpath Exception which is available at
+      |https://www.gnu.org/software/classpath/license.html.
+      |
+      |SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0""".stripMargin,
+  )
+  case object ISC extends License(
+    """Permission to use, copy, modify, and/or distribute this software for any
+      |purpose with or without fee is hereby granted, provided that the above
+      |copyright notice and this permission notice appear in all copies.
+      |
+      |THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+      |WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+      |MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+      |ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+      |WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+      |ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+      |OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.""".stripMargin,
+  )
+  case object Unlicense extends License(
+    """This is free and unencumbered software released into the public domain.
+      |
+      |Anyone is free to copy, modify, publish, use, compile, sell, or
+      |distribute this software, either in source code form or as a compiled
+      |binary, for any purpose, commercial or non-commercial, and by any means.
+      |
+      |In jurisdictions that recognize copyright laws, the author or authors of
+      |this software dedicate any and all copyright interest in the software to
+      |the public domain. We make this dedication for the benefit of the public
+      |at large and to the detriment of our heirs and successors. We intend this
+      |dedication to be an overt act of relinquishment in perpetuity of all
+      |present and future rights to this software under copyright law.
+      |
+      |THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+      |OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      |MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      |IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      |LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+      |FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+      |DEALINGS IN THE SOFTWARE.
+      |
+      |For more information, please refer to <https://unlicense.org>""".stripMargin,
+  )
+  implicit val codec: ConfCodecEx[License] = ConfCodecEx.oneOf[License](
+    `Apache-2.0`, MIT, `BSD-2-Clause`, `BSD-3-Clause`,
+    `MPL-2.0`, `GPL-2.0-only`, `GPL-3.0-only`,
+    `LGPL-2.1-only`, `LGPL-3.0-only`,
+    `EPL-2.0`, ISC, Unlicense,
+  )
+
+  def detailed(license: License, copyrightLine: Option[String]): String = {
+    val header = copyrightLine.fold("")(_ + "\n\n")
+    header + license.text
+  }
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/LicenseTemplates.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/LicenseTemplates.scala
@@ -5,201 +5,230 @@ import metaconfig._
 sealed abstract class License(val text: String)
 
 object License {
-  case object `Apache-2.0` extends License(
-    """Licensed under the Apache License, Version 2.0 (the "License");
-      |you may not use this file except in compliance with the License.
-      |You may obtain a copy of the License at
-      |
-      |    http://www.apache.org/licenses/LICENSE-2.0
-      |
-      |Unless required by applicable law or agreed to in writing, software
-      |distributed under the License is distributed on an "AS IS" BASIS,
-      |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      |See the License for the specific language governing permissions and
-      |limitations under the License.""".stripMargin,
-  )
-  case object MIT extends License(
-    """Permission is hereby granted, free of charge, to any person obtaining a copy
-      |of this software and associated documentation files (the "Software"), to deal
-      |in the Software without restriction, including without limitation the rights
-      |to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-      |copies of the Software, and to permit persons to whom the Software is
-      |furnished to do so, subject to the following conditions:
-      |
-      |The above copyright notice and this permission notice shall be included in all
-      |copies or substantial portions of the Software.
-      |
-      |THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-      |IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-      |FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-      |AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-      |LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-      |OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-      |SOFTWARE.""".stripMargin,
-  )
-  case object `BSD-2-Clause` extends License(
-    """Redistribution and use in source and binary forms, with or without
-      |modification, are permitted provided that the following conditions are met:
-      |
-      |1. Redistributions of source code must retain the above copyright notice, this
-      |   list of conditions and the following disclaimer.
-      |
-      |2. Redistributions in binary form must reproduce the above copyright notice,
-      |   this list of conditions and the following disclaimer in the documentation
-      |   and/or other materials provided with the distribution.
-      |
-      |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-      |AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-      |IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-      |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-      |FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-      |DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-      |SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-      |CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-      |OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-      |OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.""".stripMargin,
-  )
-  case object `BSD-3-Clause` extends License(
-    """Redistribution and use in source and binary forms, with or without
-      |modification, are permitted provided that the following conditions are met:
-      |
-      |1. Redistributions of source code must retain the above copyright notice, this
-      |   list of conditions and the following disclaimer.
-      |
-      |2. Redistributions in binary form must reproduce the above copyright notice,
-      |   this list of conditions and the following disclaimer in the documentation
-      |   and/or other materials provided with the distribution.
-      |
-      |3. Neither the name of the copyright holder nor the names of its
-      |   contributors may be used to endorse or promote products derived from
-      |   this software without specific prior written permission.
-      |
-      |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-      |AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-      |IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-      |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-      |FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-      |DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-      |SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-      |CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-      |OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-      |OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.""".stripMargin,
-  )
-  case object `MPL-2.0` extends License(
-    """This Source Code Form is subject to the terms of the Mozilla Public
-      |License, v. 2.0. If a copy of the MPL was not distributed with this
-      |file, You can obtain one at https://mozilla.org/MPL/2.0/.""".stripMargin,
-  )
-  case object `GPL-2.0-only` extends License(
-    """This program is free software; you can redistribute it and/or modify
-      |it under the terms of the GNU General Public License as published by
-      |the Free Software Foundation; version 2.
-      |
-      |This program is distributed in the hope that it will be useful,
-      |but WITHOUT ANY WARRANTY; without even the implied warranty of
-      |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-      |GNU General Public License for more details.
-      |
-      |You should have received a copy of the GNU General Public License along
-      |with this program; if not, write to the Free Software Foundation, Inc.,
-      |51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.""".stripMargin,
-  )
-  case object `GPL-3.0-only` extends License(
-    """This program is free software: you can redistribute it and/or modify
-      |it under the terms of the GNU General Public License as published by
-      |the Free Software Foundation, version 3.
-      |
-      |This program is distributed in the hope that it will be useful,
-      |but WITHOUT ANY WARRANTY; without even the implied warranty of
-      |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-      |GNU General Public License for more details.
-      |
-      |You should have received a copy of the GNU General Public License
-      |along with this program. If not, see <https://www.gnu.org/licenses/>.""".stripMargin,
-  )
-  case object `LGPL-2.1-only` extends License(
-    """This library is free software; you can redistribute it and/or modify
-      |it under the terms of the GNU Lesser General Public License as
-      |published by the Free Software Foundation; version 2.1.
-      |
-      |This library is distributed in the hope that it will be useful,
-      |but WITHOUT ANY WARRANTY; without even the implied warranty of
-      |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-      |GNU Lesser General Public License for more details.
-      |
-      |You should have received a copy of the GNU Lesser General Public
-      |License along with this library; if not, write to the Free Software
-      |Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.""".stripMargin,
-  )
-  case object `LGPL-3.0-only` extends License(
-    """This library is free software: you can redistribute it and/or modify
-      |it under the terms of the GNU Lesser General Public License as
-      |published by the Free Software Foundation, version 3.
-      |
-      |This library is distributed in the hope that it will be useful,
-      |but WITHOUT ANY WARRANTY; without even the implied warranty of
-      |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-      |GNU Lesser General Public License for more details.
-      |
-      |You should have received a copy of the GNU Lesser General Public
-      |License along with this library. If not, see
-      |<https://www.gnu.org/licenses/>.""".stripMargin,
-  )
-  case object `EPL-2.0` extends License(
-    """This program and the accompanying materials are made available under the
-      |terms of the Eclipse Public License v. 2.0 which is available at
-      |https://www.eclipse.org/legal/epl-2.0.
-      |
-      |This Source Code may also be made available under the following Secondary
-      |Licenses when the conditions for such availability set forth in the Eclipse
-      |Public License v. 2.0 are satisfied: GNU General Public License, version 2
-      |with the GNU Classpath Exception which is available at
-      |https://www.gnu.org/software/classpath/license.html.
-      |
-      |SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0""".stripMargin,
-  )
-  case object ISC extends License(
-    """Permission to use, copy, modify, and/or distribute this software for any
-      |purpose with or without fee is hereby granted, provided that the above
-      |copyright notice and this permission notice appear in all copies.
-      |
-      |THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-      |WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-      |MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-      |ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-      |WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-      |ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-      |OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.""".stripMargin,
-  )
-  case object Unlicense extends License(
-    """This is free and unencumbered software released into the public domain.
-      |
-      |Anyone is free to copy, modify, publish, use, compile, sell, or
-      |distribute this software, either in source code form or as a compiled
-      |binary, for any purpose, commercial or non-commercial, and by any means.
-      |
-      |In jurisdictions that recognize copyright laws, the author or authors of
-      |this software dedicate any and all copyright interest in the software to
-      |the public domain. We make this dedication for the benefit of the public
-      |at large and to the detriment of our heirs and successors. We intend this
-      |dedication to be an overt act of relinquishment in perpetuity of all
-      |present and future rights to this software under copyright law.
-      |
-      |THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-      |OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-      |MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-      |IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-      |LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-      |FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-      |DEALINGS IN THE SOFTWARE.
-      |
-      |For more information, please refer to <https://unlicense.org>""".stripMargin,
-  )
+  case object `Apache-2.0`
+      extends License(
+        """Licensed under the Apache License, Version 2.0 (the "License");
+          |you may not use this file except in compliance with the License.
+          |You may obtain a copy of the License at
+          |
+          |    http://www.apache.org/licenses/LICENSE-2.0
+          |
+          |Unless required by applicable law or agreed to in writing, software
+          |distributed under the License is distributed on an "AS IS" BASIS,
+          |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          |See the License for the specific language governing permissions and
+          |limitations under the License.""".stripMargin,
+      )
+  case object MIT
+      extends License(
+        """Permission is hereby granted, free of charge, to any person obtaining a copy
+          |of this software and associated documentation files (the "Software"), to deal
+          |in the Software without restriction, including without limitation the rights
+          |to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+          |copies of the Software, and to permit persons to whom the Software is
+          |furnished to do so, subject to the following conditions:
+          |
+          |The above copyright notice and this permission notice shall be included in all
+          |copies or substantial portions of the Software.
+          |
+          |THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+          |IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+          |FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+          |AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+          |LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+          |OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+          |SOFTWARE.""".stripMargin,
+      )
+  case object `BSD-2-Clause`
+      extends License(
+        """Redistribution and use in source and binary forms, with or without
+          |modification, are permitted provided that the following conditions are met:
+          |
+          |1. Redistributions of source code must retain the above copyright notice, this
+          |   list of conditions and the following disclaimer.
+          |
+          |2. Redistributions in binary form must reproduce the above copyright notice,
+          |   this list of conditions and the following disclaimer in the documentation
+          |   and/or other materials provided with the distribution.
+          |
+          |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+          |AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+          |IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+          |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+          |FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+          |DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+          |SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+          |CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+          |OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+          |OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."""
+          .stripMargin,
+      )
+  case object `BSD-3-Clause`
+      extends License(
+        """Redistribution and use in source and binary forms, with or without
+          |modification, are permitted provided that the following conditions are met:
+          |
+          |1. Redistributions of source code must retain the above copyright notice, this
+          |   list of conditions and the following disclaimer.
+          |
+          |2. Redistributions in binary form must reproduce the above copyright notice,
+          |   this list of conditions and the following disclaimer in the documentation
+          |   and/or other materials provided with the distribution.
+          |
+          |3. Neither the name of the copyright holder nor the names of its
+          |   contributors may be used to endorse or promote products derived from
+          |   this software without specific prior written permission.
+          |
+          |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+          |AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+          |IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+          |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+          |FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+          |DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+          |SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+          |CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+          |OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+          |OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."""
+          .stripMargin,
+      )
+  case object `MPL-2.0`
+      extends License(
+        """This Source Code Form is subject to the terms of the Mozilla Public
+          |License, v. 2.0. If a copy of the MPL was not distributed with this
+          |file, You can obtain one at https://mozilla.org/MPL/2.0/."""
+          .stripMargin,
+      )
+  case object `GPL-2.0-only`
+      extends License(
+        """This program is free software; you can redistribute it and/or modify
+          |it under the terms of the GNU General Public License as published by
+          |the Free Software Foundation; version 2.
+          |
+          |This program is distributed in the hope that it will be useful,
+          |but WITHOUT ANY WARRANTY; without even the implied warranty of
+          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+          |GNU General Public License for more details.
+          |
+          |You should have received a copy of the GNU General Public License along
+          |with this program; if not, write to the Free Software Foundation, Inc.,
+          |51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
+          .stripMargin,
+      )
+  case object `GPL-3.0-only`
+      extends License(
+        """This program is free software: you can redistribute it and/or modify
+          |it under the terms of the GNU General Public License as published by
+          |the Free Software Foundation, version 3.
+          |
+          |This program is distributed in the hope that it will be useful,
+          |but WITHOUT ANY WARRANTY; without even the implied warranty of
+          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+          |GNU General Public License for more details.
+          |
+          |You should have received a copy of the GNU General Public License
+          |along with this program. If not, see <https://www.gnu.org/licenses/>."""
+          .stripMargin,
+      )
+  case object `LGPL-2.1-only`
+      extends License(
+        """This library is free software; you can redistribute it and/or modify
+          |it under the terms of the GNU Lesser General Public License as
+          |published by the Free Software Foundation; version 2.1.
+          |
+          |This library is distributed in the hope that it will be useful,
+          |but WITHOUT ANY WARRANTY; without even the implied warranty of
+          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+          |GNU Lesser General Public License for more details.
+          |
+          |You should have received a copy of the GNU Lesser General Public
+          |License along with this library; if not, write to the Free Software
+          |Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA."""
+          .stripMargin,
+      )
+  case object `LGPL-3.0-only`
+      extends License(
+        """This library is free software: you can redistribute it and/or modify
+          |it under the terms of the GNU Lesser General Public License as
+          |published by the Free Software Foundation, version 3.
+          |
+          |This library is distributed in the hope that it will be useful,
+          |but WITHOUT ANY WARRANTY; without even the implied warranty of
+          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+          |GNU Lesser General Public License for more details.
+          |
+          |You should have received a copy of the GNU Lesser General Public
+          |License along with this library. If not, see
+          |<https://www.gnu.org/licenses/>.""".stripMargin,
+      )
+  case object `EPL-2.0`
+      extends License(
+        """This program and the accompanying materials are made available under the
+          |terms of the Eclipse Public License v. 2.0 which is available at
+          |https://www.eclipse.org/legal/epl-2.0.
+          |
+          |This Source Code may also be made available under the following Secondary
+          |Licenses when the conditions for such availability set forth in the Eclipse
+          |Public License v. 2.0 are satisfied: GNU General Public License, version 2
+          |with the GNU Classpath Exception which is available at
+          |https://www.gnu.org/software/classpath/license.html.
+          |
+          |SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0"""
+          .stripMargin,
+      )
+  case object ISC
+      extends License(
+        """Permission to use, copy, modify, and/or distribute this software for any
+          |purpose with or without fee is hereby granted, provided that the above
+          |copyright notice and this permission notice appear in all copies.
+          |
+          |THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+          |WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+          |MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+          |ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+          |WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+          |ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+          |OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE."""
+          .stripMargin,
+      )
+  case object Unlicense
+      extends License(
+        """This is free and unencumbered software released into the public domain.
+          |
+          |Anyone is free to copy, modify, publish, use, compile, sell, or
+          |distribute this software, either in source code form or as a compiled
+          |binary, for any purpose, commercial or non-commercial, and by any means.
+          |
+          |In jurisdictions that recognize copyright laws, the author or authors of
+          |this software dedicate any and all copyright interest in the software to
+          |the public domain. We make this dedication for the benefit of the public
+          |at large and to the detriment of our heirs and successors. We intend this
+          |dedication to be an overt act of relinquishment in perpetuity of all
+          |present and future rights to this software under copyright law.
+          |
+          |THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+          |OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+          |MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+          |IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+          |LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+          |FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+          |DEALINGS IN THE SOFTWARE.
+          |
+          |For more information, please refer to <https://unlicense.org>"""
+          .stripMargin,
+      )
   implicit val codec: ConfCodecEx[License] = ConfCodecEx.oneOf[License](
-    `Apache-2.0`, MIT, `BSD-2-Clause`, `BSD-3-Clause`,
-    `MPL-2.0`, `GPL-2.0-only`, `GPL-3.0-only`,
-    `LGPL-2.1-only`, `LGPL-3.0-only`,
-    `EPL-2.0`, ISC, Unlicense,
+    `Apache-2.0`,
+    MIT,
+    `BSD-2-Clause`,
+    `BSD-3-Clause`,
+    `MPL-2.0`,
+    `GPL-2.0-only`,
+    `GPL-3.0-only`,
+    `LGPL-2.1-only`,
+    `LGPL-3.0-only`,
+    `EPL-2.0`,
+    ISC,
+    Unlicense,
   )
 
   def detailed(license: License, copyrightLine: Option[String]): String = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -124,6 +124,7 @@ case class ScalafmtConfig(
     project: ProjectFiles = ProjectFiles(),
     fileOverride: Conf.Obj = Conf.Obj.empty,
     xmlLiterals: XmlLiterals = XmlLiterals(),
+    fileHeader: FileHeader = FileHeader(),
     private val formatOn: List[String] = ScalafmtConfig.defaultFormatOn,
     private val formatOff: List[String] = ScalafmtConfig.defaultFormatOff,
 ) {
@@ -422,6 +423,10 @@ object ScalafmtConfig {
         if (rewrite.scala3.removeOptionalBraces.removeBraces.maxSpan > 0)
           addIf(rewrite.scala3.removeOptionalBraces.removeBraces.maxSpan < rewrite.scala3.removeOptionalBraces.fewerBraces.maxSpan)
       }
+      if (fileHeader.isActive) {
+        val usesBlockComment = fileHeader.raw.isEmpty && (fileHeader.style ne FileHeader.Style.line)
+        if (usesBlockComment && comments.willWrap) addIfDirect(true, "fileHeader with block/framed style requires comments.wrap = no")
+      }
       if (rewrite.rules.contains(Imports)) binPack.importSelectors match {
         case Some(ImportSelectors.singleLine) => // if we fold but not bin pack, we might end up with very long lines
           addIfDirect(importSelectorsRewrite eq Newlines.fold, "rewrite.imports.selectors == fold && binPack.importSelectors == singleLine")
@@ -539,7 +544,7 @@ object ScalafmtConfig {
       case x => x
     }
 
-  private lazy val (defaultFormatOn, defaultFormatOff) = {
+  private[scalafmt] lazy val (defaultFormatOn, defaultFormatOff) = {
     val prefixes = List(
       "@formatter:", // IntelliJ
       "format: ", // scalariform

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -608,18 +608,15 @@ class FormatWriter(formatOps: FormatOps) {
 
       def formatComment(implicit sb: StringBuilder): Unit = {
         val text = tok.meta.left.text
+        // File header block comments are preserved verbatim to prevent
+        // FormatMlc/FormatMlDoc from altering the intended style.
+        // (// headers are already preserved by FormatSlc's isCommentedOut.)
+        def isFileHeader = style.fileHeader.isActive && tok.meta.idx <= 1 &&
+          prevState.indentation == 0
         if (text.startsWith("//")) new FormatSlc(text).format()
         else if (text == "/**/") sb.append(text)
-        else if (isDocstring(text))
-          // Preserve file header comments verbatim. The guard checks:
-          // 1. Config would produce a /** comment (framed style or raw /**)
-          // 2. This is the first token in the file (idx <= 1)
-          // 3. We're at the top level (indent 0)
-          if (
-            style.fileHeader.producesDocstringComment && tok.meta.idx <= 1 &&
-            prevState.indentation == 0
-          ) sb.append(text)
-          else formatDocstring(text)
+        else if (isFileHeader) sb.append(text)
+        else if (isDocstring(text)) formatDocstring(text)
         else new FormatMlc(text).format()
       }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -610,7 +610,16 @@ class FormatWriter(formatOps: FormatOps) {
         val text = tok.meta.left.text
         if (text.startsWith("//")) new FormatSlc(text).format()
         else if (text == "/**/") sb.append(text)
-        else if (isDocstring(text)) formatDocstring(text)
+        else if (isDocstring(text))
+          // Preserve file header comments verbatim. The guard checks:
+          // 1. Config would produce a /** comment (framed style or raw /**)
+          // 2. This is the first token in the file (idx <= 1)
+          // 3. We're at the top level (indent 0)
+          if (
+            style.fileHeader.producesDocstringComment && tok.meta.idx <= 1 &&
+            prevState.indentation == 0
+          ) sb.append(text)
+          else formatDocstring(text)
         else new FormatMlc(text).format()
       }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FileHeaderOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FileHeaderOps.scala
@@ -22,7 +22,8 @@ object FileHeaderOps {
     if (expectedHeader.isEmpty) {
       if (parts.header.isEmpty) return content
       val bodyTrimmed = parts.body.dropWhile(_.isWhitespace)
-      return s"${parts.preamble}${if (bodyTrimmed.nonEmpty) "\n" else ""}$bodyTrimmed"
+      return s"${parts
+          .preamble}${if (bodyTrimmed.nonEmpty) "\n" else ""}$bodyTrimmed"
     }
 
     // Idempotent short-circuit
@@ -45,38 +46,30 @@ object FileHeaderOps {
       style: ScalafmtConfig,
   ): Option[String] =
     if (!cfg.isActive) None
-    else cfg.raw.map(_.stripMargin.trim).orElse {
-      resolveInnerContent(cfg).map { c =>
-        if (c.isEmpty) ""
-        else wrapInComment(c, cfg, style)
-      }
-    }
+    else cfg.raw.map(_.stripMargin.trim).orElse(resolveInnerContent(cfg).map(
+      c => if (c.isEmpty) "" else wrapInComment(c, cfg, style),
+    ))
 
-  private def resolveInnerContent(cfg: FileHeader): Option[String] =
-    cfg.text.map(_.stripMargin.trim)
-      .orElse(cfg.license.map(generateFromLicense(_, cfg)))
+  private def resolveInnerContent(cfg: FileHeader): Option[String] = cfg.text
+    .map(_.stripMargin.trim).orElse(cfg.license.map(generateFromLicense(_, cfg)))
 
-  private def generateFromLicense(
-      license: License,
-      cfg: FileHeader,
-  ): String = {
+  private def generateFromLicense(license: License, cfg: FileHeader): String = {
     val year = cfg.year.getOrElse(currentYear)
     val yearStr = cfg.since match {
       case Some(s) if s < year => s"$s-$year"
-      case Some(s)             => s.toString
+      case Some(s) => s.toString
       case None if cfg.year.isDefined => year.toString
-      case None                => ""
+      case None => ""
     }
     val copyrightLine = cfg.copyrightHolder.map { holder =>
       val yr = if (yearStr.nonEmpty) s"$yearStr " else ""
       s"Copyright $yr$holder"
     }
     cfg.licenseStyle match {
-      case FileHeader.LicenseStyle.spdx =>
-        (copyrightLine.toSeq :+ s"SPDX-License-Identifier: $license")
-          .mkString("\n")
-      case FileHeader.LicenseStyle.detailed =>
-        License.detailed(license, copyrightLine)
+      case FileHeader.LicenseStyle.spdx => (copyrightLine.toSeq :+
+          s"SPDX-License-Identifier: $license").mkString("\n")
+      case FileHeader.LicenseStyle.detailed => License
+          .detailed(license, copyrightLine)
     }
   }
 
@@ -97,8 +90,7 @@ object FileHeaderOps {
         val blockStyle = comment.style.getOrElse(style.docstrings.style)
         wrapBlock(content, blockStyle, blankFirst, blankLast)
       case FileHeader.Style.line => wrapLine(content)
-      case FileHeader.Style.framed =>
-        wrapFramed(
+      case FileHeader.Style.framed => wrapFramed(
           content,
           comment.width.getOrElse(style.maxColumn),
           blankFirst,
@@ -115,7 +107,7 @@ object FileHeaderOps {
   ): String = {
     val (prefix, closer) = blockStyle match {
       case Docstrings.Asterisk => ("*", "*/")
-      case _                   => (" *", " */")
+      case _ => (" *", " */")
     }
     val last = if (blankLast) s"\n$prefix" else ""
     val contentLines = content.linesIterator.toSeq
@@ -134,10 +126,8 @@ object FileHeaderOps {
     }
   }
 
-  private def wrapLine(content: String): String =
-    content.linesIterator
-      .map(l => if (l.isEmpty) "//" else s"// $l")
-      .mkString("\n")
+  private def wrapLine(content: String): String = content.linesIterator
+    .map(l => if (l.isEmpty) "//" else s"// $l").mkString("\n")
 
   private def wrapFramed(
       content: String,
@@ -153,13 +143,13 @@ object FileHeaderOps {
 
     val top = "/" + "*" * (width - 1)
     val bottom = " " + "*" * (width - 2) + "/"
-    val lines = contentLines.map { l =>
+    val lines = contentLines.map(l =>
       if (l.isEmpty) blankLine
       else {
         val padded = (leftPad + l).take(innerWidth).padTo(innerWidth, ' ')
         s" * $padded *"
-      }
-    }
+      },
+    )
     val first = if (blankFirst) Seq(blankLine) else Seq.empty
     val last = if (blankLast) Seq(blankLine) else Seq.empty
     (Seq(top) ++ first ++ lines ++ last ++ Seq(bottom)).mkString("\n")
@@ -175,8 +165,8 @@ object FileHeaderOps {
   )
 
   // Reuses the canonical format-off strings from ScalafmtConfig (lines 550-556)
-  private def isFormatOff(commentContent: String): Boolean =
-    ScalafmtConfig.defaultFormatOff.contains(commentContent.trim.toLowerCase)
+  private def isFormatOff(commentContent: String): Boolean = ScalafmtConfig
+    .defaultFormatOff.contains(commentContent.trim.toLowerCase)
 
   // Matches the scalafmt directive pattern from StyleMap (line 16)
   private val scalafmtDirectivePattern = "\\s*scalafmt: ".r
@@ -208,7 +198,7 @@ object FileHeaderOps {
     var headerEnd = -1
     var scanning = true
 
-    while (scanning && pos < len) {
+    while (scanning && pos < len)
       if (content.startsWith("//", pos)) {
         // Single line comment - read to end of line
         val lineEnd = content.indexOf('\n', pos)
@@ -230,10 +220,10 @@ object FileHeaderOps {
         }
       } else if (content.startsWith("/*", pos)) {
         val blockEnd = findBlockCommentEnd(content, pos)
-        if (blockEnd < 0) {
+        if (blockEnd < 0)
           // Unterminated block comment - treat as no header
           scanning = false
-        } else {
+        else {
           val commentText = content.substring(pos + 2, blockEnd - 2)
           if (isFormatOff(commentText)) {
             formatOff = true
@@ -247,11 +237,9 @@ object FileHeaderOps {
             scanning = false
           }
         }
-      } else {
+      } else
         // Not a comment - no header found
         scanning = false
-      }
-    }
 
     if (formatOff) return FileParts(
       content.substring(0, preambleEnd),
@@ -268,14 +256,12 @@ object FileHeaderOps {
       val beforeHeader = content.substring(preambleEnd, headerStart)
       val afterHeader = content.substring(headerEnd)
       FileParts(preamble, header, beforeHeader + afterHeader, formatOff = false)
-    } else {
-      FileParts(
-        content.substring(0, preambleEnd),
-        "",
-        content.substring(preambleEnd),
-        formatOff = false,
-      )
-    }
+    } else FileParts(
+      content.substring(0, preambleEnd),
+      "",
+      content.substring(preambleEnd),
+      formatOff = false,
+    )
   }
 
   /** Finds end position of block comment starting at `pos`, or -1. */
@@ -294,8 +280,7 @@ object FileHeaderOps {
     var lastEnd = pos
     while (p < len && content.startsWith("//", p)) {
       val nl = content.indexOf('\n', p)
-      if (nl < 0) { lastEnd = len; p = len }
-      else { lastEnd = nl; p = nl + 1 }
+      if (nl < 0) { lastEnd = len; p = len } else { lastEnd = nl; p = nl + 1 }
     }
     lastEnd
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FileHeaderOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FileHeaderOps.scala
@@ -1,0 +1,303 @@
+package org.scalafmt.rewrite
+
+import org.scalafmt.config._
+
+object FileHeaderOps {
+
+  private def currentYear: Int = java.time.Year.now().getValue
+
+  def apply(content: String, style: ScalafmtConfig, range: Set[Range]): String = {
+    if (range.nonEmpty) return content
+
+    val cfg = style.fileHeader
+    val headerOpt = resolveHeader(cfg, style)
+    if (headerOpt.isEmpty) return content
+
+    val expectedHeader = headerOpt.get
+    val parts = splitFile(content)
+
+    if (parts.formatOff) return content
+
+    // Strip mode: active but empty content - remove existing header
+    if (expectedHeader.isEmpty) {
+      if (parts.header.isEmpty) return content
+      val bodyTrimmed = parts.body.dropWhile(_.isWhitespace)
+      return s"${parts.preamble}${if (bodyTrimmed.nonEmpty) "\n" else ""}$bodyTrimmed"
+    }
+
+    // Idempotent short-circuit
+    if (parts.header == expectedHeader) return content
+
+    val preambleSep = if (parts.preamble.nonEmpty) "\n" else ""
+    val bodySep = parts.body match {
+      case b if b.isEmpty => "\n"
+      case _ => if (cfg.blankLineAfter) "\n\n" else "\n"
+    }
+    val bodyContent = parts.body.dropWhile(_.isWhitespace)
+
+    s"${parts.preamble}$preambleSep$expectedHeader$bodySep$bodyContent"
+  }
+
+  // -- Content resolution --
+
+  private def resolveHeader(
+      cfg: FileHeader,
+      style: ScalafmtConfig,
+  ): Option[String] =
+    if (!cfg.isActive) None
+    else cfg.raw.map(_.stripMargin.trim).orElse {
+      resolveInnerContent(cfg).map { c =>
+        if (c.isEmpty) ""
+        else wrapInComment(c, cfg, style)
+      }
+    }
+
+  private def resolveInnerContent(cfg: FileHeader): Option[String] =
+    cfg.text.map(_.stripMargin.trim)
+      .orElse(cfg.license.map(generateFromLicense(_, cfg)))
+
+  private def generateFromLicense(
+      license: License,
+      cfg: FileHeader,
+  ): String = {
+    val year = cfg.year.getOrElse(currentYear)
+    val yearStr = cfg.since match {
+      case Some(s) if s < year => s"$s-$year"
+      case Some(s)             => s.toString
+      case None if cfg.year.isDefined => year.toString
+      case None                => ""
+    }
+    val copyrightLine = cfg.copyrightHolder.map { holder =>
+      val yr = if (yearStr.nonEmpty) s"$yearStr " else ""
+      s"Copyright $yr$holder"
+    }
+    cfg.licenseStyle match {
+      case FileHeader.LicenseStyle.spdx =>
+        (copyrightLine.toSeq :+ s"SPDX-License-Identifier: $license")
+          .mkString("\n")
+      case FileHeader.LicenseStyle.detailed =>
+        License.detailed(license, copyrightLine)
+    }
+  }
+
+  // -- Comment wrapping --
+
+  private def wrapInComment(
+      content: String,
+      cfg: FileHeader,
+      style: ScalafmtConfig,
+  ): String = {
+    val comment = cfg.comment
+    val blankFirst = comment.blankFirstLine
+      .orElse(style.docstrings.blankFirstLine)
+      .forall(_ ne Docstrings.BlankFirstLine.fold)
+    val blankLast = comment.blankLastLine
+    cfg.style match {
+      case FileHeader.Style.block =>
+        val blockStyle = comment.style.getOrElse(style.docstrings.style)
+        wrapBlock(content, blockStyle, blankFirst, blankLast)
+      case FileHeader.Style.line => wrapLine(content)
+      case FileHeader.Style.framed =>
+        wrapFramed(
+          content,
+          comment.width.getOrElse(style.maxColumn),
+          blankFirst,
+          blankLast,
+        )
+    }
+  }
+
+  private def wrapBlock(
+      content: String,
+      blockStyle: Docstrings.Style,
+      blankFirst: Boolean,
+      blankLast: Boolean,
+  ): String = {
+    val (prefix, closer) = blockStyle match {
+      case Docstrings.Asterisk => ("*", "*/")
+      case _                   => (" *", " */")
+    }
+    val last = if (blankLast) s"\n$prefix" else ""
+    val contentLines = content.linesIterator.toSeq
+    val prefixed = contentLines
+      .map(l => if (l.isEmpty) prefix else s"$prefix $l")
+    if (blankFirst)
+      // First line blank: /*
+      //                    * content
+      s"/*\n${prefixed.mkString("\n")}$last\n$closer"
+    else {
+      // First line has content: /* content
+      //                          * more
+      val rest = prefixed.tail
+      val mid = if (rest.isEmpty) "" else s"\n${rest.mkString("\n")}"
+      s"/* ${contentLines.head}$mid$last\n$closer"
+    }
+  }
+
+  private def wrapLine(content: String): String =
+    content.linesIterator
+      .map(l => if (l.isEmpty) "//" else s"// $l")
+      .mkString("\n")
+
+  private def wrapFramed(
+      content: String,
+      width: Int,
+      blankFirst: Boolean,
+      blankLast: Boolean,
+  ): String = {
+    val innerWidth = width - 5
+    val contentLines = content.linesIterator.toSeq
+    val maxLen = if (contentLines.isEmpty) 0 else contentLines.map(_.length).max
+    val leftPad = " " * ((innerWidth - maxLen) / 2).max(0)
+    val blankLine = " *" + " " * (width - 3) + "*"
+
+    val top = "/" + "*" * (width - 1)
+    val bottom = " " + "*" * (width - 2) + "/"
+    val lines = contentLines.map { l =>
+      if (l.isEmpty) blankLine
+      else {
+        val padded = (leftPad + l).take(innerWidth).padTo(innerWidth, ' ')
+        s" * $padded *"
+      }
+    }
+    val first = if (blankFirst) Seq(blankLine) else Seq.empty
+    val last = if (blankLast) Seq(blankLine) else Seq.empty
+    (Seq(top) ++ first ++ lines ++ last ++ Seq(bottom)).mkString("\n")
+  }
+
+  // -- File decomposition --
+
+  private case class FileParts(
+      preamble: String,
+      header: String,
+      body: String,
+      formatOff: Boolean,
+  )
+
+  // Reuses the canonical format-off strings from ScalafmtConfig (lines 550-556)
+  private def isFormatOff(commentContent: String): Boolean =
+    ScalafmtConfig.defaultFormatOff.contains(commentContent.trim.toLowerCase)
+
+  // Matches the scalafmt directive pattern from StyleMap (line 16)
+  private val scalafmtDirectivePattern = "\\s*scalafmt: ".r
+
+  private def isConfigOverride(commentContent: String): Boolean =
+    scalafmtDirectivePattern.findPrefixOf(commentContent).isDefined
+
+  private def splitFile(content: String): FileParts = {
+    val len = content.length
+    var pos = 0
+
+    // BOM detection
+    if (len > 0 && content.charAt(0) == '\uFEFF') pos = 1
+
+    // Shebang detection
+    if (pos < len && content.startsWith("#!", pos)) {
+      val nl = content.indexOf('\n', pos)
+      pos = if (nl < 0) len else nl + 1
+    }
+
+    val preambleEnd = pos
+
+    // Skip whitespace before first comment
+    while (pos < len && content.charAt(pos).isWhitespace) pos += 1
+
+    // Scan leading comments
+    var formatOff = false
+    var headerStart = -1
+    var headerEnd = -1
+    var scanning = true
+
+    while (scanning && pos < len) {
+      if (content.startsWith("//", pos)) {
+        // Single line comment - read to end of line
+        val lineEnd = content.indexOf('\n', pos)
+        val end = if (lineEnd < 0) len else lineEnd
+        val commentText = content.substring(pos + 2, end)
+
+        if (isFormatOff(commentText)) {
+          formatOff = true
+          scanning = false
+        } else if (isConfigOverride(commentText)) {
+          // Skip this line, continue scanning
+          pos = if (lineEnd < 0) len else lineEnd + 1
+          while (pos < len && content.charAt(pos).isWhitespace) pos += 1
+        } else {
+          // Found header - consume contiguous // lines
+          headerStart = pos
+          headerEnd = findLineCommentsEnd(content, pos)
+          scanning = false
+        }
+      } else if (content.startsWith("/*", pos)) {
+        val blockEnd = findBlockCommentEnd(content, pos)
+        if (blockEnd < 0) {
+          // Unterminated block comment - treat as no header
+          scanning = false
+        } else {
+          val commentText = content.substring(pos + 2, blockEnd - 2)
+          if (isFormatOff(commentText)) {
+            formatOff = true
+            scanning = false
+          } else if (isConfigOverride(commentText)) {
+            pos = blockEnd
+            while (pos < len && content.charAt(pos).isWhitespace) pos += 1
+          } else {
+            headerStart = pos
+            headerEnd = blockEnd
+            scanning = false
+          }
+        }
+      } else {
+        // Not a comment - no header found
+        scanning = false
+      }
+    }
+
+    if (formatOff) return FileParts(
+      content.substring(0, preambleEnd),
+      "",
+      content.substring(preambleEnd),
+      formatOff = true,
+    )
+
+    if (headerStart >= 0) {
+      // Preamble is only BOM/shebang. Directives between preamble and header
+      // go into the body so the header is always the first comment in output.
+      val preamble = content.substring(0, preambleEnd)
+      val header = content.substring(headerStart, headerEnd)
+      val beforeHeader = content.substring(preambleEnd, headerStart)
+      val afterHeader = content.substring(headerEnd)
+      FileParts(preamble, header, beforeHeader + afterHeader, formatOff = false)
+    } else {
+      FileParts(
+        content.substring(0, preambleEnd),
+        "",
+        content.substring(preambleEnd),
+        formatOff = false,
+      )
+    }
+  }
+
+  /** Finds end position of block comment starting at `pos`, or -1. */
+  private def findBlockCommentEnd(content: String, pos: Int): Int = {
+    val idx = content.indexOf("*/", pos + 2)
+    if (idx < 0) -1 else idx + 2
+  }
+
+  /** Find the end of contiguous `//` comment lines starting at `pos`. Returns
+    * the position of the newline after the last `//` line (or end of string),
+    * so that the header text does not include the trailing newline.
+    */
+  private def findLineCommentsEnd(content: String, pos: Int): Int = {
+    val len = content.length
+    var p = pos
+    var lastEnd = pos
+    while (p < len && content.startsWith("//", p)) {
+      val nl = content.indexOf('\n', p)
+      if (nl < 0) { lastEnd = len; p = len }
+      else { lastEnd = nl; p = nl + 1 }
+    }
+    lastEnd
+  }
+
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -17,7 +17,7 @@ import munit.FunSuite
   */
 class FidelityTest extends FunSuite with FormatAssertions {
 
-  private val numFiles = 277
+  private val numFiles = 282
 
   private val denyList = Set(
     "ConfigReader.scala",

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FileHeaderTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FileHeaderTest.scala
@@ -1,0 +1,593 @@
+package org.scalafmt
+
+import org.scalafmt.config._
+
+import metaconfig.Configured
+import munit.FunSuite
+
+class FileHeaderTest extends FunSuite {
+
+  private def format(code: String, hocon: String): String = {
+    val cfg = ScalafmtConfig.fromHoconString(hocon).get
+    Scalafmt.format(code, cfg).get
+  }
+
+  private def configOk(hocon: String): ScalafmtConfig =
+    ScalafmtConfig.fromHoconString(hocon).get
+
+  private def configErr(hocon: String): String =
+    ScalafmtConfig.fromHoconString(hocon) match {
+      case Configured.NotOk(err) => err.msg
+      case Configured.Ok(_)      => fail("expected config error"); ""
+    }
+
+  // --- Config parsing / validation ---
+
+  test("HOCON: license config parses correctly") {
+    val cfg = configOk(
+      """|fileHeader {
+         |  license = Apache-2.0
+         |  copyrightHolder = "Org"
+         |  since = 2020
+         |}
+         |""".stripMargin,
+    )
+    assertEquals(cfg.fileHeader.license, Some(License.`Apache-2.0`))
+    assertEquals(cfg.fileHeader.copyrightHolder, Some("Org"))
+    assertEquals(cfg.fileHeader.since, Some(2020))
+    assert(cfg.fileHeader.isActive)
+  }
+
+  test("HOCON: fileHeader = none produces inactive FileHeader") {
+    val cfg = configOk("fileHeader = none")
+    assert(!cfg.fileHeader.isActive)
+    assertEquals(cfg.fileHeader, FileHeader())
+  }
+
+  test("HOCON: fileHeader = \"Custom text\" produces text shortcut") {
+    val cfg = configOk("""fileHeader = "Custom text" """)
+    assertEquals(cfg.fileHeader.text, Some("Custom text"))
+    assert(cfg.fileHeader.isActive)
+  }
+
+  test("HOCON: invalid license - config error") {
+    val err = configErr("fileHeader { license = INVALID }")
+    assert(err.contains("INVALID"), err)
+  }
+
+  test("HOCON: since > year - config error") {
+    val err = configErr(
+      "fileHeader { since = 2030, year = 2020, license = MIT }",
+    )
+    assert(err.contains("fileHeader.since must be <= fileHeader.year"), err)
+  }
+
+  test("fileOverride with different fileHeader.style per glob") {
+    val cfg = configOk(
+      """|fileHeader {
+         |  license = MIT
+         |  copyrightHolder = "Org"
+         |}
+         |fileOverride {
+         |  "glob:**.sbt" {
+         |    fileHeader.style = line
+         |  }
+         |}
+         |""".stripMargin,
+    )
+    val sbtCfg = cfg.getConfigFor("build.sbt").get
+    assert(sbtCfg.fileHeader.style eq FileHeader.Style.line)
+    val scalaCfg = cfg.getConfigFor("src/Main.scala").get
+    assert(scalaCfg.fileHeader.style eq FileHeader.Style.block)
+  }
+
+  test("cross-config: block style + comments.wrap = standalone - error") {
+    val err = configErr(
+      """|fileHeader {
+         |  license = MIT
+         |  copyrightHolder = "Org"
+         |}
+         |comments.wrap = standalone
+         |""".stripMargin,
+    )
+    assert(err.contains("fileHeader"), err)
+  }
+
+  test("cross-config: line style + comments.wrap = standalone - accepted") {
+    configOk(
+      """|fileHeader {
+         |  license = MIT
+         |  copyrightHolder = "Org"
+         |  style = line
+         |}
+         |comments.wrap = standalone
+         |""".stripMargin,
+    )
+  }
+
+  // --- Content resolution ---
+
+  test("raw > text > license precedence") {
+    val result = format(
+      "object A\n",
+      """|fileHeader {
+         |  raw = "// raw header"
+         |  text = "text header"
+         |  license = MIT
+         |  copyrightHolder = "Org"
+         |}
+         |""".stripMargin,
+    )
+    assert(result.startsWith("// raw header"), result)
+  }
+
+  test("text = empty string - strip mode (existing header removed)") {
+    val code =
+      """|/*
+         | * Old header
+         | */
+         |
+         |object A
+         |""".stripMargin
+    val result = format(code, """fileHeader.text = "" """)
+    assert(!result.contains("Old header"), result)
+    assert(result.contains("object A"), result)
+  }
+
+  test("license = Apache-2.0 with since and explicit year") {
+    val cfg =
+      """|fileHeader {
+         |  license = Apache-2.0
+         |  copyrightHolder = "Org"
+         |  since = 2020
+         |  year = 2025
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.contains("Copyright 2020-2025 Org"), result)
+    assert(result.contains("SPDX-License-Identifier: Apache-2.0"), result)
+  }
+
+  test("since = year - single year, no range") {
+    val cfg =
+      """|fileHeader {
+         |  license = MIT
+         |  copyrightHolder = "Org"
+         |  since = 2025
+         |  year = 2025
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.contains("Copyright 2025 Org"), result)
+    assert(!result.contains("2025-2025"), result)
+  }
+
+  test("license without copyrightHolder - SPDX line only") {
+    val cfg = "fileHeader { license = MIT, year = 2025 }"
+    val result = format("object A\n", cfg)
+    assert(result.contains("SPDX-License-Identifier: MIT"), result)
+    assert(!result.contains("Copyright"), result)
+  }
+
+  test("copyrightHolder without since or year - no year in copyright") {
+    val cfg =
+      """|fileHeader {
+         |  license = MIT
+         |  copyrightHolder = "Holder"
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.contains("Copyright Holder"), result)
+    // Both since and year are None, so yearStr = ""  - no year in copyright line
+  }
+
+  // --- Comment wrapping: block style ---
+
+  test("block style: default SpaceAsterisk prefix") {
+    val cfg =
+      """|fileHeader {
+         |  text = "line"
+         |  style = block
+         |  comment.style = SpaceAsterisk
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.contains("/*\n * line\n */"), result)
+  }
+
+  test("block style: Asterisk prefix") {
+    // At indent 0, FormatMlc normalizes leading * to " *", so Asterisk
+    // and SpaceAsterisk produce the same formatted output.
+    val cfg =
+      """|fileHeader {
+         |  text = "line"
+         |  style = block
+         |  comment.style = Asterisk
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.contains("/*"), result)
+    assert(result.contains("line"), result)
+    assert(result.contains("*/"), result)
+  }
+
+  test("block style: blankFirstLine = unfold (default, content on next line)") {
+    val cfg =
+      """|fileHeader {
+         |  text = "line"
+         |  style = block
+         |  comment.blankFirstLine = unfold
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    // unfold = first line blank (no content on /* line)
+    assert(result.contains("/*\n * line\n */"), result)
+  }
+
+  test("block style: blankFirstLine = fold (content on /* line)") {
+    val cfg =
+      """|fileHeader {
+         |  text = "line"
+         |  style = block
+         |  comment.blankFirstLine = fold
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.contains("/* line\n */"), result)
+  }
+
+  test("block style: blankLastLine = true") {
+    val cfg =
+      """|fileHeader {
+         |  text = "line"
+         |  style = block
+         |  comment.blankLastLine = true
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.contains("/*\n * line\n *\n */"), result)
+  }
+
+  // --- Comment wrapping: line style ---
+
+  test("line style: single line") {
+    val cfg =
+      """|fileHeader {
+         |  text = "line"
+         |  style = line
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.startsWith("// line\n"), result)
+  }
+
+  test("line style: multi-line") {
+    val cfg =
+      """|fileHeader {
+         |  text = "line1\nline2"
+         |  style = line
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.startsWith("// line1\n// line2\n"), result)
+  }
+
+  // --- Comment wrapping: framed style ---
+
+  test("framed style: all lines exactly width chars") {
+    val cfg =
+      """|fileHeader {
+         |  text = "Hello World"
+         |  style = framed
+         |  comment.width = 40
+         |}
+         |comments.wrap = no
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    val headerLines = result.linesIterator.takeWhile(_.contains("*")).toSeq
+    headerLines.foreach { line =>
+      assertEquals(line.length, 40, s"Line not 40 chars: '$line'")
+    }
+  }
+
+  test("framed style: content is centered") {
+    val cfg =
+      """|fileHeader {
+         |  text = "Hi"
+         |  style = framed
+         |  comment.width = 40
+         |}
+         |comments.wrap = no
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    val contentLine = result.linesIterator
+      .find(l => l.contains("Hi") && l.startsWith(" * ")).get
+    assertEquals(contentLine.length, 40)
+    // Verify centering: " * " prefix (3 chars) + leftPad + "Hi" should be well past col 3
+    assert(contentLine.indexOf("Hi") > 5, s"Content should be centered: $contentLine")
+  }
+
+  test("framed style: blankFirstLine and blankLastLine") {
+    val cfg =
+      """|fileHeader {
+         |  text = "Hi"
+         |  style = framed
+         |  comment.width = 40
+         |  comment.blankFirstLine = unfold
+         |  comment.blankLastLine = true
+         |}
+         |comments.wrap = no
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    val headerLines = result.linesIterator.takeWhile(_.contains("*")).toSeq
+    // top, blank, content, blank, bottom = 5 lines
+    assertEquals(headerLines.length, 5, s"Expected 5 lines: $headerLines")
+  }
+
+  // --- File decomposition ---
+
+  test("file with no comment - header inserted") {
+    val result = format("object A\n", "fileHeader.text = \"header\"")
+    assert(result.contains("header"), result)
+    assert(result.contains("object A"), result)
+  }
+
+  test("file with block comment header - header replaced") {
+    val code =
+      """|/*
+         | * Old
+         | */
+         |
+         |object A
+         |""".stripMargin
+    val result = format(code, "fileHeader.text = \"New\"")
+    assert(result.contains("New"), result)
+    assert(!result.contains("Old"), result)
+  }
+
+  test("file with line comment header - header replaced") {
+    val code =
+      """|// Old header
+         |
+         |object A
+         |""".stripMargin
+    val result =
+      format(code, """fileHeader { text = "New", style = line }""")
+    assert(result.contains("// New"), result)
+    assert(!result.contains("Old"), result)
+  }
+
+  test("shebang - preamble preserved, header after") {
+    val code = "#!/usr/bin/env scala\nobject A\n"
+    val result = format(
+      code,
+      """fileHeader { text = "header", style = line }""",
+    )
+    assert(result.startsWith("#!/usr/bin/env scala\n"), result)
+    assert(result.contains("// header"), result)
+  }
+
+  test("scalafmt: directive - not treated as header") {
+    val code =
+      """|// scalafmt: { maxColumn = 120 }
+         |object A
+         |""".stripMargin
+    val result = format(
+      code,
+      """fileHeader { text = "header", style = line }""",
+    )
+    assert(result.contains("// header"), result)
+    assert(result.contains("scalafmt: { maxColumn = 120 }"), result)
+  }
+
+  test("@formatter:off - content returned unchanged") {
+    val code =
+      """|// @formatter:off
+         |object A
+         |""".stripMargin
+    val result = format(
+      code,
+      """fileHeader { text = "header", style = line }""",
+    )
+    // Header should NOT be inserted
+    assert(!result.contains("header"), result)
+  }
+
+  test("comment starting with 'format: off' prefix is not false positive") {
+    // Verifies exact match: "format: official" should NOT trigger format-off
+    val code =
+      """|// format: official documentation
+         |object A
+         |""".stripMargin
+    val result = format(
+      code,
+      """fileHeader { text = "header", style = line }""",
+    )
+    // format-off should NOT be triggered, so header IS inserted
+    assert(result.contains("// header"), result)
+  }
+
+  test("scalafmt: directive then format: off - formatOff") {
+    val code =
+      """|// scalafmt: { maxColumn = 120 }
+         |// format: off
+         |object A
+         |""".stripMargin
+    val result = format(
+      code,
+      """fileHeader { text = "header", style = line }""",
+    )
+    assert(!result.contains("// header"), result)
+  }
+
+  test("directive before existing header - header replaced, directive preserved") {
+    val code =
+      """|// scalafmt: { maxColumn = 120 }
+         |// Old Header
+         |object A
+         |""".stripMargin
+    val result = format(
+      code,
+      """fileHeader { text = "New Header", style = line }""",
+    )
+    assert(result.contains("// New Header"), result)
+    assert(!result.contains("Old Header"), result)
+    assert(result.contains("scalafmt: { maxColumn = 120 }"), result)
+    // Header should appear before directive
+    val headerIdx = result.indexOf("// New Header")
+    val directiveIdx = result.indexOf("scalafmt:")
+    assert(headerIdx < directiveIdx, s"Header should precede directive:\n$result")
+  }
+
+  test("framed header with directive - idempotent") {
+    val cfg =
+      """|fileHeader {
+         |  text = "Header"
+         |  style = framed
+         |  comment.width = 40
+         |}
+         |""".stripMargin
+    val code =
+      """|// scalafmt: { maxColumn = 120 }
+         |object A
+         |""".stripMargin
+    val first = format(code, cfg)
+    val second = format(first, cfg)
+    assertEquals(second, first)
+  }
+
+  // --- Integration (full round-trip) ---
+
+  test("license header inserted and code formatted") {
+    val code = "object   A  {  val x=1  }\n"
+    val result = format(
+      code,
+      """|fileHeader {
+         |  license = MIT
+         |  copyrightHolder = "Org"
+         |  year = 2025
+         |  style = line
+         |}
+         |""".stripMargin,
+    )
+    assert(result.contains("SPDX-License-Identifier: MIT"), result)
+    assert(result.contains("object A"), result)
+    // Code should be formatted (spaces cleaned up)
+    assert(!result.contains("object   A"), result)
+  }
+
+  test("already correct header - idempotent") {
+    val cfg =
+      """|fileHeader {
+         |  text = "My Header"
+         |  style = line
+         |}
+         |""".stripMargin
+    val code = "object A\n"
+    val first = format(code, cfg)
+    val second = format(first, cfg)
+    assertEquals(second, first)
+  }
+
+  test("wrong header replaced") {
+    val code =
+      """|// Wrong Header
+         |
+         |object A
+         |""".stripMargin
+    val cfg =
+      """|fileHeader {
+         |  text = "Right Header"
+         |  style = line
+         |}
+         |""".stripMargin
+    val result = format(code, cfg)
+    assert(result.contains("// Right Header"), result)
+    assert(!result.contains("Wrong"), result)
+  }
+
+  test("range formatting - header NOT inserted") {
+    val code = "object A { val x = 1 }\n"
+    val cfg = ScalafmtConfig.fromHoconString(
+      """fileHeader { text = "header", style = line }""",
+    ).get
+    val result = Scalafmt
+      .format(code, cfg, range = Set(Range(0, 0))).get
+    assert(!result.contains("header"), result)
+  }
+
+  test("header + lineEndings = windows - header gets CRLF") {
+    val code = "object A\n"
+    val cfg =
+      """|fileHeader {
+         |  text = "My Header"
+         |  style = line
+         |}
+         |lineEndings = windows
+         |""".stripMargin
+    val result = format(code, cfg)
+    assert(result.contains("\r\n"), result)
+  }
+
+  test("framed header with comments.wrap = no - preserved through formatter") {
+    val cfg =
+      """|fileHeader {
+         |  text = "Header"
+         |  style = framed
+         |  comment.width = 40
+         |}
+         |comments.wrap = no
+         |""".stripMargin
+    val code = "object A\n"
+    val first = format(code, cfg)
+    val second = format(first, cfg)
+    assertEquals(second, first)
+  }
+
+  // --- Missing coverage from audit ---
+
+  test("licenseStyle = detailed produces full license text") {
+    val cfg =
+      """|fileHeader {
+         |  license = MIT
+         |  licenseStyle = detailed
+         |  copyrightHolder = "Org"
+         |  year = 2025
+         |}
+         |""".stripMargin
+    val result = format("object A\n", cfg)
+    assert(result.contains("Copyright 2025 Org"), result)
+    assert(result.contains("Permission is hereby granted"), result)
+    assert(result.contains("WITHOUT WARRANTY"), result)
+    assert(!result.contains("SPDX-License-Identifier"), result)
+  }
+
+  test("blankLineAfter = false removes blank line between header and code") {
+    val cfg =
+      """|fileHeader {
+         |  text = "My Header"
+         |  style = line
+         |  blankLineAfter = false
+         |}
+         |""".stripMargin
+    val result = format("package com.example\n\nobject Main\n", cfg)
+    assert(result.startsWith("// My Header\npackage"), result)
+  }
+
+  test("raw header starting with /** is preserved through formatter") {
+    val cfg =
+      """|fileHeader {
+         |  raw = "/** Custom verbatim header */"
+         |}
+         |""".stripMargin
+    val first = format("object A\n", cfg)
+    assert(first.contains("/** Custom verbatim header */"), first)
+    val second = format(first, cfg)
+    assertEquals(second, first)
+  }
+
+  test("empty file with active header produces header + newline") {
+    val result = format("\n", """fileHeader { text = "Header", style = line }""")
+    assert(result.contains("// Header"), result)
+  }
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FileHeaderTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FileHeaderTest.scala
@@ -12,13 +12,13 @@ class FileHeaderTest extends FunSuite {
     Scalafmt.format(code, cfg).get
   }
 
-  private def configOk(hocon: String): ScalafmtConfig =
-    ScalafmtConfig.fromHoconString(hocon).get
+  private def configOk(hocon: String): ScalafmtConfig = ScalafmtConfig
+    .fromHoconString(hocon).get
 
   private def configErr(hocon: String): String =
     ScalafmtConfig.fromHoconString(hocon) match {
       case Configured.NotOk(err) => err.msg
-      case Configured.Ok(_)      => fail("expected config error"); ""
+      case Configured.Ok(_) => fail("expected config error"); ""
     }
 
   // --- Config parsing / validation ---
@@ -56,9 +56,8 @@ class FileHeaderTest extends FunSuite {
   }
 
   test("HOCON: since > year - config error") {
-    val err = configErr(
-      "fileHeader { since = 2030, year = 2020, license = MIT }",
-    )
+    val err =
+      configErr("fileHeader { since = 2030, year = 2020, license = MIT }")
     assert(err.contains("fileHeader.since must be <= fileHeader.year"), err)
   }
 
@@ -93,7 +92,7 @@ class FileHeaderTest extends FunSuite {
     assert(err.contains("fileHeader"), err)
   }
 
-  test("cross-config: line style + comments.wrap = standalone - accepted") {
+  test("cross-config: line style + comments.wrap = standalone - accepted")(
     configOk(
       """|fileHeader {
          |  license = MIT
@@ -102,8 +101,8 @@ class FileHeaderTest extends FunSuite {
          |}
          |comments.wrap = standalone
          |""".stripMargin,
-    )
-  }
+    ),
+  )
 
   // --- Content resolution ---
 
@@ -196,8 +195,6 @@ class FileHeaderTest extends FunSuite {
   }
 
   test("block style: Asterisk prefix") {
-    // At indent 0, FormatMlc normalizes leading * to " *", so Asterisk
-    // and SpaceAsterisk produce the same formatted output.
     val cfg =
       """|fileHeader {
          |  text = "line"
@@ -206,9 +203,7 @@ class FileHeaderTest extends FunSuite {
          |}
          |""".stripMargin
     val result = format("object A\n", cfg)
-    assert(result.contains("/*"), result)
-    assert(result.contains("line"), result)
-    assert(result.contains("*/"), result)
+    assert(result.contains("/*\n* line\n*/"), result)
   }
 
   test("block style: blankFirstLine = unfold (default, content on next line)") {
@@ -285,9 +280,9 @@ class FileHeaderTest extends FunSuite {
          |""".stripMargin
     val result = format("object A\n", cfg)
     val headerLines = result.linesIterator.takeWhile(_.contains("*")).toSeq
-    headerLines.foreach { line =>
-      assertEquals(line.length, 40, s"Line not 40 chars: '$line'")
-    }
+    headerLines.foreach(line =>
+      assertEquals(line.length, 40, s"Line not 40 chars: '$line'"),
+    )
   }
 
   test("framed style: content is centered") {
@@ -304,7 +299,10 @@ class FileHeaderTest extends FunSuite {
       .find(l => l.contains("Hi") && l.startsWith(" * ")).get
     assertEquals(contentLine.length, 40)
     // Verify centering: " * " prefix (3 chars) + leftPad + "Hi" should be well past col 3
-    assert(contentLine.indexOf("Hi") > 5, s"Content should be centered: $contentLine")
+    assert(
+      contentLine.indexOf("Hi") > 5,
+      s"Content should be centered: $contentLine",
+    )
   }
 
   test("framed style: blankFirstLine and blankLastLine") {
@@ -351,18 +349,14 @@ class FileHeaderTest extends FunSuite {
          |
          |object A
          |""".stripMargin
-    val result =
-      format(code, """fileHeader { text = "New", style = line }""")
+    val result = format(code, """fileHeader { text = "New", style = line }""")
     assert(result.contains("// New"), result)
     assert(!result.contains("Old"), result)
   }
 
   test("shebang - preamble preserved, header after") {
     val code = "#!/usr/bin/env scala\nobject A\n"
-    val result = format(
-      code,
-      """fileHeader { text = "header", style = line }""",
-    )
+    val result = format(code, """fileHeader { text = "header", style = line }""")
     assert(result.startsWith("#!/usr/bin/env scala\n"), result)
     assert(result.contains("// header"), result)
   }
@@ -372,10 +366,7 @@ class FileHeaderTest extends FunSuite {
       """|// scalafmt: { maxColumn = 120 }
          |object A
          |""".stripMargin
-    val result = format(
-      code,
-      """fileHeader { text = "header", style = line }""",
-    )
+    val result = format(code, """fileHeader { text = "header", style = line }""")
     assert(result.contains("// header"), result)
     assert(result.contains("scalafmt: { maxColumn = 120 }"), result)
   }
@@ -385,10 +376,7 @@ class FileHeaderTest extends FunSuite {
       """|// @formatter:off
          |object A
          |""".stripMargin
-    val result = format(
-      code,
-      """fileHeader { text = "header", style = line }""",
-    )
+    val result = format(code, """fileHeader { text = "header", style = line }""")
     // Header should NOT be inserted
     assert(!result.contains("header"), result)
   }
@@ -399,10 +387,7 @@ class FileHeaderTest extends FunSuite {
       """|// format: official documentation
          |object A
          |""".stripMargin
-    val result = format(
-      code,
-      """fileHeader { text = "header", style = line }""",
-    )
+    val result = format(code, """fileHeader { text = "header", style = line }""")
     // format-off should NOT be triggered, so header IS inserted
     assert(result.contains("// header"), result)
   }
@@ -413,10 +398,7 @@ class FileHeaderTest extends FunSuite {
          |// format: off
          |object A
          |""".stripMargin
-    val result = format(
-      code,
-      """fileHeader { text = "header", style = line }""",
-    )
+    val result = format(code, """fileHeader { text = "header", style = line }""")
     assert(!result.contains("// header"), result)
   }
 
@@ -426,17 +408,18 @@ class FileHeaderTest extends FunSuite {
          |// Old Header
          |object A
          |""".stripMargin
-    val result = format(
-      code,
-      """fileHeader { text = "New Header", style = line }""",
-    )
+    val result =
+      format(code, """fileHeader { text = "New Header", style = line }""")
     assert(result.contains("// New Header"), result)
     assert(!result.contains("Old Header"), result)
     assert(result.contains("scalafmt: { maxColumn = 120 }"), result)
     // Header should appear before directive
     val headerIdx = result.indexOf("// New Header")
     val directiveIdx = result.indexOf("scalafmt:")
-    assert(headerIdx < directiveIdx, s"Header should precede directive:\n$result")
+    assert(
+      headerIdx < directiveIdx,
+      s"Header should precede directive:\n$result",
+    )
   }
 
   test("framed header with directive - idempotent") {
@@ -508,11 +491,9 @@ class FileHeaderTest extends FunSuite {
 
   test("range formatting - header NOT inserted") {
     val code = "object A { val x = 1 }\n"
-    val cfg = ScalafmtConfig.fromHoconString(
-      """fileHeader { text = "header", style = line }""",
-    ).get
-    val result = Scalafmt
-      .format(code, cfg, range = Set(Range(0, 0))).get
+    val cfg = ScalafmtConfig
+      .fromHoconString("""fileHeader { text = "header", style = line }""").get
+    val result = Scalafmt.format(code, cfg, range = Set(Range(0, 0))).get
     assert(!result.contains("header"), result)
   }
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/FileHeaderConfigTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/FileHeaderConfigTest.scala
@@ -5,7 +5,7 @@ import munit.FunSuite
 class FileHeaderConfigTest extends FunSuite {
 
   test("fileOverride correctly merges fileHeader per glob") {
-    val cfg = ScalafmtConfig.fromHoconString(
+    val cfg = ScalafmtConfig.fromHoconString {
       """|fileHeader {
          |  license = Apache-2.0
          |  copyrightHolder = "Org"
@@ -19,8 +19,8 @@ class FileHeaderConfigTest extends FunSuite {
          |    fileHeader.text = "Test only"
          |  }
          |}
-         |""".stripMargin,
-    ).get
+         |""".stripMargin
+    }.get
 
     val sbtCfg = cfg.getConfigFor("build.sbt").get
     assert(sbtCfg.fileHeader.style eq FileHeader.Style.line)
@@ -34,7 +34,9 @@ class FileHeaderConfigTest extends FunSuite {
     assertEquals(mainCfg.fileHeader.license, Some(License.`Apache-2.0`))
   }
 
-  test("shortcut fileHeader = \"text\" in override replaces entire FileHeader") {
+  test(
+    "shortcut fileHeader = \"text\" in override replaces entire FileHeader",
+  ) {
     val cfg = ScalafmtConfig.fromHoconString(
       """|fileHeader {
          |  license = Apache-2.0
@@ -77,15 +79,22 @@ class FileHeaderConfigTest extends FunSuite {
 
   test("all 12 SPDX identifiers are accepted") {
     val ids = Seq(
-      "Apache-2.0", "MIT", "BSD-2-Clause", "BSD-3-Clause",
-      "MPL-2.0", "GPL-2.0-only", "GPL-3.0-only",
-      "LGPL-2.1-only", "LGPL-3.0-only",
-      "EPL-2.0", "ISC", "Unlicense",
+      "Apache-2.0",
+      "MIT",
+      "BSD-2-Clause",
+      "BSD-3-Clause",
+      "MPL-2.0",
+      "GPL-2.0-only",
+      "GPL-3.0-only",
+      "LGPL-2.1-only",
+      "LGPL-3.0-only",
+      "EPL-2.0",
+      "ISC",
+      "Unlicense",
     )
     ids.foreach { id =>
-      val cfg = ScalafmtConfig.fromHoconString(
-        s"""fileHeader.license = "$id" """,
-      )
+      val cfg = ScalafmtConfig
+        .fromHoconString(s"""fileHeader.license = "$id" """)
       assert(cfg.isOk, s"License $id should be accepted: ${cfg.toEither}")
     }
   }
@@ -102,9 +111,8 @@ class FileHeaderConfigTest extends FunSuite {
   }
 
   test("year out of range - config error") {
-    val result = ScalafmtConfig.fromHoconString(
-      "fileHeader { text = \"hi\", year = 100 }",
-    )
+    val result = ScalafmtConfig
+      .fromHoconString("fileHeader { text = \"hi\", year = 100 }")
     assert(result.isNotOk, "year = 100 should fail")
   }
 }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/FileHeaderConfigTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/FileHeaderConfigTest.scala
@@ -1,0 +1,110 @@
+package org.scalafmt.config
+
+import munit.FunSuite
+
+class FileHeaderConfigTest extends FunSuite {
+
+  test("fileOverride correctly merges fileHeader per glob") {
+    val cfg = ScalafmtConfig.fromHoconString(
+      """|fileHeader {
+         |  license = Apache-2.0
+         |  copyrightHolder = "Org"
+         |  since = 2020
+         |}
+         |fileOverride {
+         |  "glob:**.sbt" {
+         |    fileHeader.style = line
+         |  }
+         |  "glob:**/test/**" {
+         |    fileHeader.text = "Test only"
+         |  }
+         |}
+         |""".stripMargin,
+    ).get
+
+    val sbtCfg = cfg.getConfigFor("build.sbt").get
+    assert(sbtCfg.fileHeader.style eq FileHeader.Style.line)
+    assertEquals(sbtCfg.fileHeader.license, Some(License.`Apache-2.0`))
+
+    val testCfg = cfg.getConfigFor("src/test/Foo.scala").get
+    assertEquals(testCfg.fileHeader.text, Some("Test only"))
+
+    val mainCfg = cfg.getConfigFor("src/main/Foo.scala").get
+    assert(mainCfg.fileHeader.style eq FileHeader.Style.block)
+    assertEquals(mainCfg.fileHeader.license, Some(License.`Apache-2.0`))
+  }
+
+  test("shortcut fileHeader = \"text\" in override replaces entire FileHeader") {
+    val cfg = ScalafmtConfig.fromHoconString(
+      """|fileHeader {
+         |  license = Apache-2.0
+         |  copyrightHolder = "Org"
+         |}
+         |fileOverride {
+         |  "glob:**.sbt" {
+         |    fileHeader = "SBT header"
+         |  }
+         |}
+         |""".stripMargin,
+    ).get
+
+    val sbtCfg = cfg.getConfigFor("build.sbt").get
+    assertEquals(sbtCfg.fileHeader.text, Some("SBT header"))
+    // The shortcut replaces the whole FileHeader, so license should be gone
+    assertEquals(sbtCfg.fileHeader.license, None)
+  }
+
+  test("fileHeader = none in override disables header for matched files") {
+    val cfg = ScalafmtConfig.fromHoconString(
+      """|fileHeader {
+         |  license = MIT
+         |  copyrightHolder = "Org"
+         |}
+         |fileOverride {
+         |  "glob:**/generated/**" {
+         |    fileHeader = none
+         |  }
+         |}
+         |""".stripMargin,
+    ).get
+
+    val genCfg = cfg.getConfigFor("src/generated/Foo.scala").get
+    assert(!genCfg.fileHeader.isActive)
+
+    val mainCfg = cfg.getConfigFor("src/main/Foo.scala").get
+    assert(mainCfg.fileHeader.isActive)
+  }
+
+  test("all 12 SPDX identifiers are accepted") {
+    val ids = Seq(
+      "Apache-2.0", "MIT", "BSD-2-Clause", "BSD-3-Clause",
+      "MPL-2.0", "GPL-2.0-only", "GPL-3.0-only",
+      "LGPL-2.1-only", "LGPL-3.0-only",
+      "EPL-2.0", "ISC", "Unlicense",
+    )
+    ids.foreach { id =>
+      val cfg = ScalafmtConfig.fromHoconString(
+        s"""fileHeader.license = "$id" """,
+      )
+      assert(cfg.isOk, s"License $id should be accepted: ${cfg.toEither}")
+    }
+  }
+
+  test("comment.width < 20 - config error") {
+    val result = ScalafmtConfig.fromHoconString(
+      """|fileHeader {
+         |  text = "hi"
+         |  comment.width = 10
+         |}
+         |""".stripMargin,
+    )
+    assert(result.isNotOk, "width < 20 should fail")
+  }
+
+  test("year out of range - config error") {
+    val result = ScalafmtConfig.fromHoconString(
+      "fileHeader { text = \"hi\", year = 100 }",
+    )
+    assert(result.isNotOk, "year = 100 should fail")
+  }
+}


### PR DESCRIPTION
Adds copyright/header management. Revisits #705

Whilst this issue was brought up previously, hopefully it can be reconsidered. In my view, a formatter/linter enforces canonical source file form. Headers are part of that form. With header management in the build tool (`sbt-header`), identical source files under identical `.scalafmt.conf` produce different results depending on whether the project uses sbt, Mill, Gradle, scala-cli, Maven etc. Moving this to the formatter guarantees uniform sources regardless of build toolchain - the same guarantee scalafmt already provides for indentation, line endings, and import order.

This is one possible take at the problem
- Went with pre-format text insertion (in `Scalafmt.doFormat`, before `doFormatOne`) since:
  - Headers are not AST constructs - text-level insertion avoids coupling to the token/tree layer
  - Idempotent: string equality short-circuits when header is correct
  - `--check` works with no additional code
  - Post-format breaks idempotency (formatter's BOF split decisions differ with/without header).
- Added a `fileHeader` config section.
- Tried to address the reproducibility concern from #705:
  - `year` defaults to current calendar year but can be pinned explicitly in config
  - `since` sets range start: `since = 2020` with current year 2026 produces `2020-2026`

Example config:
```hocon
fileHeader {
  license = Apache-2.0 # 12 SPDX licenses supported
  copyrightHolder = "My Organization"
  since = 2020
  style = block  # block | line | framed
}
  