### PR TITLE
benchmarks: modernize JVM options and harness

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -323,19 +323,11 @@ lazy val benchmarks = project.in(file("scalafmt-benchmarks")).settings(
   libraryDependencies += scalametaTestkit.value,
   run / javaOptions ++= Seq(
     "-Djava.net.preferIPv4Stack=true",
-    "-XX:+AggressiveOpts",
-    "-XX:+UseParNewGC",
-    "-XX:+UseConcMarkSweepGC",
-    "-XX:+CMSParallelRemarkEnabled",
-    "-XX:+CMSClassUnloadingEnabled",
     "-XX:ReservedCodeCacheSize=128m",
     "-XX:MaxMetaspaceSize=1024m",
-    "-XX:SurvivorRatio=128",
-    "-XX:MaxTenuringThreshold=0",
     "-Xss8M",
     "-Xms512M",
     "-Xmx2G",
-    "-server",
   ),
 ).dependsOn(coreJVM).enablePlugins(JmhPlugin)
 

--- a/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
+++ b/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
@@ -2,12 +2,18 @@ package org.scalafmt.benchmarks
 
 import org.scalafmt.Scalafmt
 import org.scalafmt.config.{RewriteSettings, ScalafmtConfig}
-import org.scalafmt.rewrite.{RedundantBraces, SortImports}
+import org.scalafmt.rewrite.{Imports, RedundantBraces}
 
 trait FormatBenchmark {
+  // `SortImports` is a deprecated shim that throws NotImplementedError; the
+  // modern equivalent is the unified `Imports` rule with `imports.sort`.
   def formatRewrite(code: String): String = Scalafmt.formatCode(
     code,
-    baseStyle = ScalafmtConfig.default
-      .copy(rewrite = RewriteSettings(rules = Seq(SortImports, RedundantBraces))),
+    baseStyle = ScalafmtConfig.default.copy(rewrite =
+      RewriteSettings(
+        rules = Seq(Imports, RedundantBraces),
+        imports = Imports.Settings(sort = Imports.Sort.ascii),
+      ),
+    ),
   ).get
 }

--- a/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/MicroBenchmark.scala
+++ b/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/MicroBenchmark.scala
@@ -1,6 +1,7 @@
 package org.scalafmt.benchmarks
 
 import org.scalafmt.Scalafmt
+import org.scalafmt.config.{Indents, ScalafmtConfig}
 import org.scalafmt.sysops.{FileOps, PlatformFileOps}
 
 import java.nio.file.Path
@@ -44,6 +45,17 @@ abstract class MicroBenchmark(path: String*) extends FormatBenchmark {
 
   @Benchmark
   def scalafmt(): String = Scalafmt.format(code).get
+
+  // exercises State.getUnexpired's non-empty `relativeToLhsLastLine` path
+  private val relLhsConfig: ScalafmtConfig = ScalafmtConfig.default
+    .copy(indent =
+      ScalafmtConfig.default.indent.copy(relativeToLhsLastLine =
+        Seq(Indents.RelativeToLhs.`match`, Indents.RelativeToLhs.`infix`),
+      ),
+    )
+
+  @Benchmark
+  def scalafmt_relLhs(): String = Scalafmt.format(code, relLhsConfig).get
 
   @Benchmark
   def scalafmt_rewrite(): String = formatRewrite(code)


### PR DESCRIPTION
Drop obsolete benchmark JVM options (-XX:+AggressiveOpts, CMS flags, -server) so JMH runs on modern JDKs; add a relativeToLhsLastLine Micro variant; fix the scalafmt_rewrite benchmark (the SortImports shim threw NotImplementedError) to use the Imports rule + RedundantBraces.