### PR TITLE
Imports, FormatWriter: use Tree.text, vs .toString

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1993,33 +1993,33 @@ object FormatWriter {
   private def getEndMarkerLabel(tree: Tree): String = tree match {
     // templates
     case _: Term.NewAnonymous => "new"
-    case t: Defn.Class => t.name.toString
-    case t: Defn.Object => t.name.toString
-    case t: Defn.Trait => t.name.toString
-    case t: Defn.Enum => t.name.toString
+    case t: Defn.Class => t.name.text
+    case t: Defn.Object => t.name.text
+    case t: Defn.Trait => t.name.text
+    case t: Defn.Enum => t.name.text
     case t: Defn.Given =>
-      val label = t.name.toString
+      val label = t.name.text
       if (label.isEmpty) "given" else label
-    case t: Pkg.Object => t.name.toString
+    case t: Pkg.Object => t.name.text
     // definitions
-    case t: Defn.Def => t.name.toString
-    case t: Defn.Macro => t.name.toString
+    case t: Defn.Def => t.name.text
+    case t: Defn.Macro => t.name.text
     case t: Defn.GivenAlias =>
-      val label = t.name.toString
+      val label = t.name.text
       if (label.isEmpty) "given" else label
-    case t: Defn.Type => t.name.toString
+    case t: Defn.Type => t.name.text
     case t: Defn.Val => t.pats match {
-        case List(Pat.Var(n)) => n.toString
+        case (p: Pat.Var) :: Nil => p.name.text
         case _ => "val"
       }
     case t: Defn.Var => t.pats match {
-        case List(Pat.Var(n)) => n.toString
+        case (p: Pat.Var) :: Nil => p.name.text
         case _ => "var"
       }
     // other
     case t: Pkg => t.ref match {
-        case x: Term.Name => x.toString
-        case x: Term.Select => x.name.toString
+        case x: Term.Name => x.text
+        case x: Term.Select => x.name.text
         case _ => null
       }
     case _: Ctor.Secondary => "this"

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
@@ -185,7 +185,7 @@ object Imports extends RewriteFactory {
     }
 
     protected final def selectorToTuple(tree: Importee): (Importee, String) =
-      (tree, tree.toString)
+      (tree, tree.text)
   }
 
   private[scalafmt] object Sort {
@@ -385,7 +385,7 @@ object Imports extends RewriteFactory {
         selector: Importee,
         needRaw: Boolean = true,
     ): Selectors = {
-      val selectorString = selector.toString()
+      val selectorString = selector.text
       val (commentsBefore, commentAfter) = getCommentsAround(selector)
       if (mustUseBraces(selector)) {
         val sb = new StringBuilder
@@ -931,7 +931,7 @@ object Imports extends RewriteFactory {
   }
 
   private def getRef(importer: Importer): String = {
-    val ref = importer.ref.toString()
+    val ref = importer.ref.text
     if (ref.isEmpty) "" else ref + "."
   }
 


### PR DESCRIPTION
The former prints just the original text whereas the latter might also include any leading or trailing comments.