### PR TITLE
Splits/Router dispatch: ju.HashMap lookup + null/empty-Seq cascade

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1207,16 +1207,16 @@ class FormatWriter(formatOps: FormatOps) {
         val isMultiline = styleMap.init.align.multiline
 
         // all blocks must be here, to get final flush
-        val blocks = new mutable.HashMap[Tree, AlignBlock]
-        def createBlock(x: Tree) = blocks.getOrElseUpdate(x, new AlignBlock)
+        val blocks = new java.util.HashMap[Tree, AlignBlock]
+        def createBlock(x: Tree) = blocks.computeIfAbsent(x, _ => new AlignBlock)
         var prevAlignContainer: Tree = null
         var prevBlock: AlignBlock = if (isMultiline) null else createBlock(null)
         val getOrCreateBlock: Tree => AlignBlock =
           if (isMultiline) createBlock else _ => prevBlock
-        val getBlockToFlush: (=> Tree, Boolean) => Option[AlignBlock] =
+        val getBlockToFlush: (=> Tree, Boolean) => AlignBlock =
           if (isMultiline) // don't flush unless blank line
-            (x, isBlankLine) => if (isBlankLine) blocks.get(x) else None
-          else (_, _) => Some(prevBlock)
+            (x, isBlankLine) => if (isBlankLine) blocks.get(x) else null
+          else (_, _) => prevBlock
         val shouldFlush: Tree => Boolean =
           if (!isMultiline) _ => true else (x: Tree) => x eq prevAlignContainer
         val wasSameContainer: Tree => Boolean =
@@ -1258,9 +1258,13 @@ class FormatWriter(formatOps: FormatOps) {
               prevAlignContainer = alignContainer
               prevBlock = block
             }
-            if (isBlankLine || alignContainer.eq(null))
-              getBlockToFlush(getAlignContainer(isSlc = wasSlc)._1, isBlankLine)
-                .foreach(flushAlignBlock)
+            if (isBlankLine || alignContainer.eq(null)) {
+              val toFlush = getBlockToFlush(
+                getAlignContainer(isSlc = wasSlc)._1,
+                isBlankLine,
+              )
+              if (toFlush ne null) flushAlignBlock(toFlush)
+            }
           }
 
           @tailrec
@@ -1311,7 +1315,7 @@ class FormatWriter(formatOps: FormatOps) {
 
           processLine(wasSlc = false)
         }
