### PR TITLE
search loop: cut per-state and init-time allocation

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -121,7 +121,8 @@ object Scalafmt {
       },
       tree => {
         implicit val formatOps = new FormatOps(tree, style, file)
-        runner.event(FormatEvent.CreateFormatOps(formatOps))
+        val evtCb = runner.eventCallback
+        if (evtCb ne null) evtCb(FormatEvent.CreateFormatOps(formatOps))
         implicit val formatWriter = new FormatWriter(formatOps)
         Try(BestFirstSearch(range)).flatMap { res =>
           val formattedString = formatWriter.mkString(res.state)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FormatEvent.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/FormatEvent.scala
@@ -16,7 +16,8 @@ object FormatEvent {
       totalExplored: Int,
       finalState: State,
       visits: IndexedSeq[Int],
-      best: collection.Map[Int, State],
+      // indexed by state depth; null entries are absent
+      best: IndexedSeq[State],
   ) extends FormatEvent
   case class Written(formatLocations: FormatWriter#FormatLocations)
       extends FormatEvent

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RunnerSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RunnerSettings.scala
@@ -17,8 +17,8 @@ import metaconfig._
   */
 case class RunnerSettings(
     debug: Boolean = false,
-    private val completeCallback: FormatEvent.CompleteFormat => Unit = _ => (),
-    private val eventCallback: FormatEvent => Unit = null,
+    completeCallback: FormatEvent.CompleteFormat => Unit = _ => (),
+    eventCallback: FormatEvent => Unit = null,
     private[config] val parser: ScalafmtParser = ScalafmtParser.Source,
     optimizer: ScalafmtOptimizer = ScalafmtOptimizer.default,
     maxStateVisits: Option[Int] = None,
@@ -53,11 +53,6 @@ case class RunnerSettings(
   private[scalafmt] def withCompleteCallback(
       cb: FormatEvent.CompleteFormat => Unit,
   ) = copy(completeCallback = cb)
-
-  def event(evt: FormatEvent.CompleteFormat): Unit = completeCallback(evt)
-
-  def event(evt: => FormatEvent): Unit =
-    if (null != eventCallback) eventCallback(evt)
 
   private implicit val parserOptions: ParserOptions = ParserOptions.default
     .withCaptureComments(false)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -27,9 +27,13 @@ private class BestFirstSearch private (range: Set[Range])(implicit
     */
   val routes: Array[Seq[Split]] = {
     val router = new Router
-    val result = Array.newBuilder[Seq[Split]]
-    tokens.foreach(t => result += router.getSplits(t))
-    result.result()
+    val result = new Array[Seq[Split]](tokens.length)
+    var i = 0
+    while (i < result.length) {
+      result(i) = router.getSplits(tokens(i))
+      i += 1
+    }
+    result
   }
   private val noOptZones =
     if (useNoOptZones(initStyle)) getNoOptZones(tokens) else null
@@ -47,8 +51,14 @@ private class BestFirstSearch private (range: Set[Range])(implicit
         }) => close.idx
   }
 
-  private val memo = mutable.Map.empty[Long, Option[State]]
-  private val slbMemo = mutable.Map.empty[Long, Option[State]]
+  // LongMap: primitive Long key, no boxing on get/update in the search recursion
+  private val memo = mutable.LongMap.empty[Option[State]]
+  private val slbMemo = mutable.LongMap.empty[Option[State]]
+
+  // out-param for getActiveSplits: number of valid splits in the returned array
+  // (avoids a per-state `(Array[Split], Int)` tuple). Single-threaded search, so
+  // a field is safe; every caller reads it into a local right after the call.
+  private[this] var activeSplitsCount: Int = 0
 
   def shortestPathMemo(
       start: State,
@@ -109,10 +119,10 @@ private class BestFirstSearch private (range: Set[Range])(implicit
       import style.runner.optimizer
 
       if (idx > deepestState.depth) deepestState = curr
-      val noOptZoneOrBlock =
-        if (noOptZones == null || !useNoOptZones) Some(true)
-        else noOptZones.get(idx)
-      val noOptZone = noOptZoneOrBlock.contains(true)
+      // 0 = absent (no block here), 1 = Some(false), 2 = Some(true)/no-opt
+      val noOptZoneCode: Int =
+        if (noOptZones == null || !useNoOptZones) 2 else noOptZones(idx)
+      val noOptZone = noOptZoneCode == 2
 
       if (noOptZone || stats.shouldEnterState(curr)) {
         if (Q.generation.nonEmpty) preFork = false
@@ -124,14 +134,14 @@ private class BestFirstSearch private (range: Set[Range])(implicit
           if (
             emptyQueueSpots.contains(idx) ||
             optimizer.dequeueOnNewStatements && !(depth == 0 && noOptZone) &&
-            optimizationEntities.statementStarts.contains(idx)
+            optimizationEntities.isStatementStart(idx)
           ) {
             preFork = false
             Q.addGeneration()
           }
 
-        val noBlockClose = start == curr && !isOpt ||
-          noOptZoneOrBlock.isEmpty || !optimizer.recurseOnBlocks
+        val noBlockClose = start == curr && !isOpt || noOptZoneCode == 0 ||
+          !optimizer.recurseOnBlocks
         val blockCloseState =
           if (noBlockClose) None
           else getBlockCloseToRecurse(splitToken, curr.indentation)
@@ -146,10 +156,11 @@ private class BestFirstSearch private (range: Set[Range])(implicit
             )
 
           val actualSplits = getActiveSplits(curr)(activeSplitsFilter)
+          val numSplits = activeSplitsCount
 
           var optimalFound = false
           val handleOptimalTokens = optimizer.acceptOptimalAtHints &&
-            depth < optimizer.maxDepth && actualSplits.lengthCompare(1) > 0
+            depth < optimizer.maxDepth && numSplits > 1
 
           def processNextState(implicit nextState: State): Unit = {
             val split = nextState.split
@@ -173,10 +184,13 @@ private class BestFirstSearch private (range: Set[Range])(implicit
             } else preFork = false
           }
 
-          actualSplits.foreach(split =>
-            if (optimalFound) sendEvent(split)
-            else processNextState(getNext(curr, split)),
-          )
+          var sidx = 0
+          while (sidx < numSplits) {
+            val split = actualSplits(sidx)
+            sidx += 1
+            if (optimalFound) stats.sendEvent(split)
+            else processNextState(getNext(curr, split))
+          }
         }
       }
     }
@@ -189,13 +203,10 @@ private class BestFirstSearch private (range: Set[Range])(implicit
     else Left(preForkState)
   }
 
-  private def sendEvent(split: Split): Unit = initStyle.runner
-    .event(FormatEvent.Enqueue(split))
-
   private def getNext(state: State, split: Split)(implicit
       style: ScalafmtConfig,
   ): State = {
-    sendEvent(split)
+    stats.sendEvent(split)
     state.next(split)
   }
 
@@ -247,32 +258,57 @@ private class BestFirstSearch private (range: Set[Range])(implicit
     }
   }
 
+  // returns the splits array; the valid-count is written to `activeSplitsCount`
   private def getActiveSplits(
       state: State,
-  )(pred: Split => Boolean)(implicit Q: StateQueue): Seq[Split] = {
+  )(pred: Split => Boolean)(implicit Q: StateQueue): Array[Split] = {
     stats.trackState(state)
     val idx = state.depth
     val ft = tokens(idx)
-    val active = state.policy.execute(Decision(ft, routes(idx)))
-      .filter(s => s.isActive && pred(s))
-    val splits =
-      if (active.isEmpty || !ft.meta.formatOff && ft.inside(range)) active
-      else {
-        val isNL = ft.hasBreak
-        val mod = Provided(ft)
-        active.map { x =>
-          val penalty = if (x.isNL == isNL) 0 else Constants.ShouldBeNewline
-          x.withMod(mod).withPenalty(penalty)
-        }
+    // with no policies, `execute` is the identity, so skip the Decision alloc
+    // copy into an array we own (`routes(idx)` is shared), then filter/map/sort
+    // in place; `pred` may have side effects, so call it exactly once per split
+    val arr = {
+      val splits = routes(idx)
+      if (state.policy.numPolicies == 0) splits
+      else state.policy.execute(ft, splits)
+    }.toArray
+    var widx = 0
+    var ridx = 0
+    while (ridx < arr.length) {
+      val s = arr(ridx)
+      if (s.isActive && pred(s)) { arr(widx) = s; widx += 1 }
+      ridx += 1
+    }
+    if (widx != 0 && (ft.meta.formatOff || !ft.inside(range))) {
+      val isNL = ft.hasBreak
+      val mod = Provided(ft)
+      var i = 0
+      while (i < widx) {
+        val x = arr(i)
+        val penalty = if (x.isNL == isNL) 0 else Constants.ShouldBeNewline
+        arr(i) = x.withMod(mod).withPenalty(penalty)
+        i += 1
       }
-    splits.sortBy(_.costWithPenalty)
+    }
+    if (widx > 1) java.util.Arrays
+      .sort(arr, 0, widx, BestFirstSearch.splitByCost)
+    activeSplitsCount = widx
+    arr
   }
 
-  private def stateAsOptimal(state: State, splits: Seq[Split]) = {
-    val isOptimal = splits
-      .exists(s => s.isNL && s.penalty < Constants.ShouldBeNewline) ||
-      tokens.isRightCommentWithBreak(tokens(state.depth))
-    if (isOptimal) Some(state) else None
+  private def stateIsOptimal(
+      state: State,
+      splits: Array[Split],
+      numSplits: Int,
+  ): Boolean = {
+    var i = 0
+    while (i < numSplits) {
+      val s = splits(i)
+      if (s.isNL && s.penalty < Constants.ShouldBeNewline) return true
+      i += 1
+    }
+    tokens.isRightCommentWithBreak(tokens(state.depth))
   }
 
   /** Follow states having single active non-newline split
@@ -282,19 +318,24 @@ private class BestFirstSearch private (range: Set[Range])(implicit
       state: State,
   )(implicit queue: StateQueue): Either[State, State] =
     if (state.depth >= tokens.length) Right(state)
-    else getActiveSplits(state)(_ => true) match {
-      case Seq() => Left(null) // dead end if empty
-      case Seq(split) =>
+    else {
+      val ss = getActiveSplits(state)(_ => true)
+      val numSplits = activeSplitsCount
+      if (numSplits == 0) Left(null) // dead end if empty
+      else if (numSplits == 1) {
+        val split = ss(0)
         if (split.isNL) Right(state)
         else {
           implicit val style: ScalafmtConfig = styleMap.at(tokens(state.depth))
           traverseSameLine(getNext(state, split))
         }
-      case ss => stateAsOptimal(state, ss).toRight(state)
+      } else if (stateIsOptimal(state, ss, numSplits)) Right(state)
+      else Left(state)
     }
 
   def getBestPath: SearchResult = {
-    initStyle.runner.event(FormatEvent.Routes(routes))
+    if (stats.eventCallback ne null) stats
+      .eventCallback(FormatEvent.Routes(routes))
     val state = {
       def run = shortestPath(State.start, Int.MaxValue)
       run.getOrElse(stats.retry.flatMap { x =>
@@ -309,12 +350,12 @@ private class BestFirstSearch private (range: Set[Range])(implicit
       val deepestYet = stats.deepestYet
       val nextSplits = routes(deepestYet.depth)
       val tok = tokens(deepestYet.depth)
-      val splitsAfterPolicy = deepestYet.policy.execute(Decision(tok, nextSplits))
-      def printSeq(vals: Seq[_]): String = vals.mkString("\n  ", "\n  ", "")
+      val splitsAfterPolicy = deepestYet.policy.execute(tok, nextSplits)
+      def printSeq(vals: Iterable[_]): String = vals.mkString("\n  ", "\n  ", "")
       val msg =
         s"""|UNABLE TO FORMAT,
             |tok #${deepestYet.depth}/${tokens.length}: $tok
-            |policies:${printSeq(deepestYet.policy.policies)}
+            |policies:${printSeq(deepestYet.policy.toIterable)}
             |splits (before policy):${printSeq(nextSplits)}
             |splits (after policy):${printSeq(splitsAfterPolicy)}
             |""".stripMargin
@@ -332,21 +373,29 @@ case class SearchResult(state: State, reachedEOF: Boolean)
 
 object BestFirstSearch {
 
+  // stable in-place sort key for getActiveSplits (matches `sortBy(costWithPenalty)`)
+  private val splitByCost: java.util.Comparator[Split] =
+    (a: Split, b: Split) => Integer.compare(a.costWithPenalty, b.costWithPenalty)
+
   def apply(
       range: Set[Range],
   )(implicit formatOps: FormatOps, formatWriter: FormatWriter): SearchResult =
     new BestFirstSearch(range).getBestPath
 
-  private def getNoOptZones(tokens: FormatTokens)(implicit styleMap: StyleMap) = {
-    val result = mutable.Map.empty[Int, Boolean]
+  // dense table keyed by token idx: 0 = absent, 1 = Some(false), 2 = Some(true)
+  // (an array, not a boxed-Int Map, since it's read on every search state)
+  private def getNoOptZones(
+      tokens: FormatTokens,
+  )(implicit styleMap: StyleMap): Array[Byte] = {
+    val result = new Array[Byte](tokens.length)
     var expire: FT = null
     @inline
     def addRange(ft: FT): Unit = expire = tokens.matchingLeft(ft)
     @inline
-    def addBlock(idx: Int): Unit = result.getOrElseUpdate(idx, false)
+    def addBlock(idx: Int): Unit = if (result(idx) == 0) result(idx) = 1
     tokens.foreach {
       case ft if expire ne null =>
-        if (ft eq expire) expire = null else result.update(ft.idx, true)
+        if (ft eq expire) expire = null else result(ft.idx) = 2
       case ft @ FT(t: T.LeftParen, _, m) if (m.leftOwner match {
             case lo: Term.ArgClause => !lo.parent.is[Term.ApplyInfix] &&
               !styleMap.at(t).newlines.keep
@@ -364,7 +413,7 @@ object BestFirstSearch {
         }
       case _ =>
     }
-    result.result()
+    result
   }
 
   private def useNoOptZones(implicit style: ScalafmtConfig): Boolean =
@@ -401,7 +450,9 @@ object BestFirstSearch {
   ) {
     var explored = 0
     var deepestYet = State.start
-    val best = mutable.Map.empty[Int, State]
+    // keyed by dense state depth; array (null = absent) avoids the per-state
+    // Int-key box + Some that mutable.Map.get allocated in shouldEnterState
+    val best = new Array[State](tokens.length)
     val visits = new Array[Int](tokens.length)
 
     def this(tokens: FormatTokens, runner: RunnerSettings) =
@@ -410,22 +461,30 @@ object BestFirstSearch {
     /** Returns true if it's OK to skip over state.
       */
     def shouldEnterState(state: State): Boolean = state.policy.noDequeue ||
-      (pruneSlowStates eq ScalafmtOptimizer.PruneSlowStates.No) ||
-      // TODO(olafur) document why/how this optimization works.
-      best.get(state.depth).forall(state.possiblyBetter)
+      (pruneSlowStates eq ScalafmtOptimizer.PruneSlowStates.No) || {
+        // TODO(olafur) document why/how this optimization works.
+        val b = best(state.depth)
+        (b eq null) || state.possiblyBetter(b)
+      }
+
+    val eventCallback = runner.eventCallback
 
     def trackState(state: State)(implicit Q: StateQueue): Unit = {
       val idx = state.depth
       if (idx > deepestYet.depth) deepestYet = state
-      runner.event(FormatEvent.VisitToken(tokens(idx)))
+      if (eventCallback ne null) eventCallback(FormatEvent.VisitToken(tokens(idx)))
       visits(idx) += 1
       explored += 1
-      runner.event(FormatEvent.Explored(explored, Q.nested, Q.length))
+      if (eventCallback ne null)
+        eventCallback(FormatEvent.Explored(explored, Q.nested, Q.length))
     }
 
     private def updateBestImpl(state: State): Boolean = state.split.isNL &&
-      !state.terminal() &&
-      (best.getOrElseUpdate(state.prev.depth, state) eq state)
+      !state.terminal() && {
+        val d = state.prev.depth
+        val b = best(d)
+        if (b eq null) { best(d) = state; true } else b eq state
+      }
 
     def updateBest(state: State, furtherState: State)(implicit
         Q: StateQueue,
@@ -448,10 +507,13 @@ object BestFirstSearch {
     }
 
     def complete(state: State): Unit = runner
-      .event(FormatEvent.CompleteFormat(explored, state, visits, best))
+      .completeCallback(FormatEvent.CompleteFormat(explored, state, visits, best))
+
+    def sendEvent(split: Split): Unit =
+      if (eventCallback ne null) eventCallback(FormatEvent.Enqueue(split))
 
     def retry: Option[StateStats] = {
-      val ok = best.nonEmpty &&
+      val ok = best.exists(_ ne null) &&
         (pruneSlowStates eq ScalafmtOptimizer.PruneSlowStates.Yes)
       if (ok)
         Some(new StateStats(tokens, runner, ScalafmtOptimizer.PruneSlowStates.No))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Decision.scala
@@ -4,7 +4,7 @@ package org.scalafmt.internal
   *
   * Used by [[Policy]] to enforce non-local formatting.
   */
-case class Decision(formatToken: FT, splits: Seq[Split]) {
+case class Decision(formatToken: FT, var splits: Seq[Split]) {
 
   @inline
   def noNewlines: Seq[Split] = Decision.noNewlineSplits(splits)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -11,6 +11,7 @@ import scala.meta.tokens.{Token => T}
 import scala.meta.{Token => _, _}
 
 import scala.annotation.tailrec
+import scala.collection.immutable.BitSet
 
 /** Helper functions for generating splits/policies for a given tree.
   */
@@ -555,12 +556,14 @@ class FormatOps(
     }
   }
 
-  def getForceConfigStyle: (Set[Int], Set[Int]) = {
+  // BitSet (not Set[Int]): contains/apply take a primitive Int, no key boxing
+  // on the per-state `emptyQueueSpots.contains` / `forceConfigStyle(idx)` reads
+  def getForceConfigStyle: (BitSet, BitSet) = {
     val callSite = initStyle.runner.optimizer.callSite
     val defnSite = initStyle.runner.optimizer.defnSite
     if (callSite.isEnabled || defnSite.isEnabled) {
-      val clearQueues = Set.newBuilder[Int]
-      val forces = Set.newBuilder[Int]
+      val clearQueues = BitSet.newBuilder
+      val forces = BitSet.newBuilder
       def process(clause: Member.SyntaxValuesClause, ftOpen: FT)(
           cfg: ScalafmtOptimizer.ClauseElement,
       ): Unit = if (cfg.isEnabled) {
@@ -588,7 +591,7 @@ class FormatOps(
         case _ =>
       }
       (forces.result(), clearQueues.result())
-    } else (Set.empty, Set.empty)
+    } else (BitSet.empty, BitSet.empty)
   }
 
   /** Implementation for `verticalMultiline`

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -11,7 +11,7 @@ import scala.annotation.tailrec
 
 import TokenOps._
 
-class FormatTokens(leftTok2tok: Map[TokenHash, Int])(val arr: Array[FT])
+class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT])
     extends IndexedSeq[FT] {
 
   private def this(arr: Array[FT]) = this {
@@ -38,10 +38,13 @@ class FormatTokens(leftTok2tok: Map[TokenHash, Int])(val arr: Array[FT])
       else at(idx + 1)
     }
 
-  private def get(tok: T, isBefore: Boolean): FT = getAt(tok, isBefore)(
-    leftTok2tok
-      .getOrElse(hash(tok), FormatTokens.throwNoToken(tok, "Missing token index")),
-  )
+  private def get(tok: T, isBefore: Boolean): FT = {
+    val idx = leftTok2tok.getIndex(hash(tok))
+    getAt(tok, isBefore)(
+      if (idx >= 0) idx
+      else FormatTokens.throwNoToken(tok, "Missing token index"),
+    )
+  }
 
   def at(off: Int): FT =
     if (off < 0) arr.head else if (off < arr.length) arr(off) else arr.last
@@ -446,7 +449,7 @@ object FormatTokens {
     * Since tokens might be very large, we try to allocate as little memory as
     * possible.
     */
-  def apply(tokens: Tokens, owners: collection.Map[TokenHash, Tree])(implicit
+  def apply(tokens: Tokens, owners: Array[Tree])(implicit
       style: ScalafmtConfig,
   ): (FormatTokens, StyleMap) = {
     var left: T = null
@@ -456,7 +459,7 @@ object FormatTokens {
     var prevNonWsIdx = -1
     var fmtWasOff = false
     def process(right: T, tokIdx: Int): Unit = if (!right.is[T.Whitespace]) {
-      val rmeta = FT.TokenMeta(owners(hash(right)), right.text)
+      val rmeta = FT.TokenMeta(owners(tokIdx), right.text)
       if (left eq null) fmtWasOff = style.isFormatOff(right)
       else {
         val between = tokens.arraySlice(prevNonWsIdx + 1, tokIdx)
@@ -484,10 +487,84 @@ object FormatTokens {
     )
 
   class TokenToIndexMapBuilder {
-    private val builder = Map.newBuilder[TokenHash, Int]
-    def sizeHint(size: Int): Unit = builder.sizeHint(size)
-    def add(idx: Int)(token: T): Unit = builder += hash(token) -> idx
-    def result(): Map[TokenHash, Int] = builder.result()
+    private var builder = new TokenToIndexMap(16)
+    def sizeHint(size: Int): Unit = builder = new TokenToIndexMap(size)
+    def add(idx: Int)(token: T): Unit = builder.update(hash(token), idx)
+    def result(): TokenToIndexMap = builder
+  }
+
+  /** Open-addressing `Long`→`Int` map (linear probing), replacing
+    * `mutable.LongMap[Int]` which boxes the `Int` *value* on every insert and
+    * lookup. Parallel primitive arrays ⇒ zero boxing of key or value.
+    *
+    * Occupancy lives in the **value** slot, not the key: an empty slot has
+    * `vals == 0`, and stored indices are offset by `+1` (token indices are
+    * always `>= 0`). So *any* `Long` hash works as a key — negative, zero, or
+    * positive — with no key sentinel. Bucketing uses the unsigned shift `>>>`,
+    * so negative hashes still map into `[0, cap)`. Auto-grows (init-time only),
+    * so correctness never depends on the `sizeHint`.
+    */
+  final class TokenToIndexMap(sizeHint: Int) {
+    private[this] var cap = {
+      var c = 16
+      val target = if (sizeHint > 0) sizeHint * 2 else 16
+      while (c < target) c <<= 1
+      c
+    }
+    private[this] var shift = 64 - java.lang.Integer.numberOfTrailingZeros(cap)
+    private[this] var keys = new Array[Long](cap)
+    private[this] var vals = new Array[Int](cap) // 0 = empty, else idx + 1
+    private[this] var size = 0
+    private[this] var maxFill = cap - (cap >> 2) // grow past 0.75 load
+
+    @inline
+    private[this] def slotOf(key: Long, sh: Int): Int =
+      (key * 0x9e3779b97f4a7c15L >>> sh).toInt // Fibonacci hash, unsigned
+
+    def update(key: Long, idx: Int): Unit = {
+      var i = slotOf(key, shift)
+      while (vals(i) != 0) {
+        if (keys(i) == key) { vals(i) = idx + 1; return }
+        i += 1; if (i == cap) i = 0
+      }
+      keys(i) = key
+      vals(i) = idx + 1
+      size += 1
+      if (size >= maxFill) grow()
+    }
+
+    /** Stored index for `key`, or `-1` if absent (real indices are `>= 0`). */
+    def getIndex(key: Long): Int = {
+      var i = slotOf(key, shift)
+      while (vals(i) != 0) {
+        if (keys(i) == key) return vals(i) - 1
+        i += 1; if (i == cap) i = 0
+      }
+      -1
+    }
+
+    private[this] def grow(): Unit = {
+      val oldKeys = keys
+      val oldVals = vals
+      val oldCap = cap
+      cap <<= 1
+      shift = 64 - java.lang.Integer.numberOfTrailingZeros(cap)
+      maxFill = cap - (cap >> 2)
+      keys = new Array[Long](cap)
+      vals = new Array[Int](cap)
+      var j = 0
+      while (j < oldCap) {
+        val v = oldVals(j)
+        if (v != 0) {
+          val k = oldKeys(j)
+          var i = slotOf(k, shift)
+          while (vals(i) != 0) { i += 1; if (i == cap) i = 0 }
+          keys(i) = k
+          vals(i) = v
+        }
+        j += 1
+      }
+    }
   }
 
   class Offsets(val nonWs: Int, val width: Int, val nonWsNonPunct: Int) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -29,7 +29,8 @@ class FormatWriter(formatOps: FormatOps) {
   def mkString(state: State): String = {
     implicit val sb = new StringBuilder()
     val locations = getFormatLocations(state)
-    styleMap.init.runner.event(FormatEvent.Written(locations))
+    val evtCb = styleMap.init.runner.eventCallback
+    if (evtCb ne null) evtCb(FormatEvent.Written(locations))
 
     var delayedAlign = 0
     var totalAlignShift = 0
@@ -1446,25 +1447,24 @@ class FormatWriter(formatOps: FormatOps) {
       }
     }
 
-    private def shiftStateColumnIndent(startIdx: Int, offset: Int): Unit = {
+    private def shiftStateColumnIndent(startIdx: Int, offset: Int): Unit =
       // look for StateColumn; it returns indent=0 for withStateOffset(0)
-      val stateIndentIter = locations(startIdx).state.modExt.indents.iterator
-        .flatMap(x => if (x.hasStateColumn) x.withStateOffset(0) else None)
-      if (stateIndentIter.hasNext) {
-        val indent = stateIndentIter.next()
-        @tailrec
-        def updateLocation(idx: Int): Unit = {
-          val floc = locations(idx)
-          if (indent.notExpiredBy(floc.formatToken)) {
-            val state = floc.state
-            if (state.split.isNL) floc.state.indentation += offset
-            val nextIdx = idx + 1
-            if (nextIdx < locations.length) updateLocation(nextIdx)
+      locations(startIdx).state.modExt.indents.iterator.foreach(x =>
+        if (x.hasStateColumn) {
+          val indent = x.withStateOffset(0)
+          @tailrec
+          def updateLocation(idx: Int): Unit = {
+            val floc = locations(idx)
+            if (indent.notExpiredBy(floc.formatToken)) {
+              val state = floc.state
+              if (state.split.isNL) floc.state.indentation += offset
+              val nextIdx = idx + 1
+              if (nextIdx < locations.length) updateLocation(nextIdx)
+            }
           }
-        }
-        updateLocation(startIdx)
-      }
-    }
+          updateLocation(startIdx)
+        },
+      )
 
     private class ExtraBlankTokens {
       val extraBlankMap = new mutable.HashMap[Int, Int]

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Indent.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Indent.scala
@@ -2,7 +2,6 @@ package org.scalafmt.internal
 
 import scala.meta.tokens.{Token => T}
 
-import scala.annotation.tailrec
 import scala.language.implicitConversions
 
 sealed abstract class ExpiresOn {
@@ -65,7 +64,11 @@ case class ActualIndent(
 
 abstract class Indent {
   def switch(trigger: T, on: Boolean): Indent
-  def withStateOffset(offset: Int): Option[ActualIndent]
+
+  /** Returns `null` (rather than an `Option`) when there's no indent, to avoid
+    * a per-element allocation on the hot path in [[State.next]].
+    */
+  def withStateOffset(offset: Int): ActualIndent
   def hasStateColumn: Boolean
 }
 
@@ -89,9 +92,8 @@ private class IndentImpl(length: Length, expire: FT, expiresAt: ExpiresOn)
     extends Indent {
   override def hasStateColumn: Boolean = length eq Length.StateColumn
   override def switch(trigger: T, on: Boolean): Indent = this
-  override def withStateOffset(offset: Int): Option[ActualIndent] = Some(
-    ActualIndent(length.withStateOffset(offset), expire, expiresAt, length.reset),
-  )
+  override def withStateOffset(offset: Int): ActualIndent =
+    ActualIndent(length.withStateOffset(offset), expire, expiresAt, length.reset)
   override def toString: String = {
     val when = if (expiresAt == ExpiresOn.Before) '<' else '>'
     s"$length$when${expire.left}[${expire.idx}]"
@@ -109,7 +111,7 @@ object Indent {
   @inline
   def empty: Indent = Empty
   case object Empty extends Indent {
-    override def withStateOffset(offset: Int): Option[ActualIndent] = None
+    override def withStateOffset(offset: Int): ActualIndent = null
     override def switch(trigger: T, on: Boolean): Indent = this
     override def hasStateColumn: Boolean = false
   }
@@ -120,7 +122,7 @@ object Indent {
       if (trigger ne this.trigger) this
       else if (on) before
       else after.switch(trigger, false)
-    override def withStateOffset(offset: Int): Option[ActualIndent] = before
+    override def withStateOffset(offset: Int): ActualIndent = before
       .withStateOffset(offset)
     override def hasStateColumn: Boolean = before.hasStateColumn
     override def toString: String = s"$before>($trigger:${trigger.end})?$after"
@@ -137,17 +139,16 @@ object Indent {
   def after(trigger: T, indent: Indent): Indent =
     Switch(Indent.Empty, trigger, indent)
 
-  def getIndent(indents: Iterable[ActualIndent]): Int = {
-    val iter = indents.iterator
-    @tailrec
-    def run(indent: Int): Int =
-      if (!iter.hasNext) indent
-      else {
-        val actualIndent = iter.next()
-        val nextIndent = indent + actualIndent.length
-        if (actualIndent.reset) nextIndent else run(nextIndent)
-      }
-    run(0)
+  def getIndent(indents: Array[ActualIndent]): Int = {
+    var indent = 0
+    var i = 0
+    while (i < indents.length) {
+      val actualIndent = indents(i)
+      indent += actualIndent.length
+      if (actualIndent.reset) return indent
+      i += 1
+    }
+    indent
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
@@ -11,7 +11,7 @@ import scala.annotation.tailrec
   */
 case class ModExt(
     mod: Modification,
-    indents: Seq[Indent] = Nil,
+    indents: List[Indent] = Nil,
     altOpt: Option[ModExt] = None,
     noAltIndent: Boolean = false,
 ) {
@@ -76,31 +76,5 @@ case class ModExt(
       .flatMap(x => Some(x.switch(trigger, on)).filter(_ ne Indent.Empty))
     copy(indents = newIndents)
   }
-
-  /** This gap is necessary for pretty alignment multiline expressions on the
-    * right-side of enumerator. Without:
-    * ```
-    * for {
-    *   a <- new Integer {
-    *         value = 1
-    *       }
-    *   x <- if (variable) doSomething
-    *       else doAnything
-    * }
-    * ```
-    *
-    * With:
-    * ```
-    * for {
-    *   a <- new Integer {
-    *           value = 1
-    *        }
-    *   x <- if (variable) doSomething
-    *        else doAnything
-    * }
-    * ```
-    */
-  def getActualIndents(offset: Int): Iterator[ActualIndent] = indents.iterator
-    .flatMap(_.withStateOffset(offset + mod.length))
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptimizationEntities.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptimizationEntities.scala
@@ -12,13 +12,18 @@ import scala.reflect.ClassTag
 class OptimizationEntities(
     argumentStarts: Map[Int, Tree],
     optionalNewlines: Set[Int],
-    val statementStarts: Map[Int, Tree],
+    // indexed by token idx (null = absent); array, not boxed-Int Map, since
+    // `isStatementStart` is read per NL state in the search
+    statementStarts: Array[Tree],
     val semicolons: Map[Int, FT],
 ) {
   def argumentAt(idx: Int): Option[Tree] = argumentStarts.get(idx)
   def argument(implicit ft: FT): Option[Tree] = argumentAt(ft.meta.idx)
   def optionalNL(implicit ft: FT): Boolean = optionalNewlines(ft.meta.idx)
   def semicolonAfterStatement(idx: Int): Option[FT] = semicolons.get(idx)
+  def statementStart(idx: Int): Tree =
+    if (idx >= 0 && idx < statementStarts.length) statementStarts(idx) else null
+  def isStatementStart(idx: Int): Boolean = statementStart(idx) ne null
 }
 
 object OptimizationEntities {
@@ -34,7 +39,7 @@ object OptimizationEntities {
 
     private val arguments = mutable.Map.empty[Int, Tree]
     private val optional = Set.newBuilder[Int]
-    private val statements = Map.newBuilder[Int, Tree]
+    private val statements = new Array[Tree](ftoks.length)
     private val semicolons = Map.newBuilder[Int, FT]
 
     def build(): OptimizationEntities = {
@@ -48,7 +53,7 @@ object OptimizationEntities {
       new OptimizationEntities(
         arguments.toMap,
         optional.result(),
-        statements.result(),
+        statements,
         semicolons.result(),
       )
     }
@@ -93,7 +98,7 @@ object OptimizationEntities {
       if (stmt ne null) {
         val isComment = ft.left.is[T.Comment]
         val nft = if (isComment) ftoks.nextAfterNonComment(ft) else ft
-        statements += nft.meta.idx -> stmt
+        statements(nft.meta.idx) = stmt
       }
       prev.foreach { prev =>
         val pft = ftoks.prevNonCommentBefore(ft)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/PolicySummary.scala
@@ -5,32 +5,68 @@ import org.scalafmt.util.LoggerOps
 import scala.meta.classifiers._
 import scala.meta.tokens.{Token => T}
 
-class PolicySummary(val policies: Seq[Policy]) extends AnyVal {
+class PolicySummary(policies: Array[Policy], val numPolicies: Int) {
   import LoggerOps._
 
   @inline
-  def noDequeue = policies.exists(_.noDequeue)
+  def noDequeue: Boolean = exists(_.noDequeue)
 
   def combine(split: Split, nextft: FT): PolicySummary =
     if (nextft.right.is[T.EOF]) PolicySummary.empty
-    else new PolicySummary(
-      (split.policy +: policies).flatMap(_.unexpiredOpt(split, nextft))
-        .sortBy(_.rank),
-    )
-
-  def execute(decision: Decision, debug: Boolean = false): Seq[Split] = policies
-    .foldLeft(decision) { case (result, policy) =>
-      def withSplits(splits: Seq[Split]): Decision = {
-        if (debug) logger.debug(s"$policy defined at $result")
-        result.withSplits(splits)
+    else {
+      // `policies` is kept sorted by rank; filtering expired entries preserves
+      // that order, so we only need to (stable-)sort when adding a new policy.
+      val res = new Array[Policy](1 + numPolicies)
+      def add(p: Policy, idx: Int): Int = {
+        val u = p.unexpired(split, nextft)
+        if (u eq Policy.NoPolicy) idx else { res(idx) = u; idx + 1 }
       }
-      policy.f.andThen(withSplits _).applyOrElse(result, identity[Decision])
-    }.splits
+      val added = add(split.policy, 0)
+      var ridx = 0
+      var widx = added
+      while (ridx < numPolicies) {
+        widx = add(policies(ridx), widx)
+        ridx += 1
+      }
+      if (added > 0 && widx > 1) java.util.Arrays
+        .sort(res, 0, widx, PolicySummary.byRank)
+      new PolicySummary(res, widx)
+    }
 
-  @inline
-  def exists(f: Policy => Boolean): Boolean = policies.exists(f)
+  def execute(
+      ft: FT,
+      splits: Seq[Split],
+      debug: Boolean = false,
+  ): Seq[Split] = {
+    val result = Decision(ft, splits)
+    var idx = 0
+    while (idx < numPolicies) {
+      val policy = policies(idx)
+      idx += 1
+      val splits = policy.f.applyOrElse(result, (_: Decision) => null)
+      if (splits ne null) {
+        if (debug) logger.debug(s"$policy defined at $result")
+        result.splits = splits
+      }
+    }
+    result.splits
+  }
+
+  def exists(f: Policy => Boolean): Boolean = {
+    var idx = 0
+    while (idx < numPolicies) {
+      if (f(policies(idx))) return true
+      idx += 1
+    }
+    false
+  }
+
+  def toIterable: Iterable[Policy] = policies.view.take(numPolicies)
 }
 
 object PolicySummary {
-  val empty = new PolicySummary(Seq.empty)
+  val empty = new PolicySummary(Array.empty, 0)
+
+  private val byRank: java.util.Comparator[Policy] =
+    (a, b) => Integer.compare(a.rank, b.rank)
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -78,7 +78,7 @@ object SplitsNewline2X extends Splits {
 object SplitsBeforeStatement extends Splits { // New statement
   def get(implicit ft: FT, fo: FormatOps, cfg: ScalafmtConfig) = {
     import fo._, tokens._, ft._
-    if (optimizationEntities.statementStarts.contains(idx + 1)) {
+    if (optimizationEntities.isStatementStart(idx + 1)) {
       val annoRight = right.is[T.At]
       val annoLeft = isSingleIdentifierAnnotation(prev(ft))
 
@@ -1126,8 +1126,8 @@ object SplitsAfterSemicolon extends Splits {
       cfg: ScalafmtConfig,
   ): Seq[Split] = {
     import fo._, tokens._, ft._
-    optimizationEntities.statementStarts.get(idx + 1) match {
-      case Some(stmt) if !stmt.is[Term.EndMarker] =>
+    optimizationEntities.statementStart(idx + 1) match {
+      case stmt if (stmt ne null) && !stmt.is[Term.EndMarker] =>
         val noSpace = !cfg.newlines.okSpaceForSource(newlinesBetween) ||
           cfg.dialect.allowSignificantIndentation &&
           stmt.is[Case] && stmt.parent.forall {
@@ -3347,7 +3347,7 @@ object SplitsAfterCase extends Splits {
     val bodyIndent = if (bodyBlock) 0 else cfg.indent.main
     val arrowIndent = cfg.indent.caseSite - bodyIndent
     val indents =
-      Seq(Indent(bodyIndent, expire, After), Indent(arrowIndent, arrow, After))
+      List(Indent(bodyIndent, expire, After), Indent(arrowIndent, arrow, After))
     val mod = ModExt(Space, indents)
     val slbExpireOpt = prevNotTrailingComment(ownerEnd).toOption
     val policy = slbExpireOpt.fold(postArrowPolicy) { slbExpire =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -18,7 +18,7 @@ final class State(
     val depth: Int,
     val prev: State,
     var indentation: Int,
-    pushes: Seq[ActualIndent],
+    pushes: Array[ActualIndent],
     var column: Int,
     var pendingSpaces: List[Policy.End.WithPos],
     val appliedPenalty: Int, // penalty applied from overflow
@@ -62,41 +62,103 @@ final class State(
     val tok = tokens(depth)
     val right = tok.right
 
-    val (nextSplit, nextIndent, nextIndents) =
-      if (right.is[T.EOF]) (initialNextSplit, 0, Seq.empty)
-      else {
-        def getUnexpired(modExt: ModExt) = {
-          val extendedEnd = getRelativeToLhsLastLineEnd(modExt.isNL)
-          (modExt.getActualIndents(column) ++ pushes).flatMap(x =>
-            if (x.notExpiredBy(tok)) Some(x)
-            else extendedEnd
-              .map(y => x.copy(expire = y, expiresAt = ExpiresOn.After)),
-          ).toSeq
-        }
-
-        val initialModExt = initialNextSplit.modExt
-        val nextPushes = getUnexpired(initialModExt)
-        val nextIndent = Indent.getIndent(nextPushes)
-        initialModExt.altOpt.flatMap(alt =>
-          if (tok.left.is[T.Comment]) None
-          else if (nextIndent < alt.mod.length + column) None
-          else if (initialModExt.noAltIndent) Some(alt)
-          else Some(alt.withIndents(initialModExt.indents)),
-        ).fold((initialNextSplit, nextIndent, nextPushes)) { alt =>
-          val altPushes = getUnexpired(alt)
-          val altIndent = Indent.getIndent(altPushes)
-          val split = initialNextSplit.withMod(alt)
-          (split, altIndent, altPushes)
+    // vars (not a Tuple3-valued val) to avoid a per-state tuple alloc on the
+    // hot path; the declared defaults are the EOF case.
+    var nextSplit: Split = initialNextSplit
+    var nextIndent: Int = 0
+    var nextIndents: Array[ActualIndent] = State.noIndents
+    if (!right.is[T.EOF]) {
+      // Build the next indents into one pre-sized array (this runs per state
+      // transition); avoids the ListBuffer + per-element cons cells the old
+      // `List.newBuilder` allocated. The element logic is INLINED at both
+      // sources (not a nested `def add`) on purpose: a nested closure would
+      // capture the `k`/`end` vars and allocate an Int/ObjectRef holder per
+      // call. `end` sentinels: `nullFT` = relative-end not yet computed
+      // (computed at most once, on first expiry), `null` = computed-but-none,
+      // else the FT. `out` is over-sized by the upper bound and trimmed only
+      // when something actually expired (the common case adds everything).
+      def getUnexpired(modExt: ModExt): Array[ActualIndent] = {
+        val srcIndents = modExt.indents
+        val maxSize = srcIndents.length + pushes.length
+        if (maxSize == 0) State.noIndents
+        else {
+          val out = new Array[ActualIndent](maxSize)
+          var k = 0
+          var end: FT = State.nullFT
+          // indents are taken relative to the column *after* this token's mod
+          // (hence `+ mod.length`); that extra gap pretty-aligns continuation
+          // lines of a multiline expression on an enumerator's RHS, e.g. the
+          // `else` of `x <- if (cond) a else b` in a `for` comprehension
+          val offset = column + modExt.mod.length
+          var indents = srcIndents
+          while (indents ne Nil) {
+            // `withStateOffset` returns null when there's no actual indent
+            val x = indents.head.withStateOffset(offset)
+            if (x ne null)
+              if (x.notExpiredBy(tok)) { out(k) = x; k += 1 }
+              else {
+                if (end eq State.nullFT)
+                  end = getRelativeToLhsLastLineEnd(modExt.isNL)
+                if (end ne null) {
+                  out(k) = x.copy(expire = end, expiresAt = ExpiresOn.After)
+                  k += 1
+                }
+              }
+            indents = indents.tail
+          }
+          var i = 0
+          while (i < pushes.length) {
+            val x = pushes(i)
+            if (x.notExpiredBy(tok)) { out(k) = x; k += 1 }
+            else {
+              if (end eq State.nullFT)
+                end = getRelativeToLhsLastLineEnd(modExt.isNL)
+              if (end ne null) {
+                out(k) = x.copy(expire = end, expiresAt = ExpiresOn.After)
+                k += 1
+              }
+            }
+            i += 1
+          }
+          if (k == maxSize) out
+          else if (k == 0) State.noIndents
+          else java.util.Arrays.copyOf(out, k)
         }
       }
 
-    val (prevPendingSpaces, confirmedSpaces) =
-      if (nextSplit.isNL) Nil -> pendingSpaces.count(_.notExpiredBy(tok))
-      else pendingSpaces.filter(_.notExpiredBy(tok)) -> 0
-    val (nextPendingSpaces, modLength) = nextSplit.mod match {
-      case SpaceOrNoSplit(p) if p.notExpiredBy(tok) =>
-        (p :: prevPendingSpaces, 0)
-      case m => (prevPendingSpaces, m.length)
+      val initialModExt = initialNextSplit.modExt
+      val nextPushes = getUnexpired(initialModExt)
+      val initIndent = Indent.getIndent(nextPushes)
+      initialModExt.altOpt.flatMap(alt =>
+        if (tok.left.is[T.Comment]) None
+        else if (initIndent < alt.mod.length + column) None
+        else if (initialModExt.noAltIndent) Some(alt)
+        else Some(alt.withIndents(initialModExt.indents)),
+      ) match {
+        case Some(alt) =>
+          nextIndents = getUnexpired(alt)
+          nextIndent = Indent.getIndent(nextIndents)
+          nextSplit = initialNextSplit.withMod(alt)
+        case None =>
+          nextIndent = initIndent
+          nextIndents = nextPushes
+      }
+    }
+
+    // vars instead of tuple-valued vals: avoids a Tuple2 alloc per next() on
+    // the hottest path (the tuples never escape, but don't rely on EA here)
+    var confirmedSpaces = 0
+    val prevPendingSpaces: List[Policy.End.WithPos] =
+      if (nextSplit.isNL) {
+        confirmedSpaces = pendingSpaces.count(_.notExpiredBy(tok))
+        Nil
+      } else pendingSpaces.filter(_.notExpiredBy(tok))
+    var modLength = 0
+    val nextPendingSpaces = nextSplit.mod match {
+      case SpaceOrNoSplit(p) if p.notExpiredBy(tok) => p :: prevPendingSpaces
+      case m =>
+        modLength = m.length
+        prevPendingSpaces
     }
 
     // Some tokens contain newline, like multiline strings/comments.
@@ -282,47 +344,51 @@ final class State(
 
   private def getRelativeToLhsLastLineEnd(
       isNL: Boolean,
-  )(implicit style: ScalafmtConfig, tokens: FormatTokens): Option[FT] = {
+  )(implicit style: ScalafmtConfig, tokens: FormatTokens): FT = {
     val allowed = style.indent.relativeToLhsLastLine
 
     def treeEnd(x: Tree) = tokens.getLast(x)
-    def indentEnd(ft: FT, isNL: Boolean)(onComment: => Option[FT]) = {
+    def indentEnd(ft: FT, isNL: Boolean) = {
       val leftOwner = ft.meta.leftOwner
       ft.left match {
         case _: T.KwMatch
             if leftOwner.is[Term.Match] &&
               allowed.contains(Indents.RelativeToLhs.`match`) =>
-          Some(treeEnd(leftOwner))
+          treeEnd(leftOwner)
         case _: T.Ident if !isNL =>
           leftOwner.parent match {
             case Some(p: Term.ApplyInfix)
                 if p.op.eq(leftOwner) &&
-                  allowed.contains(Indents.RelativeToLhs.`infix`) =>
-              Some(treeEnd(p))
-            case _ => None
+                  allowed.contains(Indents.RelativeToLhs.`infix`) => treeEnd(p)
+            case _ => null
           }
-        case _: T.Comment if !isNL => onComment
-        case _ => None
+        case _ => null
       }
     }
 
     val tok = tokens(depth)
     val right = tok.right
-    if (allowed.isEmpty) None
-    else if (!isNL && right.is[T.Comment]) Some(tokens.next(tok))
-    else indentEnd(tok, isNL) {
-      val earlierState = prev.prevNonCommentSameLine
-      indentEnd(tokens(earlierState.depth), earlierState.split.isNL)(None)
-    }.orElse {
-      val delay = !isNL &&
-        (right match {
+    if (allowed.isEmpty) null
+    else if (!isNL && right.is[T.Comment]) tokens.next(tok)
+    else {
+      val end =
+        if (!tok.left.is[T.Comment]) indentEnd(tok, isNL)
+        else if (isNL) null
+        else {
+          val earlierState = prev.prevNonCommentSameLine
+          indentEnd(tokens(earlierState.depth), earlierState.split.isNL)
+        }
+      if ((end ne null) || isNL) end
+      else {
+        val delay = right match {
           case _: T.KwMatch => tok.meta.rightOwner.is[Term.Match] &&
             allowed.contains(Indents.RelativeToLhs.`match`)
           case _: T.Ident => tok.meta.rightOwner.parent.is[Term.ApplyInfix] &&
             allowed.contains(Indents.RelativeToLhs.`infix`)
           case _ => false
-        })
-      if (delay) Some(tokens.next(tok)) else None
+        }
+        if (delay) tokens.next(tok) else null
+      }
     }
   }
 
@@ -334,6 +400,9 @@ final class State(
 
 object State {
 
+  // shared empty indents array (immutable when empty, safe to share per state)
+  private val noIndents = new Array[ActualIndent](0)
+
   val start: State = new State(
     cost = 0,
     policy = PolicySummary.empty,
@@ -341,7 +410,7 @@ object State {
     depth = 0,
     prev = null,
     indentation = 0,
-    pushes = Nil,
+    pushes = noIndents,
     column = 0,
     pendingSpaces = Nil,
     appliedPenalty = 0,
@@ -392,7 +461,7 @@ object State {
     private def compareSplitOrigin(s1: State, s2: State): Int = {
       // We assume the same number of splits, see compareSplitsLength
       // Break ties by the last split's line origin.
-      val r = s1.split.rank.compare(s2.split.rank)
+      val r = Integer.compare(s1.split.rank, s2.split.rank)
       if (r != 0) r
       else {
         val r = s1.split.fileLineStack.compare(s2.split.fileLineStack)
@@ -534,4 +603,5 @@ object State {
   private def isWithinInterpolation(tree: Tree): Boolean =
     findTreeOrParentSimple(tree)(isInterpolation).isDefined
 
+  private val nullFT = FT(null, null, null)
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/LoggerOps.scala
@@ -28,10 +28,11 @@ object LoggerOps {
 
   def log(s: State, indent: String = "", nlIndices: Boolean = true): String = {
     val delim = s"\n$indent  "
-    val policies = s.policy.policies match {
-      case Nil => ""
-      case p :: Nil => s";${delim}P($p)"
-      case pp => pp.map(_.toString).mkString(s";${delim}P[", s",$delim  ", s"]")
+    val policies = s.policy.numPolicies match {
+      case 0 => ""
+      case 1 => s";${delim}P(${s.policy.toIterable.head})"
+      case _ => s.policy.toIterable.map(_.toString)
+          .mkString(s";${delim}P[", s",$delim  ", s"]")
     }
     @tailrec
     def getNlIndices(x: State, res: List[String]): List[String] =

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -11,7 +11,6 @@ import scala.meta.classifiers.Classifier
 import scala.meta.tokens.{Token => T, Tokens}
 
 import scala.annotation.tailrec
-import scala.collection.immutable.HashMap
 import scala.collection.mutable
 
 /** Stateless helper functions on `scala.meta.Tree`.
@@ -791,17 +790,20 @@ object TreeOps {
   def getStyleAndOwners(
       topSourceTree: Tree,
       baseStyle: ScalafmtConfig,
-  ): (ScalafmtConfig, collection.Map[TokenHash, Tree]) = {
+  ): (ScalafmtConfig, Array[Tree]) = {
     var termInfixCount = 0
     var typeInfixCount = 0
     var patInfixCount = 0
-    // Creates lookup table from token offset to its closest scala.meta tree
-    val ownersMap = HashMap.newBuilder[TokenHash, Tree]
-    @inline
-    def setOwner(tok: T, tree: Tree): Unit = ownersMap += hash(tok) -> tree
-
     val allTokens = topSourceTree.tokens
-    var prevParens: List[T] = Nil
+    // Lookup table from token index to its closest scala.meta tree. Token
+    // indices are dense (== position in `allTokens`), so an array beats a
+    // boxed-Long-keyed map and skips per-token hashing; every token gets an
+    // owner, so the array is no sparser than the map was.
+    val ownersArr = new Array[Tree](allTokens.length)
+    @inline
+    def setOwner(idx: Int, tree: Tree): Unit = ownersArr(idx) = tree
+
+    var prevParens: List[Int] = Nil
 
     def treeAt(
         elemIdx: Int,
@@ -819,21 +821,30 @@ object TreeOps {
 
       val treeBeg = elemBeg.start
       val treeEnd = elemEnd.end
+      // Explicit loop (not a for-comprehension, which allocates a binding-tuple
+      // per `x = ...` step) + `sortWith` (primitive `<`, no Int boxing like
+      // `sortBy`); `sortWith` is stable, so equal-start children keep order.
       val allChildren: List[(Tree, T, T)] = {
-        for {
-          x <- elem.children
-          tokens = x.tokens if tokens.nonEmpty
-          beg = tokens.head if beg.start >= treeBeg // sometimes with implicit
-          end = tokens.last if end.end <= treeEnd
-        } yield (x, beg, end)
-      }.sortBy(_._2.start)
+        val buf = List.newBuilder[(Tree, T, T)]
+        elem.children.foreach { x =>
+          val tokens = x.tokens
+          if (tokens.nonEmpty) {
+            val beg = tokens.head
+            if (beg.start >= treeBeg) { // sometimes with implicit
+              val end = tokens.last
+              if (end.end <= treeEnd) buf += ((x, beg, end))
+            }
+          }
+        }
+        buf.result()
+      }.sortWith(_._2.start < _._2.start)
 
       allChildren match {
         case Nil =>
           @tailrec
           def tokenAt(idx: Int): Int = {
             val tok = allTokens(idx)
-            setOwner(tok, elem)
+            setOwner(idx, elem)
             val nextIdx = idx + 1
             if (tok eq elemEnd) nextIdx else tokenAt(nextIdx)
           }
@@ -846,7 +857,7 @@ object TreeOps {
           var children = rest
           var prevChild: Tree = null
           var prevLPs = outerPrevLPs
-          var prevComma: T = null
+          var prevComma: Int = -1
 
           @tailrec
           def tokenAt(idx: Int): Int =
@@ -865,7 +876,7 @@ object TreeOps {
                     nextChildBeg = beg
                     nextChildEnd = end
                 }
-                prevComma = null
+                prevComma = -1
                 tokenAt(nextIdx)
               } else {
                 def excludeRightParen: Boolean = elem match {
@@ -881,26 +892,26 @@ object TreeOps {
 
                 if (prevParens.nonEmpty && tok.is[T.RightParen]) {
                   if (prevChild == null || prevLPs <= 0 || excludeRightParen)
-                    setOwner(tok, elem)
+                    setOwner(idx, elem)
                   else {
-                    setOwner(tok, prevChild)
+                    setOwner(idx, prevChild)
                     setOwner(prevParens.head, prevChild)
-                    if (prevComma != null) setOwner(prevComma, prevChild)
+                    if (prevComma >= 0) setOwner(prevComma, prevChild)
                   }
                   prevLPs -= 1
                   prevParens = prevParens.tail
-                  prevComma = null
+                  prevComma = -1
                 } else if (tok.is[T.Comma]) {
-                  prevComma = tok
-                  setOwner(tok, elem)
+                  prevComma = idx
+                  setOwner(idx, elem)
                 } else {
-                  setOwner(tok, elem)
+                  setOwner(idx, elem)
                   if (!tok.is[T.Trivia] && !tok.isEmpty) {
-                    prevComma = null
+                    prevComma = -1
                     prevChild = null
                     if (tok.is[T.LeftParen]) {
                       prevLPs += 1
-                      prevParens = tok :: prevParens
+                      prevParens = idx :: prevParens
                     } else prevLPs = 0
                   }
                 }
@@ -921,7 +932,7 @@ object TreeOps {
     val initStyle =
       if (ok) baseStyle
       else baseStyle.copy(newlines = checkedNewlines, runner = checkedRunner)
-    (initStyle, ownersMap.result())
+    (initStyle, ownersArr)
   }
 
   def isFewerBraces(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/Debug.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/Debug.scala
@@ -89,8 +89,8 @@ object Debug {
       if (null != completedEvent.best) {
         val sb = new StringBuilder()
         sb.append("Best splits:")
-        completedEvent.best.values.toSeq.sortBy(_.depth).take(5)
-          .foreach(state => sb.append("\n\t").append(log(state)))
+        completedEvent.best.iterator.filter(_ ne null).toSeq.sortBy(_.depth)
+          .take(5).foreach(state => sb.append("\n\t").append(log(state)))
         sb.append("\n")
         logger.debug(sb.toString())
       }


### PR DESCRIPTION
Reduce allocation on the best-first search / State.next / route-building paths by swapping boxed Scala collections and multi-value returns for primitives:

- boxed-Int Map/Set/List -> Array / immutable.BitSet / mutable.LongMap / open-addressing Long->Int map: owners map, token-to-index map, memo tables, noOptZones (Array[Byte]), best (Array[State]), forceConfigStyle/ emptyQueueSpots (BitSet), statementStarts (Array[Tree]), routes (pre-sized array), per-state indents (Array not List).
- drop multi-value/aux allocations: array-backed PolicySummary.combine without per-policy Option; State.next indents without per-element Option; skip the Decision alloc/sort in getActiveSplits; no event-thunk alloc when there is no listener; unbox Ordering.compareSplitOrigin; treeAt children without for-comp/sortBy boxing; drop pendingSpaces tuples and per-state Tuple2/Tuple3 returns.

Byte-identical output; 2.12/2.13/3.