### PR TITLE
Update to Scala Native 0.5.12

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,6 +20,6 @@ addSbtPlugin("org.scalameta"    % "sbt-mdoc"         % "2.9.0")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"     % "2.5.6")
 addSbtPlugin("org.scalameta"    % "sbt-native-image" % "0.3.4")
 addSbtPlugin("org.scala-js"     % "sbt-scalajs"      % "1.21.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")


### PR DESCRIPTION
Scala Native 0.5.12 includes [scala-native/scala-native#4875](https://github.com/scala-native/scala-native/pull/4875), which fixes a GC race that causes the scalafmt native binary to intermittently crash or deadlock under multithreaded file reads. Depending on timing, the race may surface as a variety of errors, including the `ClassCastException`/NPE variants originally reported in #5254.

This appears to fix #5254 for me locally.

### Reproduction

I reproduced the bug with the released [3.11.1 native binary](https://github.com/scalameta/scalafmt/releases/tag/v3.11.1) (macOS arm64) against [apache/pekko](https://github.com/apache/pekko) (~2.7k Scala files), using pekko's own `.scalafmt.conf` with the `version` line bumped to `3.11.1`:

```
git clone https://github.com/apache/pekko && cd pekko
sed -i.bak 's/^version.*=.*$/version = "3.11.1"/' .scalafmt.conf
for i in $(seq 1 50); do ./scalafmt --test --mode anygit --non-interactive || break; done
```

A crash hit on iteration 3:

```
ScalaNative: Unrecoverable NullPointerException in user thread
	at stackOverflowHandler
	at _sigtramp
	at scalanative_GC_alloc_array
```

I then tested with a locally-built `cli/native` against scala-native 0.5.12, and was able to run the same workload without crashing.
