### PR TITLE
release-native: disable trap-based GC yieldpoints

### DIFF
--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -43,6 +43,10 @@ jobs:
       - run: sbt scala-native
         env:
           CI: true
+          # Workaround for scala-native/scala-native#4917 (intermittent SIGSEGV
+          # in the multithreaded native binary). Disables trap-based GC
+          # yieldpoints in the released binary.
+          SCALANATIVE_GC_TRAP_BASED_YIELDPOINTS: "0"
       - name: Zip artifact for deployment
         if:  ${{ !startsWith(matrix.deploy.os, 'windows') }}
         run: zip ${{ matrix.deploy.name }} scalafmt


### PR DESCRIPTION
Builds the released native binaries with `SCALANATIVE_GC_TRAP_BASED_YIELDPOINTS=0` as a workaround for an intermittent SIGSEGV.

Even after #5285 (Scala Native 0.5.12, which includes scala-native/scala-native#4875), the native binary still crashes with SIGSEGV at a low rate when formatting a large codebase. The issue is tracked upstream in scala-native/scala-native#4917. A related allocator bug, scala-native/scala-native#4916, also came out of the investigation.

Performance comparison on Linux/aarch64 (Ubuntu 24.04 in colima on a macOS arm64 host, 8 vCPU, 24 GB RAM), averaged over 20 successful runs of `scalafmt --test` on the apache/pekko codebase for each build:

|  | trap (current) | notrap (this PR) | Δ |
|---|---|---|---|
| wall (mean) | 4.95 s | 5.46 s | +10.3% |
| user CPU (mean) | 25.4 CPU·s | 29.0 CPU·s | +13.7% |

For typical scalafmt CLI usage, this overhead is negligible.