-        blocks.valuesIterator.foreach(flushAlignBlock)
+        blocks.values.forEach(flushAlignBlock(_))
         finalResult.result()
       }
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Router.scala
@@ -22,28 +22,47 @@ class Router(implicit formatOps: FormatOps) {
   def getSplits(implicit ft: FT): Seq[Split] = {
     implicit val style = styleMap.at(ft)
     import ft._, SplitsBuilder._
-    val splitsRaw = lookupAfter.get(left.getClass).flatMap(_.getOpt)
-      .orElse(lookupBefore.get(right.getClass).flatMap(_.getOpt))
-      .orElse(SplitsBeforeStatement.getOpt)
-      .orElse(lookupAfterLowPriority.get(left.getClass).flatMap(_.getOpt))
-      .orElse(lookupBeforeLowPriority.get(right.getClass).flatMap(_.getOpt))
-      .orElse(SplitsWithOptionalNL.getOpt).getOrElse(Seq(Split(Space, 0)))
-      .flatMap(s =>
-        if (s.isIgnored) None
-        else {
-          val penalize = !s.isNL && s.policy.exists {
-            case p: PolicyOps.PenalizeAllNewlines => p.failsSyntaxNL(ft)
-            case _ => false
-          }
-          if (penalize) Some(s.withPenalty(1)) else Some(s)
-        },
-      )
-    val splits = optimizationEntities.semicolonAfterStatement(idx)
-      .fold(splitsRaw) { xft =>
-        import PolicyOps._
-        val policy = delayedBreakPolicyFor(xft)(decideNewlinesOnlyAfterToken)
-        splitsRaw.map(_.andPolicy(policy))
+    // null-returning ju.HashMap lookup + Splits.get (empty Seq = no match, fall
+    // through), avoiding a `Some` per hit from immutable.Map.get/getOpt and the
+    // intermediate Options of an `orElse` chain (this runs once per token)
+    def fromMap(m: LookupMap, cls: Class[_]): Seq[Split] = {
+      val s = m.get(cls)
+      if (s eq null) Nil else s.get
+    }
+    def fromMaps(): Seq[Split] = {
+      var raw = fromMap(lookupAfter, left.getClass)
+      if (raw.nonEmpty) return raw
+      raw = fromMap(lookupBefore, right.getClass)
+      if (raw.nonEmpty) return raw
+      raw = SplitsBeforeStatement.get
+      if (raw.nonEmpty) return raw
+      raw = fromMap(lookupAfterLowPriority, left.getClass)
+      if (raw.nonEmpty) return raw
+      raw = fromMap(lookupBeforeLowPriority, right.getClass)
+      if (raw.nonEmpty) return raw
+      raw = SplitsWithOptionalNL.get
+      if (raw.nonEmpty) return raw
+      Seq(Split(Space, 0))
+    }
+    val optimizationPolicy =
+      optimizationEntities.semicolonAfterStatement(idx) match {
+        case Some(xft) =>
+          import PolicyOps._
+          delayedBreakPolicyFor(xft)(decideNewlinesOnlyAfterToken)
+        case _ => Policy.NoPolicy
       }
+    val splitsBuilder = Seq.newBuilder[Split]
+    fromMaps().foreach(s =>
+      if (!s.isIgnored) {
+        val penalize = !s.isNL && s.policy.exists {
+          case p: PolicyOps.PenalizeAllNewlines => p.failsSyntaxNL(ft)
+          case _ => false
+        }
+        splitsBuilder += // .andPolicy is a no-op on NoPolicy
+          (if (penalize) s.withPenalty(1) else s).andPolicy(optimizationPolicy)
+      },
+    )
+    val splits = splitsBuilder.result()
     require(
       splits.nonEmpty,
       s"""|

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -20,14 +20,6 @@ import TreeOps._
 
 sealed trait Splits {
   def get(implicit ft: FT, fo: FormatOps, cfg: ScalafmtConfig): Seq[Split]
-  final def getOpt(implicit
-      ft: FT,
-      fo: FormatOps,
-      cfg: ScalafmtConfig,
-  ): Option[Seq[Split]] = {
-    val res = get
-    if (res.isEmpty) None else Some(res)
-  }
 }
 
 object Splits {
@@ -761,21 +753,25 @@ object SplitsBeforeLeftBrace extends Splits {
           .map(_.preActivateFor(SplitTag.OneArgPerLine))
         else otherSplits.map(_.onlyFor(SplitTag.OneArgPerLine))
       singleSplit +: oneArgPerLineSplits
-    } else SplitsBeforeStatement.getOpt.getOrElse {
-      def maybeBracesToParensWithRB(rb: FT)(implicit fl: FileLine) =
-        Seq(Split(getBracesToParensModOnly(rb, isWithinBraces = false), 0))
-      def maybeBracesToParens()(implicit fl: FileLine) =
-        maybeBracesToParensWithRB(matchingRight(ft))
-      // partial initial expr
-      if (!isTokenHeadOrBefore(right, rightOwner)) maybeBracesToParens()
-      else rightOwner.parent.fold(Seq.empty[Split]) {
-        case _: Term.ApplyInfix => Seq.empty // exclude start of infix
-        case _: Term.ArgClause => maybeBracesToParens()
-        case p => matchingOptRight(ft).fold(Seq.empty[Split]) { rb =>
-            val ko = isTokenHeadOrBefore(right, p) &&
-              isTokenLastOrAfter(rb.left, rightOwner)
-            if (ko) Seq.empty else maybeBracesToParensWithRB(rb)
-          }
+    } else {
+      val beforeStmt = SplitsBeforeStatement.get
+      if (beforeStmt.nonEmpty) beforeStmt
+      else {
+        def maybeBracesToParensWithRB(rb: FT)(implicit fl: FileLine) =
+          Seq(Split(getBracesToParensModOnly(rb, isWithinBraces = false), 0))
+        def maybeBracesToParens()(implicit fl: FileLine) =
+          maybeBracesToParensWithRB(matchingRight(ft))
+        // partial initial expr
+        if (!isTokenHeadOrBefore(right, rightOwner)) maybeBracesToParens()
+        else rightOwner.parent.fold(Seq.empty[Split]) {
+          case _: Term.ApplyInfix => Seq.empty // exclude start of infix
+          case _: Term.ArgClause => maybeBracesToParens()
+          case p => matchingOptRight(ft).fold(Seq.empty[Split]) { rb =>
+              val ko = isTokenHeadOrBefore(right, p) &&
+                isTokenLastOrAfter(rb.left, rightOwner)
+              if (ko) Seq.empty else maybeBracesToParensWithRB(rb)
+            }
+        }
       }
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitsBuilder.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/SplitsBuilder.scala
@@ -2,7 +2,9 @@ package org.scalafmt.internal
 
 import scala.meta.tokens.{Token => T}
 
-import scala.collection.{immutable, mutable}
+import java.{util => ju}
+
+import scala.collection.mutable
 import scala.reflect.ClassTag
 
 /* scalafmt: {
@@ -13,7 +15,7 @@ import scala.reflect.ClassTag
  */
 object SplitsBuilder {
 
-  type LookupMap = immutable.Map[Class[_], Splits]
+  type LookupMap = ju.HashMap[Class[_], Splits]
 
   def build(f: SplitsBuilder => Unit): LookupMap = {
     val builder = new SplitsBuilder
@@ -153,9 +155,9 @@ private[internal] class SplitsBuilder {
   }
 
   def result(): SplitsBuilder.LookupMap = {
-    val builder = immutable.Map.newBuilder[Class[_], Splits]
-    map.foreach { case (k, v) => builder += k -> Splits(v.toList) }
-    builder.result()
+    val jmap = new ju.HashMap[Class[_], Splits](map.size * 2)
+    map.foreach { case (k, v) => jmap.put(k, Splits(v.toList)) }
+    jmap
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -17,7 +17,7 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
 
   implicit val dialect: Dialect = style.dialect
 
-  private val patchBuilder = mutable.Map.empty[(Int, Int), TokenPatch]
+  private val patchBuilder = mutable.LongMap.empty[TokenPatch]
 
   val tokens: Tokens = tree.tokens
   val tokenTraverser = new TokenTraverser(tokens, input)(style)
@@ -169,6 +169,7 @@ object RewriteCtx {
     }
 
   @inline
-  private def lookupKey(tok: T) = tok.start -> tok.end
+  private def lookupKey(tok: T): Long = tok.start.toLong << 32 |
+    tok.end.toLong & 0xffffffffL
 
 }


### PR DESCRIPTION
Eliminate Option allocation on the once-per-token split-dispatch path:
- SplitsBuilder.LookupMap: immutable.Map -> ju.HashMap (get returns value-or-null, no per-hit Some).
- Router.getSplits: the flatMap(_.getOpt).orElse(...) 4-deep Option chain becomes a null/empty-Seq fall-through cascade in a local `fromMaps` def (plain def, so the early returns are ordinary returns, not closure NonLocalReturnControl), calling Splits.get directly.
- Splits: the last getOpt caller (SplitsBeforeLeftBrace fallthrough) inlined as get/nonEmpty; the now-unused getOpt method removed.

Byte-identical (16604 tests, Total explored 2594848); cross-builds 2.12/2.13/3. Perf-neutral (init-time route dispatch, not per-state): 2-fork AC A/B ~-0.9% Large / -0.7% Medium alloc, wall-clock flat. Kept for clarity.