### PR TITLE
State: fix computing indent for StateColumn

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Indent.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Indent.scala
@@ -48,7 +48,7 @@ object Length {
     */
   case object StateColumn extends Length {
     override def withStateOffset(offset: Int): Int = offset
-    override val reset: Boolean = false
+    override val reset: Boolean = true
   }
 }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -65,10 +65,9 @@ final class State(
     val (nextSplit, nextIndent, nextIndents) =
       if (right.is[T.EOF]) (initialNextSplit, 0, Seq.empty)
       else {
-        val offset = column - indentation
         def getUnexpired(modExt: ModExt) = {
           val extendedEnd = getRelativeToLhsLastLineEnd(modExt.isNL)
-          (modExt.getActualIndents(offset) ++ pushes).flatMap(x =>
+          (modExt.getActualIndents(column) ++ pushes).flatMap(x =>
             if (x.notExpiredBy(tok)) Some(x)
             else extendedEnd
               .map(y => x.copy(expire = y, expiresAt = ExpiresOn.After)),

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -14031,10 +14031,10 @@ object Example {
 >>>
 object Example {
   def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
-                          (implicit ctx: RequestContext): Future[Int] = ???
+                                                         (implicit ctx: RequestContext): Future[Int] = ???
   object Nested {
     def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
-                            (implicit ctx: RequestContext): Future[Int] = ???
+                                                           (implicit ctx: RequestContext): Future[Int] = ???
   }
 }
 <<< #5290 !binPack.defnSite

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -14013,3 +14013,50 @@ object a {
   else
     baz
 }
+<<< #5290 binPack.defnSite
+maxColumn = 160
+binPack.defnSite = always
+align.beforeOpenParenDefnSite = true
+align.closeParenSite = true
+newlines.beforeOpenParenDefnSite = fold
+align.openParenDefnSite = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+>>>
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                          (implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                            (implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+<<< #5290 !binPack.defnSite
+maxColumn = 160
+align.beforeOpenParenDefnSite = true
+align.closeParenSite = true
+newlines.beforeOpenParenDefnSite = fold
+align.openParenDefnSite = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+>>>
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                                                         (implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                                                           (implicit ctx: RequestContext): Future[Int] = ???
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -13174,10 +13174,10 @@ object Example {
 >>>
 object Example {
   def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
-                          (implicit ctx: RequestContext): Future[Int] = ???
+                                                         (implicit ctx: RequestContext): Future[Int] = ???
   object Nested {
     def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
-                            (implicit ctx: RequestContext): Future[Int] = ???
+                                                           (implicit ctx: RequestContext): Future[Int] = ???
   }
 }
 <<< #5290 !binPack.defnSite

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -13156,3 +13156,50 @@ object a {
 
   else baz
 }
+<<< #5290 binPack.defnSite
+maxColumn = 160
+binPack.defnSite = always
+align.beforeOpenParenDefnSite = true
+align.closeParenSite = true
+newlines.beforeOpenParenDefnSite = fold
+align.openParenDefnSite = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+>>>
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                          (implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                            (implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+<<< #5290 !binPack.defnSite
+maxColumn = 160
+align.beforeOpenParenDefnSite = true
+align.closeParenSite = true
+newlines.beforeOpenParenDefnSite = fold
+align.openParenDefnSite = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+>>>
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                                                         (implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                                                           (implicit ctx: RequestContext): Future[Int] = ???
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -13864,10 +13864,10 @@ object Example {
 >>>
 object Example {
   def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
-                          (implicit ctx: RequestContext): Future[Int] = ???
+                                                         (implicit ctx: RequestContext): Future[Int] = ???
   object Nested {
     def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
-                            (implicit ctx: RequestContext): Future[Int] = ???
+                                                           (implicit ctx: RequestContext): Future[Int] = ???
   }
 }
 <<< #5290 !binPack.defnSite

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -13846,3 +13846,50 @@ object a {
   else
     baz
 }
+<<< #5290 binPack.defnSite
+maxColumn = 160
+binPack.defnSite = always
+align.beforeOpenParenDefnSite = true
+align.closeParenSite = true
+newlines.beforeOpenParenDefnSite = fold
+align.openParenDefnSite = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+>>>
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                          (implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                            (implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+<<< #5290 !binPack.defnSite
+maxColumn = 160
+align.beforeOpenParenDefnSite = true
+align.closeParenSite = true
+newlines.beforeOpenParenDefnSite = fold
+align.openParenDefnSite = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+>>>
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                                                         (implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                                                           (implicit ctx: RequestContext): Future[Int] = ???
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -14374,3 +14374,50 @@ object a {
   else
     baz
 }
+<<< #5290 binPack.defnSite
+maxColumn = 160
+binPack.defnSite = always
+align.beforeOpenParenDefnSite = true
+align.closeParenSite = true
+newlines.beforeOpenParenDefnSite = fold
+align.openParenDefnSite = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+>>>
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                          (implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                            (implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+<<< #5290 !binPack.defnSite
+maxColumn = 160
+align.beforeOpenParenDefnSite = true
+align.closeParenSite = true
+newlines.beforeOpenParenDefnSite = fold
+align.openParenDefnSite = true
+newlines.sometimesBeforeColonInMethodReturnType = false
+===
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)(implicit ctx: RequestContext): Future[Int] = ???
+  }
+}
+>>>
+object Example {
+  def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                                                         (implicit ctx: RequestContext): Future[Int] = ???
+  object Nested {
+    def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
+                                                           (implicit ctx: RequestContext): Future[Int] = ???
+  }
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -14392,10 +14392,10 @@ object Example {
 >>>
 object Example {
   def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
-                          (implicit ctx: RequestContext): Future[Int] = ???
+                                                         (implicit ctx: RequestContext): Future[Int] = ???
   object Nested {
     def notificationEventDispatcher[T <: PayloadMarkerBase](eventData: T, errors: Seq[IssueDetail], originalRawContent: String)
-                            (implicit ctx: RequestContext): Future[Int] = ???
+                                                           (implicit ctx: RequestContext): Future[Int] = ???
   }
 }
 <<< #5290 !binPack.defnSite

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2591368, "total explored")
+      assertEquals(explored, 2594848, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Each state column should really reset the indent computation and use the current column value.

Earlier logic that didn't reset it and used `column - indentation`, only worked for cases when there's only one StateColumn, since `indentation` is likely equal to the sum of indents prior to the StateColumn.

Fixes #5290.