### PR TITLE
use tree.begOffset/endOffset/foreachChild

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -233,7 +233,7 @@ class FormatOps(
       trees: Seq[Tree],
       func: TemplateSupertypeGroup => A,
   )(expireFunc: Seq[Tree] => FT)(implicit ft: FT): Option[A] = trees
-    .find(_.pos.end >= ft.right.end)
+    .find(_.endOffset >= ft.right.end)
     .map(x => func(TemplateSupertypeGroup(x, trees, expireFunc)))
 
   def findTemplateGroupOnRight[A](
@@ -281,7 +281,7 @@ class FormatOps(
           ft.leftOwner.is[Term.Block] && ft.left.is[T.RightBrace] &&
           !prevNonCommentSameLineBefore(ft).left.is[T.LeftBrace] &&
           matchingOptLeft(ft)
-            .exists(lb => prev(lb).left.start < term.thenp.pos.start)
+            .exists(lb => prev(lb).left.start < term.thenp.begOffset)
         }
         if (ok) Some(ft) else None
       case _ => None
@@ -398,7 +398,7 @@ class FormatOps(
         case _: T.LeftBrace => matchingOptRight(ft)
         case _ => None
       }) match {
-        case Some(cft) if cft.right.end >= app.arg.pos.end =>
+        case Some(cft) if cft.right.end >= app.arg.endOffset =>
           sourceIgnoredSplits
             .map(s => if (s.isNL) s.copy(cost = 0, rank = -1) else s)
         case _ => withIndent(nl(1))
@@ -630,7 +630,7 @@ class FormatOps(
         }
       case _ => Nil
     }
-    val allParenOwners = allClauses.filter(_.pos.start > open.start)
+    val allParenOwners = allClauses.filter(_.begOffset > open.start)
     val allOwners = lpOwner +: allParenOwners
 
     // find the last param on the defn so that we can apply our `policy`
@@ -1268,7 +1268,7 @@ class FormatOps(
       tbounds: Type.Bounds,
       bounds: => Seq[Type],
   )(implicit style: ScalafmtConfig, ft: FT): Seq[Split] = {
-    val boundOpt = bounds.find(_.pos.start > ft.right.end)
+    val boundOpt = bounds.find(_.begOffset > ft.right.end)
     val expireOpt = boundOpt.map(getLastNonTrivial)
     getSplitsForTypeBounds(noNLMod, tbounds, expireOpt)
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1291,19 +1291,18 @@ class FormatWriter(formatOps: FormatOps) {
                   isSlc,
                 )
                 if (alignContainer eq null) alignContainer = container
-                else if (alignContainer ne container) {
-                  val pos1 = alignContainer.pos
+                else if (alignContainer ne container)
                   if (isSlc) {
                     val prevFt = prevNonCommentSameLine(ft)
-                    if (pos1.end >= prevFt.left.end) appendCandidate()
-                  } else {
-                    val pos2 = container.pos
-                    if (pos2.start <= pos1.start && pos2.end >= pos1.end) {
-                      alignContainer = container
-                      columnCandidates.clear()
-                    }
+                    if (alignContainer.endOffset >= prevFt.left.end)
+                      appendCandidate()
+                  } else if (
+                    container.begOffset <= alignContainer.begOffset &&
+                    container.endOffset >= alignContainer.endOffset
+                  ) {
+                    alignContainer = container
+                    columnCandidates.clear()
                   }
-                }
                 if (alignContainer eq container) appendCandidate()
               }
               processLine(wasSlc = isSlc)
