### PR TITLE
RewriteScala3Settings: common style guide preset

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3557,7 +3557,7 @@ def f() = {
 > formatter might need to be run twice.
 >
 > This rule cannot be used with
-> [`rewrite.scala3.endMarker.insertMinSpan`](#rewritescala3endmarkerinsert) or
+> [`rewrite.scala3.endMarker.insert.span`](#rewritescala3endmarkerinsertremove) or
 > [`rewrite.scala3.optionalBraces.oldSyntaxToo == true`](#rewritescala3optionalbraces).
 
 This rewrite in essence provides the opposite of what `RedundantBraces` achieves,
@@ -4613,43 +4613,49 @@ The section contains the following settings (available since v3.8.1):
 - (since v3.10.8) `insert`: will add braces to a braceless region if at least
   one check below is enabled and **unless** all (or "any" if `preferInsert = false`)
   of the enabled checks are satisfied
-  - `insert.minSpan`:
-    - disabled if negative
-    - satisfied if it exceeds the cumulative span of all visible tokens within the region
-    - or, for single-statement blocks, if that span is less than
+  - (since v3.11.2) `insert.span`
+    - an [interval](#rewritescala3-interval-checks) parameter,
+      applied to the cumulative span of all visible tokens within the region
+    - for single-statement blocks, that span may not be less than
       `maxColumn` (to avoid non-idempotent formatting)
-  - `insert.minBlankGaps`:
-    - disabled if negative
-    - satisfied if it exceeds the number of blank-line gaps within the region
-  - if `preferInsert = false`, these values will be increased, if necessary,
-    to be greater than those in `remove` section
+    - `insert.minSpan` was used earlier for `insert.span.min`
+  - (since v3.11.2) `insert.blankGaps`
+    - an [interval](#rewritescala3-interval-checks) parameter,
+      applied to the number of blank-line gaps within the region
+    - `remove.maxBlankGaps` was used earlier for `remove.blankGaps.max`
+  - if `preferInsert = false`, these intervals will be modified, if necessary,
+    to exclude those in `remove` section
 - (since v3.10.8) `remove`: will remove braces if at least
   one check below is enabled and **if** all (or "any" if `preferInsert = false`)
   of the enabled checks are satisfied
   - the only exception is when all checks both here and in `insert` above are
     disabled, in which case the rule will **always** remove braces
-  - `remove.maxSpan`
-    - disabled if negative
-    - satisfied if the cumulative span of all visible tokens between the braces does not exceed it
-  - `remove.maxBlankGaps`
-    - disabled if negative
-    - satisfied if the number of blank-line gaps between the braces does not exceed it
+  - `remove.span`
+    - an [interval](#rewritescala3-interval-checks) parameter,
+      applied to the cumulative span of all visible tokens between the braces
+    - before v3.11.2, `remove.maxSpan` was used instead of `remove.span.max`
+  - `remove.blankGaps`
+    - an [interval](#rewritescala3-interval-checks) parameter,
+      applied to the number of blank-line gaps between the braces
+    - before v3.11.2, `remove.maxBlankGaps` was used instead of `remove.blankGaps.max`
   - if `preferInsert = true`, these values will be decreased, if necessary,
     to be less than those in `insert` section
-- (since v3.8.1) `fewerBraces.minSpan` and `fewerBraces.maxSpan`
-  - in v3.10.8, was renamed from `fewerBracesMinSpan` and `fewerBracesMaxSpan`
-  - this is an additional restriction to the rule just above
-  - will apply the rewrite to last curried single-argument group if
-    it is enclosed in curly braces (or would be rewritten to curly
-    braces by the `RedundantBraces` rule)
-  - will only apply the rewrite if `fewerBraces.maxSpan` is positive and
-    the visible span between the braces is within this range (inclusive)
-- (since v3.8.1) `fewerBraces.parensToo`
-  - in v3.10.8, was renamed from `fewerBracesParensToo`
-  - will apply the rule just above to an argument in parentheses as well,
-    if the one of following is also satisfied:
-    - [`newlines.infix.xxxSite.style`](#newlinesinfix-stylenonekeep) is NOT `keep`; or
-    - current dialect supports `allowInfixOperatorAfterNL`
+- (since v3.8.1) `fewerBraces`
+  - will apply the `remove` rule just above, as an additional restriction,
+    to last curried single-argument group if it is enclosed in curly braces
+    (or would be rewritten to curly braces by the `RedundantBraces` rule)
+  - `fewerBraces.span`
+    - an [interval](#rewritescala3-interval-checks) parameter,
+      applied to the visible span between the braces
+    - disabled unless `span.max` is positive
+    - in v3.11.2, was renamed from `fewerBraces.{minSpan,maxSpan}`
+    - in v3.10.8, was renamed from `fewerBracesMinSpan` and `fewerBracesMaxSpan`
+  - `fewerBraces.parensToo`
+    - will apply to an argument in parentheses as well,
+      if the one of following is also satisfied:
+      - [`newlines.infix.xxxSite.style`](#newlinesinfix-stylenonekeep) is NOT `keep`; or
+      - current dialect supports `allowInfixOperatorAfterNL`
+    - in v3.10.8, was renamed from `fewerBracesParensToo`
 
 Prior to v3.10.8, the section was called `removeOptionalBraces`.
 Prior to v3.8.1, it was a single flag which
@@ -4664,33 +4670,10 @@ took three possible values (with their equivalent current settings shown):
 This setting, added in v3.10.8, controls whether we prefer to insert missing
 end markers over removing existing ones. See the two sections below for details.
 
-### `rewrite.scala3.endMarker.insert`
+### `rewrite.scala3.endMarker.{insert,remove}`
 
-This section controls when to insert an end marker (if one is missing) after an expression containing an
-[optional braces](https://dotty.epfl.ch/docs/reference/other-new-features/indentation.html)
-region.
-
-Several checks are defined, and the rule applies if:
-
-- at least one check is enabled
-- if `endMarker.preferInsert` is
-  - enabled: at least one check is satisfied
-  - disabled: all checks must be satisfied
-
-The following flags are defined, with corresponding checks:
-
-- (since v3.10.8) `minBreaks`: the check is enabled if this value is non-negative
-  and satisfied if the region contains at least as many line breaks
-- (since v3.10.8) `minBlankGaps`: the check is enabled if this value is non-negative
-  and satisfied if the region contains at least as many blank-line gaps
-
-> We will not insert end markers if the statement is not part of a template body,
-> or a multi-stat block. Doing so might turn a single-stat expression (which
-> doesn't require significant indentation handling) into a multi-stat block.
-
-### `rewrite.scala3.endMarker.remove`
-
-This section controls when to delete a standalone end marker(i.e., no other
+This section controls when to insert an end marker (if one is missing) or,
+conversely, when to remove an existing standalone end marker (i.e., no other
 tokens on that line, including comments) after an expression containing an
 [optional braces](https://dotty.epfl.ch/docs/reference/other-new-features/indentation.html)
 region.
@@ -4699,23 +4682,34 @@ Several checks are defined, and the rule applies if:
 
 - at least one check is enabled
 - if `endMarker.preferInsert` is
-  - enabled: all checks must be satisfied
-  - disabled: at least one check is satisfied
+  - enabled: all checks must be satisfied to remove, and at least one to insert
+  - disabled: all checks must be satisfied to insert, and at least one to remove
 
 The following flags are defined, with corresponding checks:
 
-- (since v3.10.8) `maxBreaks`: the check is enabled if this value is non-negative,
-  and satisfied if the region contains at most as many line breaks
-- (since v3.10.8) `maxBlankGaps`: the check is enabled if this value is non-negative,
-  and satisfied if the region contains at most as many blank-line gaps
+- (since v3.11.2) `breaks`:
+  - an [interval](#rewritescala3-interval-checks) parameter,
+    applied to the number of line breaks in the region
+  - (since v3.10.8) `remove.maxBreaks` was used earlier for `remove.breaks.max`
+  - (since v3.10.8) `insert.minBreaks` was used earlier for `insert.breaks.min`
+- (since v3.11.2) `blankGaps.{min,max}`:
+  - an [interval](#rewritescala3-interval-checks) parameter,
+    applied to the number of blank-line gaps in the region
+  - (since v3.10.8) `remove.maxBlankGaps` was used earlier for `remove.blankGaps.max`
+  - (since v3.10.8) `insert.minBlankGaps` was used earlier for `insert.blankGaps.min`
 
-> We will not remove end markers if
+> We will not
 >
-> - the statement is not part of a template body, or a block with at least 3
->   statements. Doing so might turn a multi-stat expression (which requires
->   significant indentation handling) into a single-stat.
-> - there are comments before the end marker, as without the end marker they
->   would be treated as outside of the optional-braces region.
+> - remove end markers if
+>   - the statement is not part of a template body, or a block with at least 3
+>     statements. Doing so might turn a multi-stat expression (which requires
+>     significant indentation handling) into a single-stat.
+>   - there are comments before the end marker, as without the end marker they
+>     would be treated as outside of the optional-braces region.
+> - insert end markers if
+>   - the statement is not part of a template body, or a multi-stat block.
+>     Doing so might turn a single-stat expression (which doesn't require
+>     significant indentation handling) into a multi-stat block.
 
 ### `rewrite.scala3.endMarker.spanHas`
 
@@ -4732,6 +4726,17 @@ is used to calculate the span.
   - but for an if-else, this would be just the `else` part
 
 Prior to v3.10.3, this setting was named `scala3.countEndMarkerLines`.
+
+### `rewrite.scala3` interval checks
+
+In v3.11.2, some single-bound parameters have been converted to an interval,
+with two bounds, `min` and `max`, and the check associated with this interval
+parameter works as follows:
+
+- enabled if at least one of `min` or `max` is non-negative
+- satisfied for a given value if both hold:
+  - `min` is negative or value is at least `min`
+  - `max` is negative or value is at most `max`
 
 ## Vertical Multiline
 
@@ -6504,8 +6509,7 @@ Currently, the formatting process consists of several stages:
       many line breaks we have selected to output for a given code passage);
       for instance,
       - [inserting](#inserting-braces) braces,
-      - [adding](#rewritescala3endmarkerinsert) or
-        [removing](#rewritescala3endmarkerremove) end markers
+      - [adding or removing](#rewritescala3endmarkerinsertremove) end markers
       - modifying [blank lines](#newlines-around-package-or-template-body)
     - rewrite comments and docstrings if configured
     - [rewrite trailing commas](#trailing-commas):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4555,6 +4555,18 @@ This section describes rules which are applied if the appropriate dialect (e.g.,
 > This logic is not triggered via the `rewrite.rules` parameter, but by setting
 > parameters under `rewrite.scala3` subsection.
 
+### `rewrite.scala3` presets
+
+The following presets are available for the `rewrite.scala3` section:
+
+- `common`: intends to approximate the
+  [common style recommendation](https://contributors.scala-lang.org/t/towards-a-common-scala-style-recommendation/7383)
+  - as of v3.11.2, it includes:
+    - `rewrite.scala3.convertToNewSyntax = true`
+    - `rewrite.scala3.newSyntax.deprecated = false`
+    - `rewrite.scala3.endMarker.remove.blankGaps.min = 1`
+    - `rewrite.scala3.optionalBraces.insert.blankGaps.min = 1`
+
 ### `rewrite.scala3.convertToNewSyntax`
 
 If this flag is enabled, the following new syntax will be applied (also,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -23,11 +23,21 @@ object RewriteScala3Settings {
 
   val default = new RewriteScala3Settings
 
+  private val styleGuideCommon = new RewriteScala3Settings(
+    convertToNewSyntax = true,
+    newSyntax = ConvertToNewSyntax(deprecated = false),
+    optionalBraces = RemoveOptionalBraces(insert =
+      Some(BracesFilters(blankGaps = Between(min = 1))),
+    ),
+    endMarker = EndMarker(remove = EndMarker.Filters(blankGaps = Between(min = 1))),
+  )
+
   implicit val decodec: ConfDecoderEx[RewriteScala3Settings] = Presets
     .mapDecoder(
       generic.deriveDecoderEx(default).noTypos.detectSectionRenames,
       "rewrite.scala3",
     ) {
+      case Conf.Str("common") => styleGuideCommon
       case Conf.Bool(true) => new RewriteScala3Settings(
           convertToNewSyntax = true,
           optionalBraces = RemoveOptionalBraces.yes,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -41,8 +41,8 @@ object RewriteScala3Settings {
   case class RemoveOptionalBraces(
       enabled: Boolean = true,
       preferInsert: Boolean = true,
-      insert: Option[InsertBraces] = None,
-      remove: Option[RemoveBraces] = None,
+      insert: Option[BracesFilters] = None,
+      remove: Option[BracesFilters] = None,
       fewerBraces: FewerBraces = FewerBraces.default,
       oldSyntaxToo: Boolean = false,
   ) {
@@ -54,10 +54,10 @@ object RewriteScala3Settings {
       val rbOpt = remove.filter(_.enabled)
       ibOpt.fold(copy(insert = None, remove = rbOpt))(ib =>
         rbOpt.fold( // if insert is Some, remove must be too
-          copy(insert = ibOpt, remove = Some(RemoveBraces.default)),
+          copy(insert = ibOpt, remove = Some(BracesFilters.disabled)),
         )(rb =>
-          if (preferInsert) copy(insert = ibOpt, remove = Some(rb.normalize(ib)))
-          else copy(insert = Some(ib.normalize(rb)), remove = rbOpt),
+          if (preferInsert) copy(insert = ibOpt, remove = Some(rb.exclude(ib)))
+          else copy(insert = Some(ib.exclude(rb)), remove = rbOpt),
         ),
       )
     }
@@ -87,45 +87,35 @@ object RewriteScala3Settings {
 
   }
 
-  case class RemoveBraces(maxSpan: Int = -1, maxBlankGaps: Int = -1) {
-    def enabled: Boolean = maxSpan >= 0 || maxBlankGaps >= 0
+  @annotation.SectionRename("minSpan", "span.min") // 3.11.2
+  @annotation.SectionRename("maxSpan", "span.max") // 3.11.2
+  @annotation.SectionRename("minBlankGaps", "blankGaps.min") // 3.11.2
+  @annotation.SectionRename("maxBlankGaps", "blankGaps.max") // 3.11.2
+  case class BracesFilters(
+      span: Between = Between.disabled,
+      blankGaps: Between = Between.disabled,
+  ) {
+    def enabled: Boolean = span.enabled || blankGaps.enabled
 
-    def normalize(ib: InsertBraces): RemoveBraces = {
-      val span = if (ib.minSpan < 0) maxSpan else maxSpan.min(ib.minSpan - 1)
-      val blankGaps =
-        if (ib.minBlankGaps < 0) maxBlankGaps
-        else maxBlankGaps.min(ib.minBlankGaps - 1)
-      copy(maxSpan = span, maxBlankGaps = blankGaps)
+    def exclude(that: BracesFilters): BracesFilters = {
+      val span = this.span.exclude(that.span)
+      val blankGaps = this.blankGaps.exclude(that.blankGaps)
+      if ((span eq this.span) && (blankGaps eq this.blankGaps)) this
+      else copy(span = span, blankGaps = blankGaps)
     }
   }
-  object RemoveBraces {
-    val default = new RemoveBraces()
-    implicit val surface: generic.Surface[RemoveBraces] = generic.deriveSurface
-    implicit val codec: ConfCodecEx[RemoveBraces] = generic
-      .deriveCodecEx(default).noTypos.detectSectionRenames
+
+  object BracesFilters {
+    val disabled = new BracesFilters()
+    implicit val surface: generic.Surface[BracesFilters] = generic.deriveSurface
+    implicit val codec: ConfCodecEx[BracesFilters] = generic
+      .deriveCodecEx(disabled).noTypos.detectSectionRenames
   }
 
-  case class InsertBraces(minSpan: Int = -1, minBlankGaps: Int = -1) {
-    def enabled: Boolean = minSpan >= 0 || minBlankGaps >= 0
-
-    def normalize(rb: RemoveBraces): InsertBraces = {
-      val span = if (rb.maxSpan < 0) minSpan else minSpan.max(rb.maxSpan + 1)
-      val blankGaps =
-        if (rb.maxBlankGaps < 0) minBlankGaps
-        else minBlankGaps.max(rb.maxBlankGaps + 1)
-      copy(minSpan = span, minBlankGaps = blankGaps)
-    }
-  }
-  object InsertBraces {
-    val default = new InsertBraces()
-    implicit val surface: generic.Surface[InsertBraces] = generic.deriveSurface
-    implicit val codec: ConfCodecEx[InsertBraces] = generic
-      .deriveCodecEx(default).noTypos.detectSectionRenames
-  }
-
+  @annotation.SectionRename("minSpan", "span.min") // 3.11.2
+  @annotation.SectionRename("maxSpan", "span.max") // 3.11.2
   case class FewerBraces(
-      minSpan: Int = 2,
-      maxSpan: Int = 0,
+      span: Between = Between(min = 2),
       parensToo: Boolean = false,
   )
   object FewerBraces {
@@ -137,8 +127,8 @@ object RewriteScala3Settings {
 
   case class EndMarker(
       spanHas: EndMarker.SpanHas = EndMarker.SpanHas.all,
-      insert: EndMarker.Insert = EndMarker.Insert.default,
-      remove: EndMarker.Remove = EndMarker.Remove.default,
+      insert: EndMarker.Filters = EndMarker.Filters.disabled,
+      remove: EndMarker.Filters = EndMarker.Filters.disabled,
       preferInsert: Boolean = true,
   )
 
@@ -157,16 +147,14 @@ object RewriteScala3Settings {
           case Conf.Str("blankGaps") => useBlankGaps = true; null
         }.fold(conf)(x => Conf.Obj(x._2)).replace {
           case ("insertMinSpan", v: Conf.Num) =>
-            val obj = Insert.default
             val kv =
-              if (useBlankGaps) Conf.nameOf(obj.minBlankGaps).value -> v
-              else Conf.nameOf(obj.minBreaks).value -> Conf.Num(v.value - 1)
+              if (useBlankGaps) "minBlankGaps" -> v
+              else "minBreaks" -> Conf.Num(v.value - 1)
             List((Conf.nameOf(default.insert), Conf.Obj(kv)))
           case ("removeMaxSpan", v: Conf.Num) =>
-            val obj = Remove.default
             val kv =
-              if (useBlankGaps) Conf.nameOf(obj.maxBlankGaps).value -> v
-              else Conf.nameOf(obj.maxBreaks).value -> Conf.Num(v.value - 1)
+              if (useBlankGaps) "maxBlankGaps" -> v
+              else "maxBreaks" -> Conf.Num(v.value - 1)
             List((Conf.nameOf(default.remove), Conf.Obj(kv)))
         }
       }
@@ -179,25 +167,50 @@ object RewriteScala3Settings {
       case object lastBlockOnly extends SpanHas
     }
 
-    case class Insert(minBreaks: Int = -1, minBlankGaps: Int = -1) {
-      def enabled: Boolean = minBreaks >= 0 || minBlankGaps >= 0
+    @annotation.SectionRename("minBreaks", "breaks.min") // 3.11.2
+    @annotation.SectionRename("maxBreaks", "breaks.max") // 3.11.2
+    @annotation.SectionRename("minBlankGaps", "blankGaps.min") // 3.11.2
+    @annotation.SectionRename("maxBlankGaps", "blankGaps.max") // 3.11.2
+    case class Filters(
+        breaks: Between = Between.disabled,
+        blankGaps: Between = Between.disabled,
+    ) {
+      def enabled: Boolean = breaks.enabled || blankGaps.enabled
     }
-    object Insert {
-      val default = new Insert()
-      implicit val surface: generic.Surface[Insert] = generic.deriveSurface
-      implicit val codec: ConfCodecEx[Insert] = generic.deriveCodecEx(default)
-        .noTypos
+    object Filters {
+      val disabled = new Filters()
+      implicit val surface: generic.Surface[Filters] = generic.deriveSurface
+      implicit val codec: ConfCodecEx[Filters] = generic.deriveCodecEx(disabled)
+        .noTypos.detectSectionRenames
     }
+  }
 
-    case class Remove(maxBreaks: Int = -1, maxBlankGaps: Int = -1) {
-      def enabled: Boolean = maxBreaks >= 0 || maxBlankGaps >= 0
-    }
-    object Remove {
-      val default = new Remove()
-      implicit val surface: generic.Surface[Remove] = generic.deriveSurface
-      implicit val codec: ConfCodecEx[Remove] = generic.deriveCodecEx(default)
-        .noTypos
-    }
+  case class Between(min: Int = -1, max: Int = -1) {
+    def enabled: Boolean = if (max >= 0) max >= min else min >= 0
+    def satisfied(fvalue: => Int): Boolean =
+      min <= 0 && (max < 0 || max == Int.MaxValue) || {
+        val value = fvalue
+        min <= value && (max < 0 || value <= max)
+      }
+    def overlaps(other: Between): Boolean =
+      if (min < 0)
+        if (other.min < 0) max >= 0 && other.max >= 0 else max >= other.min
+      else if (max < 0) if (other.max < 0) other.min >= 0 else min <= other.max
+      else if (other.min < 0) min <= other.max
+      else if (other.max < 0) max >= other.min
+      else max >= other.min && min <= other.max
+    def exclude(other: Between): Between =
+      if (other.enabled) copy(
+        min = if (other.max < 0) min else min.max(other.max + 1),
+        max = if (other.min < 0) max else max.min(other.min - 1),
+      )
+      else this
+  }
+  object Between {
+    val disabled = new Between()
+    implicit val surface: generic.Surface[Between] = generic.deriveSurface
+    implicit val codec: ConfCodecEx[Between] = generic.deriveCodecEx(disabled)
+      .noTypos
   }
 
   case class ConvertToNewSyntax(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala
@@ -406,11 +406,15 @@ object ScalafmtConfig {
       checkPositive(indent.main, indent.callSite, indent.defnSite, indent.commaSiteRelativeToExtends)
       checkNonNeg(indent.caseSite, indent.extendSite, indent.withSiteRelativeToExtends)
       checkPositiveOpt(indent.significant, indent.ctorSite)
-      if (rewrite.scala3.endMarker.insert.minBreaks >= 0)
-        addIf(rewrite.scala3.endMarker.remove.maxBreaks >= rewrite.scala3.endMarker.insert.minBreaks)
-      if (rewrite.scala3.endMarker.insert.minBlankGaps >= 0)
-        addIf(rewrite.scala3.endMarker.remove.maxBlankGaps >= rewrite.scala3.endMarker.insert.minBlankGaps)
-      addIf(rewrite.insertBraces.settings.minBreaks != 0 && rewrite.scala3.endMarker.insert.minBreaks >= 0)
+      addIfDirect(
+        rewrite.scala3.endMarker.insert.breaks.overlaps(rewrite.scala3.endMarker.remove.breaks),
+        "rewrite.scala3.endMarker.insert.breaks and rewrite.scala3.endMarker.remove.breaks overlap",
+      )
+      addIfDirect(
+        rewrite.scala3.endMarker.insert.blankGaps.overlaps(rewrite.scala3.endMarker.remove.blankGaps),
+        "rewrite.scala3.endMarker.insert.blankGaps and rewrite.scala3.endMarker.remove.blankGaps overlap",
+      )
+      addIf(rewrite.insertBraces.settings.minBreaks != 0 && rewrite.scala3.endMarker.insert.breaks.enabled)
       addIf(rewrite.insertBraces.settings.minBreaks != 0 && rewrite.scala3.optionalBraces.oldSyntaxToo)
       if (RedundantBraces.usedIn(rewrite)) {
         if (rewrite.insertBraces.settings.minBreaks != 0) addIf(rewrite.insertBraces.settings.minBreaks <= rewrite.redundantBraces.maxBreaks)
@@ -419,8 +423,8 @@ object ScalafmtConfig {
       }
       addIf(align.beforeOpenParenDefnSite && !align.closeParenSite)
       addIf(align.beforeOpenParenCallSite && !align.closeParenSite)
-      if (rewrite.scala3.optionalBraces.fewerBraces.maxSpan > 0)
-        addIf(rewrite.scala3.optionalBraces.fewerBraces.minSpan > rewrite.scala3.optionalBraces.fewerBraces.maxSpan)
+      if (rewrite.scala3.optionalBraces.fewerBraces.span.max > 0)
+        addIf(rewrite.scala3.optionalBraces.fewerBraces.span.min > rewrite.scala3.optionalBraces.fewerBraces.span.max)
       if (rewrite.rules.contains(Imports)) binPack.importSelectors match {
         case Some(ImportSelectors.singleLine) => // if we fold but not bin pack, we might end up with very long lines
           addIfDirect(importSelectorsRewrite eq Newlines.fold, "rewrite.imports.selectors == fold && binPack.importSelectors == singleLine")

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -223,10 +223,10 @@ class FormatWriter(formatOps: FormatOps) {
       def processBody(begFt: FT, needBreak: Boolean): Unit = {
         val bLoc = locations(begFt.idx)
         val eLoc = locations(endIdx)
-        val ok = verifySpan(cfg.preferInsert)(
-          (cfg.remove.maxBreaks, getNumBreaks(needBreak)),
-          (cfg.remove.maxBlankGaps, getBlankGapsDiff),
-        ) { case (max, f) => max >= f(bLoc, eLoc) }
+        val ok = verifySpanInRange(cfg.preferInsert)(
+          (cfg.remove.breaks, getNumBreaks(needBreak)),
+          (cfg.remove.blankGaps, getBlankGapsDiff),
+        )(bLoc, eLoc)
         if (ok) {
           val loc2 = locations(idx + 2)
           locations(idx + 1) = locations(idx + 1).remove
@@ -301,10 +301,10 @@ class FormatWriter(formatOps: FormatOps) {
           if (eLoc.hasBreakAfter) {
             val cfg = floc.style.rewrite.scala3.endMarker
             def okSpan(loc: FormatLocation, needBreak: Boolean = false) =
-              verifySpan(!cfg.preferInsert)(
-                (cfg.insert.minBreaks, getNumBreaks(needBreak)),
-                (cfg.insert.minBlankGaps, getBlankGapsDiff),
-              ) { case (min, f) => min <= f(loc, eLoc) }
+              verifySpanInRange(!cfg.preferInsert)(
+                (cfg.insert.breaks, getNumBreaks(needBreak)),
+                (cfg.insert.blankGaps, getBlankGapsDiff),
+              )(loc, eLoc)
 
             val bLoc = locations(getHead(ownerTokens, owner).idx)
             val begIndent = bLoc.state.prev.indentation
@@ -2080,13 +2080,19 @@ object FormatWriter {
       .append(CharBuffer.wrap(csq, beg, end))
   }
 
-  private type SpanCheck = (Int, (FormatLocation, FormatLocation) => Int)
+  private type SpanCheck =
+    (RewriteScala3Settings.Between, (FormatLocation, FormatLocation) => Int)
 
   private def verifySpan(
       all: Boolean,
   )(checks: SpanCheck*)(p: SpanCheck => Boolean): Boolean = {
-    val it = checks.iterator.filter(_._1 >= 0)
+    val it = checks.iterator.filter(_._1.enabled)
     if (all) it.hasNext && it.forall(p) else it.exists(p)
   }
+
+  private def verifySpanInRange(
+      all: Boolean,
+  )(checks: SpanCheck*)(bLoc: FormatLocation, eLoc: FormatLocation): Boolean =
+    verifySpan(all)(checks: _*) { case (bw, f) => bw.satisfied(f(bLoc, eLoc)) }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -155,10 +155,11 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
     val notOkToRewrite = hasFormatOff || { // can't force significant indentation
       val cfg = settings
       !cfg.remove.forall { x =>
-        val checks = Iterator(
-          (x.maxSpan, (max: Int) => session.getSpan(left) <= max),
-          (x.maxBlankGaps, (max: Int) => session.getBlankGaps(left) <= max),
-        ).flatMap { case (max, f) => if (max < 0) None else Some(f(max)) }
+        import RewriteScala3Settings.Between
+        val checks = Iterator[(Between, Between => Boolean)](
+          (x.span, _.satisfied(session.getSpan(left))),
+          (x.blankGaps, _.satisfied(session.getBlankGaps(left))),
+        ).flatMap { case (bw, f) => if (bw.enabled) Some(f(bw)) else None }
         if (!cfg.preferInsert) checks.contains(true)
         else checks.hasNext && !checks.contains(false)
       }
@@ -206,16 +207,20 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
         case x: ReplacementType.AppendAfter => x.ft.rightOwner
         case _ => left.ft.rightOwner
       })
-
-      val checkSpan = (x: Int) =>
-        if (isSingleStatBlock) session.getSpan(left) >= x.max(style.maxColumn)
-        else x == 0 || session.getSpan(left) >= x
-      val checkBlankGaps = (x: Int) =>
-        if (isSingleStatBlock) session.getBlankGaps(left) >= x.max(1)
-        else x == 0 || session.getBlankGaps(left) >= x
-      val checks =
-        Iterator((ib.minSpan, checkSpan), (ib.minBlankGaps, checkBlankGaps))
-          .flatMap { case (min, f) => if (min < 0) None else Some(f(min)) }
+      def getSpan = session.getSpan(left)
+      def getBlankGaps = session.getBlankGaps(left)
+      val checkSpan = (x: RewriteScala3Settings.Between) =>
+        if (isSingleStatBlock) {
+          val range = getSpan
+          range >= style.maxColumn && x.satisfied(range)
+        } else x.max == 0 || x.satisfied(getSpan)
+      val checkBlankGaps = (x: RewriteScala3Settings.Between) =>
+        if (isSingleStatBlock) {
+          val range = getBlankGaps
+          range >= 1 && x.satisfied(range)
+        } else x.max == 0 || x.satisfied(getBlankGaps)
+      val checks = Iterator((ib.span, checkSpan), (ib.blankGaps, checkBlankGaps))
+        .flatMap { case (bw, f) => if (bw.enabled) Some(f(bw)) else None }
       if (cfg.preferInsert) checks.contains(true)
       else checks.hasNext && !checks.contains(false)
     }
@@ -321,7 +326,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       tree: Term.ArgClause,
   )(implicit ft: FT, style: ScalafmtConfig): Replacement = {
     val cfg = settings
-    val ok = style.dialect.allowFewerBraces && cfg.fewerBraces.maxSpan > 0 &&
+    val ok = style.dialect.allowFewerBraces && cfg.fewerBraces.span.max > 0 &&
       (ft.right.is[T.LeftBrace] ||
         cfg.fewerBraces.parensToo &&
         (style.dialect.allowInfixOperatorAfterNL ||
@@ -357,11 +362,8 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       left: Replacement,
   )(implicit session: Session, style: ScalafmtConfig): Boolean = {
     def shouldRewriteArgClause(ac: Term.ArgClause): Boolean =
-      0 == ac.values.lengthCompare(1) && {
-        val rob = settings
-        val span = session.getSpan(left)
-        span >= rob.fewerBraces.minSpan && span <= rob.fewerBraces.maxSpan
-      }
+      0 == ac.values.lengthCompare(1) &&
+        settings.fewerBraces.span.satisfied(session.getSpan(left))
     val lft = left.ft
     lft.meta.rightOwner match {
       case t: Term.ArgClause => shouldRewriteArgClause(t)

--- a/scalafmt-tests-community/common/shared/src/test/scala/org/scalafmt/community/common/TestStyles.scala
+++ b/scalafmt-tests-community/common/shared/src/test/scala/org/scalafmt/community/common/TestStyles.scala
@@ -44,7 +44,8 @@ private[community] object TestStyles {
           convertToNewSyntax = true,
           optionalBraces = RewriteScala3Settings.RemoveOptionalBraces.yes,
           endMarker = style.rewrite.scala3.endMarker.copy(insert =
-            style.rewrite.scala3.endMarker.insert.copy(minBreaks = 4),
+            style.rewrite.scala3.endMarker.insert
+              .copy(breaks = RewriteScala3Settings.Between(min = 4)),
           ),
         ),
         redundantBraces = RedundantBracesSettings.all

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -16,7 +16,7 @@ import munit.FunSuite
   */
 class FidelityTest extends FunSuite with FormatAssertions {
 
-  private val numFiles = 278
+  private val numFiles = 279
 
   private val denyList = Set(
     "ConfigReader.scala",

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
@@ -1,0 +1,46 @@
+package org.scalafmt.config
+
+class RewriteScala3SettingsTest extends munit.FunSuite {
+
+  import RewriteScala3Settings.Between
+
+  Seq(
+    Between(),
+    Between(min = -2),
+    Between(min = 1, max = 0),
+    Between(min = Int.MaxValue, max = Int.MaxValue - 1),
+  ).foreach(bw =>
+    test(s"RewriteScala3Settings.Between: not enabled [$bw}]")(
+      assert(!bw.enabled, s"Between should not be enabled for $bw"),
+    ),
+  )
+
+  Seq(
+    (Between(max = 1), Between(max = 2), true),
+    (Between(min = 1), Between(min = 2), true),
+    (Between(min = 1), Between(max = 1), true),
+    (Between(min = 2), Between(max = 1), false),
+    (Between(min = 1, max = 2), Between(max = 0), false),
+    (Between(min = 1, max = 2), Between(max = 1), true),
+    (Between(min = 1, max = 2), Between(max = 2), true),
+    (Between(min = 1, max = 2), Between(max = 3), true),
+    (Between(min = 1, max = 2), Between(min = 1), true),
+    (Between(min = 1, max = 2), Between(min = 2), true),
+    (Between(min = 1, max = 2), Between(min = 3), false),
+    (Between(min = 1, max = 2), Between(min = 1, max = 0), false),
+    (Between(min = 1, max = 2), Between(min = 2, max = 1), true),
+    (Between(min = 1, max = 2), Between(min = 3, max = 2), false),
+  ).foreach { case (lt, rt, overlaps) =>
+    test(s"RewriteScala3Settings.Between: overlaps [$lt, $rt}]")(
+      assert(
+        lt.overlaps(rt) == overlaps,
+        s"Between should overlap=$overlaps: $lt and $rt",
+      ),
+      assert(
+        rt.overlaps(lt) == overlaps,
+        s"Between should overlap=$overlaps: $lt and $rt",
+      ),
+    )
+  }
+
+}


### PR DESCRIPTION
Based on https://contributors.scala-lang.org/t/towards-a-common-scala-style-recommendation/7383

Requires changing some parameters from single-bound to interval version.