### PR TITLE
tests: share munit config via SharedFunSuiteBase

### DIFF
--- a/scalafmt-tests/jvm/src/test/scala/org/scalafmt/ScalafmtProps.scala
+++ b/scalafmt-tests/jvm/src/test/scala/org/scalafmt/ScalafmtProps.scala
@@ -10,9 +10,9 @@ import scala.meta.testkit._
 
 import scala.collection.mutable
 
-import munit.{FailException, FunSuite}
+import munit.FailException
 
-class ScalafmtProps extends FunSuite with FormatAssertions {
+class ScalafmtProps extends SharedFunSuiteBase with FormatAssertions {
   import ScalafmtProps._
   def getBugs(
       config: ScalafmtConfig = ScalafmtConfig.default,

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/CommentTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/CommentTest.scala
@@ -2,9 +2,7 @@ package org.scalafmt
 
 import org.scalafmt.config.{Docstrings, ScalafmtConfig}
 
-import munit.FunSuite
-
-class CommentTest extends FunSuite {
+class CommentTest extends SharedFunSuiteBase {
 
   private val javadocStyle: ScalafmtConfig = ScalafmtConfig.default
     .copy(docstrings =

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/CustomStructureTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/CustomStructureTest.scala
@@ -4,9 +4,7 @@ import scala.meta._
 import scala.meta.internal.parsers.ScalametaParser
 import scala.meta.parsers.ParserOptions
 
-import munit.FunSuite
-
-class CustomStructureTest extends FunSuite {
+class CustomStructureTest extends SharedFunSuiteBase {
 
   private implicit val parserOptions: ParserOptions = ParserOptions.default
     .withCaptureComments(false)

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/EmptyFileTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/EmptyFileTest.scala
@@ -6,9 +6,7 @@ import scala.meta.internal.prettyprinters.DoubleQuotes
 
 import java.lang.System.lineSeparator
 
-import munit.FunSuite
-
-class EmptyFileTest extends FunSuite {
+class EmptyFileTest extends SharedFunSuiteBase {
 
   private val cfgWithLineEndingsCRLF = ScalafmtConfig.default
     .withLineEndings(LineEndings.windows)

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -8,13 +8,11 @@ import org.scalafmt.util.FormatAssertions
 import java.io.File
 import java.nio.file.Path
 
-import munit.FunSuite
-
 /** Asserts formatter does not alter original source file's AST.
   *
   * Will maybe use scalacheck someday.
   */
-class FidelityTest extends FunSuite with FormatAssertions {
+class FidelityTest extends SharedFunSuiteBase with FormatAssertions {
 
   private val numFiles = 279
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -8,12 +8,12 @@ import org.scalafmt.util._
 
 import scala.meta.parsers.ParseException
 
-import munit.FunSuite
 import munit.diff.Diff
 
 // TODO(olafur) property test: same solution without optimization or timeout.
 
-class FormatTests extends FunSuite with CanRunTests with FormatAssertions {
+class FormatTests
+    extends SharedFunSuiteBase with CanRunTests with FormatAssertions {
   import LoggerOps._
   lazy val onlyUnit = UnitTests.tests.exists(_.only.isDefined)
   lazy val onlyManual = !onlyUnit && ManualTests.tests.exists(_.only.isDefined)

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/LineEndingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/LineEndingsTest.scala
@@ -3,9 +3,7 @@ package org.scalafmt
 import org.scalafmt.config.LineEndings._
 import org.scalafmt.config.ScalafmtConfig
 
-import munit.FunSuite
-
-class LineEndingsTest extends FunSuite {
+class LineEndingsTest extends SharedFunSuiteBase {
 
   test("code with windows line endings after formatting with line endings preserve setting should have the same endings") {
     val original = "@ Singleton\r\nobject a {\r\nval y = 2\r\n}"

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/RangeTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/RangeTest.scala
@@ -2,9 +2,7 @@ package org.scalafmt
 
 import org.scalafmt.util.HasTests
 
-import munit.FunSuite
-
-class RangeTest extends FunSuite {
+class RangeTest extends SharedFunSuiteBase {
   test("range preserves indent") {
     val original =
       """|object a {

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/ScalafmtTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/ScalafmtTest.scala
@@ -4,9 +4,7 @@ import org.scalafmt.config.ScalafmtConfig
 
 import org.scalameta.logger
 
-import munit.FunSuite
-
-class ScalafmtTest extends FunSuite {
+class ScalafmtTest extends SharedFunSuiteBase {
   def check(
       original: String,
       expected: String,

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/SharedFunSuiteBase.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/SharedFunSuiteBase.scala
@@ -1,8 +1,10 @@
-package org
+package org.scalafmt
 
 import munit.diff.DiffOptions
 
-package object scalafmt {
+trait SharedFunSuiteBase extends munit.FunSuite {
+
   implicit val diffOptions: DiffOptions = DiffOptions.withShowLines(true)
     .withContextSize(10)
+
 }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/AvoidInfixSettingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/AvoidInfixSettingsTest.scala
@@ -1,6 +1,7 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
-class AvoidInfixSettingsTest extends munit.FunSuite {
+class AvoidInfixSettingsTest extends SharedFunSuiteBase {
 
   Seq(Nil, Seq("foo"), Seq("cross"), Seq("cross", "foo")).foreach { extra =>
     test(s"AvoidInfixSettings.forSbtOpt: [${extra.mkString(",")}]") {

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ConfigDialectOverrideTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ConfigDialectOverrideTest.scala
@@ -1,12 +1,12 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
 import scala.meta.Dialect
 import scala.meta.dialects.Scala213
 
 import metaconfig.{ConfError, Configured}
-import munit.FunSuite
 
-class ConfigDialectOverrideTest extends FunSuite {
+class ConfigDialectOverrideTest extends SharedFunSuiteBase {
   private val generatedMap = DialectMacro.dialectMap
 
   test("throws on an non-existent setting") {

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
@@ -1,6 +1,7 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
-class RewriteScala3SettingsTest extends munit.FunSuite {
+class RewriteScala3SettingsTest extends SharedFunSuiteBase {
 
   import RewriteScala3Settings.Between
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RunnerSettingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RunnerSettingsTest.scala
@@ -1,10 +1,9 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
 import scala.meta._
 
-import munit.FunSuite
-
-class RunnerSettingsTest extends FunSuite {
+class RunnerSettingsTest extends SharedFunSuiteBase {
   test("sbt dialect supports trailing commas")(
     RunnerSettings.sbt.getDialect(
       """|

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ScalafmtConfigTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ScalafmtConfigTest.scala
@@ -1,9 +1,9 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
 import metaconfig.{Conf, Configured}
-import munit.FunSuite
 
-class ScalafmtConfigTest extends FunSuite {
+class ScalafmtConfigTest extends SharedFunSuiteBase {
 
   test("project.matcher") {
     val config = ScalafmtConfig.fromHoconString(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/StandardProjectLayoutTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/StandardProjectLayoutTest.scala
@@ -1,10 +1,11 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
 import org.scalafmt.sysops._
 
 import scala.meta.dialects
 
-class StandardProjectLayoutTest extends munit.FunSuite {
+class StandardProjectLayoutTest extends SharedFunSuiteBase {
 
   import ProjectFiles.Layout.StandardConvention._
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/CanRunTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/CanRunTests.scala
@@ -1,12 +1,13 @@
-package org.scalafmt.util
+package org.scalafmt
+package util
 
 import org.scalafmt.Error
 
 import scala.meta.parsers.ParseException
 
-import munit.{FunSuite, Location}
+import munit.Location
 
-trait CanRunTests extends FunSuite with HasTests {
+trait CanRunTests extends SharedFunSuiteBase with HasTests {
   def runTest(run: DiffTest => Unit)(t: DiffTest): Unit = {
     implicit val loc: Location = t.loc
     val paddedName = f"${t.fullName}%-70s|"

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/ErrorTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/ErrorTest.scala
@@ -1,10 +1,9 @@
-package org.scalafmt.util
+package org.scalafmt
+package util
 
 import org.scalafmt.{Formatted, Scalafmt}
 
-import munit.FunSuite
-
-class ErrorTest extends FunSuite {
+class ErrorTest extends SharedFunSuiteBase {
   private val nonSourceFile = Seq("class A {", "val x + 1", "println 1")
   nonSourceFile.foreach(original =>
     test(s"errors are caught: $original")(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/FormatAssertions.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/FormatAssertions.scala
@@ -12,7 +12,7 @@ import scala.meta.{Dialect, Tree}
 
 import java.io.ByteArrayInputStream
 
-import munit.diff.Diffs
+import munit.diff.Diff
 
 trait FormatAssertions {
 
@@ -66,9 +66,9 @@ trait FormatAssertions {
 
   /** Creates diff from structures. WARNING: slow for large asts.
     */
-  def diffAsts(original: String, obtained: String): String = Diffs
-    .unifiedDiff(original.replace("(", "\n("), obtained.replace("(", "\n("))
-    .linesIterator.mkString("\n")
+  def diffAsts(original: String, obtained: String): String =
+    new Diff(original.replace("(", "\n("), obtained.replace("(", "\n("))
+      .unifiedDiff.linesIterator.mkString("\n")
 
   // TODO(olafur) move this to scala.meta?
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/StyleMapTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/util/StyleMapTest.scala
@@ -1,13 +1,12 @@
-package org.scalafmt.util
+package org.scalafmt
+package util
 
 import org.scalafmt.config.{BinPack, Newlines, ScalafmtConfig}
 import org.scalafmt.internal.FormatOps
 
 import scala.meta._
 
-import munit.FunSuite
-
-class StyleMapTest extends FunSuite {
+class StyleMapTest extends SharedFunSuiteBase {
   test("basic") {
     val code =
       """|object a {


### PR DESCRIPTION
scalafmt-tests defined its own `package object scalafmt` (only an implicit munit `DiffOptions`). A package may have just one package object across a classpath, so once scalafmt-core also defines `package object scalafmt`, the two `org/scalafmt/package$.class` files collide: it compiles, but at test runtime the test module's copy shadows core's and core's calls throw `NoSuchMethodError`.

Centralize the implicit `DiffOptions` in a new `SharedFunSuiteBase extends munit.FunSuite` that all suites extend, remove the test `package object scalafmt`, and migrate `FormatAssertions` off the deprecated `Diffs.unifiedDiff` (which required the implicit) to `new Diff(...).unifiedDiff`.