@@ -1487,7 +1486,7 @@ class FormatWriter(formatOps: FormatOps) {
       ): Unit = {
         val (nest, isTop) = getNest(Some(owner))
         if (nest < 0) return
-        val end = owner.pos.end
+        val end = owner.endOffset
         def setStat(
             stat: Tree,
             idx: Int,
@@ -1586,7 +1585,7 @@ class FormatWriter(formatOps: FormatOps) {
         val ft = getLast(stats.last)
         val nl = locations(ft.meta.idx).style.newlines
         if (insideBody(stats, nl, Newlines.after))
-          setFt(trailingComment(ft, owner.pos.end))
+          setFt(trailingComment(ft, owner.endOffset))
       }
 
       private def traverse(tree: Tree): Unit = tree.dfsIf(traverseFunc)
@@ -1883,7 +1882,8 @@ object FormatWriter {
           case (false, false) =>
             val isMatchPossible = sameOwner &&
               (floc.style.align.multiline ||
-                refStop.ft.rightOwner.pos.end <= curStop.ft.rightOwner.pos.start)
+                refStop.ft.rightOwner.endOffset <=
+                curStop.ft.rightOwner.begOffset)
             if (isMatchPossible) {
               val cmpDepth = Integer.compare(refStop.depth, curStop.depth)
               if (0 < cmpDepth) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/InfixSplits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/InfixSplits.scala
@@ -180,7 +180,7 @@ class InfixSplits(
   private val isLeftInfix = leftInfix eq app
   private val isAfterOp = ft.meta.leftOwner eq app.op
   private val appPrecedence = app.precedence
-  private val beforeLhs = !isAfterOp && ft.left.start < app.pos.start
+  private val beforeLhs = !isAfterOp && ft.left.start < app.begOffset
   private val isFirstOp = beforeLhs || isLeftInfix && isAfterOp
   private val fullExpire = ftoks
     .nextNonCommentSameLine(ftoks.getLastExceptParen(fullInfix))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptimizationEntities.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptimizationEntities.scala
@@ -43,12 +43,13 @@ object OptimizationEntities {
     private val semicolons = Map.newBuilder[Int, FT]
 
     def build(): OptimizationEntities = {
-      val queue = new mutable.ListBuffer[Seq[Tree]]
-      queue += topSourceTree :: Nil
-      while (queue.nonEmpty) queue.remove(0).foreach { tree =>
+      val queue = new mutable.ListBuffer[Tree]
+      queue += topSourceTree
+      while (queue.nonEmpty) {
+        val tree = queue.remove(0)
         processForArguments(tree)
         processForStatements(tree)
-        queue += tree.children
+        tree.foreachChild(queue += _)
       }
       new OptimizationEntities(
         arguments.toMap,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptionalBraces.scala
@@ -249,7 +249,7 @@ object OptionalBraces {
       def createImpl(tb: Tree.Block, ownerOpt: => Option[Tree]) =
         if (
           nft.right.is[T.LeftBrace] && (nft.meta.rightOwner eq tb) ||
-          tb.pos.start > nft.right.start
+          tb.begOffset > nft.right.start
         ) None
         else Some(new OptionalBraces {
           def owner = ownerOpt
@@ -402,8 +402,8 @@ object OptionalBraces {
     ): Option[OptionalBraces] = ft.meta.leftOwner match {
       case t: Term.While => t.expr match {
           case b: Term.Block
-              if isMultiStatBlock(b) &&
-                !ftoks.matchingOptRight(nft).exists(_.left.end >= b.pos.end) =>
+              if isMultiStatBlock(b) && !ftoks.matchingOptRight(nft)
+                .exists(_.left.end >= b.endOffset) =>
             Some(new OptionalBraces {
               def owner = Some(t)
               def block: Tree = b
@@ -590,7 +590,7 @@ object OptionalBraces {
     ): Option[OptionalBraces] = ft.meta.leftOwner match {
       case t: Term.If => t.cond match {
           case b: Term.Block if (ftoks.matchingOptRight(nft) match {
-                case Some(t) => t.left.end < b.pos.end
+                case Some(t) => t.left.end < b.endOffset
                 case None => isMultiStatBlock(b)
               }) =>
             Some(new OptionalBraces {
@@ -754,7 +754,7 @@ object OptionalBraces {
       case _: T.LeftBrace => false
       case _ => !isTreeSingleExpr(thenp) &&
         (!before.right.is[T.LeftBrace] || matchingOptRight(before)
-          .exists(_.left.end < thenp.pos.end))
+          .exists(_.left.end < thenp.endOffset))
     }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -767,14 +767,13 @@ object SplitsBeforeLeftBrace extends Splits {
       def maybeBracesToParens()(implicit fl: FileLine) =
         maybeBracesToParensWithRB(matchingRight(ft))
       // partial initial expr
-      val roPos = rightOwner.pos
-      if (!isTokenHeadOrBefore(right, roPos)) maybeBracesToParens()
+      if (!isTokenHeadOrBefore(right, rightOwner)) maybeBracesToParens()
       else rightOwner.parent.fold(Seq.empty[Split]) {
         case _: Term.ApplyInfix => Seq.empty // exclude start of infix
         case _: Term.ArgClause => maybeBracesToParens()
         case p => matchingOptRight(ft).fold(Seq.empty[Split]) { rb =>
             val ko = isTokenHeadOrBefore(right, p) &&
-              isTokenLastOrAfter(rb.left, roPos)
+              isTokenLastOrAfter(rb.left, rightOwner)
             if (ko) Seq.empty else maybeBracesToParensWithRB(rb)
           }
       }
@@ -1046,7 +1045,7 @@ object SplitsBeforeRightArrow extends Splits {
             val nlOnly = !cfg.newlines.sourceIgnored && hasBreak
             def spaceSplit(implicit fl: FileLine) = Split(nlOnly, 0)(Space)
             val nextParamClause = (pcg.tparamClause +: pcg.paramClauses).find(
-              _.pos.end > right.end,
+              _.endOffset > right.end,
             ).orElse(gvn.paramClauseGroups.dropWhile(_ ne pcg) match {
               case `pcg` :: pcgNext :: _ =>
                 val tpc = pcgNext.tparamClause
@@ -1359,7 +1358,7 @@ object SplitsBeforeLeftBracket extends Splits {
       fo: FormatOps,
       cfg: ScalafmtConfig,
   ): Seq[Split] =
-    if (!ft.rightOwner.parent.exists(_.pos.start < ft.right.start)) Seq.empty
+    if (!ft.rightOwner.parent.exists(_.begOffset < ft.right.start)) Seq.empty
     else Seq(Split(Space(!ft.leftOwner.is[Mod.WithWithin]), 0))
 }
 
@@ -1412,7 +1411,8 @@ object SplitsAfterTemplateKeyword extends Splits {
       case lo: Stat.WithTemplate =>
         import lo._
         val policy = Policy ?
-          (cfg.binPack.keepParentConstructors || templ.pos.isEmpty) || {
+          (cfg.binPack.keepParentConstructors ||
+            templ.begOffset == templ.endOffset) || {
             val expire = templateDerivesOrCurlyOrLastNonTrivial(templ)
             val forceNewlineBeforeExtends = Policy.beforeLeft(expire, "NLPCTOR") {
               case Decision(FT(_, soft.ExtendsOrDerives(), m), s)
@@ -2960,7 +2960,7 @@ object SplitsBeforeWith extends Splits {
       case t: Template
           if t.parent.isAny[Term.New, Term.NewAnonymous, Defn.Given] =>
         val (isFirstCtor, extendsThenWith) = t.inits match {
-          case _ :: x :: _ => (x.pos.start > ft.right.start, true)
+          case _ :: x :: _ => (x.begOffset > ft.right.start, true)
           case _ => (false, false)
         }
         binPackParentConstructorSplits(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -36,7 +36,7 @@ class SortModifiers(implicit ctx: RewriteCtx) extends RewriteSession {
     case o: Defn.Object => sortMods(o.mods.filterNot(_.is[Mod.Case]))
     case s: Stat.WithMods => sortMods(s.mods)
     case p: Term.Param =>
-      val start = p.pos.start
+      val start = p.begOffset
       sortMods(p.mods.filterNot(m =>
         m.isAny[Mod.ValParam, Mod.VarParam, Mod.Using, Mod.Erased] ||
           TreeOps.noExplicitImplicit(start, orElse = false)(m),

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -90,12 +90,10 @@ class StyleMap(tokens: FormatTokens, initStyle: ScalafmtConfig) {
   private def isSimpleLiteral(tree: Tree): Boolean = tree match {
     case t: Term.SelectLike => isSimpleLiteral(t.qual)
     case t: Term.Assign => isSimpleLiteral(t.rhs)
-    case _ => isBasicLiteral(tree) ||
-      (tree.children match {
-        case Nil => true
-        case one :: Nil => isSimpleLiteral(one)
-        case _ => false
-      })
+    case _ => isBasicLiteral(tree) || {
+        val child = getSingleChild(tree)
+        (child eq Tree.NoTree) || (child ne null) && isSimpleLiteral(child)
+      }
   }
 
   @tailrec
@@ -113,12 +111,10 @@ class StyleMap(tokens: FormatTokens, initStyle: ScalafmtConfig) {
         case Term.ArgClause(arg :: Nil, None) :: Nil => isComplexLiteral(arg)
         case _ => false
       })
-    case _ => isSimpleLiteral(tree) ||
-      (tree.children match {
-        case Nil => true
-        case one :: Nil => isComplexLiteral(one)
-        case _ => false
-      })
+    case _ => isSimpleLiteral(tree) || {
+        val child = getSingleChild(tree)
+        (child eq Tree.NoTree) || (child ne null) && isComplexLiteral(child)
+      }
   }
 
   private def opensLiteralArgumentList(
@@ -164,5 +160,14 @@ object StyleMap {
   def setBinPack(curr: ScalafmtConfig, callSite: BinPack.Site): ScalafmtConfig =
     if (curr.binPack.callSite == callSite) curr
     else curr.copy(binPack = curr.binPack.copy(callSite = callSite))
+
+  private def getSingleChild(tree: Tree): Tree = {
+    var singleChild = Tree.NoTree
+    tree.foreachChild { child =>
+      if (singleChild ne null)
+        singleChild = if (singleChild eq Tree.NoTree) child else null
+    }
+    singleChild
+  }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -274,19 +274,11 @@ object TreeOps {
   }
 
   @inline
-  def isTokenHeadOrBefore(token: T, owner: Tree): Boolean =
-    isTokenHeadOrBefore(token, owner.pos)
-
-  @inline
-  def isTokenHeadOrBefore(token: T, pos: Position): Boolean = pos.start >=
+  def isTokenHeadOrBefore(token: T, owner: Tree): Boolean = owner.begOffset >=
     token.start
 
   @inline
-  def isTokenLastOrAfter(token: T, owner: Tree): Boolean =
-    isTokenLastOrAfter(token, owner.pos)
-
-  @inline
-  def isTokenLastOrAfter(token: T, pos: Position): Boolean = pos.end <=
+  def isTokenLastOrAfter(token: T, owner: Tree): Boolean = owner.endOffset <=
     token.end
 
   def isArgClauseSite(tree: Tree): Boolean = tree match {
@@ -593,8 +585,8 @@ object TreeOps {
     * `var i3` has a ``Mod.Implicit`` which is included.
     */
   def noExplicitImplicit(m: Mod.Implicit, ownerStart: Int): Boolean = {
-    val modPos = m.pos
-    modPos.start < ownerStart || modPos.isEmpty
+    val beg = m.begOffset
+    beg < ownerStart || beg == m.endOffset
   }
 
   def noExplicitImplicit(ownerStart: Int, orElse: Boolean)(m: Mod): Boolean =
@@ -604,7 +596,7 @@ object TreeOps {
     }
 
   def noExplicitImplicit(param: Term.Param): Boolean = {
-    val pStart = param.pos.start
+    val pStart = param.begOffset
     param.mods.forall(noExplicitImplicit(pStart, true))
   }
 
@@ -661,7 +653,7 @@ object TreeOps {
   }
 
   def findArgAfter(end: Int, trees: Seq[Tree]): Option[Tree] = trees
-    .find(_.pos.start >= end)
+    .find(_.begOffset >= end)
 
   def getStripMarginCharForInterpolate(tree: Tree): Option[Char] =
     findInterpolate(tree).flatMap(getStripMarginChar)
@@ -769,22 +761,28 @@ object TreeOps {
   def findEnclosedBetweenParens(lt: T, rt: T, tree: Tree): Option[Tree] = {
     val beforeParens = lt.start
     val afterParens = rt.end
-    @tailrec
-    def iter(trees: List[Tree]): Option[Tree] = trees match {
-      case head :: rest =>
-        val headPos = head.pos
-        val headEnd = headPos.end
-        if (headEnd <= beforeParens) iter(rest)
-        else if (
-          headEnd <= afterParens && headPos.start < headEnd &&
-          rest.headOption.forall(_.pos.start >= afterParens)
-        ) Some(head)
-        else None
-      case _ => None
+    val found = beforeParens <= tree.begOffset && tree.endOffset <= afterParens
+    if (found) Some(tree)
+    else {
+      // `result` (null until decided) + a decided-flag avoids a non-local return
+      // out of the `foreachChild` closure (which would allocate/throw a
+      // NonLocalReturnControl); we just skip work once decided.
+      var candidate: Tree = null
+      var result: Option[Tree] = null
+      tree.foreachChild { child =>
+        if (result eq null)
+          if (candidate ne null) result =
+            if (child.begOffset >= afterParens) Some(candidate) else None
+          else {
+            val headEnd = child.endOffset
+            if (headEnd > beforeParens)
+              if (headEnd > afterParens || child.begOffset >= headEnd)
+                result = None
+              else candidate = child
+          }
+      }
+      if (result ne null) result else Option(candidate)
     }
-    val pos = tree.pos
-    val found = beforeParens <= pos.start && pos.end <= afterParens
-    if (found) Some(tree) else iter(tree.children)
   }
 
   def getStyleAndOwners(
@@ -826,7 +824,7 @@ object TreeOps {
       // `sortBy`); `sortWith` is stable, so equal-start children keep order.
       val allChildren: List[(Tree, T, T)] = {
         val buf = List.newBuilder[(Tree, T, T)]
-        elem.children.foreach { x =>
+        elem.foreachChild { x =>
           val tokens = x.tokens
           if (tokens.nonEmpty) {
             val beg = tokens.head


### PR DESCRIPTION
scalameta's Tree.begOffset/endOffset read the offsets directly from Origin without forcing (allocating) the tree's Position. Swept the hot readers (FormatOps/FormatWriter/InfixSplits/OptionalBraces/Splits/SortModifiers/ TreeOps) that only needed the offsets.

Similarly, the new .foreachChild avoids allocation of children List.