### PR TITLE
BestFirstSearch: recurse on Term.Block siblings in wide arg clauses

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -39,9 +39,25 @@ private class BestFirstSearch private (range: Set[Range])(implicit
   private def getBlockCloseToRecurse(ft: FT)(implicit
       style: ScalafmtConfig,
   ): Option[Int] = TokenOps.getEndOfBlock(ft, parens = true).collect {
-    // Block must span at least 3 lines to be worth recursing.
-    case (close, _) if tokens.width(ft, close) > style.maxColumn * 3 =>
-      close.idx
+    // Block must span at least 3 lines to be worth recursing, except for
+    // narrow blocks that are one of several Term.Block siblings inside a
+    // wide arg clause, which would combinatorially explode BFS without
+    // recursion+memoization (e.g., `Seq({ s1; s2 }, { s1; s2 }, ...)` × N).
+    case (close, _)
+        if tokens.width(ft, close) > style.maxColumn * 3 ||
+        isInWideMultiBlockArgClause(ft.meta.leftOwner) => close.idx
+  }
+
+  private def isInWideMultiBlockArgClause(t: Tree)(implicit
+      style: ScalafmtConfig,
+  ): Boolean = t match {
+    case b: Term.Block => b.parent.exists {
+        case ac: Term.ArgClause =>
+          ac.values.count(_.is[Term.Block]) > 1 &&
+          tokens.span(ac) > style.maxColumn * 3
+        case _ => false
+      }
+    case _ => false
   }
 
   private val memo = mutable.Map.empty[Long, Option[State]]

--- a/scalafmt-tests/shared/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/Advanced.stat
@@ -565,3 +565,47 @@ else {
           uri.getRawQuery(),
           uri.getRawFragment()).normalize()
 }
+<<< many narrow Term.Block siblings in arg clause
+runner.dialect = scala213
+maxColumn = 120
+onTestFailure = "Search state exploded"
+===
+object X {
+  val cases = Seq(
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+  )
+}
+>>> { stateVisits = 150001 }
+object X {
+  val cases = Seq(
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/default/Advanced.stat
+++ b/scalafmt-tests/shared/src/test/resources/default/Advanced.stat
@@ -206,7 +206,7 @@ options.testFilter match {
           }, { // else
             callStatement
           })(jstpe.AnyType)
->>> { stateVisits = 1485, stateVisits2 = 1476 }
+>>> { stateVisits = 1482, stateVisits2 = 1473 }
 callStatement = js.If(
     genIsInstanceOf(callTrg, rtClass.tpe), {
       if (implMethodSym.owner == ObjectClass) {
@@ -377,7 +377,7 @@ private def withNewLocalDefs = {
             }))
         }))
   }
->>> { stateVisits = 5621, stateVisits2 = 5621 }
+>>> { stateVisits = 5323, stateVisits2 = 5323 }
 val createIsArrayOfStat = {
   envFieldDef(
       "isArrayOf",
@@ -568,7 +568,6 @@ else {
 <<< many narrow Term.Block siblings in arg clause
 runner.dialect = scala213
 maxColumn = 120
-onTestFailure = "Search state exploded"
 ===
 object X {
   val cases = Seq(
@@ -589,23 +588,99 @@ object X {
     { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
   )
 }
->>> { stateVisits = 150001 }
+>>>
 object X {
   val cases = Seq(
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
-    { val node = NetworkNode(label = Some(defaultRootLabel)); GraphEdge(source = node, isDirected = true, includeMetadata = false, attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node)) },
+      {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }, {
+        val node = NetworkNode(label = Some(defaultRootLabel));
+        GraphEdge(source = node,
+                  isDirected = true,
+                  includeMetadata = false,
+                  attributes = (Map(EdgeKind.SolidLine -> Set(idOf(defaultStartNode))), node))
+      }
   )
 }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2777610, "total explored")
+      assertEquals(explored, 3077612, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 3077612, "total explored")
+      assertEquals(explored, 2782252, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Fixes a `SearchStateExploded` failure on a real-world pattern: a sequence of multi-statement `Term.Block` values inside one arg clause, e.g.

```scala
val testCases = Seq(
  { val nodeData = SomeTrigger(...); TestCase(nodeData = nodeData, ...) },
  { val nodeData = OtherTrigger(...); TestCase(nodeData = nodeData, ...) },
  // ...
)
```

This pattern arises in table-driven tests where each row needs a local `val` to bind a value used twice (typically as both input and expected output). With ≥15 such siblings, BFS exhausts its visit budget and aborts with `SearchStateExploded`.

`BestFirstSearch.getBlockCloseToRecurse` only recurses on blocks wider than `maxColumn * 3`. Each block falls under that threshold, so BFS explores the cross-product of their layouts instead of solving each subproblem once and memoizing.

Update `getBlockCloseToRecurse` to also recurse when the block is one of multiple `Term.Block` siblings inside a wide-enough enclosing `Term.ArgClause`. The "wide enclosing arg clause" guard (`tokens.span(ac) > maxColumn * 3`) keeps compact cases like `f(x, { a; b }, y, { c; d })` unaffected. Existing memoization handles the rest. Sibling blocks share `(indentation, column, depth)` keys, so the recursive subproblem is solved once and reused.