### PR TITLE
drop Option/Either on hot token/tree/split paths

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -20,6 +20,7 @@ newlines {
   avoidForSimpleOverflow = all
   ignoreInSyntax = false
   source = fold
+  infix.termSite.maxCountPerFile = 1000
 }
 rewrite {
   rules = [

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/Scalafmt.scala
@@ -110,14 +110,15 @@ object Scalafmt {
     val codeToInput: String => Input = toInput(_, file)
     val original = codeToInput(code)
     val rewritten = Rewrite(original, style)
-    runner.parse(rewritten.fold(original)(codeToInput)).fold(
+    val input = if (rewritten eq null) original else codeToInput(rewritten)
+    runner.parse(input).fold(
       x => {
         val err = x.details match {
           case ParseException(pos, msg) =>
             ParseException(pos, s"[dialect ${runner.dialectName}] $msg")
           case ed => ed
         }
-        Failure(Error.WithCode(err, rewritten.getOrElse(code)))
+        Failure(Error.WithCode(err, rewritten ?? code))
       },
       tree => {
         implicit val formatOps = new FormatOps(tree, style, file)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/AlignToken.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
 import metaconfig._
 
@@ -39,7 +40,7 @@ object AlignToken {
     ).except {
       case (_, Conf.Str("caseArrow")) => Some(Configured.Ok(caseArrow))
       case (_, Conf.Str(regex)) => Some(
-          Configured.Ok(default.find(_.code == regex).getOrElse(AlignToken(regex))),
+          Configured.Ok(default.findOrNull(_.code == regex) ?? AlignToken(regex)),
         )
       case _ => None
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Indents.scala
@@ -55,7 +55,7 @@ case class Indents(
     yieldKeyword: Boolean = true,
     infix: Seq[IndentOperator] = Seq(IndentOperator.default),
 ) {
-  lazy val getSignificant = significant.getOrElse(main)
+  val getSignificant = significant.getOrElse(main)
 
   def getDefnSite(tree: meta.Tree): Int = (tree match {
     case _: meta.Member.ParamClause | _: meta.Member.ParamClauseGroup => tree

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Newlines.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
 import org.scalafmt.config.Newlines._
 import org.scalafmt.internal._
@@ -311,18 +312,26 @@ case class Newlines(
   def allowNonTopStatBlankLines = topLevelStatementBlankLines
     .exists(_.allowNonTop)
 
-  def getTopStatBlankLines(tree: Tree)(
-      params: TopStatBlanksParams,
-  ): Option[NumBlanks] = topStatBlankLinesSorted.iterator
-    .takeWhile(_.minBreaks <= params.numBreaks)
-    .find(x => x.checkParams(params, tree)).flatMap(_.blanks)
+  def getTopStatBlankLines(tree: Tree)(params: TopStatBlanksParams): NumBlanks = {
+    val iter = topStatBlankLinesSorted.iterator
+    while (iter.hasNext) {
+      val elem = iter.next()
+      if (elem.minBreaks > params.numBreaks) return null
+      if (elem.checkParams(params, tree)) return elem.blanks.orNull
+    }
+    null
+  }
 
-  private def getBeforeOpenParen(bop: BeforeOpenParen): SourceHints =
-    Option(bop.src).getOrElse(source)
-  def getBeforeOpenParenCallSite: Option[SourceHints] = beforeOpenParenCallSite
-    .map(getBeforeOpenParen)
-  def getBeforeOpenParenDefnSite: Option[SourceHints] = beforeOpenParenDefnSite
-    .map(getBeforeOpenParen)
+  private def getBeforeOpenParen(bop: BeforeOpenParen): SourceHints = bop.src ??
+    source
+  def getBeforeOpenParenCallSite: SourceHints = beforeOpenParenCallSite match {
+    case Some(x) => getBeforeOpenParen(x)
+    case _ => null
+  }
+  def getBeforeOpenParenDefnSite: SourceHints = beforeOpenParenDefnSite match {
+    case Some(x) => getBeforeOpenParen(x)
+    case _ => null
+  }
   def isBeforeOpenParenCallSite: Boolean = beforeOpenParenCallSite.isDefined
   def isBeforeOpenParenDefnSite: Boolean = beforeOpenParenDefnSite.isDefined
 
@@ -584,11 +593,11 @@ object Newlines {
       def apply(tree: Tree): Boolean = {
         // find the first invalid tree
         val nonMemberTree = TreeOps.findTreeWithParentEx(tree) {
-          case t: Template.Body => t.parent.parent
-          case _: Pkg.Body => None // all trees valid, no need to go further
-          case _ => Some(null) // reached invalid parent, no need to go further
+          case t: Template.Body => t.parentOrNoTree.parentOrNoTree
+          case _: Pkg.Body => Tree.NoTree // all trees valid, no need to go further
+          case _ => null // reached invalid parent, no need to go further
         }
-        nonMemberTree.isEmpty
+        nonMemberTree eq null
       }
     }
 
@@ -602,13 +611,20 @@ object Newlines {
   case class NumBlanks(
       before: Int = 0,
       after: Int = 0,
-      beforeAll: Option[Int] = None,
-      afterAll: Option[Int] = None,
+      private val beforeAll: Option[Int] = None,
+      private val afterAll: Option[Int] = None,
       beforeEndMarker: Int = 0,
   ) {
     def isEmpty: Boolean = before == 0 && after == 0
+    val beforeAllOrUnset: Int = beforeAll.getOrElse(NumBlanks.unset)
+    val afterAllOrUnset: Int = afterAll.getOrElse(NumBlanks.unset)
   }
   object NumBlanks {
+
+    /** Sentinel for an unset `beforeAll`/`afterAll` (formerly `None`); ordinary
+      * values, including negatives, are valid and distinct from this.
+      */
+    final val unset: Int = Int.MinValue
     implicit val surface: generic.Surface[NumBlanks] = generic
       .deriveSurface[NumBlanks]
     implicit val encoder: ConfEncoder[NumBlanks] = generic

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteSettings.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.config
+package org.scalafmt
+package config
 
 import org.scalafmt.rewrite._
 
@@ -87,7 +88,7 @@ object RewriteSettings {
     def nonBlocks: Boolean = allBlocks && settings.nonBlocksMinBreaks != 0
 
     def settingsFor(tree: meta.Tree): InsertBraces.Settings = overrideFor
-      .find(_.matches(tree)).getOrElse(settings)
+      .findOrNull(_.matches(tree)) ?? settings
   }
 
   object InsertBraces {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -42,45 +42,54 @@ private class BestFirstSearch private (range: Set[Range])(implicit
 
   private def getBlockCloseToRecurse(ft: FT, indent: Int)(implicit
       style: ScalafmtConfig,
-  ): Option[Int] = TokenOps.getEndOfBlock(ft, parens = true).collect {
+  ): Int = TokenOps.getEndOfBlock(ft, parens = true) match {
     case (close, _) if (ft.leftOwner match {
           case Term.Block(_ :: tail) if tail.nonEmpty =>
             indent + tokens.width(ft, close) > style.maxColumn
           // Block must span at least 3 lines to be worth recursing.
           case _ => indent + tokens.width(ft, close) > style.maxColumn * 3
         }) => close.idx
+    case _ => -1
   }
 
   // LongMap: primitive Long key, no boxing on get/update in the search recursion
-  private val memo = mutable.LongMap.empty[Option[State]]
-  private val slbMemo = mutable.LongMap.empty[Option[State]]
+  private val memo = mutable.LongMap.empty[State]
+  private val slbMemo = mutable.LongMap.empty[State]
 
   // out-param for getActiveSplits: number of valid splits in the returned array
   // (avoids a per-state `(Array[Split], Int)` tuple). Single-threaded search, so
   // a field is safe; every caller reads it into a local right after the call.
   private[this] var activeSplitsCount: Int = 0
 
+  // Left(null) is a payload-less dead end; intern one instance to reuse
+  private[this] val deadEnd: Either[State, State] = Left(null)
+  private def leftState(s: State): Either[State, State] =
+    if (s eq null) deadEnd else Left(s)
+
   def shortestPathMemo(
       start: State,
       stop: Int,
       depth: Int,
       isOpt: Boolean,
-  ): Option[Option[State]] = {
+  ): State = {
     val key = start.indentation & 0xffL | (start.column & 0xffffffL) << 8 |
       (start.depth & 0xffffffffL) << 32
     def orElse(hadSlb: Boolean) = {
-      val nextState = shortestPath(start, stop, depth, isOpt).toOption
-      nextState match {
-        case None if hadSlb => slbMemo.update(key, nextState)
-        case Some(ns) if ns.terminal() => slbMemo.update(key, nextState)
-        case _ => memo.update(key, nextState)
+      val res = shortestPath(start, stop, depth, isOpt) match {
+        case Right(x) => x
+        case _ => State.start
       }
-      Some(nextState)
+      val useSlb = if (res eq State.start) hadSlb else res.terminal()
+      val map = if (useSlb) slbMemo else memo
+      map.update(key, res)
+      res
     }
-    memo.get(key).orElse(
-      if (isOpt) Some(None) // we wouldn't recurse unless the span was large
+
+    memo.getOrElse(
+      key,
+      if (isOpt) State.start // we wouldn't recurse unless the span was large
       else if (!start.terminal()) orElse(hadSlb = false)
-      else slbMemo.get(key).orElse(orElse(hadSlb = true)),
+      else slbMemo.getOrElse(key, orElse(hadSlb = true)),
     )
   }
 
@@ -143,12 +152,15 @@ private class BestFirstSearch private (range: Set[Range])(implicit
         val noBlockClose = start == curr && !isOpt || noOptZoneCode == 0 ||
           !optimizer.recurseOnBlocks
         val blockCloseState =
-          if (noBlockClose) None
-          else getBlockCloseToRecurse(splitToken, curr.indentation)
-            .flatMap(shortestPathMemo(curr, _, depth + 1, isOpt))
-        if (blockCloseState.nonEmpty) blockCloseState
-          .foreach(_.foreach(Q.enqueue))
-        else {
+          if (noBlockClose) null
+          else {
+            val close = getBlockCloseToRecurse(splitToken, curr.indentation)
+            if (close < 0) null
+            else shortestPathMemo(curr, close, depth + 1, isOpt)
+          }
+        if (blockCloseState ne null) {
+          if (blockCloseState ne State.start) Q.enqueue(blockCloseState)
+        } else {
           if (optimizer.escapeInPathologicalCases && isSeqMulti(routes(idx)))
             stats.explode(splitToken, optimizer.maxVisitsPerToken)(
               stats.visits(idx) > _,
@@ -162,26 +174,30 @@ private class BestFirstSearch private (range: Set[Range])(implicit
           val handleOptimalTokens = optimizer.acceptOptimalAtHints &&
             depth < optimizer.maxDepth && numSplits > 1
 
-          def processNextState(implicit nextState: State): Unit = {
+          // returns whether an optimal state was found (stops sibling splits);
+          // a local `var` return avoids lifting a captured var to a per-state Ref
+          def processNextState(implicit nextState: State): Boolean = {
             val split = nextState.split
             val cost = split.costWithPenalty
+            var found = false
             if (cost <= maxCost) {
-              val stateToQueue = split.optimalAt match {
-                case Some(opt) if handleOptimalTokens =>
+              val opt = split.optimalAt
+              val stateToQueue =
+                if ((opt ne null) && handleOptimalTokens) {
                   val costToCheck =
                     if (opt.ignorePenalty) split.costWithoutPenalty else cost
                   if (costToCheck > 0) killOnFail(opt)
                   else processOptimalToken(opt) match {
                     case Left(x) => x
-                    case Right(x) => optimalFound = true; x
+                    case Right(x) => found = true; x
                   }
-                case _ => nextState
-              }
+                } else nextState
               if (null ne stateToQueue) {
                 stats.updateBest(nextState, stateToQueue)
                 Q.enqueue(stateToQueue)
               }
             } else preFork = false
+            found
           }
 
           var sidx = 0
@@ -189,7 +205,7 @@ private class BestFirstSearch private (range: Set[Range])(implicit
             val split = actualSplits(sidx)
             sidx += 1
             if (optimalFound) stats.sendEvent(split)
-            else processNextState(getNext(curr, split))
+            else optimalFound = processNextState(getNext(curr, split))
           }
         }
       }
@@ -199,7 +215,7 @@ private class BestFirstSearch private (range: Set[Range])(implicit
       val okDeepest = deepestState.appliedPenalty > start.prev.appliedPenalty
       tokens(if (okDeepest) deepestState.depth else stop)
     }
-    if (preFork || willKillOnFail(isKillOnFail, endToken)(start)) Left(null)
+    if (preFork || willKillOnFail(isKillOnFail, endToken)(start)) deadEnd
     else Left(preForkState)
   }
 
@@ -230,7 +246,7 @@ private class BestFirstSearch private (range: Set[Range])(implicit
     val nextNextState =
       if (optIdx <= nextState.depth) nextState
       else if (tokens.width(nextState.depth, optIdx) > 3 * style.maxColumn)
-        return Left(killOnFail(opt))
+        return leftState(killOnFail(opt))
       else {
         val res = shortestPath(
           nextState,
@@ -253,7 +269,7 @@ private class BestFirstSearch private (range: Set[Range])(implicit
       if (useNextNext) tokens(nextNextState.depth) else opt.token
     }(opt)
     traverseSameLine(nextNextState) match {
-      case x @ Left(s) => if (s eq null) Left(kof) else checkPenalty(s, x)
+      case x @ Left(s) => if (s eq null) leftState(kof) else checkPenalty(s, x)
       case x @ Right(s) => checkPenalty(s, if (opt.recurseOnly) Left(s) else x)
     }
   }
@@ -321,7 +337,7 @@ private class BestFirstSearch private (range: Set[Range])(implicit
     else {
       val ss = getActiveSplits(state)(_ => true)
       val numSplits = activeSplitsCount
-      if (numSplits == 0) Left(null) // dead end if empty
+      if (numSplits == 0) deadEnd // dead end if empty
       else if (numSplits == 1) {
         val split = ss(0)
         if (split.isNL) Right(state)
@@ -336,13 +352,10 @@ private class BestFirstSearch private (range: Set[Range])(implicit
   def getBestPath: SearchResult = {
     if (stats.eventCallback ne null) stats
       .eventCallback(FormatEvent.Routes(routes))
-    val state = {
-      def run = shortestPath(State.start, Int.MaxValue)
-      run.getOrElse(stats.retry.flatMap { x =>
-        stats = x
-        run.toOption
-      }.orNull)
-    }
+    def run = shortestPath(State.start, Int.MaxValue)
+    val state = run.getOrElse(stats.retry.fold(null: State) { x =>
+      stats = x; run.getOrElse(null)
+    })
     if (null != state) {
       stats.complete(state)
       SearchResult(state, reachedEOF = true)
@@ -454,6 +467,7 @@ object BestFirstSearch {
     // Int-key box + Some that mutable.Map.get allocated in shouldEnterState
     val best = new Array[State](tokens.length)
     val visits = new Array[Int](tokens.length)
+    private val maxVisits = runner.getMaxStateVisits
 
     def this(tokens: FormatTokens, runner: RunnerSettings) =
       this(tokens, runner, runner.optimizer.pruneSlowStates)
@@ -494,7 +508,7 @@ object BestFirstSearch {
       updateBestImpl(state)
 
     def checkExplored(ft: FT)(implicit formatWriter: FormatWriter): Unit =
-      explode(ft, runner.getMaxStateVisits)(
+      explode(ft, maxVisits)(
         explored > _,
         x => s"exceeded `runner.maxStateVisits`=$x",
       )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config._
 import org.scalafmt.rewrite.RedundantBraces
@@ -41,17 +42,17 @@ class FormatOps(
   val optimizationEntities = OptimizationEntities(topSourceTree)
 
   @tailrec
-  final def findFirst(start: FT, end: FT)(f: FT => Boolean): Option[FT] =
-    if (start.idx >= end.idx) None
-    else if (f(start)) Some(start)
+  final def findFirst(start: FT, end: FT)(f: FT => Boolean): FT =
+    if (start.idx >= end.idx) null
+    else if (f(start)) start
     else {
       val next_ = next(start)
-      if (next_ == start) None else findFirst(next_, end)(f)
+      if (next_ == start) null else findFirst(next_, end)(f)
     }
 
   def findFirstOnRight[A](start: FT, end: FT)(implicit
       classifier: Classifier[T, A],
-  ): Option[FT] = findFirst(start, prev(end))(x => classifier(x.right))
+  ): FT = findFirst(start, prev(end))(x => classifier(x.right))
 
   @tailrec
   final def getSlbEndOnLeft(start: FT)(implicit style: ScalafmtConfig): FT = {
@@ -128,7 +129,7 @@ class FormatOps(
         }
       case _: T.Colon
           if !style.newlines.sometimesBeforeColonInMethodReturnType &&
-            colonDeclType(start.rightOwner).isDefined => tokens(start, 2) // can't break after colon either
+            (colonDeclType(start.rightOwner) ne null) => tokens(start, 2) // can't break after colon either
       case _: T.Comment if start.noBreak =>
         val nft = nextNonCommentSameLineAfter(start)
         if (!start.left.is[T.LeftParen] || nft.hasBreakOrEOF) return nft // RETURN!!!
@@ -136,32 +137,33 @@ class FormatOps(
       case _ => start
     }
 
-    if (nft eq start) start
-    else getSlbEndOnLeft(if (nft ne null) nft else next(start))
+    if (nft eq start) start else getSlbEndOnLeft(nft ?? next(start))
   }
 
-  def parensTuple(ft: FT): TokenRanges = matchingOptLeft(ft)
-    .fold(TokenRanges.empty)(other => TokenRanges(TokenRange(ft, other)))
+  def parensTuple(ft: FT): TokenRanges = {
+    val other = matchingLeftOrNull(ft)
+    if (other eq null) TokenRanges.empty else TokenRanges(TokenRange(ft, other))
+  }
   def parensTuple(tree: Tree): TokenRanges = parensTuple(getLast(tree))
 
   // invoked on opening paren, part of ParamClause
   @tailrec
-  final def defnSiteOptimalToken(t: Tree): Option[FT] = t match {
+  final def defnSiteOptimalToken(t: Tree): FT = t match {
     case _: Member.SyntaxValuesClause | _: Member.ParamClauseGroup |
         _: Type.ParamFunctionType => t.parent match {
         case Some(p) => defnSiteOptimalToken(p)
-        case _ => None
+        case _ => null
       }
     case Tree.WithDeclTpe(tpe: Type.Refine) if tpe.body.nonEmpty =>
-      getHeadOpt(tpe.body)
+      getHead(tpe.body)
     case Tree.WithDeclTpeOpt(Some(tpe: Type.Refine)) if tpe.body.nonEmpty =>
-      getHeadOpt(tpe.body)
+      getHead(tpe.body)
     // macro body comes after KwMacro, not directly after Equals
-    case t: Defn.Macro => tokenBeforeOpt(t.body).map(prevNonCommentBefore)
-    case t: Tree.WithBody => tokenBeforeOpt(t.body)
-    case t: Stat.WithTemplate => tokenBeforeOpt(t.templ)
-    case t: Decl => getLastOpt(t)
-    case _ => None
+    case t: Defn.Macro => tokenBefore(t.body).nnMap(prevNonCommentBefore)
+    case t: Tree.WithBody => tokenBefore(t.body)
+    case t: Stat.WithTemplate => tokenBefore(t.templ)
+    case t: Decl => getLast(t)
+    case _ => null
   }
 
   @inline
@@ -218,40 +220,42 @@ class FormatOps(
     if (r.is[T.LeftBrace]) SplitTag.OneArgPerLine.activateOnly(s)
     else Decision.onlyNewlineSplits(s)
 
-  def templateCurly(obj: Template.Body): Option[FT] = getHeadOpt(obj)
-    .map(x => if (x.meta.leftOwner eq obj) x else prevNonCommentBefore(x))
+  def templateCurly(obj: Template.Body): FT = getHead(obj)
+    .nnMap(x => if (x.meta.leftOwner eq obj) x else prevNonCommentBefore(x))
 
-  def templateCurlyOrLastNonTrivial(tpl: Template): FT = templateCurly(tpl.body)
-    .getOrElse(getLastNonTrivial(tpl))
+  def templateCurlyOrLastNonTrivial(tpl: Template): FT =
+    templateCurly(tpl.body) ?? getLastNonTrivial(tpl)
 
-  def templateDerivesOrCurlyOrLastNonTrivial(
-      template: Template,
-  )(implicit ft: FT): FT = findTemplateGroupOnRight(_.getExpireToken)(template)
-    .getOrElse(templateCurlyOrLastNonTrivial(template))
+  def templateDerivesOrCurlyOrLastNonTrivial(template: Template)(implicit
+      ft: FT,
+  ): FT = findTemplateGroupOnRight(_.getExpireToken)(template) ??
+    templateCurlyOrLastNonTrivial(template)
 
-  private def findTreeInGroup[A](
+  private def findTreeInGroup[A >: Null](
       trees: Seq[Tree],
       func: TemplateSupertypeGroup => A,
-  )(expireFunc: Seq[Tree] => FT)(implicit ft: FT): Option[A] = trees
-    .find(_.endOffset >= ft.right.end)
-    .map(x => func(TemplateSupertypeGroup(x, trees, expireFunc)))
+  )(expireFunc: Seq[Tree] => FT)(implicit ft: FT): A = trees.collectFirst {
+    case t if t.endOffset >= ft.right.end =>
+      func(TemplateSupertypeGroup(t, trees, expireFunc))
+  }.orNull
 
-  def findTemplateGroupOnRight[A](
+  def findTemplateGroupOnRight[A >: Null](
       func: TemplateSupertypeGroup => A,
-  )(template: Template)(implicit ft: FT): Option[A] = {
+  )(template: Template)(implicit ft: FT): A = {
     @tailrec
-    def iter(groups: Seq[Seq[Tree]]): Option[A] =
+    def iter(groups: Seq[Seq[Tree]]): A =
       if (isSeqSingle(groups))
         // for the last group, return '{' or ':'
         findTreeInGroup(groups.head, func)(x =>
-          getHeadOpt(template.body).getOrElse(getLastNonTrivial(x.last)),
+          getHead(template.body) ?? getLastNonTrivial(x.last),
         )
       else {
         // for intermediate groups, return its last token
         val res = findTreeInGroup(groups.head, func)(tokenAfter)
-        if (res.isDefined) res else iter(groups.tail)
+        if (res != null) res else iter(groups.tail)
       }
-    getTemplateGroups(template).flatMap(iter)
+    val groups = getTemplateGroups(template)
+    if (groups eq null) null else iter(groups)
   }
 
   def getBreakBeforeElsePolicy(beforeElse: FT): Policy = Policy
@@ -259,10 +263,11 @@ class FormatOps(
       Decision.onlyNewlinesWithFallback(_, Seq(Split(Newline2x(beforeElse), 0))),
     )
 
-  def getBreakBeforeElsePolicy(term: Term.If)(implicit
-      cfg: ScalafmtConfig,
-  ): Policy = getElseToken(term).flatMap { case (_, elsOpt) =>
-    elsOpt.map(getBreakBeforeElsePolicy)
+  def getBreakBeforeElsePolicy(
+      term: Term.If,
+  )(implicit cfg: ScalafmtConfig): Policy = getElseToken(term) match {
+    case null | (_, null) => Policy.NoPolicy
+    case (_, els) => getBreakBeforeElsePolicy(els)
   }
 
   def getBreaksBeforeElseChainPolicy(
@@ -274,17 +279,18 @@ class FormatOps(
 
   private final def getElseToken(term: Term.If)(implicit
       cfg: ScalafmtConfig,
-  ): Option[(FT, Option[FT])] = tokenJustBeforeOpt(term.elsep).map { ftElsep =>
+  ): (FT, FT) = tokenJustBefore(term.elsep).nnMap { ftElsep =>
     val elsOpt = prevBeforeNonComment(ftElsep) match {
       case ft @ FT(_, _: T.KwElse, _) =>
         val ok = cfg.newlines.alwaysBeforeElseAfterCurlyIf || ! {
           ft.leftOwner.is[Term.Block] && ft.left.is[T.RightBrace] &&
-          !prevNonCommentSameLineBefore(ft).left.is[T.LeftBrace] &&
-          matchingOptLeft(ft)
-            .exists(lb => prev(lb).left.start < term.thenp.begOffset)
+          !prevNonCommentSameLineBefore(ft).left.is[T.LeftBrace] && {
+            val lb = matchingLeftOrNull(ft)
+            (lb ne null) && prev(lb).left.start < term.thenp.begOffset
+          }
         }
-        if (ok) Some(ft) else None
-      case _ => None
+        if (ok) ft else null
+      case _ => null
     }
     (ftElsep, elsOpt)
   }
@@ -293,16 +299,16 @@ class FormatOps(
   private final def getElseChain(term: Term.If, res: List[FT])(implicit
       cfg: ScalafmtConfig,
   ): List[FT] = getElseToken(term) match {
-    case Some((ftElsep, elsOpt)) =>
-      val newRes = elsOpt.fold(res)(_ :: res)
+    case null => res
+    case (ftElsep, elsOpt) =>
+      val newRes = if (elsOpt eq null) res else elsOpt :: res
       term.elsep match {
         case t: Term.If => getElseChain(t, newRes)
         case b @ Term.Block((t: Term.If) :: Nil)
-            if !matchingOptRight(ftElsep).exists(_ eq getLast(b)) =>
+            if matchingRightOrNull(ftElsep).orHas(_ ne getLast(b)) =>
           getElseChain(t, newRes)
         case _ => newRes
       }
-    case _ => res
   }
 
   def insideInfixSplit(
@@ -345,7 +351,7 @@ class FormatOps(
       .findMaybeEnclosingInfix(app)
 
     def sourceIgnoredSplits(implicit fl: FileLine) = {
-      val ok = fullInfixEnclosedIn.isDefined || fullInfix.parent.forall {
+      val ok = (fullInfixEnclosedIn ne null) || fullInfix.parent.forall {
         case t: Defn.Val => t.rhs eq fullInfix
         case t: Defn.Var => t.body eq fullInfix
         case _ => true
@@ -359,9 +365,10 @@ class FormatOps(
 
     // we don't modify line breaks generally around infix expressions
     // TODO: if that ever changes, modify how rewrite rules handle infix
-    val fullInfixEnclosedInParens = fullInfixEnclosedIn.exists(_.isRight)
+    val fullInfixEnclosedInParens =
+      (fullInfixEnclosedIn ne null) && fullInfixEnclosedIn.isRight
     def okSpaceAfterOp(xft: FT) = xft.noBreak &&
-      (style.newlines.ignoreInSyntax || tokens.getNonMultilineEnd(xft).isDefined)
+      (style.newlines.ignoreInSyntax || (tokens.getNonMultilineEnd(xft) ne null))
     def okBreakBeforeOp: Boolean = fullInfixEnclosedInParens ||
       initStyle.dialect.allowInfixOperatorAfterNL ||
       (fullInfix.parent match {
@@ -395,10 +402,10 @@ class FormatOps(
         if (prev(ft).hasBreak && okBreakBeforeOp) spaceSplits
         else sourceIgnoredSplits
       else (ft.right match {
-        case _: T.LeftBrace => matchingOptRight(ft)
-        case _ => None
+        case _: T.LeftBrace => matchingRightOrNull(ft)
+        case _ => null
       }) match {
-        case Some(cft) if cft.right.end >= app.arg.endOffset =>
+        case cft if (cft ne null) && cft.right.end >= app.arg.endOffset =>
           sourceIgnoredSplits
             .map(s => if (s.isNL) s.copy(cost = 0, rank = -1) else s)
         case _ => withIndent(nl(1))
@@ -408,7 +415,8 @@ class FormatOps(
 
   def functionExpire(function: Member.Function): (FT, ExpiresOn) =
     function.parent match {
-      case Some(SingleArgInBraces.OrBlock(_, _, e)) => e -> ExpiresOn.Before
+      case Some(SingleArgInBraces.OrBlock(_, delims)) => delims._2 ->
+          ExpiresOn.Before
       case _ => getLastExceptParen(function) -> ExpiresOn.After
     }
 
@@ -466,7 +474,7 @@ class FormatOps(
         }
       case _ => Policy.NoPolicy
     }
-    findTemplateGroupOnRight { x =>
+    val res = findTemplateGroupOnRight { x =>
       // this method is called on a `with` or comma; hence, it can
       // only refer to second or subsequent init/derive in a group
       // we'll indent only the second, but not any subsequent ones
@@ -488,15 +496,14 @@ class FormatOps(
           nlSplit(1),
         )
       }
-    }(template).getOrElse(
-      Seq(Split(Space, 0)), // shouldn't happen
-    )
+    }(template)
+    res ?? Seq(Split(Space, 0)) // shouldn't happen
   }
 
   def binPackParentConstructorSplits(
       isFirstCtor: Boolean,
       owners: => Set[Tree],
-      rhs: => Option[Tree],
+      rhs: => Tree,
       lastFt: FT,
       indentLen: Int,
       extendsThenWith: => Boolean = false,
@@ -515,7 +522,7 @@ class FormatOps(
     if (style.binPack.keepParentConstructors)
       if (ft.hasBreak) Seq(Split(nlMod, 0).withIndent(indent))
       else {
-        val slbEnd = getSlbEndOnLeft(rhs.fold(lastFt)(getLast))
+        val slbEnd = getSlbEndOnLeft(rhs.nnMap(getLast) ?? lastFt)
         Seq(
           Split(Space, 0).withIndent(indent).withSingleLine(
             slbEnd,
@@ -568,7 +575,8 @@ class FormatOps(
           cfg: ScalafmtOptimizer.ClauseElement,
       ): Unit = if (cfg.isEnabled) {
         val openIdx = ftOpen.idx
-        matchingOpt(openIdx).foreach { close =>
+        val close = matchingOrNull(openIdx)
+        if (close ne null) {
           val values = clause.values
           if (
             values.lengthCompare(cfg.minCount) >= 0 &&
@@ -620,7 +628,7 @@ class FormatOps(
           case t: Tree.WithParamClauseGroups => t.paramClauseGroups
               .flatMap(getClausesFromClauseGroup)
           case t: Tree.WithParamClauseGroup => t.paramClauseGroup
-              .map(getClausesFromClauseGroup).getOrElse(Nil)
+              .fold(List.empty[Member.ParamClause])(getClausesFromClauseGroup)
           case t: Stat.WithCtor with Tree.WithTParamClause => t.tparamClause +:
               t.ctor.paramClauses
           case t: Tree.WithParamClauses => t.paramClauses
@@ -636,7 +644,7 @@ class FormatOps(
     // find the last param on the defn so that we can apply our `policy`
     // till the end.
     val lastParens = allParenOwners.map(getLast)
-    val lastParen = lastParens.lastOption.getOrElse(close)
+    val lastParen = lastParens.lastOrNull ?? close
 
     val shouldNotDangle =
       !style.danglingParentheses.atVerticalMultilineSite(lpOwner)
@@ -720,9 +728,10 @@ class FormatOps(
       val implicitNL = rightIsImplicit &&
         style.newlines.forceBeforeImplicitParamListModifier
       val implicitParams =
-        if (rightIsImplicit) getImplicitParamList(ft.meta.rightOwner)
-          .fold(Nil: List[Tree])(_.values)
-        else Nil
+        if (rightIsImplicit) {
+          val params = getImplicitParamList(ft.meta.rightOwner)
+          if (params eq null) Nil else params.values
+        } else Nil
       val noSlb = implicitNL || aboveArityThreshold ||
         ft.hasBreak && !style.newlines.sourceIgnored &&
         style.newlines.configStyle.getDefnSite(isBracket).prefer ||
@@ -737,8 +746,8 @@ class FormatOps(
         // If we can fit all in one block, make it so
         slbSplit.notIf(noSlb),
         Split(space, 0, policy).onlyIf(spaceImplicit).andPolicy(
-          decideNewlinesOnlyAfterClose(nft),
-          isRightCommentThenBreak(nft),
+          if (isRightCommentThenBreak(nft)) null
+          else decideNewlinesOnlyAfterClose(nft),
         ).withIndent(firstIndent),
         // Otherwise split vertically
         Split(nlMod, 1, policy).withIndent(firstIndent),
@@ -788,75 +797,76 @@ class FormatOps(
   @tailrec
   private def findLastApplyAndNextSelectEnclosed(
       tree: Tree,
-      select: Option[Select] = None,
-      prevApply: Option[Tree] = None,
-  ): (Tree, Option[Select]) =
-    if (isEnclosedWithinParens(tree)) (prevApply.getOrElse(tree), select)
+      select: Select = null,
+      prevApply: Tree = null,
+  ): (Tree, Select) =
+    if (isEnclosedWithinParens(tree)) (prevApply ?? tree, select)
     else tree.parent match {
       case Some(Select(p)) =>
-        findLastApplyAndNextSelectEnclosed(p.tree, select.orElse(Some(p)))
+        findLastApplyAndNextSelectEnclosed(p.tree, select ?? p)
       case Some(p: Member.Apply) if p.fun eq tree =>
         findLastApplyAndNextSelectEnclosed(p, select)
       case Some(p @ Term.Block(`tree` :: Nil)) if !isEnclosedInBraces(p) =>
-        findLastApplyAndNextSelectEnclosed(p, select, prevApply.orElse(Some(tree)))
-      case _ => (prevApply.getOrElse(tree), select)
+        findLastApplyAndNextSelectEnclosed(p, select, prevApply ?? tree)
+      case _ => (prevApply ?? tree, select)
     }
 
   @tailrec
   private def findLastApplyAndNextSelectPastEnclosed(
       tree: Tree,
-      select: Option[Select] = None,
-      prevEnclosed: Option[Tree] = None,
-      prevApply: Option[Tree] = None,
-  ): (Tree, Option[Select]) = tree.parent match {
+      select: Select = null,
+      prevEnclosed: Tree = null,
+      prevApply: Tree = null,
+  ): (Tree, Select) = tree.parent match {
     case Some(Select(p)) =>
-      findLastApplyAndNextSelectPastEnclosed(p.tree, select.orElse(Some(p)))
+      findLastApplyAndNextSelectPastEnclosed(p.tree, select ?? p)
     case Some(p: Member.Apply) if p.fun eq tree =>
-      prevEnclosed match {
-        case Some(t) => (t, select)
-        case _ =>
-          val nextEnclosed = prevApply.orElse(Some(tree))
-            .filter(isEnclosedWithinParens)
-          findLastApplyAndNextSelectPastEnclosed(p, select, nextEnclosed)
+      if (prevEnclosed ne null) (prevEnclosed, select)
+      else {
+        val nextApply = prevApply ?? tree
+        val nextEnclosed =
+          if (isEnclosedWithinParens(nextApply)) nextApply else null
+        findLastApplyAndNextSelectPastEnclosed(p, select, nextEnclosed)
       }
     case Some(p: Term.AnonymousFunction) =>
-      findLastApplyAndNextSelectPastEnclosed(p, select, Some(p))
+      findLastApplyAndNextSelectPastEnclosed(p, select, p)
     case Some(p @ Term.Block(`tree` :: Nil)) if !isEnclosedInBraces(p) =>
-      val nextApply = prevApply.orElse(Some(tree))
+      val nextApply = prevApply ?? tree
       findLastApplyAndNextSelectPastEnclosed(p, select, prevEnclosed, nextApply)
-    case _ => (prevEnclosed.orElse(prevApply).getOrElse(tree), select)
+    case _ => (prevEnclosed ?? prevApply ?? tree, select)
   }
 
   final def findLastApplyAndNextSelect(
       tree: Tree,
       enclosed: Boolean,
-  ): (Tree, Option[Select]) =
+  ): (Tree, Select) =
     if (enclosed) findLastApplyAndNextSelectEnclosed(tree)
     else findLastApplyAndNextSelectPastEnclosed(tree)
 
   def canStartSelectChain(
       thisSelectLike: Select,
-      nextSelectLike: Option[Select],
+      nextSelectLike: Select,
       lastApply: Tree,
   )(implicit style: ScalafmtConfig): Boolean = {
     val thisTree = thisSelectLike.tree
-    val nextSelect = nextSelectLike.map(_.tree)
+    val nextSelect = nextSelectLike.nnMap(_.tree)
     val ok = thisTree.ne(lastApply) &&
       !cannotStartSelectChainOnExpr(thisSelectLike.qual)
     val cfg = style.newlines.selectChains
-    def checkParent = thisTree.parent match {
-      case `nextSelect` => cfg.classicCanStartWithoutApply
-      case Some(p: Term.Apply) if getHead(p.argClause).left.is[T.LeftBrace] =>
-        cfg.classicCanStartWithBraceApply && !nextSelect.contains(lastApply) // exclude short curly
-      case Some(p: Member.Apply) => p.fun eq thisTree
-      case _ => false
-    }
+    def checkParent =
+      if (thisTree.parentOrNull eq nextSelect) cfg.classicCanStartWithoutApply
+      else thisTree.parent match {
+        case Some(p: Term.Apply) if getHead(p.argClause).left.is[T.LeftBrace] =>
+          cfg.classicCanStartWithBraceApply && (nextSelect ne lastApply) // exclude short curly
+        case Some(p: Member.Apply) => p.fun eq thisTree
+        case _ => false
+      }
     ok &&
     (thisTree match {
       case _: Term.SelectMatch => // like select and apply in one
         !tokenAfter(thisSelectLike.nameFt).right.is[T.LeftBrace] ||
-        cfg.classicCanStartWithBraceApply &&
-        nextSelect.isDefined && !nextSelect.contains(lastApply)
+        cfg.classicCanStartWithBraceApply && (nextSelect ne null) &&
+        (nextSelect ne lastApply)
       case _ => checkParent
     })
   }
@@ -864,13 +874,13 @@ class FormatOps(
   /** Checks if an earlier select started the chain */
   @tailrec
   final def inSelectChain(
-      prevSelect: Option[Select],
+      prevSelect: Select,
       thisSelect: Select,
       lastApply: Tree,
   )(implicit style: ScalafmtConfig): Boolean = prevSelect match {
-    case None => false
-    case Some(p) if canStartSelectChain(p, Some(thisSelect), lastApply) => true
-    case Some(p) => inSelectChain(Select.prev(p), p, lastApply)
+    case null => false
+    case p if canStartSelectChain(p, thisSelect, lastApply) => true
+    case p => inSelectChain(Select.prev(p), p, lastApply)
   }
 
   @tailrec
@@ -884,27 +894,25 @@ class FormatOps(
     case _ => findXmlLastLineIndent(prev(ft))
   }
 
-  private def withIndentOnXmlToken(
-      ft: => Option[FT],
-      xmlEnd: => FT,
-      splits: Seq[Split],
-  )(implicit style: ScalafmtConfig): Seq[Split] =
+  private def withIndentOnXmlToken(ft: => FT, xmlEnd: => FT, splits: Seq[Split])(
+      implicit style: ScalafmtConfig,
+  ): Seq[Split] =
     if (style.xmlLiterals.assumeFormatted) {
       val end = xmlEnd
-      val len = findXmlLastLineIndent(prev(ft.getOrElse(end)))
+      val len = findXmlLastLineIndent(prev(ft ?? end))
       val indent = Indent(Length.Num(len, reset = true), end, ExpiresOn.After)
       splits.map(_.withIndent(indent))
     } else splits
 
   def withIndentOnXmlStart(xmlEnd: => FT, splits: Seq[Split])(implicit
       style: ScalafmtConfig,
-  ): Seq[Split] = withIndentOnXmlToken(None, xmlEnd, splits)
+  ): Seq[Split] = withIndentOnXmlToken(null, xmlEnd, splits)
 
   def withIndentOnXmlSpliceStart(ft: FT, splits: Seq[Split])(implicit
       style: ScalafmtConfig,
   ): Seq[Split] = ft.left match {
     case _: T.Xml.SpliceStart =>
-      withIndentOnXmlToken(Some(ft), matchingLeft(ft), splits)
+      withIndentOnXmlToken(ft, matchingLeft(ft), splits)
     case _ => splits
   }
 
@@ -1047,21 +1055,22 @@ class FormatOps(
           else getSlbSplits()
         case _: Term.Block | _: Term.MatchLike | _: Type.Match |
             _: Term.NewAnonymous => getSplits(getSpaceSplit(1))
-        case t: Term.ForYield => getDelimsIfEnclosed(t.enumsBlock) match {
-            case Some((forEnumHead, forEnumLast)) =>
-              val exclude = TokenRanges(TokenRange(forEnumHead, forEnumLast))
-              val afterYield = (t.body match {
-                case b: Term.Block => getHeadAndLastIfEnclosed(b)
-                    .map { case (forBodyHead, forBodyLastOpt) =>
-                      if (forBodyLastOpt.isDefined) forBodyHead
-                      else prevNonCommentBefore(forBodyHead)
-                    }
-                case b => tokenBeforeOpt(b)
-              }).getOrElse(getLast(t))
-              val end = getSlbEndOnLeft(afterYield)
-              getSlbSplits(end, exclude, penalize(1))
-            case None => getSlbSplits()
-          }
+        case t: Term.ForYield =>
+          val delims = getDelimsIfEnclosed(t.enumsBlock)
+          if (delims ne null) {
+            val (forEnumHead, forEnumLast) = delims
+            val exclude = TokenRanges(TokenRange(forEnumHead, forEnumLast))
+            val afterYield = t.body match {
+              case b: Term.Block => getHeadAndLastIfEnclosed(b)
+                  .nnMap { case (forBodyHead, forBodyLast) =>
+                    if (forBodyLast ne null) forBodyHead
+                    else prevNonCommentBefore(forBodyHead)
+                  }
+              case b => tokenBefore(b)
+            }
+            val end = getSlbEndOnLeft(afterYield ?? getLast(t))
+            getSlbSplits(end, exclude, penalize(1))
+          } else getSlbSplits()
         case ia: Member.Infix =>
           val lia = InfixSplits.findLeftInfix(ia)
           val callPolicy = CallSite.getFoldedPolicy(lia.lhs)
@@ -1110,7 +1119,7 @@ class FormatOps(
         case _: Term.TryClause => Split.ignored
         // don't tuck curried apply
         case t: Term.Apply if t.fun.is[Term.Apply] => slbSplit(expire)
-        case t => slbSplit(getEndOfFirstCall(t).getOrElse(expire))
+        case t => slbSplit(getEndOfFirstCall(t) ?? expire)
       }
     }
 
@@ -1124,12 +1133,12 @@ class FormatOps(
       else {
         val nextFt = nextNonCommentSameLineAfter(ft)
         val last = getLastNonTrivial(body)
-        getClosingIfWithinParens(last)(nextFt).fold {
+        if (getClosingIfWithinParens(last)(nextFt) eq null) {
           val spaceSplit =
             if (!style.newlines.sourceIgnored && ft.hasBreak) Split.ignored
             else unfoldedSpaceNonEmptyNonComment(body, slbOnly, last)
           Seq(spaceSplit.withIndents(spaceIndents), nlSplitFunc(1).forThisLine)
-        } { _ =>
+        } else {
           val policy = Policy.onlyFor(nextFt, "CTRLUF")(ss =>
             ss.map(s =>
               if (s.isNL) s
@@ -1155,7 +1164,7 @@ class FormatOps(
         if (nextFt.hasBreakOrEOF)
           Seq(nlSplitFunc(1).forThisLine.withMod(Space).andPolicy(nlPolicy))
         else splitsFunc(nextFt)
-          .map(s => s.withMod(Space).andPolicy(nlPolicy, !s.isNL))
+          .map(s => s.withMod(Space).andPolicy(if (s.isNL) nlPolicy else null))
       }
 
     def folded(
@@ -1188,9 +1197,9 @@ class FormatOps(
         case Newlines.unfold =>
           unfoldedNonComment(body, nlSplitFunc, spaceIndents, slbOnly = false)
         case Newlines.classic if x.noBreak =>
-          Option(classicNoBreakFunc).fold(getFolded(true))(func =>
-            func.forThisLine +: getFoldedKeepNLOnly,
-          )
+          val func = classicNoBreakFunc
+          if (func eq null) getFolded(true)
+          else func.forThisLine +: getFoldedKeepNLOnly
         case Newlines.keep if x.noBreak => getFolded(true)
         case _ => getFoldedKeepNLOnly // keep/classic with break
       }
@@ -1212,9 +1221,9 @@ class FormatOps(
         style: ScalafmtConfig,
     ): Split = withNLPolicy(endFt) {
       val nft = nextNonComment(ft)
-      val rpOpt = if (nft.right.is[T.LeftParen]) matchingOptRight(nft) else None
+      val rp = if (nft.right.is[T.LeftParen]) matchingRightOrNull(nft) else null
       val expire = nextNonCommentSameLine(
-        rpOpt.fold(endFt)(rp => if (rp.left.end >= endFt.left.end) rp else endFt),
+        if ((rp ne null) && rp.left.end >= endFt.left.end) rp else endFt,
       )
       nlSplit.withIndent(style.indent.main, expire, ExpiresOn.After)
     }
@@ -1222,8 +1231,9 @@ class FormatOps(
     def withIndent(nlSplit: Split, body: Tree, endFt: => FT)(implicit
         ft: FT,
         style: ScalafmtConfig,
-    ): Split = asInfixApp(body)
-      .fold(withIndent(nlSplit, endFt))(InfixSplits.withNLIndent(nlSplit))
+    ): Split = asInfixApp(body).nnFold(withIndent(nlSplit, endFt))(x =>
+      InfixSplits.withNLIndent(nlSplit)(x),
+    )
 
   }
 
@@ -1243,43 +1253,43 @@ class FormatOps(
   // Redundant () delims around case statements
   def getClosingIfCaseBodyEnclosedAsBlock(postArrowFt: FT, caseStat: CaseTree)(
       implicit beforeMultiline: Newlines.SourceHints,
-  ): Option[FT] = {
+  ): FT = {
     val body = caseStat.body
     val ok = body.eq(postArrowFt.meta.rightOwner) &&
       (beforeMultiline.ignoreSourceSplit || postArrowFt.noBreak)
-    if (ok) getClosingIfBodyEnclosedAsBlock(body) else None
+    if (ok) getClosingIfBodyEnclosedAsBlock(body) else null
   }
 
   // Redundant () delims around body
-  def getClosingIfBodyEnclosedAsBlock(body: Tree): Option[FT] = body match {
-    case _: Lit.Unit | _: Term.Tuple => None
+  def getClosingIfBodyEnclosedAsBlock(body: Tree): FT = body match {
+    case _: Lit.Unit | _: Term.Tuple => null
     case t: Term.ApplyInfix if {
           val op = t.op.value
           op == "->" || op == "→"
-        } => None
+        } => null
     case _ => getClosingIfWithinParens(body)
   }
 
   def isBodyEnclosedAsBlock(body: Tree): Boolean =
-    getClosingIfBodyEnclosedAsBlock(body).isDefined
+    getClosingIfBodyEnclosedAsBlock(body) ne null
 
   def getSplitsForTypeBounds(
       noNLMod: => Modification,
       tbounds: Type.Bounds,
       bounds: => Seq[Type],
   )(implicit style: ScalafmtConfig, ft: FT): Seq[Split] = {
-    val boundOpt = bounds.find(_.begOffset > ft.right.end)
-    val expireOpt = boundOpt.map(getLastNonTrivial)
+    val boundOpt = bounds.findOrNull(_.begOffset > ft.right.end)
+    val expireOpt = boundOpt.nnMap(getLastNonTrivial)
     getSplitsForTypeBounds(noNLMod, tbounds, expireOpt)
   }
 
   def getSplitsForTypeBounds(
       noNLMod: => Modification,
       tbounds: Type.Bounds,
-      boundEndOpt: Option[FT],
+      boundEndOpt: FT,
   )(implicit style: ScalafmtConfig, ft: FT): Seq[Split] = {
     val typeEnd = getLastNonTrivial(tbounds)
-    val boundEnd = boundEndOpt.getOrElse(typeEnd)
+    val boundEnd = boundEndOpt ?? typeEnd
     def indent = Indent(style.indent.main, boundEnd, ExpiresOn.After)
     def unfoldPolicy = Policy.onLeft(typeEnd, prefix = "VB/CB") {
       case Decision(FT(_, _: T.Colon | _: T.Viewbound, m), s)
@@ -1455,50 +1465,48 @@ class FormatOps(
 
   object BinPackOneline {
 
-    private def noRighDelim(xtok: T, xft: FT): Option[FT] = xtok match {
-      case _: T.CloseDelim => None
-      case _: T.Comma => Some(null) // trailing comma, has NL
-      case _: T.Comment => if (xft.noBreak) None else Some(null)
-      case _ => Some(xft)
-    }
+    // Scan via `iter`, skipping right-delimiters (and same-line comments), and
+    // return: the first "real" token; or `null` for a trailing comma or broken
+    // comment (both denoting a newline); or the last token reached if the scan
+    // runs off the end.
+    @tailrec
+    private def findRightDelim(ft: FT, iter: FT => FT)(tok: FT => T): FT =
+      tok(ft) match {
+        case _: T.Comma => null // trailing comma, has NL
+        case _: T.Comment if ft.hasBreak => null
+        case _: T.CloseDelim | _: T.Comment =>
+          val nextFt = iter(ft)
+          if (nextFt eq ft) ft else findRightDelim(nextFt, iter)(tok)
+        case _ => ft
+      }
 
-    @inline
-    def getBeforeRightDelims(ft: FT): FT =
-      findTokenWith(ft, prev)(xft => noRighDelim(xft.left, xft)).merge
-    @inline
-    def getAfterRightDelims(ft: FT): FT =
-      findTokenWith(ft, next)(xft => noRighDelim(xft.right, xft)).merge
+    def getBeforeRightDelims(ft: FT): FT = findRightDelim(ft, prev)(_.left)
+    def getAfterRightDelims(ft: FT): FT = findRightDelim(ft, next)(_.right)
 
-    private def policyOnRightDelim(
-        ft: FT,
-        exclude: TokenRanges,
-    ): (Option[FT], Policy) = {
+    private def policyOnRightDelim(ft: FT, exclude: TokenRanges): (FT, Policy) = {
       val beforeDelims = getBeforeRightDelims(ft)
-      if (beforeDelims eq null) return (None, Policy.NoPolicy)
+      if (beforeDelims eq null) return (null, Policy.NoPolicy)
 
       val afterDelims = getAfterRightDelims(ft)
-      if (afterDelims eq null) return (None, Policy.NoPolicy)
+      if (afterDelims eq null) return (null, Policy.NoPolicy)
 
       def closeBreakPolicy() = {
         @tailrec
-        def iter(currft: FT): Option[Policy] = {
+        def iter(currft: FT): Policy = {
           val prevft = prevNonComment(currft)
-          val breakBeforeClose = matchingOptLeft(prevft) match {
-            case Some(open) =>
-              val cfg = styleMap.at(open)
-              val owner = prevft.meta.leftOwner
-              def cfgStyle = cfg.newlines.configStyle.getCallSite(owner).prefer
-              def dangle = cfg.danglingParentheses.atCallSite(owner)
-              cfg.newlines.source match {
-                case Newlines.unfold => true
-                case Newlines.fold => cfgStyle ||
-                  !cfg.binPack.indentCallSiteOnce
-                case _ => !cfgStyle || dangle || prev(prevft).hasBreak
-              }
-            case _ => false
+          val breakBeforeClose = matchingLeftOrNull(prevft).nnHas { open =>
+            val cfg = styleMap.at(open)
+            val owner = prevft.meta.leftOwner
+            def cfgStyle = cfg.newlines.configStyle.getCallSite(owner).prefer
+            def dangle = cfg.danglingParentheses.atCallSite(owner)
+            cfg.newlines.source match {
+              case Newlines.unfold => true
+              case Newlines.fold => cfgStyle || !cfg.binPack.indentCallSiteOnce
+              case _ => !cfgStyle || dangle || prev(prevft).hasBreak
+            }
           }
-          if (breakBeforeClose) Some(decideNewlinesOnlyBeforeClose(prevft))
-          else if (prevft eq beforeDelims) None
+          if (breakBeforeClose) decideNewlinesOnlyBeforeClose(prevft)
+          else if (prevft eq beforeDelims) null
           else iter(prev(prevft))
         }
 
@@ -1515,22 +1523,26 @@ class FormatOps(
 
       (afterDelims.right match {
         case _: T.Dot => // check if Dot rule includes a break option
-          afterDelims -> Select.onRightOpt(afterDelims).map { x =>
-            implicit val cfg = styleMap.at(afterDelims)
-            cfg.newlines.getSelectChains match {
-              case Newlines.classic =>
-                val (expireTree, nextSelect) = findLastApplyAndNextSelect(
-                  x.tree,
-                  cfg.newlines.encloseSelectChains,
-                )
-                Right(canStartSelectChain(x, nextSelect, expireTree))
-              case Newlines.keep => Left(Policy.onlyFor(afterDelims, "BP1L.NL")(
-                  Decision.onlyNewlineSplits(_)
-                    .map(_.preActivateFor(SplitTag.SelectChainBinPackNL)),
-                ))
-              case _ => Right(true)
+          val select = Select.onRightOrNull(afterDelims)
+          val policyOrOkToBreak =
+            if (select eq null) Right(false)
+            else {
+              implicit val cfg = styleMap.at(afterDelims)
+              cfg.newlines.getSelectChains match {
+                case Newlines.classic =>
+                  val (expireTree, nextSelect) = findLastApplyAndNextSelect(
+                    select.tree,
+                    cfg.newlines.encloseSelectChains,
+                  )
+                  Right(canStartSelectChain(select, nextSelect, expireTree))
+                case Newlines.keep => Left(Policy.onlyFor(afterDelims, "BP1L.NL")(
+                    Decision.onlyNewlineSplits(_)
+                      .map(_.preActivateFor(SplitTag.SelectChainBinPackNL)),
+                  ))
+                case _ => Right(true)
+              }
             }
-          }.getOrElse(Right(false))
+          afterDelims -> policyOrOkToBreak
         case x @ LeftParenOrBracket() =>
           val nft = nextNonCommentSameLineAfter(afterDelims)
           nft.right match {
@@ -1545,33 +1557,31 @@ class FormatOps(
               nft -> Right(ok)
           }
         case _ => null
-      }) match {
-        case null => (None, Policy.NoPolicy)
-        case (nft, policyOrOkToBreak) =>
-          val policyOpt = policyOrOkToBreak match {
-            case Left(policy) => Some(policy)
-            case Right(okToBreak) if !okToBreak => closeBreakPolicy()
-            case _ => Some(decideNewlinesOnlyBeforeToken(next(nft)))
-          }
-          (Some(nft), policyOpt.fold(Policy.noPolicy)(policyWithDelay))
-      }
+      }).nnMapOr { case (nft, policyOrOkToBreak) =>
+        val policyOpt = policyOrOkToBreak match {
+          case Left(policy) => policy
+          case Right(okToBreak) if !okToBreak => closeBreakPolicy()
+          case _ => decideNewlinesOnlyBeforeToken(next(nft))
+        }
+        (nft, policyOpt.nnMap(policyWithDelay) ?? Policy.NoPolicy)
+      }((null, Policy.NoPolicy))
     }
 
     def getPolicy(isCallSite: Boolean, exclude: TokenRanges)(
         afterArg: FT,
-    )(implicit fl: FileLine, ft: FT): (Option[FT], Policy) =
-      afterArg.right match {
-        case _: T.Comma // check for trailing comma, which needs no breaks
-            if !nextNonCommentAfter(afterArg).right.is[T.CloseDelim] =>
-          (None, splitOneArgPerLineAfterCommaOnBreak(exclude)(next(afterArg)))
-        case _: T.CloseDelim if isCallSite =>
-          policyOnRightDelim(afterArg, exclude)
-        case _ => (None, Policy.NoPolicy)
-      }
+    )(implicit fl: FileLine, ft: FT): (FT, Policy) = afterArg.right match {
+      case _: T.Comma // check for trailing comma, which needs no breaks
+          if !nextNonCommentAfter(afterArg).right.is[T.CloseDelim] =>
+        (null, splitOneArgPerLineAfterCommaOnBreak(exclude)(next(afterArg)))
+      case _: T.CloseDelim if isCallSite => policyOnRightDelim(afterArg, exclude)
+      case _ => (null, Policy.NoPolicy)
+    }
   }
 
-  def indentedPackage(body: Pkg.Body): Boolean = getHeadOpt(body)
-    .exists(_.meta.leftOwner eq body)
+  def indentedPackage(body: Pkg.Body): Boolean = {
+    val h = getHead(body)
+    (h ne null) && (h.meta.leftOwner eq body)
+  }
   @inline
   def indentedPackage(pkg: Pkg): Boolean = indentedPackage(pkg.body)
 
@@ -1594,12 +1604,12 @@ class FormatOps(
         if (tr.ranges.exists(!_.lt.left.is[T.LeftBrace])) null else Some(tr)
       }
       (nft.leftOwner match {
-        case Term.Block(arg :: Nil) if style.newlines.fold => Some(arg)
-        case Term.ArgClause(arg :: Nil, _) if style.newlines.fold => Some(arg)
-        case _ => None
+        case Term.Block(arg :: Nil) if style.newlines.fold => arg
+        case Term.ArgClause(arg :: Nil, _) if style.newlines.fold => arg
+        case _ => null
       }) match {
-        case Some(_: Term.FunctionLike) => Some(TokenRanges.empty)
-        case Some(arg) if isTreeEndingInArgumentClause(arg) =>
+        case _: Term.FunctionLike => Some(TokenRanges.empty)
+        case arg if (arg ne null) && isTreeEndingInArgumentClause(arg) =>
           Some(parensTuple(arg))
         case _ => getTokenRanges
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.rewrite.FormatTokensRewrite
@@ -22,7 +23,7 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
     result.result()
   }(arr)
 
-  private lazy val matchingDelims: Map[Int, FT] = TreeOps
+  private lazy val matchingDelims: java.util.HashMap[Int, FT] = TreeOps
     .getMatchingDelims(arr)(_.idx)(_.left)
 
   override def length: Int = arr.length
@@ -78,119 +79,118 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   def next(ft: FT): FT = apply(ft, 1)
 
   @inline
-  private def matching(idx: Int, tok: => T): FT = matchingDelims.getOrElse(
-    idx,
-    FormatTokens.throwNoToken(tok, "Missing matching token index"),
-  )
+  private def matching(idx: Int, tok: => T): FT = matchingDelims.get(idx) ??
+    FormatTokens.throwNoToken(tok, "Missing matching token index")
   @inline
   def matchingLeft(ft: FT): FT = matching(ft.idx, ft.left)
   @inline
   def matchingRight(ft: FT): FT = matching(ft.idx + 1, ft.right)
   @inline
-  def matchingOpt(idx: Int): Option[FT] = matchingDelims.get(idx)
+  def matchingOrNull(idx: Int): FT = matchingDelims.get(idx)
   @inline
-  def matchingOptLeft(ft: FT): Option[FT] = matchingOpt(ft.idx)
+  def matchingLeftOrNull(ft: FT): FT = matchingOrNull(ft.idx)
   @inline
-  def matchingOptRight(ft: FT): Option[FT] = matchingOpt(ft.idx + 1)
+  def matchingRightOrNull(ft: FT): FT = matchingOrNull(ft.idx + 1)
 
-  def getHeadAndLastIfEnclosed(
-      tokens: Tokens,
-      tree: Tree,
-  ): Option[(FT, Option[FT])] = getHeadOpt(tokens, tree).map(head =>
-    head -> matchingOptLeft(head).flatMap { other =>
-      val last = getLastNonTrivial(tokens, tree)
-      if (last eq other) Some(last) else None
-    },
-  )
-  def getHeadAndLastIfEnclosed(tree: Tree): Option[(FT, Option[FT])] =
+  def getHeadAndLastIfEnclosed(tokens: Tokens, tree: Tree): (FT, FT) =
+    getHead(tokens, tree).nnMap(h =>
+      h -> matchingLeftOrNull(h).nnMap { other =>
+        val last = getLastNonTrivial(tokens, tree)
+        if (last eq other) last else null
+      },
+    )
+  def getHeadAndLastIfEnclosed(tree: Tree): (FT, FT) =
     getHeadAndLastIfEnclosed(tree.tokens, tree)
 
-  def getDelimsIfEnclosed(tokens: Tokens, tree: Tree): Option[(FT, FT)] =
-    getHeadAndLastIfEnclosed(tokens, tree).flatMap { case (head, lastOpt) =>
-      lastOpt.map(last => (head, last))
-    }
-  def getDelimsIfEnclosed(tree: Tree): Option[(FT, FT)] =
+  def getDelimsIfEnclosed(tokens: Tokens, tree: Tree): (FT, FT) =
+    getHeadAndLastIfEnclosed(tokens, tree).nnIf(_.nnHas(_._2 ne null))
+
+  def getDelimsIfEnclosed(tree: Tree): (FT, FT) =
     getDelimsIfEnclosed(tree.tokens, tree)
 
-  def getHeadIfEnclosed(tokens: Tokens, tree: Tree): Option[FT] =
-    getDelimsIfEnclosed(tokens, tree).map(_._1)
-  def getHeadIfEnclosed(tree: Tree): Option[FT] = getDelimsIfEnclosed(tree)
-    .map(_._1)
+  def getHeadIfEnclosed(tokens: Tokens, tree: Tree): FT =
+    getDelimsIfEnclosed(tokens, tree).nnMap(_._1)
 
-  def getLastIfEnclosed(tokens: Tokens, tree: Tree): Option[FT] =
-    getDelimsIfEnclosed(tokens, tree).map(_._2)
-  def getLastIfEnclosed(tree: Tree): Option[FT] = getDelimsIfEnclosed(tree)
-    .map(_._2)
+  def getHeadIfEnclosed(tree: Tree): FT = getDelimsIfEnclosed(tree).nnMap(_._1)
+
+  def getLastIfEnclosed(tokens: Tokens, tree: Tree): FT =
+    getDelimsIfEnclosed(tokens, tree).nnMap(_._2)
+
+  def getLastIfEnclosed(tree: Tree): FT = getDelimsIfEnclosed(tree).nnMap(_._2)
 
   def isEnclosedInMatching(tokens: Tokens, tree: Tree): Boolean =
-    getDelimsIfEnclosed(tokens, tree).isDefined
+    getDelimsIfEnclosed(tokens, tree) ne null
   def isEnclosedInMatching(tree: Tree): Boolean =
     isEnclosedInMatching(tree.tokens, tree)
 
   @inline
-  def getBracesIfEnclosed(tree: Tree): Option[(FT, FT)] =
-    getDelimsIfEnclosed(tree).filter(_._1.left.is[T.LeftBrace])
+  def getBracesIfEnclosed(tree: Tree): (FT, FT) = getDelimsIfEnclosed(tree)
+    .nnIf(_.nnHas(_._1.left.is[T.LeftBrace]))
 
   @inline
   def isEnclosedInBraces(tree: Tree): Boolean = getDelimsIfEnclosed(tree)
-    .exists(_._1.left.is[T.LeftBrace])
+    .nnHas(_._1.left.is[T.LeftBrace])
 
   def isEnclosedWithinParens(tree: Tree): Boolean =
-    getClosingIfWithinParens(tree).isDefined
+    getClosingIfWithinParens(tree) ne null
 
-  def getClosingIfWithinParens(tree: Tree): Option[FT] =
-    getClosingIfWithinParensOrBraces(tree).flatMap(_.toOption)
+  def getClosingIfWithinParens(tree: Tree): FT =
+    getClosingIfWithinParensOrBraces(tree) match {
+      case Right(x) => x
+      case _ => null
+    }
 
-  def getClosingIfWithinParens(last: FT)(head: FT): Option[FT] =
-    getClosingIfWithinParensOrBraces(last)(head).flatMap(_.toOption)
+  def getClosingIfWithinParens(last: FT)(head: FT): FT =
+    getClosingIfWithinParensOrBraces(last)(head) match {
+      case Right(x) => x
+      case _ => null
+    }
 
   def isEnclosedWithinParensOrBraces(tree: Tree): Boolean =
-    getClosingIfWithinParensOrBraces(tree).isDefined
+    getClosingIfWithinParensOrBraces(tree) ne null
 
-  def getClosingIfWithinParensOrBraces(
-      last: FT,
-  )(head: FT): Option[Either[FT, FT]] = {
-    val innerMatched = matchingOptLeft(last).contains(head)
-    if (innerMatched && last.left.is[T.RightParen]) Some(Right(prev(last)))
+  def getClosingIfWithinParensOrBraces(last: FT)(head: FT): Either[FT, FT] = {
+    val innerMatched = matchingLeftOrNull(last) eq head
+    if (innerMatched && last.left.is[T.RightParen]) Right(prev(last))
     else {
       val afterLast = nextNonComment(last)
-      if (!matchingOptRight(afterLast).exists(_ eq prevNonCommentBefore(head)))
-        if (innerMatched) Some(Left(prev(last))) else None
-      else
-        Some(Either.cond(afterLast.right.is[T.RightParen], afterLast, afterLast))
+      if (matchingRightOrNull(afterLast) =!= prevNonCommentBefore(head))
+        if (innerMatched) Left(prev(last)) else null
+      else Either.cond(afterLast.right.is[T.RightParen], afterLast, afterLast)
     }
   }
 
-  def getClosingIfWithinParensOrBraces(tree: Tree): Option[Either[FT, FT]] = {
-    val tokens = tree.tokens
-    getHeadOpt(tokens, tree) match {
-      case Some(head) =>
-        getClosingIfWithinParensOrBraces(getLastNonTrivial(tokens, tree))(head)
-      case None => None
-    }
-  }
+  def getClosingIfWithinParensOrBraces(tree: Tree): Either[FT, FT] =
+    getHead(tree).nnMap(getClosingIfWithinParensOrBraces(getLastNonTrivial(tree)))
 
   def getLastExceptParen(tree: Tree): FT = {
-    val tokens = tree.tokens
-    val last = getLast(tokens, tree)
-    getClosingIfWithinParens(prevNonComment(last))(getHead(tokens, tree))
-      .getOrElse(last)
+    val last = getLast(tree)
+    getClosingIfWithinParens(prevNonComment(last))(getHead(tree)) ?? last
   }
 
-  final def findTokenWith[A](ft: FT, iter: FT => FT)(
-      f: FT => Option[A],
-  ): Either[FT, A] = findTokenEx(ft)(xft => f(xft).toRight(iter(xft)))
-
+  // `f` drives the scan: `Right(a)` stops with the found `a`, `Left(nextFt)`
+  // advances to `nextFt` (may jump), `null` stops empty. Returns the found `a`,
+  // or `null` if the scan stops empty or can no longer advance.
   @tailrec
-  final def findTokenEx[A](ft: FT)(f: FT => Either[FT, A]): Either[FT, A] =
+  final def findTokenEx[A >: Null](f: FT => Either[FT, A])(ft: FT): A =
     f(ft) match {
-      case null => Left(ft)
-      case Left(nextFt) if nextFt ne ft => findTokenEx(nextFt)(f)
-      case x => x
+      case Right(a) => a
+      case Left(nextFt) if nextFt ne ft => findTokenEx(f)(nextFt)
+      case _ => null
     }
 
-  final def findToken(ft: FT, iter: FT => FT)(f: FT => Boolean): FT =
-    findTokenWith(ft, iter)(Some(_).filter(f)).merge
+  // Direct, allocation-free scan: advance via `iter` until `f` holds, or until
+  // `iter` can no longer advance (returns that last token). Hot path
+  // (`nextNonComment`/`prevNonComment`/...).
+  final def findToken(ft: FT, iter: FT => FT)(f: FT => Boolean): FT = {
+    var curr = ft
+    while (!f(curr)) {
+      val nextFt = iter(curr)
+      if (nextFt eq curr) return curr
+      curr = nextFt
+    }
+    curr
+  }
 
   final def nextNonCommentSameLine(curr: FT): FT =
     findToken(curr, next)(ft => ft.hasBreak || !ft.right.is[T.Comment])
@@ -252,22 +252,13 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   @inline
   private def getHeadImpl(tokens: Tokens): FT = after(tokens.head)
   def getHead(tokens: Tokens, tree: Tree): FT =
-    getOnOrBeforeOwned(getHeadImpl(tokens), tree)
+    if (tokens.isEmpty) null else getOnOrBeforeOwned(after(tokens.head), tree)
   @inline
   def getHead(tree: Tree): FT = getHead(tree.tokens, tree)
-
-  def getHeadOpt(tokens: Tokens, tree: Tree): Option[FT] = tokens.headOption
-    .map(x => getOnOrBeforeOwned(after(x), tree))
-  @inline
-  def getHeadOpt(tree: Tree): Option[FT] = getHeadOpt(tree.tokens, tree)
 
   @inline
   private def getLastImpl(tokens: Tokens): FT =
     apply(findLastVisibleToken(tokens))
-  def getLast(tokens: Tokens, tree: Tree): FT =
-    getOnOrAfterOwned(getLastImpl(tokens), tree)
-  @inline
-  def getLast(tree: Tree): FT = getLast(tree.tokens, tree)
 
   def getOnOrAfterLast(tokens: Tokens, tree: Tree): FT = {
     val last = findLastVisibleToken(tokens)
@@ -281,24 +272,18 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   @inline
   def getOnOrAfterLast(tree: Tree): FT = getOnOrAfterLast(tree.tokens, tree)
 
-  def getLastOpt(tokens: Tokens, tree: Tree): Option[FT] =
-    findLastVisibleTokenOpt(tokens).map(x => getOnOrAfterOwned(apply(x), tree))
+  def getLast(tokens: Tokens, tree: Tree): FT =
+    findLastVisibleTokenOrNull(tokens)
+      .nnMap(last => getOnOrAfterOwned(apply(last), tree))
   @inline
-  def getLastOpt(tree: Tree): Option[FT] = getLastOpt(tree.tokens, tree)
+  def getLast(tree: Tree): FT = getLast(tree.tokens, tree)
 
-  def getLastNonTrivial(tokens: Tokens, tree: Tree): FT =
-    prevNonComment(getLast(tokens, tree))
+  def getLastNonTrivial(tokens: Tokens, tree: Tree): FT = getLast(tokens, tree)
+    .nnMap(prevNonComment)
   def getLastNonTrivial(tree: Tree): FT = getLastNonTrivial(tree.tokens, tree)
 
-  def getLastNonTrivialOpt(tokens: Tokens, tree: Tree): Option[FT] =
-    getLastOpt(tokens, tree).map(prevNonComment)
-  def getLastNonTrivialOpt(tree: Tree): Option[FT] =
-    getLastNonTrivialOpt(tree.tokens, tree)
-
-  def getLastNotTrailingComment(tree: Tree): Either[FT, FT] =
-    prevNotTrailingComment(getLast(tree))
-  def getLastNotTrailingCommentOpt(tree: Tree): Option[Either[FT, FT]] =
-    getLastOpt(tree).map(prevNotTrailingComment)
+  def getLastNotTrailingComment(tree: Tree): Either[FT, FT] = getLast(tree)
+    .nnMap(prevNotTrailingComment)
 
   /* the following methods return the first format token such that
    * its `right` is after the parameter and is not a comment */
@@ -306,15 +291,9 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   def tokenAfter(ft: FT): FT = nextNonComment(ft)
   @inline
   def tokenAfter(token: T): FT = tokenAfter(before(token))
-  @inline
-  def tokenAfter(tree: Tree): FT = tokenAfter(getLast(tree))
-  @inline
-  def tokenAfter(trees: Seq[Tree]): FT = tokenAfter(trees.last)
-
-  def tokenAfterOpt(tree: Tree): Option[FT] = getLastOpt(tree)
-    .map(nextNonComment)
-  def tokenAfterOpt(trees: Seq[Tree]): Option[FT] = trees.lastOption
-    .flatMap(tokenAfterOpt)
+  def tokenAfter(tree: Tree): FT = getLast(tree).nnMap(nextNonComment)
+  def tokenAfter(trees: Seq[Tree]): FT =
+    if (trees.isEmpty) null else tokenAfter(trees.last)
 
   /* the following methods return the last format token such that
    * its `left` is before the parameter */
@@ -322,17 +301,12 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   def justBefore(token: T): FT = apply(token, -1)
   @inline
   def tokenJustBefore(ft: FT): FT = prev(ft)
-  @inline
-  def tokenJustBefore(tree: Tree): FT = prev(getHead(tree))
+  def tokenJustBefore(tree: Tree): FT = getHead(tree).nnMap(prev)
+  def tokenJustBefore(trees: Seq[Tree]): FT =
+    if (trees.isEmpty) null else tokenJustBefore(trees.head)
 
-  def tokenJustBeforeOpt(tree: Tree): Option[FT] = getHeadOpt(tree).map(prev)
-  def tokenJustBeforeOpt(trees: Seq[Tree]): Option[FT] = trees.headOption
-    .flatMap(tokenJustBeforeOpt)
-
-  def isTokenHeadOf(tok: => T, tree: Tree): Boolean = getHeadOpt(tree) match {
-    case None => false
-    case Some(x) => x.left eq tok
-  }
+  def isTokenHeadOf(tok: => T, tree: Tree): Boolean = getHead(tree)
+    .nnHas(_.left eq tok)
 
   def isJustBeforeTree(ft: FT)(tree: Tree): Boolean =
     isTokenHeadOf(ft.right, tree)
@@ -345,15 +319,9 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   def tokenBefore(ft: FT): FT = prevNonCommentBefore(ft)
   @inline
   def tokenBefore(token: T): FT = prevNonComment(justBefore(token))
-  @inline
-  def tokenBefore(tree: Tree): FT = prevNonComment(tokenJustBefore(tree))
-  @inline
-  def tokenBefore(trees: Seq[Tree]): FT = tokenBefore(trees.head)
-
-  def tokenBeforeOpt(tree: Tree): Option[FT] = tokenJustBeforeOpt(tree)
-    .map(prevNonComment)
-  def tokenBeforeOpt(trees: Seq[Tree]): Option[FT] = trees.headOption
-    .flatMap(tokenBeforeOpt)
+  def tokenBefore(tree: Tree): FT = tokenJustBefore(tree).nnMap(prevNonComment)
+  def tokenBefore(trees: Seq[Tree]): FT =
+    if (trees.isEmpty) null else tokenBefore(trees.head)
 
   @inline
   def isBreakAfterRight(ft: FT): Boolean = next(ft).hasBreakOrEOF
@@ -417,25 +385,24 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   def span(tree: Tree): Int = span(tree.tokens)
 
   @tailrec
-  final def getNonMultilineEnd(ft: FT, inInterp: Int = 0): Option[FT] = {
+  final def getNonMultilineEnd(ft: FT, inInterp: Int = 0): FT = {
     def nft = next(ft)
     ft.right match {
       case _: T.Comment =>
-        if (ft.hasBreak) Some(ft)
-        else if (ft.rightHasNewline) None
+        if (ft.hasBreak) ft
+        else if (ft.rightHasNewline) null
         else {
           val xft = nft
-          if (xft.hasBreak) Some(xft)
-          else getNonMultilineEnd(xft, inInterp = inInterp)
+          if (xft.hasBreak) xft else getNonMultilineEnd(xft, inInterp = inInterp)
         }
       case _: T.Interpolation.Id =>
         getNonMultilineEnd(nft, inInterp = inInterp + 1)
-      case _: T.Constant.String if ft.rightHasNewline => None
-      case _ if inInterp == 0 => Some(nft)
+      case _: T.Constant.String if ft.rightHasNewline => null
+      case _ if inInterp == 0 => nft
       case _: T.Interpolation.End =>
-        if (inInterp == 1) Some(nft)
+        if (inInterp == 1) nft
         else getNonMultilineEnd(nft, inInterp = inInterp - 1)
-      case _: T.Interpolation.Part if ft.rightHasNewline => None
+      case _: T.Interpolation.Part if ft.rightHasNewline => null
       case _ => getNonMultilineEnd(nft, inInterp = inInterp)
     }
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config._
 import org.scalafmt.internal.RegexCompat._
@@ -17,7 +18,6 @@ import java.util.regex.Pattern
 
 import scala.annotation.tailrec
 import scala.collection.{AbstractIterator, mutable}
-import scala.util.Try
 
 /** Produces formatted output from sequence of splits.
   */
@@ -52,7 +52,7 @@ class FormatWriter(formatOps: FormatOps) {
         case t: T.Constant.Float => LiteralOps.prettyPrintFloat(t, ltext)
         case t: T.Constant.Double => LiteralOps.prettyPrintDouble(t, ltext)
         case _ =>
-          val syntax = Option(location.replace).getOrElse(ltext)
+          val syntax = location.replace ?? ltext
           sb.append(style.rewrite.tokens.getOrElse(syntax, syntax))
       }
 
@@ -62,7 +62,7 @@ class FormatWriter(formatOps: FormatOps) {
           if (label != null) {
             val (nest, isTop) = locations.getNest(owner.parent)
             val numBlanks = locations.getBlanks(owner, owner, nest, isTop)
-              .fold(0) { case (blanks, _, last) =>
+              .nnFold(0) { case (blanks, _, last) =>
                 val numBlanks = blanks.beforeEndMarker
                 if (numBlanks > 0) numBlanks
                 else locations.extraBlankTokens.get(last.meta.idx)
@@ -198,27 +198,29 @@ class FormatWriter(formatOps: FormatOps) {
   private def getOptionalBracesOwner(
       floc: FormatLocation,
       minBlockStats: Int,
-  ): Option[Tree] = {
+  ): Tree = {
     implicit val style = floc.style
     val ob = OptionalBraces.get(floc.formatToken)
-    ob.flatMap(_.owner).filter(
-      /* if we add the end marker, it might turn a single-stat expression (or
-       * block) into a multi-stat block and thus potentially change how that
-       * parent expression would have been formatted; so, avoid those cases.
-       */
-      _.parent match {
+    if (ob eq null) return null
+    val res = ob.owner
+    /* if we add the end marker, it might turn a single-stat expression (or
+     * block) into a multi-stat block and thus potentially change how that
+     * parent expression would have been formatted; so, avoid those cases.
+     */
+    val ok = (res ne null) &&
+      (res.parent match {
         case Some(t: Term.Block) => t.stats.lengthCompare(minBlockStats) >= 0
         case Some(_: Template.Body | _: Source | _: Pkg.Body) => true
         case _ => false
-      },
-    )
+      })
+    if (ok) res else null
   }
 
   private def checkRemoveEndMarkers(locations: Array[FormatLocation]): Unit = {
     var removedLines = 0
 
     // "<left> end name <right>"
-    def process(getOwner: => Option[Tree])(idx: Int): Unit = {
+    def process(getOwner: => Tree)(idx: Int): Unit = {
       val endIdx = locations.lastIndexWhere(_.isNotRemoved, idx)
       val loc2 = locations(idx + 2)
       val cfg = loc2.style.rewrite.scala3.endMarker
@@ -246,7 +248,10 @@ class FormatWriter(formatOps: FormatOps) {
       }
 
       // won't remove end marker if followed by comment
-      if (endIdx >= 0 && loc2.hasBreakAfter) getOwner.foreach(processOwner)
+      if (endIdx >= 0 && loc2.hasBreakAfter) getOwner match {
+        case Tree.NoTree =>
+        case x => processOwner(x)
+      }
     }
 
     (1 until locations.length - 2).foreach { idx =>
@@ -265,21 +270,22 @@ class FormatWriter(formatOps: FormatOps) {
           case Some(p: Tree.Block) =>
             var found = false
             var needStats = if (p.is[Term.Block]) 2 else 0 // block can't remain with just one stat
-            var owner: Tree = null
+            var owner: Tree = Tree.NoTree
             val ok = p.stats.exists(x =>
               if (found) { needStats -= 1; needStats <= 0 }
               else if (x eq em) { found = true; needStats <= 0 }
               else { owner = x; needStats -= 1; false }, // captures the last before em
             )
-            if (ok) Option(owner) else None
-          case _ => None
+            if (ok) owner else Tree.NoTree
+          case _ => Tree.NoTree
         })(idx)
     }
   }
 
   private def checkInsertEndMarkers(locations: Array[FormatLocation]): Unit =
     locations.foreach { floc =>
-      getOptionalBracesOwner(floc, 2).foreach { owner =>
+      val owner = getOptionalBracesOwner(floc, 2)
+      if (owner ne null) {
         val ownerTokens = owner.tokens
         val (endFt, maybeEndMarkerFt) = {
           val last = nextNonCommentSameLine(getOnOrAfterLast(ownerTokens, owner))
@@ -372,11 +378,9 @@ class FormatWriter(formatOps: FormatOps) {
         (!style.rewrite.scala3.optionalBraces.enabled &&
           style.indent.main == style.indent.getSignificant ||
           !OptionalBraces.at(ft)) && floc.missingBracesIndent.isEmpty
-      val mb =
-        if (ok) MissingBraces.getBlocks(ft)
-          .filter(res => checkInfix(res.tree) && noAnnoFor(res.tree))
-        else None
-      mb.foreach { case MissingBraces.Result(owner, otherBlocks, nonBlocks) =>
+      val mb = if (ok) MissingBraces.getBlocks(ft) else null
+      val owner = mb.nnMap(_.tree).nnIf(x => checkInfix(x) && noAnnoFor(x))
+      if (owner ne null) {
         val endFt = nextNonCommentSameLine(getLast(owner))
         val end = endFt.meta.idx
         val eLoc = locations(end)
@@ -401,8 +405,8 @@ class FormatWriter(formatOps: FormatOps) {
           val settings = ib.settingsFor(owner)
           val diff = getLineDiff(floc, eLoc) + addedLines - settings.minBreaks
           (if (settings.countBreakBefore) diff >= 0 else diff > 0) ||
-          checkOtherSpan(_.minBreaks)(otherBlocks) ||
-          checkOtherSpan(_.getNonBlocksMinBreaks)(nonBlocks)
+          checkOtherSpan(_.minBreaks)(mb.all) ||
+          checkOtherSpan(_.getNonBlocksMinBreaks)(mb.non)
         }
         if (
           !endFt.meta.formatOff && eLoc.hasBreakAfter &&
@@ -502,26 +506,26 @@ class FormatWriter(formatOps: FormatOps) {
          * have removed them first in RewriteTrailingCommas; now we simply need
          * to append them in case of 'always', but only when dangling */
         def isClosedDelimWithNewline(expectedNewline: Boolean): Boolean =
-          getClosedDelimWithNewline(expectedNewline).isDefined
+          getClosedDelimWithNewline(expectedNewline) ne null
 
-        def getClosedDelimWithNewline(whenNL: Boolean): Option[FT] = {
+        def getClosedDelimWithNewline(whenNL: Boolean): FT = {
           @tailrec
-          def iter(floc: FormatLocation, hadNL: Boolean): Option[FT] = {
+          def iter(floc: FormatLocation, hadNL: Boolean): FT = {
             val isNL = floc.hasBreakAfter
-            if (isNL && !whenNL) None
+            if (isNL && !whenNL) null
             else {
               val ft = floc.formatToken
               def gotNL = hadNL || isNL
               ft.right match {
                 case _: T.Comment =>
                   val idx = ft.meta.idx + 1
-                  if (idx == locations.length) None
+                  if (idx == locations.length) null
                   else iter(locations(idx), gotNL)
                 case _ =>
                   val ok = gotNL == whenNL &&
                     TreeOps
                       .rightIsCloseDelimForTrailingComma(tok.left, ft, whenNL)
-                  if (ok) Some(ft) else None
+                  if (ok) ft else null
               }
             }
           }
@@ -557,9 +561,10 @@ class FormatWriter(formatOps: FormatOps) {
             sb.append(',')
             ws(-1)
           // append comma if newline and multiple args
-          case TrailingCommas.multiple
-              if !tok.left.is[T.Comma] && getClosedDelimWithNewline(true)
-                .exists(isCloseDelimForTrailingCommasMultiple) =>
+          case TrailingCommas.multiple if !tok.left.is[T.Comma] && {
+                val delim = getClosedDelimWithNewline(true)
+                (delim ne null) && isCloseDelimForTrailingCommasMultiple(delim)
+              } =>
             sb.append(',')
             ws(-1)
           case _ => ws(0)
@@ -876,15 +881,16 @@ class FormatWriter(formatOps: FormatOps) {
         private var lastBreak: Int = -1
 
         def format(): Unit = {
-          val docOpt =
-            if (wrap eq Docstrings.Wrap.keep) None
-            else ScaladocParser.parse(tok.meta.left.text)
-          docOpt.flatMap { doc =>
-            val sbLen = sb.length
-            val res = Try(formatWithWrap(doc)).toOption
-            if (res.isEmpty) sb.setLength(sbLen)
-            res
-          }.getOrElse(formatNoWrap())
+          val noWrap = (wrap eq Docstrings.Wrap.keep) || {
+            ScaladocParser.parse(tok.meta.left.text) match {
+              case Some(doc) =>
+                val sbLen = sb.length
+                try { formatWithWrap(doc); false }
+                catch { case _: Throwable => sb.setLength(sbLen); true }
+              case None => true
+            }
+          }
+          if (noWrap) formatNoWrap()
         }
 
         private def formatWithWrap(doc: Scaladoc): Unit = {
@@ -1372,8 +1378,8 @@ class FormatWriter(formatOps: FormatOps) {
             val beg = mods.lastOption
               .fold(after(ptokens.head))(m => next(tokenAfter(m)))
             val useBody = b.eq(child) || p.eq(child)
-            val beforeBody = if (useBody) tokenJustBeforeOpt(b) else None
-            val end = beforeBody.getOrElse(before(ptokens.last))
+            val beforeBody = if (useBody) tokenJustBefore(b) else null
+            val end = beforeBody ?? before(ptokens.last)
             getLineDiff(locations, beg, end) == 0
           }
           if (keepGoing) getAlignContainerParent(p, depth) else (p, depth)
@@ -1495,23 +1501,26 @@ class FormatWriter(formatOps: FormatOps) {
             stat: Tree,
             idx: Int,
             isLast: Boolean,
-        ): Option[(Int, Newlines.NumBlanks)] = setStats(idx, stat, stat, isLast)
-        def blanks(cnt: => Int, edge: Boolean, edgeCnt: => Option[Int]): Int =
-          if (edge) edgeCnt.getOrElse(math.min(cnt, 1)) else cnt
+        ): (Int, Newlines.NumBlanks) = setStats(idx, stat, stat, isLast)
+        def blanks(cnt: => Int, edge: Boolean, edgeCnt: => Int): Int =
+          if (!edge) cnt
+          else {
+            val e = edgeCnt
+            if (e == Newlines.NumBlanks.unset) math.min(cnt, 1) else e
+          }
         @inline
         def blanksBefore(cnt: Newlines.NumBlanks, isFirst: Boolean): Int =
-          blanks(cnt.before, isFirst, cnt.beforeAll)
+          blanks(cnt.before, isFirst, cnt.beforeAllOrUnset)
         @inline
         def blanksAfter(cnt: Newlines.NumBlanks, isLast: Boolean): Int =
-          blanks(cnt.after, isLast, cnt.afterAll)
+          blanks(cnt.after, isLast, cnt.afterAllOrUnset)
         def setStats(
             idx: Int,
             stat: Tree,
             statLast: Tree,
             isLast: Boolean,
-        ): Option[(Int, Newlines.NumBlanks)] = {
-          val blanksWithEnds = getBlanks(stat, statLast, nest, isTop)
-          blanksWithEnds.map { case (x, head, last) =>
+        ): (Int, Newlines.NumBlanks) = getBlanks(stat, statLast, nest, isTop)
+          .nnMap { case (x, head, last) =>
             val beforeCnt = blanksBefore(x, notUnindentedPkg && idx == 0)
             val beforeFt = leadingComment(head)
             setFtCheck(beforeFt, beforeCnt, head eq beforeFt)
@@ -1521,7 +1530,6 @@ class FormatWriter(formatOps: FormatOps) {
             setIdxCheck(lastIdx, afterCnt, last eq afterFt)
             (lastIdx, x)
           }
-        }
         def setEndMarker(
             stat: Term.EndMarker,
             prevIdx: Int,
@@ -1539,15 +1547,15 @@ class FormatWriter(formatOps: FormatOps) {
         def iter(
             rest: Seq[Tree],
             idx: Int,
-            previous: Option[(Int, Newlines.NumBlanks)],
-            imports: Option[(Int, ImportExportStat, ImportExportStat)],
+            previous: (Int, Newlines.NumBlanks),
+            imports: (Int, ImportExportStat, ImportExportStat),
         ): Unit = {
           val stat = rest.head
           val newRest = rest.tail
           val isLast = newRest.isEmpty
           val ok = stat match {
             case t: Term.EndMarker =>
-              previous.foreach { case (prevIdx, prevBlanks) =>
+              previous.nnFor { case (prevIdx, prevBlanks) =>
                 setEndMarker(t, prevIdx, prevBlanks, isLast)
               }
               false
@@ -1557,24 +1565,25 @@ class FormatWriter(formatOps: FormatOps) {
           }
           val newImports = stat match {
             case t: ImportExportStat =>
-              val (idxHead, head) = imports.fold((idx, t)) { case (i, h, _) =>
-                (i, h)
+              val (idxHead, head) = imports match {
+                case null => (idx, t)
+                case (i, h, _) => (i, h)
               }
-              if (!isLast) Some((idxHead, head, t))
+              if (!isLast) (idxHead, head, t)
               else {
                 setStats(idxHead, head, t, isLast = true)
-                None
+                null
               }
             case _ =>
-              imports.foreach { case (idxHead, head, last) =>
+              imports.nnFor { case (idxHead, head, last) =>
                 setStats(idxHead, head, last, isLast = false)
               }
-              None
+              null
           }
-          val newPrevious = if (ok) setStat(stat, idx, isLast) else None
+          val newPrevious = if (ok) setStat(stat, idx, isLast) else null
           if (!isLast) iter(newRest, idx + 1, newPrevious, newImports)
         }
-        iter(stats, 0, None, None)
+        iter(stats, 0, null, null)
       }
       def insideBody(stats: Seq[Stat], nl: Newlines, ba: Newlines.BeforeAfter) =
         stats.lengthCompare(nl.topLevelBodyMinStatements) >= 0 &&
@@ -1676,7 +1685,7 @@ class FormatWriter(formatOps: FormatOps) {
         statLast: Tree,
         nest: Int,
         isTop: Boolean,
-    ): Option[(Newlines.NumBlanks, FT, FT)] = {
+    ): (Newlines.NumBlanks, FT, FT) = {
       val head = tokenJustBefore(statHead)
       val last = getLast(statLast)
       val bLoc = locations(head.meta.idx + 1)
@@ -1688,7 +1697,7 @@ class FormatWriter(formatOps: FormatOps) {
         isTop = isTop,
       )
       bLoc.style.newlines.getTopStatBlankLines(statHead)(params)
-        .map((_, head, last))
+        .nnMap((_, head, last))
     }
 
   }
@@ -1933,7 +1942,7 @@ object FormatWriter {
         (line.style.align.allowOverflow || // check overflow
           line.noOverflow(curShift) && buffer.forall(bl =>
             bl.style.align.allowOverflow ||
-              bl.stops.reverseIterator.find(_.isActive).forall { bs =>
+              bl.stops.reverseIterator.findOrNull(_.isActive).orHas { bs =>
                 val shiftedColumn = bs.shifted
                 val idx = newStops.lastIndexWhere(ns =>
                   ns.isActive && ns.shifted <= shiftedColumn,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/InfixSplits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/InfixSplits.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config.{IndentOperator, Newlines, ScalafmtConfig}
 import org.scalafmt.util.InfixApp._
@@ -33,9 +34,9 @@ object InfixSplits {
   @tailrec
   private def findMaybeEnclosingInfix(child: Member.Infix, childTree: Tree)(
       implicit ftoks: FormatTokens,
-  ): (Member.Infix, Option[Either[FT, FT]]) = {
+  ): (Member.Infix, Either[FT, FT]) = {
     val inParensOrBraces = ftoks.getClosingIfWithinParensOrBraces(childTree)
-    if (inParensOrBraces.isDefined) (child, inParensOrBraces)
+    if (inParensOrBraces ne null) (child, inParensOrBraces)
     else childTree.parent match {
       case Some(p: Member.Infix) if !p.isAssignment =>
         findMaybeEnclosingInfix(p, p)
@@ -43,13 +44,13 @@ object InfixSplits {
         findMaybeEnclosingInfix(child, p)
       case Some(p @ Tree.Block(`childTree` :: Nil)) =>
         findMaybeEnclosingInfix(child, p)
-      case _ => (child, None)
+      case _ => (child, null)
     }
   }
 
   def findMaybeEnclosingInfix(app: Member.Infix)(implicit
       ftoks: FormatTokens,
-  ): (Member.Infix, Option[Either[FT, FT]]) = findMaybeEnclosingInfix(app, app)
+  ): (Member.Infix, Either[FT, FT]) = findMaybeEnclosingInfix(app, app)
 
   def withNLIndent(split: Split)(
       app: Member.Infix,
@@ -70,20 +71,19 @@ object InfixSplits {
 
   private def getInfixRhsPossiblyEnclosed(app: Member.Infix)(implicit
       ftoks: FormatTokens,
-  ): Option[Either[Member.Infix, Member.Infix]] = app.singleArg
-    .map(TreeOps.getBlockStat).flatMap {
-      case t: Member.Infix =>
-        Some(Either.cond(ftoks.isEnclosedWithinParens(t), t, t))
-      case _ => None
-    }
+  ): Either[Member.Infix, Member.Infix] = app.singleArg
+    .nnMap(TreeOps.getBlockStat(_) match {
+      case t: Member.Infix => Either.cond(ftoks.isEnclosedWithinParens(t), t, t)
+      case _ => null
+    })
 
   @tailrec
   private def findRightmostArgIfEnclosedInfix(app: Member.Infix)(implicit
       ftoks: FormatTokens,
-  ): Option[Member.Infix] = getInfixRhsPossiblyEnclosed(app) match {
-    case Some(Left(ia)) => findRightmostArgIfEnclosedInfix(ia)
-    case Some(Right(ia)) => Some(ia)
-    case _ => None
+  ): Member.Infix = getInfixRhsPossiblyEnclosed(app) match {
+    case null => null
+    case Left(ia) => findRightmostArgIfEnclosedInfix(ia)
+    case Right(ia) => ia
   }
 
   def getSingleLineInfixPolicy(end: FT) = Policy
@@ -132,10 +132,7 @@ object InfixSplits {
       case ia: Member.Infix if !ftoks.isEnclosedWithinParens(tree) =>
         findNestedInfixes(ia.lhs)
         res += ia
-        ia.singleArg match {
-          case Some(arg) => findNestedInfixes(arg)
-          case _ =>
-        }
+        ia.singleArg.nnMap(findNestedInfixes)
       case _ =>
     }
 
@@ -151,19 +148,19 @@ object InfixSplits {
   private def getInfixSplitsBeforeLhs(
       lhsApp: Member.Infix,
       afterInfix: Newlines.Infix.Site,
-      newStmtMod: Option[Modification],
+      newStmtMod: Modification,
   )(implicit style: ScalafmtConfig, ft: FT, ftoks: FormatTokens): Seq[Split] = {
     val fullInfix = findTreeWithParentSimple(lhsApp, false)(isInfixApp)
-      .flatMap(asInfixApp).getOrElse(lhsApp)
+      .nnFold(lhsApp)(asInfixApp(_) ?? lhsApp)
     val app = findLeftInfix(fullInfix)
     new InfixSplits(app, ft, fullInfix, app)
       .getBeforeLhsOrRhs(afterInfix, newStmtMod)
   }
 
-  final def maybeGetInfixSplitsBeforeLhs(mod: => Option[Modification] = None)(
+  final def maybeGetInfixSplitsBeforeLhs(mod: => Modification = null)(
       nonInfixSplits: => Seq[Split],
   )(implicit style: ScalafmtConfig, ft: FT, ftoks: FormatTokens): Seq[Split] =
-    asInfixApp(ft.meta.rightOwner).fold(nonInfixSplits) { ia =>
+    asInfixApp(ft.meta.rightOwner).nnFold(nonInfixSplits) { ia =>
       val infixSite = style.newlines.infix.get(ia)
       if (infixSite.isNone) nonInfixSplits
       else getInfixSplitsBeforeLhs(ia, infixSite, mod)
@@ -215,7 +212,7 @@ class InfixSplits(
       })
     case p: Member.Function => isBlockFunction(p)
     case p: Case => p.pat.eq(tree) || p.body.eq(tree)
-    case SingleArgInBraces(_, arg, _) => tree eq arg
+    case SingleArgInBraces(arg, _) => tree eq arg
     case _ => false
   }
   private def isOldTopLevel(tree: Tree) = tree.parent
@@ -329,18 +326,18 @@ class InfixSplits(
 
   def getBeforeLhsOrRhs(
       afterInfix: Newlines.Infix.Site,
-      newStmtMod: Option[Modification] = None,
+      newStmtMod: Modification = null,
       spaceMod: Modification = Space,
   ): Seq[Split] = {
-    def getOpenClose(xft: FT): Option[(FT, FT)] = // exclude Xml.Start and similar pairs
-      if (xft.right.is[T.OpenDelim]) ftoks.matchingOptRight(xft).map(xft -> _)
-      else None
+    def getOpenClose(xft: FT): (FT, FT) = // exclude Xml.Start and similar pairs
+      if (!xft.right.is[T.OpenDelim]) null
+      else ftoks.matchingRightOrNull(xft).nnMap(xft -> _)
     val openCloseOpt = // don't need to worry about comments, they force NL
       if (!ft.right.is[T.Ident]) getOpenClose(ft)
-      else if (!ft.rightOwner.parent.is[Term.ApplyUnary]) None
+      else if (!ft.rightOwner.parent.is[Term.ApplyUnary]) null
       else getOpenClose(ftoks.next(ft))
     val nextInfixes =
-      if (openCloseOpt.isEmpty) {
+      if (openCloseOpt eq null) {
         implicit val infixes = new mutable.ListBuffer[Member.Infix]
         if (isAfterOp) {
           InfixSplits.findNestedInfixes(app.arg)
@@ -403,8 +400,7 @@ class InfixSplits(
         else PolicyOps.decideNewlinesOnlyAfterClose(end)
       }
     }
-    val nlMod = newStmtMod
-      .getOrElse(Space.orNL(ft.noBreak && ft.right.is[T.Comment]))
+    val nlMod = newStmtMod ?? Space.orNL(ft.noBreak && ft.right.is[T.Comment])
     val delayedBreak = Policy ? nlMod.isNL || breakAfterComment(ft)
 
     val isFirstOrAssignOp = isFirstOp || isAssignmentOp
@@ -421,7 +417,7 @@ class InfixSplits(
         singleLineExpire,
         ignorePenalty = isAssignmentOp && nextInfixes.nonEmpty,
       ).andPolicy(singleLinePolicy).andPolicy(delayedBreak)
-    val spaceSingleLine = Split(spaceMod, 0).onlyIf(newStmtMod.isEmpty)
+    val spaceSingleLine = Split(spaceMod, 0).onlyIf(newStmtMod eq null)
       .withSingleLine(singleLineExpire).andPolicy(singleLinePolicy)
     val singleLineSplits = Seq(
       spaceSingleLine.onlyFor(SplitTag.InfixChainNoNL),
@@ -429,26 +425,27 @@ class InfixSplits(
       nlSinglelineSplit,
     )
 
-    val rhsPossiblyEnclosedInfix = openCloseOpt.flatMap(delims =>
-      if (beforeLhs) Some(Either.cond(delims._2.idx >= fullExpire.idx, app, app))
-      else InfixSplits.getInfixRhsPossiblyEnclosed(app),
-    )
+    val rhsPossiblyEnclosedInfix =
+      if (openCloseOpt eq null) null
+      else if (beforeLhs) Either
+        .cond(openCloseOpt._2.idx >= fullExpire.idx, app, app)
+      else InfixSplits.getInfixRhsPossiblyEnclosed(app)
 
     // returns end of next LHS, really
-    def getNextOp: Option[FT] = (rhsPossiblyEnclosedInfix match {
-      case Some(Left(ia)) => Some(InfixSplits.findLeftInfix(ia))
-      case _ if app eq fullInfix => None
+    def getNextOp: FT = (rhsPossiblyEnclosedInfix match {
+      case Left(ia) => InfixSplits.findLeftInfix(ia)
+      case _ if app eq fullInfix => null
       case _ => findNextInfixInParent(app, fullInfix)
-    }).map(ia => ftoks.tokenBefore(ia.op))
+    }).nnMap(x => ftoks.tokenBefore(x.op))
 
     val isAfterOpBreakOnNested = isAfterOp && afterInfix.breakOnNested
     def mustBreakAfterNested = isAfterOpBreakOnNested &&
       (app.lhs match {
         case ia: Member.Infix =>
           val iaOpt =
-            if (isLeftInfix) Some(ia)
+            if (isLeftInfix) ia
             else InfixSplits.findRightmostArgIfEnclosedInfix(ia)
-          iaOpt.exists(_.precedence >= appPrecedence)
+          (iaOpt ne null) && iaOpt.precedence >= appPrecedence
         case _ => false
       })
 
@@ -460,7 +457,7 @@ class InfixSplits(
       val spaceSplits: Seq[Split] =
         if (ft.right.is[T.Comment] || mustBreakAfterNested) Seq.empty
         else {
-          val nextFT = if (rightAsInfix.isDefined) ftoks.next(ft) else ft
+          val nextFT = if (rightAsInfix ne null) ftoks.next(ft) else ft
           expires.map { case (expire, precedence) =>
             val cost = precedence - minPrecedence
             val exclude =
@@ -468,7 +465,7 @@ class InfixSplits(
               else TokenOps.insideBracesBlock(nextFT, expire, parens = true)
             val ignore = exclude.isEmpty && singleLinePolicy.nonEmpty &&
               (expire eq fullExpire)
-            Split(ignore, cost)(ModExt(newStmtMod.getOrElse(spaceMod)))
+            Split(ignore, cost)(ModExt(newStmtMod ?? spaceMod))
               .withSingleLine(expire, exclude, noOptimal = cost != 0)
           }
         }
@@ -477,34 +474,35 @@ class InfixSplits(
 
     def otherSplitsWithParens(openFt: FT, closeFt: FT) = {
       val nextFt = ftoks.nextNonCommentSameLineAfter(openFt)
-      val bracesLike = newStmtMod.isEmpty &&
+      val bracesLike = (newStmtMod eq null) &&
         (style.newlines.source match {
           case Newlines.fold => false
           case Newlines.unfold => !ft.hasBlankLine
           case _ => ft.noBreak && nextFt.hasBreak
         })
 
-      val noSingleLine = newStmtMod.isDefined || breakMany ||
-        isAfterOpBreakOnNested && rhsPossiblyEnclosedInfix.exists {
+      val noSingleLine = (newStmtMod ne null) || breakMany ||
+        isAfterOpBreakOnNested &&
+        (rhsPossiblyEnclosedInfix match {
           case Right(ia) => ia.precedence >= appPrecedence
           case _ => false
-        } || mustBreakAfterNested ||
-        rightAsInfix.exists(10 < infixSequenceLength(_))
-      val endOfNextOp = if (afterInfix.breakOnNested) getNextOp else None
+        }) || mustBreakAfterNested || (rightAsInfix ne null) &&
+        10 < infixSequenceLength(rightAsInfix)
+      val endOfNextOp = if (afterInfix.breakOnNested) getNextOp else null
 
       val slbPolicy = InfixSplits.getSingleLineInfixPolicy(closeFt)
-      val nlSplit = Split(nlMod, 0, nlPolicy).withIndent(nlIndent)
-        .andPolicy(slbPolicy | PolicyOps.SingleLineBlock(closeFt), !bracesLike)
-        .withOptimalToken(closeFt, killOnFail = false, ignore = !bracesLike)
+      val nlSplit = Split(nlMod, 0, nlPolicy).withIndent(nlIndent).andPolicy(
+        if (bracesLike) slbPolicy | PolicyOps.SingleLineBlock(closeFt) else null,
+      ).withOptimalToken(closeFt, killOnFail = false, ignore = !bracesLike)
       val singleLineSplit = Split(noSingleLine, 0)(spaceMod)
-        .withSingleLine(endOfNextOp.getOrElse(closeFt)).andPolicy(slbPolicy)
+        .withSingleLine(endOfNextOp ?? closeFt).andPolicy(slbPolicy)
       val noSplit = Split(!bracesLike, 1)(spaceMod)
         .withPolicy(PolicyOps.decideNewlinesOnlyAfterClose(nextFt))
       Seq(singleLineSplit, nlSplit, noSplit)
     }
 
     def otherSplitsWithBraces(closeFt: FT) = {
-      val slbEnd = getNextOp.getOrElse(fullExpire)
+      val slbEnd = getNextOp ?? fullExpire
       val slbPolicy = InfixSplits.getSingleLineInfixPolicy(closeFt)
       // check if enclosed
       if (slbEnd eq closeFt) Seq(
@@ -518,10 +516,11 @@ class InfixSplits(
       )
     }
 
-    val otherSplits = openCloseOpt.fold(otherSplitsNoDelims) { case (lt, rt) =>
-      if (rt.left.is[T.RightBrace]) otherSplitsWithBraces(rt)
-      else otherSplitsWithParens(lt, rt)
-    }
+    val otherSplits = openCloseOpt
+      .nnFold(otherSplitsNoDelims) { case (lt, rt) =>
+        if (rt.left.is[T.RightBrace]) otherSplitsWithBraces(rt)
+        else otherSplitsWithParens(lt, rt)
+      }
 
     singleLineSplits ++ otherSplits
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/MissingBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/MissingBraces.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config.RewriteSettings.InsertBraces
 import org.scalafmt.util.TreeOps
@@ -15,19 +16,20 @@ object MissingBraces {
   type AllRanges = Seq[AllRange]
 
   case class Result(tree: Tree, all: AllRanges = Nil, non: AllRanges = Nil)
-  type ResultOpt = Option[Result]
 
   private trait Factory {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt
+    ): Result
   }
 
   def getBlocks(
       ft: FT,
-  )(implicit ftoks: FormatTokens, ib: InsertBraces): ResultOpt = {
-    val impl = ft.left match {
+  )(implicit ftoks: FormatTokens, ib: InsertBraces): Result = {
+    // ascribed to the supertype: Scala 3 otherwise infers a union of the *Impl
+    // singleton types (+ Null), on which `.nnMap` won't resolve
+    val impl: Factory = ft.left match {
       case _: T.RightArrow => RightArrowImpl
       case _: T.RightParen => RightParenImpl
       case _: T.RightBrace => RightBraceImpl
@@ -41,17 +43,25 @@ object MissingBraces {
       case _: T.KwYield => YieldImpl
       case _ => null
     }
-    if (null eq impl) None
-    else {
+    impl &&& {
       val nft = ftoks.nextNonComment(ft)
       impl.getBlocks(ft, nft)
-        .filter(r => (r.tree ne nft.rightOwner) || !nft.right.is[T.LeftBrace])
+        .nnIf(r => (r.tree ne nft.rightOwner) || !nft.right.is[T.LeftBrace])
     }
   }
 
   private def rng(t: Tree): AllRange = t -> t
-  private def rng(t: Iterable[Tree]*): Option[AllRange] = t.find(_.nonEmpty)
-    .map(_.head -> t.view.filter(_.nonEmpty).last.last)
+  private def rngs(t: Iterable[Tree]*): AllRanges = {
+    val outer = t.iterator.map(_.iterator).filter(_.hasNext)
+    if (outer.hasNext) {
+      var inner = outer.next()
+      val head: Tree = inner.next()
+      var last = head
+      while (outer.hasNext) inner = outer.next()
+      while (inner.hasNext) last = inner.next()
+      Seq(head -> last)
+    } else Nil
+  }
 
   private def seq(ok: Boolean, t: Tree): AllRanges =
     if (ok) Seq(rng(t)) else Nil
@@ -60,19 +70,20 @@ object MissingBraces {
     if (ok) t.flatMap(_.map(rng)) else Nil
 
   private def seqseq(ok: Boolean, t: => Seq[Tree]): AllRanges =
-    if (ok) rng(t).toSeq else Nil
+    if (ok) rngs(t) else Nil
 
   private object BlockImpl extends Factory {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = {
+    ): Result = {
       def ok(stat: Tree): Boolean = ftoks.isJustBeforeTree(nft)(stat)
       val leftOwner = ft.meta.leftOwner
       TreeOps.findTreeWithParentSimple(nft.rightOwner)(_ eq leftOwner) match {
-        case Some(t: Term.Block) =>
-          if (t.stats.headOption.exists(ok)) Some(Result(t)) else None
-        case x => x.filter(ok).map(Result(_))
+        case t: Term.Block =>
+          if (t.stats.headOption.exists(ok)) Result(t) else null
+        case null => null
+        case t => if (ok(t)) Result(t) else null
       }
     }
   }
@@ -81,12 +92,11 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
-      case t: Term.FunctionLike =>
-        val skip = t.parent.exists(TreeOps.isExprWithParentInBraces(t))
-        if (skip) None
-        else Some(Result(t.body, non = seqseq(ib.nonBlocks, t.paramClause.values)))
-      case _ => None
+    ): Result = ft.meta.leftOwner match {
+      case t: Term.FunctionLike
+          if !t.parent.exists(TreeOps.isExprWithParentInBraces(t)) =>
+        Result(t.body, non = seqseq(ib.nonBlocks, t.paramClause.values))
+      case _ => null
     }
   }
 
@@ -94,18 +104,17 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
+    ): Result = ft.meta.leftOwner match {
       case x: Term.If if !nft.right.is[T.KwThen] => ThenImpl.getTermIf(x)
       case t: Term.EnumeratorsBlock
-          if !nft.right.is[T.KwDo] && ftoks.getLastOpt(t).contains(ft) =>
+          if !nft.right.is[T.KwDo] && (ftoks.getLast(t) eq ft) =>
         t.parent match {
-          case Some(p: Term.For) =>
-            Some(Result(p.body, all = seq(ib.allBlocks, t)))
-          case _ => None
+          case Some(p: Term.For) => Result(p.body, all = seq(ib.allBlocks, t))
+          case _ => null
         }
       case t: Term.While if !nft.right.is[T.KwDo] =>
-        Some(Result(t.body, non = seq(ib.nonBlocks, t.cond)))
-      case _ => None
+        Result(t.body, non = seq(ib.nonBlocks, t.cond))
+      case _ => null
     }
   }
 
@@ -113,15 +122,14 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
+    ): Result = ft.meta.leftOwner match {
       case t: Term.EnumeratorsBlock
-          if !nft.right.is[T.KwDo] && ftoks.getLastOpt(t).contains(ft) =>
+          if !nft.right.is[T.KwDo] && (ftoks.getLast(t) eq ft) =>
         t.parent match {
-          case Some(p: Term.For) =>
-            Some(Result(p.body, all = seq(ib.allBlocks, t)))
-          case _ => None
+          case Some(p: Term.For) => Result(p.body, all = seq(ib.allBlocks, t))
+          case _ => null
         }
-      case _ => None
+      case _ => null
     }
   }
 
@@ -129,11 +137,10 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
-      case t: Term.Do => Some(Result(t.body, non = seq(ib.nonBlocks, t.expr)))
-      case t: Term.For =>
-        Some(Result(t.body, all = seq(ib.allBlocks, t.enumsBlock)))
-      case _ => None
+    ): Result = ft.meta.leftOwner match {
+      case t: Term.Do => Result(t.body, non = seq(ib.nonBlocks, t.expr))
+      case t: Term.For => Result(t.body, all = seq(ib.allBlocks, t.enumsBlock))
+      case _ => null
     }
   }
 
@@ -141,21 +148,21 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
-      case _: Defn.Type => None
+    ): Result = ft.meta.leftOwner match {
+      case _: Defn.Type => null
       case t: Ctor.Secondary =>
-        if (t.body.stats.nonEmpty) None // must have braces
-        else Some(Result(t.body.init, non = seqseq(ib.nonBlocks, t.paramClauses)))
+        if (t.body.stats.nonEmpty) null // must have braces
+        else Result(t.body.init, non = seqseq(ib.nonBlocks, t.paramClauses))
       case t: Tree.WithBody =>
         val nonBlocks = t match {
           case _ if !ib.nonBlocks => Nil
           case t: Defn.Def if !TreeOps.isJsNative(t.body) =>
-            rng(t.paramClauseGroups, t.decltpe).toSeq
-          case t: Defn.Val => rng(t.pats, t.decltpe).toSeq
-          case t: Defn.Var => rng(t.pats, t.decltpe).toSeq
+            rngs(t.paramClauseGroups, t.decltpe)
+          case t: Defn.Val => rngs(t.pats, t.decltpe)
+          case t: Defn.Var => rngs(t.pats, t.decltpe)
           case _ => Nil
         }
-        Some(Result(t.body, non = nonBlocks))
+        Result(t.body, non = nonBlocks)
       case _ => BlockImpl.getBlocks(ft, nft)
     }
   }
@@ -164,10 +171,10 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
+    ): Result = ft.meta.leftOwner match {
       case t: Term.TryClause =>
-        Some(Result(t.expr, all = seqopt(ib.allBlocks, t.catchClause, t.finallyp)))
-      case _ => None
+        Result(t.expr, all = seqopt(ib.allBlocks, t.catchClause, t.finallyp))
+      case _ => null
     }
   }
 
@@ -175,10 +182,13 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
-      case t: Term.TryClause => t.catchClause
-          .map(Result(_, all = seqopt(ib.allBlocks, Some(t.expr), t.finallyp)))
-      case _ => None
+    ): Result = ft.meta.leftOwner match {
+      case t: Term.TryClause => t.catchClause match {
+          case Some(c) =>
+            Result(c, all = seqopt(ib.allBlocks, Some(t.expr), t.finallyp))
+          case None => null
+        }
+      case _ => null
     }
   }
 
@@ -186,10 +196,13 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
-      case t: Term.TryClause => t.finallyp
-          .map(Result(_, all = seqopt(ib.allBlocks, Some(t.expr), t.catchClause)))
-      case _ => None
+    ): Result = ft.meta.leftOwner match {
+      case t: Term.TryClause => t.finallyp match {
+          case Some(f) =>
+            Result(f, all = seqopt(ib.allBlocks, Some(t.expr), t.catchClause))
+          case None => null
+        }
+      case _ => null
     }
   }
 
@@ -197,14 +210,14 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
+    ): Result = ft.meta.leftOwner match {
       case x: Term.If => getTermIf(x)
-      case _ => None
+      case _ => null
     }
 
     def getTermIf(
         owner: Term.If,
-    )(implicit ftoks: FormatTokens, ib: InsertBraces): ResultOpt = {
+    )(implicit ftoks: FormatTokens, ib: InsertBraces): Result = {
       val all = ListBuffer.empty[AllRange]
       val non = ListBuffer.empty[AllRange]
       if (ib.allBlocks) {
@@ -212,7 +225,7 @@ object MissingBraces {
         getAllElseDn(owner, all, non)
         ElseImpl.getAllThenUp(owner, all, non)
       }
-      Some(Result(owner.thenp, all = all.toList, non = non.toList))
+      Result(owner.thenp, all = all.toList, non = non.toList)
     }
 
     @tailrec
@@ -235,13 +248,13 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
+    ): Result = ft.meta.leftOwner match {
       case x: Term.If if !x.elsep.is[Term.If] =>
         val all = ListBuffer.empty[AllRange]
         val non = ListBuffer.empty[AllRange]
         if (ib.allBlocks) getAllThenUp(x.elsep, all, non)
-        Some(Result(x.elsep, all = all.toList, non = non.toList))
-      case _ => None
+        Result(x.elsep, all = all.toList, non = non.toList)
+      case _ => null
     }
 
     @tailrec
@@ -264,10 +277,10 @@ object MissingBraces {
     def getBlocks(ft: FT, nft: FT)(implicit
         ftoks: FormatTokens,
         ib: InsertBraces,
-    ): ResultOpt = ft.meta.leftOwner match {
+    ): Result = ft.meta.leftOwner match {
       case t: Term.ForYield =>
-        Some(Result(t.body, all = seq(ib.allBlocks, t.enumsBlock)))
-      case _ => None
+        Result(t.body, all = seq(ib.allBlocks, t.enumsBlock))
+      case _ => null
     }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/ModExt.scala
@@ -12,7 +12,7 @@ import scala.annotation.tailrec
 case class ModExt(
     mod: Modification,
     indents: List[Indent] = Nil,
-    altOpt: Option[ModExt] = None,
+    alt: ModExt = null,
     noAltIndent: Boolean = false,
 ) {
   @inline
@@ -26,16 +26,14 @@ case class ModExt(
       s"$prefix$mod$indentPrefix$ind$suffix"
     }
 
-    altOpt match {
-      case None => res("")
-      case Some(x) => x.toString(res("|"), if (noAltIndent) "" else "+")
-    }
+    if (alt eq null) res("")
+    else alt.toString(res("|"), if (noAltIndent) "" else "+")
   }
 
   override def toString: String = toString("", "")
 
   def withAlt(alt: => ModExt, noAltIndent: Boolean = false): ModExt =
-    copy(altOpt = Some(alt), noAltIndent = noAltIndent)
+    copy(alt = alt, noAltIndent = noAltIndent)
 
   @inline
   def withAltIf(
@@ -45,25 +43,17 @@ case class ModExt(
 
   def orMod(flag: Boolean, mod: => ModExt): ModExt = if (flag) this else mod
 
-  def withIndent(length: => Length, expire: => FT, when: ExpiresOn): ModExt =
-    length match {
+  def withIndent(length: => Length, expire: FT, when: ExpiresOn): ModExt =
+    if (expire eq null) this
+    else length match {
       case Length.Num(0, _) => this
       case x => withIndentImpl(Indent(x, expire, when))
     }
 
-  def withIndentOpt(
-      length: => Length,
-      expire: Option[FT],
-      when: ExpiresOn,
-  ): ModExt = expire.fold(this)(withIndent(length, _, when))
-
-  def withIndent(indent: => Indent): ModExt = indent match {
+  def withIndent(indent: Indent): ModExt = indent match {
     case Indent.Empty => this
     case x => withIndentImpl(x)
   }
-
-  def withIndentOpt(indent: => Option[Indent]): ModExt = indent
-    .fold(this)(withIndent(_))
 
   def withIndents(indents: Seq[Indent]): ModExt = indents
     .foldLeft(this)(_ withIndent _)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptimizationEntities.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptimizationEntities.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.Error
 import org.scalafmt.util._
@@ -10,15 +11,16 @@ import scala.collection.mutable
 import scala.reflect.ClassTag
 
 class OptimizationEntities(
-    argumentStarts: Map[Int, Tree],
+    argumentStarts: Array[Tree],
     optionalNewlines: Set[Int],
     // indexed by token idx (null = absent); array, not boxed-Int Map, since
     // `isStatementStart` is read per NL state in the search
     statementStarts: Array[Tree],
     val semicolons: Map[Int, FT],
 ) {
-  def argumentAt(idx: Int): Option[Tree] = argumentStarts.get(idx)
-  def argument(implicit ft: FT): Option[Tree] = argumentAt(ft.meta.idx)
+  def argumentAt(idx: Int): Tree =
+    if (idx >= 0 && idx < argumentStarts.length) argumentStarts(idx) else null
+  def argument(implicit ft: FT): Tree = argumentAt(ft.meta.idx)
   def optionalNL(implicit ft: FT): Boolean = optionalNewlines(ft.meta.idx)
   def semicolonAfterStatement(idx: Int): Option[FT] = semicolons.get(idx)
   def statementStart(idx: Int): Tree =
@@ -37,7 +39,7 @@ object OptimizationEntities {
       soft: SoftKeywordClasses,
   ) {
 
-    private val arguments = mutable.Map.empty[Int, Tree]
+    private val arguments = new Array[Tree](ftoks.length)
     private val optional = Set.newBuilder[Int]
     private val statements = new Array[Tree](ftoks.length)
     private val semicolons = Map.newBuilder[Int, FT]
@@ -52,20 +54,24 @@ object OptimizationEntities {
         tree.foreachChild(queue += _)
       }
       new OptimizationEntities(
-        arguments.toMap,
+        arguments,
         optional.result(),
         statements,
         semicolons.result(),
       )
     }
 
-    private def getHeadIndex(tree: Tree): Option[Int] = ftoks.getHeadOpt(tree)
-      .map(_.meta.idx - 1)
-    private def addArgWith(key: Tree)(value: Tree): Unit = getHeadIndex(key)
-      .foreach(arguments.getOrElseUpdate(_, value))
+    private def getHeadIndex(tree: Tree): Int = ftoks.getHead(tree)
+      .nnFold(-1)(_.meta.idx - 1)
+    private def addArgWith(key: Tree)(value: Tree): Unit = {
+      val idx = getHeadIndex(key)
+      if (idx >= 0 && (arguments(idx) eq null)) arguments(idx) = value
+    }
     private def addArg(tree: Tree): Unit = addArgWith(tree)(tree)
-    private def addOptional(tree: Tree): Unit = getHeadIndex(tree)
-      .foreach(optional += _)
+    private def addOptional(tree: Tree): Unit = {
+      val idx = getHeadIndex(tree)
+      if (idx >= 0) optional += idx
+    }
     private def addParam(t: Term.Param, key: Tree): Unit = {
       addArgWith(key)(t)
       t.mods.foreach(addOptional)
@@ -95,13 +101,13 @@ object OptimizationEntities {
       case _ =>
     }
 
-    private def addStmtFT(stmt: Tree, prev: Option[FT] = None)(ft: FT): Unit = {
+    private def addStmtFT(stmt: Tree, prev: FT = null)(ft: FT): Unit = {
       if (stmt ne null) {
         val isComment = ft.left.is[T.Comment]
         val nft = if (isComment) ftoks.nextAfterNonComment(ft) else ft
         statements(nft.meta.idx) = stmt
       }
-      prev.foreach { prev =>
+      if (prev ne null) {
         val pft = ftoks.prevNonCommentBefore(ft)
         if (pft.left.is[T.Semicolon]) semicolons +=
           prev.idx -> ftoks.nextNonCommentSameLine(pft)
@@ -109,15 +115,14 @@ object OptimizationEntities {
     }
     private def addStmtTok(stmt: Tree)(token: T) =
       addStmtFT(stmt)(ftoks.after(token))
-    private def addStmtTree(t: Tree, stmt: Tree, prev: Option[FT] = None) = {
-      val ft = ftoks.getHeadOpt(t)
-      ft.foreach(addStmtFT(stmt, prev))
+    private def addStmtTree(t: Tree, stmt: Tree, prev: FT = null) = {
+      val ft = ftoks.getHead(t)
+      if (ft ne null) addStmtFT(stmt, prev)(ft)
       ft
     }
-    private def addOneStmt(t: Tree, prev: Option[FT] = None) =
-      addStmtTree(t, t, prev)
-    private def addAllStmts(trees: Seq[Tree]) = trees
-      .foldLeft(Option.empty[FT])((prev, t) => addOneStmt(t, prev))
+    private def addOneStmt(t: Tree, prev: FT = null) = addStmtTree(t, t, prev)
+    private def addAllStmts(trees: Iterable[Tree]) = trees
+      .foldLeft(null: FT)((prev, t) => addOneStmt(t, prev))
 
     private def addDefnTokens(
         mods: Seq[Mod],
@@ -125,17 +130,12 @@ object OptimizationEntities {
         what: String,
         isMatch: T => Boolean,
     ): Unit = {
-      // Each @annotation gets a separate line
-      val annotations = mods.filter(_.is[Mod.Annot])
-      addAllStmts(annotations)
-      mods.find(!_.is[Mod.Annot]) match {
-        // Non-annotation modifier, for example `sealed`/`abstract`
-        case Some(x) => addStmtTree(x, tree)
-        case _ =>
-          // No non-annotation modifier exists, fallback to keyword like `object`
-          tree.tokens.find(isMatch)
-            .fold(throw Error.CantFindDefnToken(what, tree))(addStmtTok(tree))
-      }
+      addAllStmts(mods.view.filter(_.is[Mod.Annot])) // Each @annotation gets a separate line
+      mods.findOrNull(!_.is[Mod.Annot]).nnFold(
+        tree.tokens.find(isMatch) // No non-annotation modifier, fallback to keyword like `object`
+          .fold(throw Error.CantFindDefnToken(what, tree))(addStmtTok(tree)),
+      )(x => addStmtTree(x, tree)) // Non-annotation modifier, for example `sealed`/`abstract`
+
     }
 
     private def addDefn[T](mods: Seq[Mod], tree: Tree)(implicit
@@ -179,7 +179,7 @@ object OptimizationEntities {
           ) =>
       case t: Term.EnumeratorsBlock =>
         var wasGuard = false
-        def iter(prev: Option[FT], curr: Enumerator): Option[FT] = {
+        def iter(prev: FT, curr: Enumerator): FT = {
           val isGuard = curr.is[Enumerator.Guard]
           // Only guard that follows another guard starts a statement.
           val ok = wasGuard || !isGuard
@@ -187,7 +187,7 @@ object OptimizationEntities {
           addStmtTree(curr, if (ok) curr else null, prev)
         }
         t.enums match {
-          case head :: tail => tail.foldLeft(ftoks.getHeadOpt(head))(iter)
+          case head :: tail => tail.foldLeft(ftoks.getHead(head))(iter)
           case _ =>
         }
       case t: Term.PartialFunction => t.cases match {
@@ -196,7 +196,7 @@ object OptimizationEntities {
         }
       case t @ Term.Block(s) =>
         if (t.parent.is[CaseTree]) addAllStmts(
-          if (TreeOps.getSingleStatExceptEndMarker(s).isEmpty) s else s.drop(1),
+          if (TreeOps.getSingleStatExceptEndMarker(s) eq null) s else s.drop(1),
         )
         else s match {
           case x :: Nil

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptionalBraces.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config._
 import org.scalafmt.util.ParamClauseParent
@@ -15,9 +16,9 @@ import scala.annotation.tailrec
 abstract class OptionalBraces {
 
   /** this is really the end-marker owner */
-  def owner: Option[Tree]
+  def owner: Tree
   def block: Tree
-  def splits: Option[Seq[Split]]
+  def splits: Seq[Split]
 }
 
 object OptionalBraces {
@@ -27,7 +28,7 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces]
+    ): OptionalBraces
   }
 
   // Optional braces in templates after `:|with`
@@ -38,49 +39,50 @@ object OptionalBraces {
   def getWithBrace(ft: FT)(implicit
       style: ScalafmtConfig,
       ftoks: FormatTokens,
-  ): Option[(OptionalBraces, FT, Boolean)] =
-    if (!style.dialect.allowSignificantIndentation) None
-    else Option {
-      ft.left match {
-        case _: T.Colon => ColonEolImpl
-        case _: T.KwWith => WithImpl
-        case _: T.RightArrow => RightArrowImpl
-        case _: T.ContextArrow => ContextArrowImpl
-        case _: T.RightParen => RightParenImpl
-        case _: T.KwFor => ForImpl
-        case _: T.KwWhile => WhileImpl
-        case _: T.KwDo => DoImpl
-        case _: T.Equals => EqualsImpl
-        case _: T.KwTry => TryImpl
-        case _: T.KwCatch => CatchImpl
-        case _: T.KwFinally => FinallyImpl
-        case _: T.KwMatch => MatchImpl
-        case _: T.KwThen => ThenImpl
-        case _: T.KwIf => IfImpl
-        case _: T.KwElse => ElseImpl
-        case _: T.KwReturn | _: T.ContextArrow | _: T.LeftArrow | _: T.KwThrow |
-            _: T.KwYield => BlockImpl
-        case _ => null
-      }
-    }.flatMap { impl =>
+  ): (OptionalBraces, FT, Boolean) = {
+    val impl: Factory = ft.left match {
+      case _ if !style.dialect.allowSignificantIndentation => null
+      case _: T.Colon => ColonEolImpl
+      case _: T.KwWith => WithImpl
+      case _: T.RightArrow => RightArrowImpl
+      case _: T.ContextArrow => ContextArrowImpl
+      case _: T.RightParen => RightParenImpl
+      case _: T.KwFor => ForImpl
+      case _: T.KwWhile => WhileImpl
+      case _: T.KwDo => DoImpl
+      case _: T.Equals => EqualsImpl
+      case _: T.KwTry => TryImpl
+      case _: T.KwCatch => CatchImpl
+      case _: T.KwFinally => FinallyImpl
+      case _: T.KwMatch => MatchImpl
+      case _: T.KwThen => ThenImpl
+      case _: T.KwIf => IfImpl
+      case _: T.KwElse => ElseImpl
+      case _: T.KwReturn | _: T.ContextArrow | _: T.LeftArrow | _: T.KwThrow |
+          _: T.KwYield => BlockImpl
+      case _ => null
+    }
+    if (impl eq null) null
+    else {
       implicit val ift: FT = ft
       val nft = ftoks.nextNonComment(ft)
-      impl.create(nft).map { ob =>
+      impl.create(nft).nnMap { ob =>
         val skip = nft.right.is[T.LeftBrace] && nft.meta.rightOwner == ob.block
         (ob, nft, skip)
       }
     }
-
-  def get(ft: FT)(implicit
-      style: ScalafmtConfig,
-      ftoks: FormatTokens,
-  ): Option[OptionalBraces] = getWithBrace(ft) match {
-    case Some((ob, _, false)) => Some(ob)
-    case _ => None
   }
 
+  def get(
+      ft: FT,
+  )(implicit style: ScalafmtConfig, ftoks: FormatTokens): OptionalBraces =
+    getWithBrace(ft) match {
+      case (ob, _, false) => ob
+      case _ => null
+    }
+
   def at(ft: FT)(implicit style: ScalafmtConfig, ftoks: FormatTokens): Boolean =
-    get(ft).nonEmpty
+    get(ft) ne null
 
   private def getSplits(
       tree: Tree,
@@ -88,7 +90,7 @@ object OptionalBraces {
       danglingKeyword: Boolean = true,
       indentOpt: Option[Int] = None,
       forceNLIfTrailingStandaloneComments: Boolean = true,
-      nlModOpt: Option[NewlineT] = None,
+      nlModOpt: NewlineT = null,
   )(implicit
       fileLine: FileLine,
       style: ScalafmtConfig,
@@ -101,13 +103,16 @@ object OptionalBraces {
     val nonTrivialEnd = prevNonComment(end)
     val slbExpire = nextNonCommentSameLine(nonTrivialEnd)
     def head = getHead(treeTokens, tree)
-    val close = (tree match {
-      case _: Member.Tuple => None
-      case Term.Block((_: Member.Tuple) :: Nil) if !head.left.is[T.LeftBrace] =>
-        None
-      case _ => getClosingIfWithinParens(nonTrivialEnd)(head)
-          .map(prevNonCommentSameLine)
-    }).getOrElse(nextNonCommentSameLine(end))
+    val close = {
+      val close = tree match {
+        case _: Member.Tuple => null
+        case Term.Block((_: Member.Tuple) :: Nil)
+            if !head.left.is[T.LeftBrace] => null
+        case _ => getClosingIfWithinParens(nonTrivialEnd)(head)
+      }
+      if (close eq null) nextNonCommentSameLine(end)
+      else prevNonCommentSameLine(close)
+    }
     def nlPolicy(implicit fileLine: FileLine) = Policy ? danglingKeyword && {
       val couldBeTucked = close.right.is[T.CloseDelim] &&
         close.rightOwner.is[Member.SyntaxValuesClause]
@@ -118,7 +123,7 @@ object OptionalBraces {
     val indent = Indent(indentLen, close, ExpiresOn.After)
     def nlOnly = forceNLIfTrailingStandaloneComments &&
       slbExpire.right.is[T.Comment] && slbExpire.idx < close.idx
-    val nlMod = nlModOpt.getOrElse(Newline2x(ft))
+    val nlMod = nlModOpt ?? Newline2x(ft)
     if (forceNL || nlMod.isDouble || nlOnly)
       Seq(Split(nlMod, 0).withIndent(indent).withPolicy(nlPolicy))
     else Seq(
@@ -134,19 +139,19 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       import ftoks._
       val lo = ft.meta.leftOwner
-      def createImpl(ownerOpt: => Option[Tree]) = Some(new OptionalBraces {
+      def createImpl(ownerOpt: => Tree) = new OptionalBraces {
         def owner = ownerOpt
         def block: Tree = lo
-        def splits = Some(getSplits(lo, forceNL = true))
-      })
+        def splits = getSplits(lo, forceNL = true)
+      }
       lo match {
-        case t: Template.Body if getHeadOpt(t).contains(ft) =>
-          createImpl(t.parent.parent)
-        case t: Pkg.Body if getHeadOpt(t).contains(ft) => createImpl(t.parent)
-        case t: Stat.Block if getHeadOpt(t).contains(ft) => createImpl(t.parent)
+        case t: Template.Body if getHead(t) eq ft =>
+          createImpl(t.parent.parent.orNull)
+        case t: Pkg.Body if getHead(t) eq ft => createImpl(t.parentOrNull)
+        case t: Stat.Block if getHead(t) eq ft => createImpl(t.parentOrNull)
         case t: Term.ArgClause if getHead(t) eq ft => onArgClause(t, t.values)
         case t: Term => t.parent match {
             case Some(p: Term.ArgClause)
@@ -156,9 +161,9 @@ object OptionalBraces {
                 case _ => t :: Nil
               }
               onArgClause(p, stats)
-            case _ => None
+            case _ => null
           }
-        case _ => None
+        case _ => null
       }
     }
 
@@ -166,11 +171,11 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       import ftoks._
       def funcSplit(arg: Member.Function)(implicit fl: FileLine) = {
         val end = getLast(arg)
-        getFuncArrow(arg).fold(Split(Space, 0).withSingleLine(end)) { arrow =>
+        getFuncArrow(arg).nnFold(Split(Space, 0).withSingleLine(end)) { arrow =>
           val afterArrow = nextNonCommentSameLine(arrow)
           /* TODO: dialect doesn't indicate if one-line lambdas are allowed.
            * On the other hand, with experimental features, that would force
@@ -183,7 +188,7 @@ object OptionalBraces {
             if (nlOnly) decideNewlinesOnlyAfterToken(afterArrow)
             else Policy.onlyFor(afterArrow, "FBARR") { ss =>
               val slb = SingleLineBlock(end)
-              val opt = Some(OptimalToken(end, killOnFail = true))
+              val opt = OptimalToken(end, killOnFail = true)
               ss.map(s =>
                 if (s.isNL) s
                 else s.andPolicy(slb)
@@ -210,30 +215,25 @@ object OptionalBraces {
           else Some(style.indent.main + style.indent.getSignificant)
         case _ => None
       }
-      Some {
-        new OptionalBraces {
-          def owner = ac.parent
-          def block: Tree = ac
-          def splits = Some {
-            args match {
-              case (tf: Member.Function) :: Nil
-                  if (style.newlines.beforeCurlyLambdaParams ne
-                    Newlines.BeforeCurlyLambdaParams.always) &&
-                    // https://dotty.epfl.ch/docs/internals/syntax.html
-                    (tf.paramClause match { // LambdaStart
-                      case tpc @ Term.ParamClause(tp :: Nil, mod) =>
-                        mod.isEmpty && tp.mods.isEmpty && tp.decltpe.isEmpty ||
-                        isEnclosedWithinParens(tpc)
-                      case _ => true // multiple params are always in parens
-                    }) =>
-                getSplits(ac, forceNL = false, indentOpt = indent) match {
-                  case Seq(s, rs @ _*) if !s.isNL =>
-                    funcSplit(tf)(s.fileLine) +: rs
-                  case ss => ss
-                }
-              case _ => getSplits(ac, forceNL = true, indentOpt = indent)
+      new OptionalBraces {
+        def owner = ac.parentOrNull
+        def block: Tree = ac
+        def splits = args match {
+          case (tf: Member.Function) :: Nil
+              if (style.newlines.beforeCurlyLambdaParams ne
+                Newlines.BeforeCurlyLambdaParams.always) &&
+                // https://dotty.epfl.ch/docs/internals/syntax.html
+                (tf.paramClause match { // LambdaStart
+                  case tpc @ Term.ParamClause(tp :: Nil, mod) => mod.isEmpty &&
+                    tp.mods.isEmpty && tp.decltpe.isEmpty ||
+                    isEnclosedWithinParens(tpc)
+                  case _ => true // multiple params are always in parens
+                }) =>
+            getSplits(ac, forceNL = false, indentOpt = indent) match {
+              case Seq(s, rs @ _*) if !s.isNL => funcSplit(tf)(s.fileLine) +: rs
+              case ss => ss
             }
-          }
+          case _ => getSplits(ac, forceNL = true, indentOpt = indent)
         }
       }
     }
@@ -244,22 +244,22 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       val lo = ft.meta.leftOwner
-      def createImpl(tb: Tree.Block, ownerOpt: => Option[Tree]) =
+      def createImpl(tb: Tree.Block, ownerOpt: => Tree) =
         if (
           nft.right.is[T.LeftBrace] && (nft.meta.rightOwner eq tb) ||
           tb.begOffset > nft.right.start
-        ) None
-        else Some(new OptionalBraces {
+        ) null
+        else new OptionalBraces {
           def owner = ownerOpt
           def block: Tree = lo
-          def splits = Some(getSplits(lo, forceNL = true))
-        })
+          def splits = getSplits(lo, forceNL = true)
+        }
       lo match {
-        case t: Template => createImpl(t.body, t.parent)
-        case t: Type.Refine => createImpl(t.body, Some(t))
-        case _ => None
+        case t: Template => createImpl(t.body, t.parentOrNull)
+        case t: Type.Refine => createImpl(t.body, t)
+        case _ => null
       }
     }
   }
@@ -269,12 +269,14 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       val leftOwner = ft.meta.leftOwner
       findTreeWithParentSimple(nft.meta.rightOwner)(_ eq leftOwner) match {
-        case Some(t: Term.Block) => getBlockWithNonSingleTermStat(t)
-            .flatMap(b => WithStats(nft, b.stats.headOption, t, t.parent))
-        case _ => None
+        case t: Term.Block =>
+          val b = getBlockWithNonSingleTermStat(t)
+          if ((b eq null) || b.stats.isEmpty) null
+          else WithStats(nft, b.stats.head, t, t.parentOrNull)
+        case _ => null
       }
     }
   }
@@ -284,40 +286,41 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       import ftoks._
       def createImpl(ownerTree: => Tree, blockTree: => Tree)(
-          splitsRef: => Option[Seq[Split]],
-      ) = Some(new OptionalBraces {
-        def owner = Some(ownerTree)
+          splitsRef: => Seq[Split],
+      ) = new OptionalBraces {
+        def owner = ownerTree
         def block: Tree = blockTree
         def splits = splitsRef
-      })
+      }
       def createKwDo(ownerTree: => Tree, blockTree: => Tree) =
-        if (nft.right.is[T.KwDo]) None
+        if (nft.right.is[T.KwDo]) null
         else createImpl(ownerTree, blockTree)(
-          if (isTreeSingleExpr(blockTree)) None
-          else Some(getSplits(blockTree, true)),
+          if (isTreeSingleExpr(blockTree)) Nil else getSplits(blockTree, true),
         )
       ft.meta.leftOwner match {
         case ParamClauseParent(pp: Defn.ExtensionGroup)
             if !nft.right.is[T.LeftBrace] && (tokenBefore(pp.body) eq ft) =>
-          createImpl(pp, pp.body)(Some(
+          createImpl(pp, pp.body)(
             getSplits(pp.body, shouldBreakInOptionalBraces(ft, nft)),
-          ))
+          )
         case t: Term.If if !nft.right.is[T.KwThen] && {
-              !isTreeSingleExpr(t.thenp) || t.thenp.is[Tree.CasesBlock] ||
-              getLastNotTrailingCommentOpt(t.thenp).exists(_.isLeft) ||
+              !isTreeSingleExpr(t.thenp) || t.thenp.is[Tree.CasesBlock] || {
+                val x = getLastNotTrailingComment(t.thenp)
+                (x ne null) && x.isLeft
+              } ||
               !ifWithoutElse(t) &&
               (isElsePWithOptionalBraces(t) ||
                 existsBlockIfWithoutElse(t.thenp, false))
-            } => createImpl(t, t.thenp)(Some(getSplitsForIf(nft, t)))
-        case t: Term.EnumeratorsBlock => t.parent.flatMap {
-            case p: Term.For => createKwDo(p, p.body)
-            case _ => None
+            } => createImpl(t, t.thenp)(getSplitsForIf(nft, t))
+        case t: Term.EnumeratorsBlock => t.parent match {
+            case Some(p: Term.For) => createKwDo(p, p.body)
+            case _ => null
           }
         case t: Term.While => createKwDo(t, t.body)
-        case _ => None
+        case _ => null
       }
     }
   }
@@ -327,21 +330,22 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
+    ): OptionalBraces = ft.meta.leftOwner match {
       case t: Case => // unsupported except for right brace, or when ends in comment
-        Some(new OptionalBraces {
-          def owner = None
+        new OptionalBraces {
+          def owner = null
           def block: Tree = t.body
-          def splits =
-            if (ftoks.getLastNotTrailingCommentOpt(t).forall(_.isRight)) None
-            else Some(Seq(Split(Newline2x(ft), 0)))
-        })
+          def splits = {
+            val x = ftoks.getLastNotTrailingComment(t)
+            if ((x eq null) || x.isRight) Nil else Seq(Split(Newline2x(ft), 0))
+          }
+        }
       case t @ Tree.WithBody(b: Tree.CasesBlock) if nft.right.is[T.KwCase] =>
-        Some(new OptionalBraces {
-          def owner = Some(t)
+        new OptionalBraces {
+          def owner = t
           def block: Tree = b
-          def splits = Some(getSplits(b, forceNL = true))
-        })
+          def splits = getSplits(b, forceNL = true)
+        }
       case t: Term.FunctionLike => FunctionArrowImpl.get(t)
       case _ => BlockImpl.create(nft)
     }
@@ -352,7 +356,7 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.leftOwner match {
+    ): OptionalBraces = ft.leftOwner match {
       case t: Term.FunctionLike => FunctionArrowImpl.get(t)
       case _ => BlockImpl.create(nft)
     }
@@ -363,22 +367,22 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       val skip = isTreeSingleExpr(t.body) || isBlockFunction(t)
-      if (skip) None // not really optional braces
-      else Some(new OptionalBraces {
-        def owner = Some(t)
+      if (skip) null // not really optional braces
+      else new OptionalBraces {
+        def owner = t
         def block: Tree = t.body
         def splits = {
           val (afterCurlySpace, afterCurlyNewlines) = Modification
             .getSpaceAndNewlineAfterCurlyLambda(ft.newlinesBetween)
-          Some(getSplits(
+          getSplits(
             t.body,
             forceNL = !afterCurlySpace || isTreeMultiStatBlock(t.body),
-            nlModOpt = Some(afterCurlyNewlines),
-          ))
+            nlModOpt = afterCurlyNewlines,
+          )
         }
-      })
+      }
     }
   }
 
@@ -387,10 +391,10 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
+    ): OptionalBraces = ft.meta.leftOwner match {
       case t @ Tree.WithEnums(x) if isSeqMulti(x) =>
-        WithStats(nft, x.headOption, x.last, Some(t), nlOnly = false)
-      case _ => None
+        WithStats(nft, x.head, x.last, t, nlOnly = false)
+      case _ => null
     }
   }
 
@@ -399,23 +403,23 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
+    ): OptionalBraces = ft.meta.leftOwner match {
       case t: Term.While => t.expr match {
           case b: Term.Block
-              if isMultiStatBlock(b) && !ftoks.matchingOptRight(nft)
-                .exists(_.left.end >= b.endOffset) =>
-            Some(new OptionalBraces {
-              def owner = Some(t)
+              if isMultiStatBlock(b) && ftoks.matchingRightOrNull(nft)
+                .orHas(_.left.end < b.endOffset) =>
+            new OptionalBraces {
+              def owner = t
               def block: Tree = b
-              def splits = Some {
+              def splits = {
                 val dangle = style.danglingParentheses.ctrlSite
                 val forceNL = !nft.right.is[T.LeftParen]
                 getSplits(b, forceNL = forceNL, danglingKeyword = dangle)
               }
-            })
-          case _ => None
+            }
+          case _ => null
         }
-      case _ => None
+      case _ => null
     }
   }
 
@@ -424,16 +428,16 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       val lo = ft.meta.leftOwner
-      def createImpl(body: Tree) = Some(new OptionalBraces {
-        def owner = Some(lo)
+      def createImpl(body: Tree) = new OptionalBraces {
+        def owner = lo
         def block: Tree = body
-        def splits = Some(getSplitsMaybeBlock(nft, body))
-      })
+        def splits = getSplitsMaybeBlock(nft, body)
+      }
       lo match {
         case t: Tree.WithBody => createImpl(t.body)
-        case _ => None
+        case _ => null
       }
     }
   }
@@ -443,17 +447,18 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
+    ): OptionalBraces = ft.meta.leftOwner match {
       case t: Ctor.Secondary =>
-        if (t.body.stats.isEmpty) None
-        else WithStats(nft, Some(t.body.init), t.body, t.parent)
-      case t @ Tree.WithBody(b) => (b match {
+        if (t.body.stats.isEmpty) null
+        else WithStats(nft, t.body.init, t.body, t.parentOrNull)
+      case t @ Tree.WithBody(b) =>
+        val block = b match {
           case x: Term.Block => getBlockWithNonSingleTermStat(x)
-          case x: Tree.CasesBlock => Some(x)
-          case _ => None
-        }).fold(getMaybeFewerBracesSelectSplits(b))(x =>
-          WithStats(nft, x.stats.headOption, b, Some(t)),
-        )
+          case x: Tree.CasesBlock => x
+          case _ => null
+        }
+        if (block eq null) getMaybeFewerBracesSelectSplits(b)
+        else WithStats(nft, block.stats.head, b, t)
       case _ => BlockImpl.create(nft)
     }
   }
@@ -463,23 +468,23 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       val lo = ft.meta.leftOwner
       def createImpl(expr: Term, finallyp: Option[Term], usesOB: => Boolean) =
-        Some(new OptionalBraces {
-          def owner = Some(lo)
+        new OptionalBraces {
+          def owner = lo
           def block: Tree = expr
           def splits =
-            if (!isTreeSingleExpr(expr)) Some(getSplits(expr, true))
+            if (!isTreeSingleExpr(expr)) getSplits(expr, true)
             else if (finallyp.exists(isTreeUsingOptionalBraces) || usesOB)
-              Some(getSplits(expr, shouldBreakInOptionalBraces(ft, nft)))
-            else None
-        })
+              getSplits(expr, shouldBreakInOptionalBraces(ft, nft))
+            else Nil
+        }
       ft.meta.leftOwner match {
         case t: Term.Try =>
           createImpl(t.expr, t.finallyp, isCatchUsingOptionalBraces(t))
         case t: Term.TryWithHandler => createImpl(t.expr, t.finallyp, false)
-        case _ => None
+        case _ => null
       }
     }
   }
@@ -494,34 +499,37 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
+    ): OptionalBraces = ft.meta.leftOwner match {
       case t: Term.Try => t.catchClause match {
           case Some(cb: Term.CasesBlock) =>
             val nlOnly = cb.cases match {
               // to avoid next expression being interpreted as body
               case head :: Nil => shouldBreakInOptionalBraces(ft, nft) ||
                 t.finallyp.isEmpty &&
-                (isEmptyTree(head.body) || ftoks.getLastOpt(cb).exists { x =>
-                  val xend = ftoks.nextNonCommentSameLine(x)
-                  xend.right match {
-                    case _: T.Comment => !xend.hasBlankLine
-                    case _ => false
+                (isEmptyTree(head.body) || {
+                  val x = ftoks.getLast(cb)
+                  (x ne null) && {
+                    val xend = ftoks.nextNonCommentSameLine(x)
+                    xend.right match {
+                      case _: T.Comment => !xend.hasBlankLine
+                      case _ => false
+                    }
                   }
                 })
               case _ => true
             }
-            Some(new OptionalBraces {
-              def owner = Some(t)
+            new OptionalBraces {
+              def owner = t
               def block: Tree = cb
-              def splits = Some(getSplits(
+              def splits = getSplits(
                 cb,
                 forceNL = nlOnly,
                 forceNLIfTrailingStandaloneComments = false,
-              ))
-            })
-          case _ => None
+              )
+            }
+          case _ => null
         }
-      case _ => None
+      case _ => null
     }
   }
 
@@ -530,26 +538,31 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = {
+    ): OptionalBraces = {
       val lo = ft.meta.leftOwner
       def createImpl(usingOB: => Boolean)(finallyExpr: Tree) = {
         val isMulti = !isTreeSingleExpr(finallyExpr)
         def usesOB = isMulti || usingOB
         def forceNL = isMulti || shouldBreakInOptionalBraces(ft, nft)
         new OptionalBraces {
-          def owner = Some(lo)
+          def owner = lo
           def block: Tree = finallyExpr
-          def splits =
-            if (usesOB) Some(getSplits(finallyExpr, forceNL)) else None
+          def splits = if (usesOB) getSplits(finallyExpr, forceNL) else Nil
         }
       }
       lo match {
-        case t: Term.Try => t.finallyp.map(createImpl(
-            isCatchUsingOptionalBraces(t) || isTreeUsingOptionalBraces(t.expr),
-          ))
-        case t: Term.TryWithHandler => t.finallyp
-            .map(createImpl(isTreeUsingOptionalBraces(t.expr)))
-        case _ => None
+        case t: Term.Try => t.finallyp match {
+            case Some(x) => createImpl(
+                isCatchUsingOptionalBraces(t) ||
+                  isTreeUsingOptionalBraces(t.expr),
+              )(x)
+            case _ => null
+          }
+        case t: Term.TryWithHandler => t.finallyp match {
+            case Some(x) => createImpl(isTreeUsingOptionalBraces(t.expr))(x)
+            case _ => null
+          }
+        case _ => null
       }
     }
   }
@@ -559,11 +572,11 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
+    ): OptionalBraces = ft.meta.leftOwner match {
       case t @ Tree.WithCasesBlock(x) =>
         val ind = style.indent.matchSite
-        WithStats(nft, x.cases.headOption, t, Some(t), indentOpt = ind)
-      case _ => None
+        WithStats.fromStats(nft, x.cases, t, t, indentOpt = ind)
+      case _ => null
     }
   }
 
@@ -572,13 +585,13 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
-      case t: Term.If => Some(new OptionalBraces {
-          def owner = Some(t)
+    ): OptionalBraces = ft.meta.leftOwner match {
+      case t: Term.If => new OptionalBraces {
+          def owner = t
           def block: Tree = t.thenp
-          def splits = Some(getSplitsForIf(nft, t))
-        })
-      case _ => None
+          def splits = getSplitsForIf(nft, t)
+        }
+      case _ => null
     }
   }
 
@@ -587,24 +600,23 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
+    ): OptionalBraces = ft.meta.leftOwner match {
       case t: Term.If => t.cond match {
-          case b: Term.Block if (ftoks.matchingOptRight(nft) match {
-                case Some(t) => t.left.end < b.endOffset
-                case None => isMultiStatBlock(b)
-              }) =>
-            Some(new OptionalBraces {
-              def owner = Some(t)
+          case b: Term.Block
+              if ftoks.matchingRightOrNull(nft)
+                .nnFold(isMultiStatBlock(b))(_.left.end < b.endOffset) =>
+            new OptionalBraces {
+              def owner = t
               def block: Tree = b
-              def splits = Some {
+              def splits = {
                 val dangle = style.danglingParentheses.ctrlSite
                 val forceNL = !nft.right.is[T.LeftParen]
                 getSplits(b, forceNL, dangle)
               }
-            })
-          case _ => None
+            }
+          case _ => null
         }
-      case _ => None
+      case _ => null
     }
   }
 
@@ -613,26 +625,28 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[OptionalBraces] = ft.meta.leftOwner match {
-      case t: Term.If => (getTreeSingleExpr(t.elsep) match {
-          case Some(x: Term.If) =>
+    ): OptionalBraces = ft.meta.leftOwner match {
+      case t: Term.If =>
+        val forceNL = getTreeSingleExpr(t.elsep) match {
+          case x: Term.If =>
             val forceNL = ftoks.isJustBeforeTree(nft)(x) && ft.hasBreak &&
               ((ft ne nft) || style.newlines.keep)
-            if (forceNL) Some(true) else None
-          case Some(_: Tree.CasesBlock) => Some(true)
-          case Some(_)
-              if !ftoks.getLastNotTrailingCommentOpt(t).exists(_.isLeft) =>
-            if (!isThenPWithOptionalBraces(t)) None
-            else Some(shouldBreakInOptionalBraces(ft, nft))
-          case _ => Some(true)
-        }).map(forceNL =>
-          new OptionalBraces {
-            def owner = Some(t)
-            def block: Tree = t.elsep
-            def splits = Some(getSplits(t.elsep, forceNL))
-          },
-        )
-      case _ => None
+            if (forceNL) MaybeBool.True else MaybeBool.Maybe
+          case _: Tree.CasesBlock | null => MaybeBool.True
+          case _ if {
+                val x = ftoks.getLastNotTrailingComment(t)
+                (x ne null) && x.isLeft
+              } => MaybeBool.True
+          case _ if !isThenPWithOptionalBraces(t) => MaybeBool.Maybe
+          case _ => MaybeBool(shouldBreakInOptionalBraces(ft, nft))
+        }
+        if (forceNL eq MaybeBool.Maybe) null
+        else new OptionalBraces {
+          def owner = t
+          def block: Tree = t.elsep
+          def splits = getSplits(t.elsep, forceNL.asBoolean)
+        }
+      case _ => null
     }
   }
 
@@ -651,46 +665,49 @@ object OptionalBraces {
     getSplits(tree, forceNL, danglingKeyword)
   }
 
-  private def getMaybeFewerBracesSelectSplits(
-      body: Tree,
-  )(implicit ft: FT, style: ScalafmtConfig, ftoks: FormatTokens) = {
+  private def getMaybeFewerBracesSelectSplits(body: Tree)(implicit
+      ft: FT,
+      style: ScalafmtConfig,
+      ftoks: FormatTokens,
+  ): OptionalBraces = {
     import ftoks._
-    Select.first(body, enclosed = true).filter(_.qual match {
+    val selectLike = Select.first(body, enclosed = true)
+    val keep = selectLike.nnHas(_.qual match {
       case q @ (_: Term.ForClause | _: Term.ApplyInfix |
           _: Term.SelectPostfix) => !isEnclosedInMatching(q)
       case _ => false
-    }).map { selectLike =>
-      new OptionalBraces {
-        def splits: Option[Seq[Split]] = {
-          val noFbIndent = style.getFewerBraces() == Indents.FewerBraces.never
-          val indentLen =
-            if (noFbIndent) style.indent.getSignificant
-            else style.indent.main + style.indent.getSignificant
-          val dot = prev(prevNonCommentBefore(selectLike.nameFt))
-          val beforeDot = prevNonCommentSameLine(dot)
-          val policy = Policy.End <= beforeDot ==>
-            Policy.onRight(dot, "NL-NOIND-SELECT") {
-              case Decision(`beforeDot`, ss) => ss.flatMap(s =>
-                  if ((dot eq beforeDot) && !s.isNL) None
-                  else Some(s.deActivateFor(SplitTag.SelectChainFirstNL)),
-                )
-              case Decision(_, ss) => ss
-                  .map(_.deActivateFor(SplitTag.SelectChainFirstNL))
-            }
-          val nlSplit = Split(Newline2x(ft), 1, policy)
-            .withIndent(indentLen, beforeDot, ExpiresOn.After)
-          Some(Seq(nlSplit))
-        }
-        def block: Tree = body
-        def owner: Option[Tree] = body.parent
+    })
+    if (!keep) return null
+    new OptionalBraces {
+      def splits: Seq[Split] = {
+        val noFbIndent = style.getFewerBraces() == Indents.FewerBraces.never
+        val indentLen =
+          if (noFbIndent) style.indent.getSignificant
+          else style.indent.main + style.indent.getSignificant
+        val dot = prev(prevNonCommentBefore(selectLike.nameFt))
+        val beforeDot = prevNonCommentSameLine(dot)
+        val policy = Policy.End <= beforeDot ==>
+          Policy.onRight(dot, "NL-NOIND-SELECT") {
+            case Decision(`beforeDot`, ss) => ss.flatMap(s =>
+                if ((dot eq beforeDot) && !s.isNL) None
+                else Some(s.deActivateFor(SplitTag.SelectChainFirstNL)),
+              )
+            case Decision(_, ss) => ss
+                .map(_.deActivateFor(SplitTag.SelectChainFirstNL))
+          }
+        val nlSplit = Split(Newline2x(ft), 1, policy)
+          .withIndent(indentLen, beforeDot, ExpiresOn.After)
+        Seq(nlSplit)
       }
+      def block: Tree = body
+      def owner: Tree = body.parentOrNull
     }
   }
 
   private class WithStats private (
       nft: FT,
       body: Tree,
-      val owner: Option[Tree],
+      val owner: Tree,
       nlOnly: Boolean,
       indentOpt: Option[Int],
   )(implicit
@@ -699,9 +716,9 @@ object OptionalBraces {
       ft: FT,
       ftoks: FormatTokens,
   ) extends OptionalBraces {
-    def splits: Option[Seq[Split]] = {
+    def splits: Seq[Split] = {
       val forceNL = nlOnly || shouldBreakInOptionalBraces(ft, nft)
-      Some(getSplits(body, forceNL = forceNL, indentOpt = indentOpt))
+      getSplits(body, forceNL = forceNL, indentOpt = indentOpt)
     }
     def block: Tree = body
   }
@@ -709,9 +726,9 @@ object OptionalBraces {
   private object WithStats {
     def apply(
         nft: FT,
-        head: Option[Tree],
+        head: Tree,
         body: => Tree,
-        owner: => Option[Tree],
+        owner: => Tree,
         nlOnly: Boolean = true,
         indentOpt: Option[Int] = None,
     )(implicit
@@ -719,10 +736,26 @@ object OptionalBraces {
         style: ScalafmtConfig,
         ft: FT,
         ftoks: FormatTokens,
-    ): Option[WithStats] = head.flatMap(head =>
-      if (!ftoks.isJustBeforeTree(nft)(head)) None
-      else Some(new WithStats(nft, body, owner, nlOnly, indentOpt)),
-    )
+    ): WithStats =
+      if (head eq null) null
+      else if (!ftoks.isJustBeforeTree(nft)(head)) null
+      else new WithStats(nft, body, owner, nlOnly, indentOpt)
+
+    def fromStats(
+        nft: FT,
+        stats: Seq[Tree],
+        body: => Tree,
+        owner: => Tree,
+        nlOnly: Boolean = true,
+        indentOpt: Option[Int] = None,
+    )(implicit
+        fileLine: FileLine,
+        style: ScalafmtConfig,
+        ft: FT,
+        ftoks: FormatTokens,
+    ): WithStats =
+      if (stats.isEmpty) null
+      else apply(nft, stats.head, body, owner, nlOnly, indentOpt)
   }
 
   private def getSplitsForIf(nft: FT, t: Term.If)(implicit
@@ -753,8 +786,10 @@ object OptionalBraces {
       case _: T.KwThen => true
       case _: T.LeftBrace => false
       case _ => !isTreeSingleExpr(thenp) &&
-        (!before.right.is[T.LeftBrace] || matchingOptRight(before)
-          .exists(_.left.end < thenp.endOffset))
+        (!before.right.is[T.LeftBrace] || {
+          val m = matchingRightOrNull(before)
+          (m ne null) && m.left.end < thenp.endOffset
+        })
     }
   }
 
@@ -791,26 +826,29 @@ object OptionalBraces {
       style: ScalafmtConfig,
       classifier: Classifier[T, A],
       ftoks: FormatTokens,
-  ): Option[Split] = Some {
+  ): Split = {
     import ftoks._
-    if (!style.dialect.allowSignificantIndentation) return None
+    if (!style.dialect.allowSignificantIndentation) return null
 
     val treeTokens = tree.tokens
     val head = treeTokens.head
     val hft = after(head)
-    if (hft.left.eq(head) && tree.is[Term.Block] && !split.isNL) return None
+    if (hft.left.eq(head) && tree.is[Term.Block] && !split.isNL) return null
 
     val beg = getOnOrBeforeOwned(hft, tree)
     val end = getLastNonTrivial(treeTokens, tree)
-    val kw = next(getClosingIfWithinParens(end)(beg).fold(end)(next))
-    if (!kw.left.is[A]) return None
+    val kw = next {
+      val close = getClosingIfWithinParens(end)(beg)
+      if (close eq null) end else next(close)
+    }
+    if (!kw.left.is[A]) return null
 
     val indent = style.indent.ctrlSite.getOrElse(style.indent.getSignificant)
     def policy =
       if (split.isNL) decideNewlinesOnlyBeforeClose(kw)
       else decideNewlinesOnlyBeforeCloseOnBreak(kw)
     split.withIndent(indent, kw, ExpiresOn.Before)
-      .andPolicy(policy, !style.danglingParentheses.ctrlSite)
+      .andPolicy(if (style.danglingParentheses.ctrlSite) policy else null)
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Policy.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.util.LoggerOps
 
@@ -27,28 +28,17 @@ abstract class Policy {
   def filter(pred: Clause => Boolean): Policy
   def exists(pred: Clause => Boolean): Boolean
   def appliesUntil(nextft: FT)(pred: Clause => Boolean): Boolean
-  def appliesOn(nextft: FT)(pred: Clause => Boolean): Option[Boolean]
+  def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool
   def unexpired(split: Split, nextft: FT): Policy
   def switch(trigger: T, on: Boolean): Policy
 
   def &(other: Policy): Policy =
-    if (other.isEmpty) this else new AndThen(this, other)
+    if ((other eq null) || other.isEmpty) this else new AndThen(this, other)
   def |(other: Policy): Policy =
-    if (other.isEmpty) this else new OrElse(this, other)
+    if ((other eq null) || other.isEmpty) this else new OrElse(this, other)
   def ==>(other: Policy): Policy = Relay(this, other)
   def <==(pos: End.WithPos): Policy = Expire(this, pos)
   def ?(flag: Boolean): Policy = if (flag) this else NoPolicy
-
-  @inline
-  final def unexpiredOpt(split: Split, nextft: FT): Option[Policy] =
-    Some(unexpired(split, nextft)).filter(_.nonEmpty)
-
-  @inline
-  final def &(other: Option[Policy]): Policy = other.fold(this)(&)
-  @inline
-  final def |(other: Option[Policy]): Policy = other.fold(this)(|)
-  @inline
-  final def ==>(other: Option[Policy]): Policy = other.fold(this)(==>)
 
   @inline
   final def <(exp: FT): Policy = <==(End < exp)
@@ -95,9 +85,8 @@ object Policy {
     override def unexpired(split: Split, nextft: FT): Policy = this
     override def appliesUntil(nextft: FT)(pred: Clause => Boolean): Boolean =
       false
-    override def appliesOn(nextft: FT)(
-        pred: Clause => Boolean,
-    ): Option[Boolean] = None
+    override def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool =
+      MaybeBool.Maybe
     override def filter(pred: Clause => Boolean): Policy = this
     override def exists(pred: Clause => Boolean): Boolean = false
     override def switch(trigger: T, on: Boolean): Policy = this
@@ -198,9 +187,8 @@ object Policy {
     override def appliesUntil(nextft: FT)(pred: Clause => Boolean): Boolean =
       pred(this)
 
-    override def appliesOn(nextft: FT)(
-        pred: Clause => Boolean,
-    ): Option[Boolean] = Some(pred(this))
+    override def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool =
+      MaybeBool(pred(this))
   }
 
   private class ClauseImpl(
@@ -231,22 +219,32 @@ object Policy {
 
   private def appliesOnAll(nextft: FT, p1: Policy, p2: Policy)(
       pred: Clause => Boolean,
-  ): Option[Boolean] = {
+  ): MaybeBool = {
     def r2 = p2.appliesOn(nextft)(pred)
-    p1.appliesOn(nextft)(pred).fold(r2)(r1 => Some(r1 && !r2.contains(false)))
+    p1.appliesOn(nextft)(pred) match {
+      case MaybeBool.Maybe => r2
+      case MaybeBool.False => MaybeBool.False
+      case _ => MaybeBool(r2 ne MaybeBool.False)
+    }
   }
 
   private def appliesOnAny(nextft: FT, p1: Policy, p2: Policy)(
       pred: Clause => Boolean,
-  ): Option[Boolean] = {
+  ): MaybeBool = {
     def r2 = p2.appliesOn(nextft)(pred)
-    p1.appliesOn(nextft)(pred).fold(r2)(r1 => Some(r1 || r2.contains(true)))
+    p1.appliesOn(nextft)(pred) match {
+      case MaybeBool.Maybe => r2
+      case MaybeBool.True => MaybeBool.True
+      case _ => MaybeBool(r2 eq MaybeBool.True)
+    }
   }
 
   private def appliesOn1st(nextft: FT, p1: Policy, p2: Policy)(
       pred: Clause => Boolean,
-  ): Option[Boolean] = p1.appliesOn(nextft)(pred)
-    .orElse(p2.appliesOn(nextft)(pred))
+  ): MaybeBool = {
+    val r1 = p1.appliesOn(nextft)(pred)
+    if (r1 ne MaybeBool.Maybe) r1 else p2.appliesOn(nextft)(pred)
+  }
 
   private class OrElse(p1: Policy, p2: Policy) extends WithConv {
     override def toString: String =
@@ -266,9 +264,8 @@ object Policy {
 
     override def appliesUntil(nextft: FT)(pred: Clause => Boolean): Boolean = p1
       .appliesUntil(nextft)(pred) && p2.appliesUntil(nextft)(pred)
-    override def appliesOn(nextft: FT)(
-        pred: Clause => Boolean,
-    ): Option[Boolean] = appliesOnAll(nextft, p1, p2)(pred)
+    override def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool =
+      appliesOnAll(nextft, p1, p2)(pred)
 
     override def exists(pred: Clause => Boolean): Boolean = p1.exists(pred) ||
       p2.exists(pred)
@@ -298,9 +295,8 @@ object Policy {
 
     override def appliesUntil(nextft: FT)(pred: Clause => Boolean): Boolean = p1
       .appliesUntil(nextft)(pred) || p2.appliesUntil(nextft)(pred)
-    override def appliesOn(nextft: FT)(
-        pred: Clause => Boolean,
-    ): Option[Boolean] = appliesOnAny(nextft, p1, p2)(pred)
+    override def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool =
+      appliesOnAny(nextft, p1, p2)(pred)
 
     override def exists(pred: Clause => Boolean): Boolean = p1.exists(pred) ||
       p2.exists(pred)
@@ -345,10 +341,8 @@ object Policy {
 
     override def appliesUntil(nextft: FT)(pred: Clause => Boolean): Boolean =
       endPolicy.notExpiredBy(nextft) && policy.appliesUntil(nextft)(pred)
-    override def appliesOn(
-        nextft: FT,
-    )(pred: Clause => Boolean): Option[Boolean] =
-      if (!endPolicy.notExpiredBy(nextft)) None
+    override def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool =
+      if (!endPolicy.notExpiredBy(nextft)) MaybeBool.Maybe
       else policy.appliesOn(nextft)(pred)
 
     override def exists(pred: Clause => Boolean): Boolean = policy.exists(pred)
@@ -396,10 +390,8 @@ object Policy {
 
     override def appliesUntil(nextft: FT)(pred: Clause => Boolean): Boolean =
       false
-    override def appliesOn(
-        nextft: FT,
-    )(pred: Clause => Boolean): Option[Boolean] =
-      if (begPolicy.notExpiredBy(nextft)) None
+    override def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool =
+      if (begPolicy.notExpiredBy(nextft)) MaybeBool.Maybe
       else policy.appliesOn(nextft)(pred)
   }
 
@@ -423,9 +415,8 @@ object Policy {
     override def appliesUntil(nextft: FT)(pred: Clause => Boolean): Boolean =
       before.appliesUntil(nextft)(pred) && after.appliesUntil(nextft)(pred)
 
-    override def appliesOn(nextft: FT)(
-        pred: Clause => Boolean,
-    ): Option[Boolean] = appliesOnAll(nextft, before, after)(pred)
+    override def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool =
+      appliesOnAll(nextft, before, after)(pred)
 
     override def exists(pred: Clause => Boolean): Boolean = before
       .exists(pred) || after.exists(pred)
@@ -443,9 +434,8 @@ object Policy {
     override protected def withBefore(before: Policy)(
         func: Policy => Policy,
     ): Policy = if (before.isEmpty) func(after) else new Relay(before, after)
-    override def appliesOn(nextft: FT)(
-        pred: Clause => Boolean,
-    ): Option[Boolean] = appliesOn1st(nextft, before, after)(pred)
+    override def appliesOn(nextft: FT)(pred: Clause => Boolean): MaybeBool =
+      appliesOn1st(nextft, before, after)(pred)
   }
 
   class RelayOnSplit(
@@ -503,14 +493,18 @@ object Policy {
     private object PredicateDecision {
       def unapply(d: Decision): Option[Seq[Split]] = {
         var replaced = false
-        def applyMap(s: Split): Option[Split] = Option(pred(s)).filter(ss =>
-          (s eq ss) || {
+        val splits = Seq.newBuilder[Split]
+        val iter = d.splits.iterator
+        while (iter.hasNext) {
+          val s = iter.next()
+          val ss = pred(s)
+          val ok = (s eq ss) || (ss ne null) && {
             replaced = true
             !ss.isIgnored
-          },
-        )
-        val splits = d.splits.flatMap(applyMap)
-        if (replaced) Some(splits) else None
+          }
+          if (ok) splits += ss
+        }
+        if (replaced) Some(splits.result()) else None
       }
     }
     override val f: Pf = { case PredicateDecision(ss) => ss }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Select.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Select.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config.ScalafmtConfig
 
@@ -16,27 +17,36 @@ object Select {
     new Select(tree, tree.expr, kw)
 
   def get(ro: Tree)(
-      onMatch: Term.SelectMatch => Option[FT],
-  )(implicit ftoks: FormatTokens): Option[Select] = ro match {
-    case x: Term.Select => Some(apply(x))
-    case x: Term.SelectMatch => onMatch(x).map(apply(x, _))
-    case _ => None
+      onMatch: Term.SelectMatch => FT,
+  )(implicit ftoks: FormatTokens): Select = ro match {
+    case x: Term.Select => apply(x)
+    case x: Term.SelectMatch => onMatch(x).nnMap(apply(x, _))
+    case _ => null
   }
 
-  def onRightOpt(ft: FT)(implicit ftoks: FormatTokens): Option[Select] =
-    get(ft.rightOwner) { _ =>
+  def getOrNull(ro: Tree)(
+      onMatch: Term.SelectMatch => FT,
+  )(implicit ftoks: FormatTokens): Select = ro match {
+    case x: Term.Select => apply(x)
+    case x: Term.SelectMatch => onMatch(x).nnMap(apply(x, _))
+    case _ => null
+  }
+
+  def onRightOrNull(ft: FT)(implicit ftoks: FormatTokens): Select =
+    getOrNull(ft.rightOwner) { _ =>
       val nft = ftoks.nextNonCommentAfter(ft)
-      if (nft.right.is[T.KwMatch]) Some(ftoks.next(nft)) else None
+      if (nft.right.is[T.KwMatch]) ftoks.next(nft) else null
     }
 
-  def unapply(tree: Tree)(implicit ftoks: FormatTokens): Option[Select] = Select
-    .get(tree)(x => Some(ftoks.tokenBefore(x.casesBlock)))(ftoks)
+  def unapply(tree: Tree)(implicit ftoks: FormatTokens): Option[Select] =
+    Option(Select.get(tree)(x => ftoks.tokenBefore(x.casesBlock)))
 
   @tailrec
-  final def first(tree: Tree, enclosed: Boolean, select: Option[Select] = None)(
-      implicit ftoks: FormatTokens,
-  ): Option[Select] = prevAndApply(tree, enclosed) match {
-    case (x @ Some(prevSelect), _) => first(prevSelect.qual, enclosed, x)
+  final def first(tree: Tree, enclosed: Boolean, select: Select = null)(implicit
+      ftoks: FormatTokens,
+  ): Select = prevAndApply(tree, enclosed) match {
+    case (prevSelect, _) if prevSelect ne null =>
+      first(prevSelect.qual, enclosed, prevSelect)
     case _ => select
   }
 
@@ -44,35 +54,35 @@ object Select {
   final def prevAndApply(
       tree: Tree,
       enclosed: Boolean,
-      applyTree: Option[Member.Apply] = None,
-  )(implicit ftoks: FormatTokens): (Option[Select], Option[Member.Apply]) = {
+      applyTree: Member.Apply = null,
+  )(implicit ftoks: FormatTokens): (Select, Member.Apply) = {
     @inline
     def isEnclosed: Boolean = enclosed && ftoks.isEnclosedWithinParens(tree)
     tree match {
-      case Select(t) if !isEnclosed => (Some(t), applyTree)
+      case Select(t) if !isEnclosed => (t, applyTree)
       case t: Member.Apply if !isEnclosed =>
-        prevAndApply(t.fun, enclosed, applyTree.orElse(Some(t)))
+        prevAndApply(t.fun, enclosed, if (applyTree ne null) applyTree else t)
       case t: Term.AnonymousFunction if !enclosed =>
         prevAndApply(t.body, false, applyTree)
       case Term.Block(t :: Nil) if !ftoks.isEnclosedInBraces(tree) =>
         prevAndApply(t, false, applyTree)
-      case _ => (None, applyTree)
+      case _ => (null, applyTree)
     }
   }
 
   final def prevAndApply(tree: Tree)(implicit
       ftoks: FormatTokens,
       style: ScalafmtConfig,
-  ): (Option[Select], Option[Member.Apply]) =
+  ): (Select, Member.Apply) =
     prevAndApply(tree, style.newlines.encloseSelectChains)
 
   def prev(tree: Select, enclosed: Boolean)(implicit
       ftoks: FormatTokens,
-  ): Option[Select] = prevAndApply(tree.qual, enclosed)._1
+  ): Select = prevAndApply(tree.qual, enclosed)._1
 
   def prev(
       tree: Select,
-  )(implicit ftoks: FormatTokens, style: ScalafmtConfig): Option[Select] =
+  )(implicit ftoks: FormatTokens, style: ScalafmtConfig): Select =
     prev(tree, style.newlines.encloseSelectChains)
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Split.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal.Policy.NoPolicy
@@ -54,7 +55,7 @@ case class Split(
     policy: Policy = NoPolicy,
     neededTags: Set[SplitTag] = Set.empty,
     activeTags: Set[SplitTag] = Set.empty,
-    optimalAt: Option[OptimalToken] = None,
+    optimalAt: OptimalToken = null,
     penalty: Int = 0,
     rank: Int = 0,
 )(implicit val fileLineStack: FileLineStack) {
@@ -146,13 +147,13 @@ case class Split(
     else copy()(fileLineStack.forThisLine(fileLine.file, fileLine.line))
 
   def withOptimalTokenOpt(
-      token: => Option[FT],
+      token: => FT,
       killOnFail: Boolean,
       extend: Boolean = false,
       recurseOnly: Boolean = false,
       ignorePenalty: Boolean = false,
   ): Split = withOptimalAt(
-    token.map(OptimalToken(
+    token.nnMap(OptimalToken(
       _,
       killOnFail = killOnFail,
       recurseOnly = recurseOnly,
@@ -169,31 +170,30 @@ case class Split(
       recurseOnly: Boolean = false,
       ignorePenalty: Boolean = false,
   ): Split = withOptimalAt(
-    Some(OptimalToken(
+    OptimalToken(
       token,
       killOnFail = killOnFail,
       recurseOnly = recurseOnly,
       ignorePenalty = ignorePenalty,
-    )),
+    ),
     ignore,
     extend = extend,
   )
 
   def withOptimalAt(
-      fOptimalAt: => Option[OptimalToken],
+      fOptimalAt: => OptimalToken,
       ignore: Boolean = false,
       extend: Boolean = false,
   ): Split =
     if (ignore || isIgnored) this
     else fOptimalAt match {
-      case None => this
-      case optAt @ Some(opt) =>
+      case null => this
+      case opt =>
         require(cost == 0, s"can't set optimal, cost=$cost")
-        def amend() = copy(optimalAt = optAt)
+        def amend() = copy(optimalAt = opt)
         this.optimalAt match {
-          case None => amend()
-          case Some(x) if extend =>
-            if (x.token.idx < opt.token.idx) amend() else this
+          case null => amend()
+          case x if extend => if (x.token.idx < opt.token.idx) amend() else this
           case _ =>
             throw new UnsupportedOperationException("Can't reset optimal token")
         }
@@ -216,7 +216,7 @@ case class Split(
       expire: => FT,
       exclude: => TokenRanges = TokenRanges.empty,
       noSyntaxNL: Boolean = false,
-      killOnFail: => Option[Boolean] = None,
+      killOnFail: => MaybeBool = MaybeBool.Maybe,
       rank: Int = 0,
       extend: Boolean = false,
       ignore: Boolean = false,
@@ -230,7 +230,7 @@ case class Split(
       val excludeEval = exclude
       withOptimalToken(
         expireEval,
-        killOnFail = killOnFail.getOrElse(excludeEval.isEmpty),
+        killOnFail = killOnFail.getBoolean(excludeEval.isEmpty),
         extend = extend,
         ignore = noOptimal,
         recurseOnly = recurseOnly,
@@ -258,15 +258,12 @@ case class Split(
   )
 
   def orPolicy(newPolicy: Policy): Split =
-    if (isIgnored || newPolicy.isEmpty) this
+    if (isIgnored || (newPolicy eq null) || newPolicy.isEmpty) this
     else copy(policy = policy | newPolicy)
 
   def andPolicy(newPolicy: Policy): Split =
-    if (isIgnored || newPolicy.isEmpty) this
+    if (isIgnored || (newPolicy eq null) || newPolicy.isEmpty) this
     else copy(policy = policy & newPolicy)
-
-  def andPolicy(newPolicy: => Policy, ignore: Boolean): Split =
-    if (ignore) this else andPolicy(newPolicy)
 
   def andFirstPolicy(newPolicy: Policy): Split =
     if (isIgnored || newPolicy.isEmpty) this
@@ -285,17 +282,8 @@ case class Split(
       ignore: Boolean,
   ): Split = withMod(modExt.withIndent(length, expire, when), ignore)
 
-  def withIndentOpt(
-      length: => Length,
-      expire: Option[FT],
-      when: ExpiresOn,
-  ): Split = withMod(modExt.withIndentOpt(length, expire, when))
-
   def withIndent(indent: => Indent, ignore: Boolean = false): Split =
     withMod(modExt.withIndent(indent), ignore)
-
-  def withIndentOpt(indent: => Option[Indent]): Split =
-    withMod(modExt.withIndentOpt(indent))
 
   def withIndents(indents: Indent*): Split = withMod(modExt.withIndents(indents))
 
@@ -331,7 +319,7 @@ case class Split(
         else if (wantedTags.nonEmpty) s"[$wantedTags]"
         else ""
       }
-    val opt = optimalAt.fold("")(", opt=" + _)
+    val opt = if (optimalAt eq null) "" else s", opt=$optimalAt"
     s"""${prefix}c=$cost[$penalty] $modExt:[$fileLineStack]($policy$opt)"""
   }
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config._
 import org.scalafmt.util._
@@ -78,9 +79,9 @@ object SplitsBeforeStatement extends Splits { // New statement
         (annoRight || annoLeft) && cfg.newlines.annotation &&
         !cfg.newlines.sourceIgnored
       ) Seq(Split(getMod(ft), 0))
-      else InfixSplits.maybeGetInfixSplitsBeforeLhs(Some(
+      else InfixSplits.maybeGetInfixSplitsBeforeLhs(
         if (left.is[T.Comment] && noBreak) Space else Newline2x(ft),
-      )) {
+      ) {
         val spaceCouldBeOk = annoLeft &&
           (cfg.newlines.source match {
             case Newlines.unfold => right.is[T.Comment] ||
@@ -90,16 +91,17 @@ object SplitsBeforeStatement extends Splits { // New statement
             case Newlines.keep => noBreak && (annoRight || Reserved(right))
             case _ => noBreak && Reserved(right)
           })
-        def expire = (rightOwner match {
-          case Tree.WithBody(body) => tokenBeforeOpt(body).map { x =>
-              val y = nextNonCommentSameLine(x)
-              val ok = (x ne y) && y.noBreak && y.right.is[T.LeftBrace]
-              if (ok) next(y) else y
-            }
-          case t: Mod.Annot if !cfg.newlines.keep =>
-            getLastOpt(t).map(getSlbEndOnLeft)
-          case _ => None
-        }).getOrElse(next(ft))
+        def expire =
+          (rightOwner match {
+            case Tree.WithBody(body) => tokenBefore(body).nnMap { x =>
+                val y = nextNonCommentSameLine(x)
+                val ok = (x ne y) && y.noBreak && y.right.is[T.LeftBrace]
+                if (ok) next(y) else y
+              }
+            case t: Mod.Annot if !cfg.newlines.keep =>
+              getLast(t).nnMap(getSlbEndOnLeft)
+            case _ => null
+          }) ?? next(ft)
         Seq(
           // This split needs to have an optimalAt field.
           Split(Space, 0).onlyIf(spaceCouldBeOk).withSingleLine(expire),
@@ -107,7 +109,7 @@ object SplitsBeforeStatement extends Splits { // New statement
           Split(Newline2x(ft), 0),
         )
       }
-    } else Seq.empty
+    } else Nil
   }
 }
 
@@ -121,8 +123,8 @@ object SplitsAfterInterpolationStart extends Splits {
         .onLeft(end, "INTERP-AVOID-NL", rank = -1) { case Decision(_, ss) =>
           ss.map(s =>
             if (s.isNL) s.withPenalty(penalty)
-            else if (s.optimalAt.isEmpty) s
-            else s.copy(optimalAt = None),
+            else if (s.optimalAt eq null) s
+            else s.copy(optimalAt = null),
           )
         }
       else if (!cfg.newlines.sourceIgnored && !isTripleQuote(left.text)) Policy
@@ -137,21 +139,23 @@ object SplitsAfterInterpolationStart extends Splits {
     }
     val split = Split(NoSplit, 0, policy)
     val alignIndents =
-      if (cfg.align.stripMargin) findInterpolate(leftOwner).flatMap(ti =>
-        getStripMarginChar(ti).map { pipe =>
-          val startsWithPipe = ti.parts.headOption match {
-            case Some(Lit.String(x)) => x.headOption.contains(pipe)
-            case _ => false
-          }
-          Seq(
-            Indent(StateColumn, end, After),
-            // -1 because of margin characters |
-            Indent(if (startsWithPipe) -1 else -2, end, After),
-          )
+      if (!cfg.align.stripMargin) null
+      else findInterpolate(leftOwner).nnMap(ti =>
+        getStripMarginChar(ti) match {
+          case None => null
+          case Some(pipe) =>
+            val startsWithPipe = ti.parts.headOption match {
+              case Some(Lit.String(x)) => x.headOption.contains(pipe)
+              case _ => false
+            }
+            Seq(
+              Indent(StateColumn, end, After),
+              // -1 because of margin characters |
+              Indent(if (startsWithPipe) -1 else -2, end, After),
+            )
         },
       )
-      else None
-    val indents = alignIndents.getOrElse(Seq(Indent(cfg.indent.main, end, After)))
+    val indents = alignIndents ?? Seq(Indent(cfg.indent.main, end, After))
     Seq(split.withIndents(indents))
   }
 }
@@ -247,8 +251,8 @@ object SplitsAfterLeftBrace extends Splits {
       case t: Pat.Interpolate => findArgAfter(left.end, t.args)
       case t: Term.Interpolate => findArgAfter(left.end, t.args)
       case t: Term.Block => getBlockSingleStat(t)
-      case _ => None
-    }).isOpt[Term.If]
+      case _ => null
+    }).nnHas(_.is[Term.If])
 
     cfg.newlines.inInterpolation match {
       case Newlines.InInterpolation.avoid => Seq(spaceSplit)
@@ -292,24 +296,24 @@ object SplitsAfterLeftBrace extends Splits {
       else Newline2x(!isSelfAnnotationNL && blankLineBeforeDocstring(ft))
 
     // lambdaNLOnly: None for single line only
-    type LambdaInfo = (FT, Int, Option[Boolean])
-    def getLambdaNone: LambdaInfo = (null, 0, None)
+    type LambdaInfo = (FT, Int, MaybeBool)
+    def getLambdaNone: LambdaInfo = (null, 0, MaybeBool.Maybe)
     @tailrec
     def getLambdaInfo(ts: List[Tree]): LambdaInfo = ts match {
       case (t: Case) :: Nil if t.cond.isEmpty =>
         val arrow = getCaseArrow(t)
         val nlOnly = cfg.newlines.beforeCurlyLambdaParams match {
-          case Newlines.BeforeCurlyLambdaParams.always => Some(true)
-          case Newlines.BeforeCurlyLambdaParams.never => Some(false)
-          case _ => None
+          case Newlines.BeforeCurlyLambdaParams.always => MaybeBool.True
+          case Newlines.BeforeCurlyLambdaParams.never => MaybeBool.False
+          case _ => MaybeBool.Maybe
         }
         (arrow, 0, nlOnly)
       case (t: Term.FunctionLike) :: Nil =>
-        val arrow = lastLambda(t).flatMap(getFuncArrow).getOrElse(getLast(t))
+        val arrow = lastLambda(t).nnMap(getFuncArrow) ?? getLast(t)
         val nlOnly = cfg.newlines.beforeCurlyLambdaParams match {
-          case Newlines.BeforeCurlyLambdaParams.always => Some(true)
-          case Newlines.BeforeCurlyLambdaParams.multiline => None
-          case _ => Some(false)
+          case Newlines.BeforeCurlyLambdaParams.always => MaybeBool.True
+          case Newlines.BeforeCurlyLambdaParams.multiline => MaybeBool.Maybe
+          case _ => MaybeBool.False
         }
         (arrow, 0, nlOnly)
       case (t: Term.PartialFunction) :: Nil => getLambdaInfo(t.cases)
@@ -320,38 +324,39 @@ object SplitsAfterLeftBrace extends Splits {
       case _ => getLambdaNone
     }
     val (lambdaArrow, lambdaIndent, lambdaNLOnly) = leftOwner match {
-      case t: Template.Body => t.selfOpt.fold(
-          if (t.parent.parent.isOpt[Term.NewAnonymous]) getLambdaInfo(t.stats)
-          else getLambdaNone,
-        ) { owner =>
-          val anno = owner.tokens.last
-          val indent = cfg.indent.main
-          val annoFT = tokens(anno)
-          val arrow = annoFT.left.is[T.RightArrow]
-          val expire = if (arrow) annoFT else nextAfterNonComment(annoFT)
-          (expire, indent, Some(isSelfAnnotationNL))
+      case t: Template.Body => t.selfOpt match {
+          case None =>
+            if (t.parent.parent.isOpt[Term.NewAnonymous]) getLambdaInfo(t.stats)
+            else getLambdaNone
+          case Some(owner) =>
+            val anno = owner.tokens.last
+            val indent = cfg.indent.main
+            val annoFT = tokens(anno)
+            val arrow = annoFT.left.is[T.RightArrow]
+            val expire = if (arrow) annoFT else nextAfterNonComment(annoFT)
+            (expire, indent, MaybeBool(isSelfAnnotationNL))
         }
       case t: Term.ArgClause if isEnclosedInBraces(t) => getLambdaInfo(t.values)
       case t: Term.Block => getLambdaInfo(t.stats)
       case t => getLambdaInfo(t :: Nil)
     }
     val noLambdaSplit = cfg.newlines.keepBreak(hasBreak) ||
-      lambdaArrow == null || !lambdaNLOnly.contains(false)
-    val lambdaExpire =
-      if (lambdaArrow eq null) null else nextNonCommentSameLine(lambdaArrow)
+      lambdaArrow == null || (lambdaNLOnly ne MaybeBool.False)
+    val lambdaExpire = lambdaArrow.nnMap(nextNonCommentSameLine)
 
-    def getClassicSingleLineDecisionOpt = if (noBreak) Some(true) else None
+    def getClassicSingleLineDecisionOpt =
+      if (noBreak) MaybeBool.True else MaybeBool.Maybe
 
     def getSingleLineLambdaDecisionOpt = {
-      val ok = !lambdaNLOnly.contains(true) &&
+      val ok = (lambdaNLOnly ne MaybeBool.True) &&
         Modification.getSpaceAndNewlineAfterCurlyLambda(newlinesBetween)._1
-      if (ok) Some(true) else None
+      if (ok) MaybeBool.True else MaybeBool.Maybe
     }
 
     // null if skipping
     val singleLineDecisionOpt = cfg.newlines.source match {
-      case Newlines.keep if hasBreak => None
-      case Newlines.unfold => None
+      case Newlines.keep if hasBreak => MaybeBool.Maybe
+      case Newlines.unfold => MaybeBool.Maybe
       case Newlines.fold =>
         val isTopLevelBlock = leftOwner.parent.forall {
           case t: Template =>
@@ -370,9 +375,9 @@ object SplitsAfterLeftBrace extends Splits {
         }
 
         // do not fold top-level blocks
-        if (isTopLevelBlock) None
+        if (isTopLevelBlock) MaybeBool.Maybe
         else if (lambdaArrow != null) getSingleLineLambdaDecisionOpt
-        else Some(false)
+        else MaybeBool.False
       // old behaviour
       case _ =>
         if (lambdaArrow == null) getClassicSingleLineDecisionOpt
@@ -381,72 +386,73 @@ object SplitsAfterLeftBrace extends Splits {
 
     val noSplitMod = braceSpace(leftOwner)
     val (slbMod, slbParensExclude) =
-      if (singleLineDecisionOpt.isEmpty) (noSplitMod, None)
+      if (singleLineDecisionOpt eq MaybeBool.Maybe) (noSplitMod, None)
       else getBracesToParensMod(close, noSplitMod)
-    val singleLineSplitOpt = {
-      if (slbParensExclude eq null) None else singleLineDecisionOpt
-    }.map { sld =>
-      val ownerIfNeedBreakAfterClose = close.right match {
-        case _: T.KwElse => close.rightOwner match {
-            case p: Term.If if p.thenp eq leftOwner => Some(p)
-            case _ => None
-          }
-        case _: T.KwCatch => close.rightOwner match {
-            case p: Term.TryClause if p.expr eq leftOwner => Some(p)
-            case _ => None
-          }
-        case _: T.KwFinally => close.rightOwner match {
-            case p: Term.TryClause
-                if (p.expr eq leftOwner) || p.catchClause.contains(leftOwner) =>
-              Some(p)
-            case _ => None
-          }
-        case _ => None
-      }
-      val expire = leftOwner.parent match {
-        case Some(p: Term.ForYield)
-            if !sld && ownerIfNeedBreakAfterClose.isEmpty &&
-              cfg.newlines.fold && leftOwner.is[Term.EnumeratorsBlock] =>
-          getLast(p)
-        case _ if cfg.newlines.isBeforeOpenParenCallSite => close
-        case _ => getSlbEndOnLeft(close)
-      }
-      // copy logic from `( ...`, binpack=never, defining `slbSplit`
-      val slbParensPolicy = Policy ? (slbMod eq noSplitMod) || {
-        val beforeClose = prev(close)
-        Policy.onlyFor(beforeClose, "BracesToParens")(
-          _.flatMap(s => if (s.isNL) None else Some(s.withMod(NoSplit))),
-        )
-      }
-      val exclude = slbParensExclude.getOrElse(TokenRanges.empty)
-      val slbPolicy =
-        if (exclude.isEmpty) slbParensPolicy
-        else Policy.RelayOnSplit((s, _) => s.isNL)(slbParensPolicy)(
-          Policy
-            .onLeft(close, "BracesToParensFailed", terminal = true) { case _ =>
-              Nil
-            },
-        )
-      val sldPolicy = ownerIfNeedBreakAfterClose.map(p =>
-        if (cfg.newlines.fold) {
-          val pend = getSlbEndOnLeft(getLast(p))
-          def pendSlb(s: Split) = s
-            .withSingleLine(pend, noSyntaxNL = true, extend = true)
-          Policy.onlyFor(close, s"RB-ELSE[${pend.idx}]")(ss =>
-            if (ss.exists(_.isNL)) ss.map(s => if (s.isNL) s else pendSlb(s))
-            else ss
-              .flatMap(s => Seq(pendSlb(s), s.withMod(Newline).withPenalty(1))),
+    val sld =
+      if (slbParensExclude eq null) MaybeBool.Maybe else singleLineDecisionOpt
+    val singleLineSplitOpt =
+      if (sld eq MaybeBool.Maybe) null
+      else {
+        val ownerIfNeedBreakAfterClose = close.right match {
+          case _: T.KwElse => close.rightOwner match {
+              case p: Term.If if p.thenp eq leftOwner => p
+              case _ => null
+            }
+          case _: T.KwCatch => close.rightOwner match {
+              case p: Term.TryClause if p.expr eq leftOwner => p
+              case _ => null
+            }
+          case _: T.KwFinally => close.rightOwner match {
+              case p: Term.TryClause
+                  if (p.expr eq leftOwner) ||
+                    p.catchClause.contains(leftOwner) => p
+              case _ => null
+            }
+          case _ => null
+        }
+        val expire = leftOwner.parent match {
+          case Some(p: Term.ForYield)
+              if !sld.asBoolean && (ownerIfNeedBreakAfterClose eq null) &&
+                cfg.newlines.fold && leftOwner.is[Term.EnumeratorsBlock] =>
+            getLast(p)
+          case _ if cfg.newlines.isBeforeOpenParenCallSite => close
+          case _ => getSlbEndOnLeft(close)
+        }
+        // copy logic from `( ...`, binpack=never, defining `slbSplit`
+        val slbParensPolicy = Policy ? (slbMod eq noSplitMod) || {
+          val beforeClose = prev(close)
+          Policy.onlyFor(beforeClose, "BracesToParens")(
+            _.flatMap(s => if (s.isNL) None else Some(s.withMod(NoSplit))),
           )
-        } else decideNewlinesOnlyAfterClose(close),
-      )
-      Split(slbMod, 0).withSingleLine(
-        expire,
-        exclude = exclude,
-        noOptimal = cfg.newlines.fold && !exclude.isEmpty &&
-          exclude.ranges.forall(_.lt.left.is[T.LeftParen]),
-        noSyntaxNL = true,
-      ).andPolicy(sldPolicy & slbPolicy)
-    }
+        }
+        val exclude = slbParensExclude.getOrElse(TokenRanges.empty)
+        val slbPolicy =
+          if (exclude.isEmpty) slbParensPolicy
+          else Policy.RelayOnSplit((s, _) => s.isNL)(slbParensPolicy)(
+            Policy.onLeft(close, "BracesToParensFailed", terminal = true) {
+              case _ => Nil
+            },
+          )
+        val sldPolicy = Policy ? (ownerIfNeedBreakAfterClose eq null) || {
+          if (cfg.newlines.fold) {
+            val pend = getSlbEndOnLeft(getLast(ownerIfNeedBreakAfterClose))
+            def pendSlb(s: Split) = s
+              .withSingleLine(pend, noSyntaxNL = true, extend = true)
+            Policy.onlyFor(close, s"RB-ELSE[${pend.idx}]")(ss =>
+              if (ss.exists(_.isNL)) ss.map(s => if (s.isNL) s else pendSlb(s))
+              else ss
+                .flatMap(s => Seq(pendSlb(s), s.withMod(Newline).withPenalty(1))),
+            )
+          } else decideNewlinesOnlyAfterClose(close)
+        }
+        Split(slbMod, 0).withSingleLine(
+          expire,
+          exclude = exclude,
+          noOptimal = cfg.newlines.fold && !exclude.isEmpty &&
+            exclude.ranges.forall(_.lt.left.is[T.LeftParen]),
+          noSyntaxNL = true,
+        ).andPolicy(sldPolicy & slbPolicy)
+      }
 
     val lambdaNLPolicy = leftOwner match {
       case t: Template.Body if lambdaExpire ne null =>
@@ -459,31 +465,37 @@ object SplitsAfterLeftBrace extends Splits {
     val (nlCost, nlArrowPenalty) =
       if (!nl.isNL) (0, 0)
       else {
-        if (slbMod eq noSplitMod) None
+        if (slbMod eq noSplitMod) null
         else getLambdaPenaltiesOnLeftBraceOnLeft(ft)
-      }.fold((1, 0)) { case (shared, here) => (shared + here, shared + 1) }
+      } match {
+        case null => (1, 0)
+        case (shared, here) => (shared + here, shared + 1)
+      }
     val newlineBeforeClosingCurly =
       decideNewlinesOnlyBeforeClose(Split(Newline, 0, rank = -1))(close)
     val nlPolicy = lambdaNLPolicy ==> newlineBeforeClosingCurly
     val nlSplit = Split(nl, nlCost, nlPolicy)
       .withIndent(cfg.indent.main, close, Before)
 
-    val singleLineSplit = singleLineSplitOpt match {
-      case Some(slbSplit)
-          if noLambdaSplit || !slbParensExclude.forall(_.isEmpty) => slbSplit
-      case _ => Split.ignored
-    }
+    val singleLineSplit =
+      if (
+        (singleLineSplitOpt ne null) &&
+        (noLambdaSplit || !slbParensExclude.forall(_.isEmpty))
+      ) singleLineSplitOpt
+      else Split.ignored
 
     // must be after nlSplit
     val lambdaSplit =
       if (noLambdaSplit) Split.ignored
       else {
         val nlPolicy = newlineBeforeClosingCurly
-        val (mod, policy) = singleLineSplitOpt match {
-          case Some(slbSplit) if singleLineSplit.isIgnored =>
-            val arrSplit = slbSplit.withMod(Space)
+        var mod: Modification = null
+        val policy =
+          if ((singleLineSplitOpt ne null) && singleLineSplit.isIgnored) {
+            val arrSplit = singleLineSplitOpt.withMod(Space)
             val fnarrDesc = s"FNARR($nlArrowPenalty;$arrSplit)"
-            slbMod -> Policy.onlyFor(lambdaExpire, fnarrDesc) { ss =>
+            mod = slbMod
+            Policy.onlyFor(lambdaExpire, fnarrDesc) { ss =>
               var hadNoSplit = false
               val nlSplits = ss.flatMap(s =>
                 // penalize NL one extra, for closing brace
@@ -493,9 +505,10 @@ object SplitsAfterLeftBrace extends Splits {
               )
               if (hadNoSplit) arrSplit +: nlSplits else nlSplits
             }
-          case _ => noSplitMod ->
-              (decideNewlinesOnlyAfterToken(lambdaExpire) ==> nlPolicy)
-        }
+          } else {
+            mod = noSplitMod
+            decideNewlinesOnlyAfterToken(lambdaExpire) ==> nlPolicy
+          }
         Split(mod, 0, SingleLineBlock(lambdaExpire) ==> policy)
           .withOptimalToken(lambdaExpire, killOnFail = true)
           .withIndent(lambdaIndent, close, Before)
@@ -518,7 +531,7 @@ object SplitsAfterEquals extends Splits {
   ): Seq[Split] = ft.leftOwner match {
     case x: Enumerator.Assign => SplitsAfterEqualsLeftArrow
         .getSplitsEnumerator(x.rhs)
-    case _: Enumerator => Seq.empty // it's WithBody
+    case _: Enumerator => Nil // it's WithBody
     case t: Ctor.Secondary => getDefValAssign(t.body.init)
     case t: Defn.Macro if fo.dialect.allowSignificantIndentation =>
       // scala3 compiler doesn't allow newline before `macro`
@@ -526,8 +539,11 @@ object SplitsAfterEquals extends Splits {
       getDefValAssign(t.body)
         .map(s => if (s.isNL) s.withMod(Space).andPolicy(nlPolicy) else s)
     case t: Tree.WithBody => getDefValAssign(t.body)
-    case t: Term.Param => t.default.fold(Seq.empty[Split])(getDefValAssign)
-    case _ => Seq.empty
+    case t: Term.Param => t.default match {
+        case Some(x) => getDefValAssign(x)
+        case _ => Nil
+      }
+    case _ => Nil
   }
 
   private def getDefValAssign(
@@ -642,7 +658,7 @@ object SplitsAfterEquals extends Splits {
 
     val body = TreeOps.getBlockStat(rawBody)
     def noSpace: Boolean = hasBreak && leftOwner.is[Defn] ||
-      !cfg.newlines.ignoreInSyntax && tokens.getNonMultilineEnd(ft).isEmpty
+      !cfg.newlines.ignoreInSyntax && (tokens.getNonMultilineEnd(ft) eq null)
     Seq(
       if (isRightCommentThenBreak(ft)) Split.ignored
       else if (body.isAny[Term.If, Term.ForYield, Term.TryClause])
@@ -668,7 +684,7 @@ object SplitsAfterLeftArrow extends Splits {
   ): Seq[Split] = ft.leftOwner match {
     case x: Enumerator.Assign => SplitsAfterEqualsLeftArrow
         .getSplitsEnumerator(x.rhs)
-    case _ => Seq.empty
+    case _ => Nil
   }
 
 }
@@ -700,13 +716,12 @@ object SplitsAfterEqualsLeftArrow {
               case t: Term.If => ifWithoutElse(t)
               case _ => true
             }
-            val noSlbOpt =
-              if (!noSlb) None
-              else if (cfg.newlines.ignoreInSyntax) Some(next(ft))
+            val noSlbEnd =
+              if (!noSlb) null
+              else if (cfg.newlines.ignoreInSyntax) next(ft)
               else tokens.getNonMultilineEnd(ft)
-            noSlbOpt.fold(Split(Space, 0).withSingleLine(endFt))(xft =>
-              Split(Space, 0).withOptimalToken(xft, killOnFail = false),
-            )
+            if (noSlbEnd eq null) Split(Space, 0).withSingleLine(endFt)
+            else Split(Space, 0).withOptimalToken(noSlbEnd, killOnFail = false)
           }
         }(cost => CtrlBodySplits.withIndent(Splits.lowRankNL(ft, cost), endFt))
       }
@@ -763,14 +778,18 @@ object SplitsBeforeLeftBrace extends Splits {
           maybeBracesToParensWithRB(matchingRight(ft))
         // partial initial expr
         if (!isTokenHeadOrBefore(right, rightOwner)) maybeBracesToParens()
-        else rightOwner.parent.fold(Seq.empty[Split]) {
-          case _: Term.ApplyInfix => Seq.empty // exclude start of infix
-          case _: Term.ArgClause => maybeBracesToParens()
-          case p => matchingOptRight(ft).fold(Seq.empty[Split]) { rb =>
-              val ko = isTokenHeadOrBefore(right, p) &&
-                isTokenLastOrAfter(rb.left, rightOwner)
-              if (ko) Seq.empty else maybeBracesToParensWithRB(rb)
-            }
+        else rightOwner.parent match {
+          case None => Nil
+          case Some(_: Term.ApplyInfix) => Nil // exclude start of infix
+          case Some(_: Term.ArgClause) => maybeBracesToParens()
+          case Some(p) =>
+            val rb = matchingRightOrNull(ft)
+            if (
+              (rb eq null) ||
+              isTokenHeadOrBefore(right, p) &&
+              isTokenLastOrAfter(rb.left, rightOwner)
+            ) Nil
+            else maybeBracesToParensWithRB(rb)
         }
       }
     }
@@ -792,9 +811,9 @@ object SplitsAfterRightBraceLowPriority extends Splits {
             def nlSplit(cost: Int) = Splits.lowRankNL(ft, cost)
               .withIndent(cfg.indent.main, getLast(body), After)
             CtrlBodySplits.get(body)(null)(nlSplit)
-          case _ => Seq.empty
+          case _ => Nil
         }
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -834,7 +853,7 @@ object SplitsAfterFunctionArrow extends Splits {
           !tokens.isEmpty(leftFunc.body) && isBlockFunction(leftFunc)
         if (isBlockFunc) blockFunctionTerm(leftFunc) else functionOrSelf
       case t: Self if t.ancestor(2).is[Term.NewAnonymous] => functionOrSelf
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 
@@ -946,7 +965,7 @@ object SplitsAfterRightArrow extends Splits {
       case t: CaseTree if !right.isAny[T.KwCatch, T.KwFinally, T.Dot] => // Case arrow
         caseTree(t)
       case _: Type.ByNameType => Seq(Split(Space(cfg.spaces.inByNameTypes), 0))
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 
@@ -973,7 +992,7 @@ object SplitsAfterRightArrow extends Splits {
         .foldedNonEmptyNonComment(body, nlSplit(nft), isKeep)
       if (
         isCaseBodyABlock(nft, owner) ||
-        getClosingIfCaseBodyEnclosedAsBlock(nft, owner).isDefined
+        (getClosingIfCaseBodyEnclosedAsBlock(nft, owner) ne null)
       ) Seq(baseSplit)
       else if (nft.right.is[T.KwCase]) getNLOnlySplit(0)
       else if (hasBreak && !beforeMultiline.ignoreSourceSplit)
@@ -988,7 +1007,7 @@ object SplitsAfterRightArrow extends Splits {
         if (cfg.newlines.unfold) getNLOnlySplit(0) else withSlbSplit
       else if (
         condIsDefined || beforeMultiline.eq(Newlines.classic) ||
-        getSingleStatExceptEndMarker(body).isEmpty
+        (getSingleStatExceptEndMarker(body) eq null)
       ) withSlbSplit
       else getFolded(beforeMultiline eq Newlines.keep)
     }
@@ -1021,7 +1040,7 @@ object SplitsAfterGiven extends Splits {
             Split(Space, 1, nonSlbPolicy),
           )
         } else Seq(Split(Space, 0))
-      case _ => Seq.empty
+      case _ => Nil
     }
 
   }
@@ -1040,20 +1059,20 @@ object SplitsBeforeRightArrow extends Splits {
           case Some(gvn: Stat.GivenLike) =>
             val nlOnly = !cfg.newlines.sourceIgnored && hasBreak
             def spaceSplit(implicit fl: FileLine) = Split(nlOnly, 0)(Space)
-            val nextParamClause = (pcg.tparamClause +: pcg.paramClauses).find(
-              _.endOffset > right.end,
-            ).orElse(gvn.paramClauseGroups.dropWhile(_ ne pcg) match {
-              case `pcg` :: pcgNext :: _ =>
-                val tpc = pcgNext.tparamClause
-                if (tpc.nonEmpty) Some(tpc) else pcgNext.paramClauses.headOption
-              case _ => None
-            })
-            nextParamClause.fold {
+            val nextParamClause = (pcg.tparamClause +: pcg.paramClauses)
+              .findOrNull(_.endOffset > right.end) ??
+              (gvn.paramClauseGroups.dropWhile(_ ne pcg) match {
+                case `pcg` :: pcgNext :: _ =>
+                  val tpc = pcgNext.tparamClause
+                  if (tpc.nonEmpty) tpc else pcgNext.paramClauses.headOrNull
+                case _ => null
+              })
+            nextParamClause.nnFold {
               gvn match {
                 case gvn: Defn.Given => binPackParentConstructorSplits(
                     isFirstCtor = true,
                     owners = Set(gvn.templ),
-                    rhs = gvn.templ.inits.headOption,
+                    rhs = gvn.templ.inits.headOrNull,
                     lastFt = templateDerivesOrCurlyOrLastNonTrivial(gvn.templ),
                     indentLen = cfg.indent.extendSite,
                     extendsThenWith = gvn.templ.inits.lengthCompare(1) > 0,
@@ -1087,9 +1106,9 @@ object SplitsBeforeRightArrow extends Splits {
               )
             }
 
-          case _ => Seq.empty
+          case _ => Nil
         }
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -1134,7 +1153,7 @@ object SplitsAfterSemicolon extends Splits {
           // For some reason, this newline cannot cost 1.
           Split(Newline2x(ft), 0),
         )
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -1161,9 +1180,9 @@ object SplitsAfterRightParen extends Splits {
             getIfWhileFor(p.body)
           case Some(p: Term.ForYield) if cfg.indent.yieldKeyword =>
             getIfWhileFor(p.body)
-          case _ => Seq.empty
+          case _ => Nil
         }
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 
@@ -1244,13 +1263,13 @@ object SplitsBeforeLeftParenOrBracket extends Splits {
       }
       def baseNoSplit(implicit fileLine: FileLine) = Split(modification, 0)
       val defn = isParamClauseSite(rightOwner)
-      val defRhs = if (defn) defDefBodyParent(rightOwner) else None
-      val beforeDefRhs = defRhs.flatMap(tokenJustBeforeOpt)
+      val defRhs = if (defn) defDefBodyParent(rightOwner) else null
+      val beforeDefRhs = defRhs.nnMap(tokenJustBefore)
       def getSplitsBeforeOpenParen(
           src: Newlines.SourceHints,
           indentLen: Int,
           shouldAlignBefore: Align => Boolean,
-      )(lastSyntaxClause: => Option[Member.SyntaxValuesClause]) = {
+      )(lastSyntaxClause: => Member.SyntaxValuesClause) = {
         val close = matchingRight(ft)
         val indent = Indent(indentLen, close, ExpiresOn.After)
         val isAlignFirstParen = shouldAlignBefore(cfg.align) &&
@@ -1258,38 +1277,38 @@ object SplitsBeforeLeftParenOrBracket extends Splits {
         def noSplitSplit(implicit fileLine: FileLine) =
           if (isAlignFirstParen) baseNoSplit
           else baseNoSplit.withSingleLine(close)
-        def afterClose: Option[FT] = {
+        def afterClose: FT = {
           val ftAfterClose = nextNonComment(close)
           val matches = ftAfterClose.right match {
             case _: T.LeftParen => true
             case _: T.Colon if defn =>
               ftAfterClose.left.is[T.Comment] ||
               cfg.newlines.sometimesBeforeColonInMethodReturnType &&
-              colonDeclType(ftAfterClose.meta.rightOwner).isDefined
+              (colonDeclType(ftAfterClose.meta.rightOwner) ne null)
             case _ => false
           }
-          if (matches) Some(next(ftAfterClose)) else None
+          if (matches) next(ftAfterClose) else null
         }
         val splits = src match {
           case Newlines.unfold =>
             val rightParent = rightOwner.parent.get
             val slbEnd =
-              if (defn) beforeDefRhs.fold(getLast(rightParent))(prevNonComment)
-              else getLast(getLastCall(rightParent))
+              if (!defn) getLast(getLastCall(rightParent))
+              else if (beforeDefRhs eq null) getLast(rightParent)
+              else prevNonComment(beforeDefRhs)
             Seq(
               baseNoSplit.withSingleLine(slbEnd),
               Split(Newline, 1).withIndent(indent).withPolicy(
                 penalizeNewlineByNesting(ft, close),
                 isSeqMulti(getArgs(rightOwner)),
-              ).andPolicy(afterClose.map(decideNewlinesOnlyBeforeClose)),
+              ).andPolicy(afterClose.nnMap(decideNewlinesOnlyBeforeClose)),
             )
           case Newlines.keep =>
             if (hasBreak) Seq(Split(Newline, 0).withIndent(indent))
             else Seq(noSplitSplit, Split(Newline, 1).withIndent(indent))
           case _ =>
             val nlColonPolicy = afterClose match {
-              case Some(x @ FT(_: T.Colon, _, _)) =>
-                decideNewlinesOnlyBeforeClose(x)
+              case x @ FT(_: T.Colon, _, _) => decideNewlinesOnlyBeforeClose(x)
               case _ => NoPolicy
             }
             Seq(
@@ -1297,38 +1316,42 @@ object SplitsBeforeLeftParenOrBracket extends Splits {
               Split(Newline, 1).withIndent(indent).withPolicy(nlColonPolicy),
             )
         }
-        val argsOpt = if (isAlignFirstParen) lastSyntaxClause else None
-        argsOpt.flatMap(getLastOpt).fold(splits) { x =>
+        val args = if (isAlignFirstParen) lastSyntaxClause else null
+        val argsLast = args.nnMap(getLast)
+        if (argsLast eq null) splits
+        else {
           val noSplitIndents = Seq(
-            Indent(StateColumn, x, ExpiresOn.Before),
-            Indent(-indentLen, x, ExpiresOn.Before),
+            Indent(StateColumn, argsLast, ExpiresOn.Before),
+            Indent(-indentLen, argsLast, ExpiresOn.Before),
           )
           splits.map(s => if (s.isNL) s else s.withIndents(noSplitIndents))
         }
       }
       val beforeOpenParenSplits =
-        if (!right.is[T.LeftParen]) None
-        else if (defn) cfg.newlines.getBeforeOpenParenDefnSite.map { x =>
-          val indent = beforeDefRhs.fold(cfg.indent.main) { y =>
-            val ob = OptionalBraces.at(y)
-            cfg.indent.extraBeforeOpenParenDefnSite +
-              (if (ob) cfg.indent.getSignificant else cfg.indent.main)
-          }
+        if (!right.is[T.LeftParen]) null
+        else if (defn) cfg.newlines.getBeforeOpenParenDefnSite.nnMap { x =>
+          val indent =
+            if (beforeDefRhs eq null) cfg.indent.main
+            else {
+              val ob = OptionalBraces.at(beforeDefRhs)
+              cfg.indent.extraBeforeOpenParenDefnSite +
+                (if (ob) cfg.indent.getSignificant else cfg.indent.main)
+            }
           getSplitsBeforeOpenParen(x, indent, _.beforeOpenParenDefnSite) {
             @tailrec
-            def iter(tree: Tree): Option[Member.ParamClause] = tree match {
+            def iter(tree: Tree): Member.ParamClause = tree match {
               case _: Member.ParamClause => tree.parent match {
                   case Some(p) => iter(p)
-                  case None => None
+                  case None => null
                 }
-              case p: Tree.WithParamClauses => p.paramClauses.lastOption
-              case _ => None
+              case p: Tree.WithParamClauses => p.paramClauses.lastOrNull
+              case _ => null
             }
             iter(rightOwner)
           }
         }
         else if (cfg.dialect.allowSignificantIndentation) cfg.newlines
-          .getBeforeOpenParenCallSite.map { x =>
+          .getBeforeOpenParenCallSite.nnMap { x =>
             val indent = cfg.indent.getSignificant
             @tailrec
             def findLastCallArgs(t: Member.Apply): Member.ArgClause =
@@ -1337,14 +1360,15 @@ object SplitsBeforeLeftParenOrBracket extends Splits {
                 case _ => t.argClause
               }
             getSplitsBeforeOpenParen(x, indent, _.beforeOpenParenCallSite)(
-              rightOwner.parent.collect { case p: Member.Apply =>
-                findLastCallArgs(p)
+              rightOwner.parent match {
+                case Some(p: Member.Apply) => findLastCallArgs(p)
+                case _ => null
               },
             )
           }
-        else None
-      beforeOpenParenSplits.getOrElse(Seq(baseNoSplit))
-    } else Seq.empty
+        else null
+      beforeOpenParenSplits ?? Seq(baseNoSplit)
+    } else Nil
   }
 }
 
@@ -1354,7 +1378,7 @@ object SplitsBeforeLeftBracket extends Splits {
       fo: FormatOps,
       cfg: ScalafmtConfig,
   ): Seq[Split] =
-    if (!ft.rightOwner.parent.exists(_.begOffset < ft.right.start)) Seq.empty
+    if (!ft.rightOwner.parent.exists(_.begOffset < ft.right.start)) Nil
     else Seq(Split(Space(!ft.leftOwner.is[Mod.WithWithin]), 0))
 }
 
@@ -1418,21 +1442,17 @@ object SplitsAfterTemplateKeyword extends Splits {
             delayedBreakPolicyBefore(expire)(forceNewlineBeforeExtends)
           }
         Seq(Split(Space, 0).withPolicy(policy))
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
 
 object SplitsAfterLeftParenOrBracket {
-  def get1(implicit
-      ft: FT,
-      fo: FormatOps,
-      cfg: ScalafmtConfig,
-  ): Option[Seq[Split]] = {
+  def get1(implicit ft: FT, fo: FormatOps, cfg: ScalafmtConfig): Seq[Split] = {
     import fo._, tokens._, ft._
     if (
       meta.formatOff && leftOwner.isAny[Member.SyntaxValuesClause, Member.Tuple]
-    ) Some {
+    ) {
       val close = matchingLeft(ft)
       def splits(xft: FT, policy: Policy)(implicit l: FileLine) =
         Seq(Split(Provided(xft), 0, policy))
@@ -1444,25 +1464,23 @@ object SplitsAfterLeftParenOrBracket {
     // Parameter opening for one parameter group. This format works
     // on the WHOLE defnSite (via policies)
     else if (cfg.verticalMultiline.atDefnSite && isParamClauseSite(leftOwner))
-      Some(verticalMultiline())
-    else None
+      verticalMultiline()
+    else null
   }
 
   def get2(
       isBracket: Boolean,
-  )(implicit ft: FT, fo: FormatOps, cfg: ScalafmtConfig): Option[Seq[Split]] = {
+  )(implicit ft: FT, fo: FormatOps, cfg: ScalafmtConfig): Seq[Split] = {
     import ft._
-    if (isArgClauseSite(leftOwner)) Some {
+    if (isArgClauseSite(leftOwner)) {
       val binPack = cfg.binPack.callSiteFor(left)
       if (binPack == BinPack.Site.Never) getNoBinPack(isBracket)
       else getArgSiteBinPack(isBracket, binPack)
-    }
-    else if (isParamClauseSite(leftOwner)) Some {
+    } else if (isParamClauseSite(leftOwner)) {
       val binPack = cfg.binPack.defnSiteFor(left)
       if (binPack == BinPack.Site.Never) getNoBinPack(isBracket)
       else getParamSiteBinPack(isBracket, binPack)
-    }
-    else None
+    } else null
   }
 
   def getArgSiteBinPack(isBracket: Boolean, binPack: BinPack.Site)(implicit
@@ -1478,9 +1496,8 @@ object SplitsAfterLeftParenOrBracket {
 
     val args = getArgs(leftOwner)
     val isSingleArg = isSeqSingle(args)
-    val firstArg = args.headOption
-    val singleArgAsInfix =
-      if (isSingleArg) firstArg.flatMap(asInfixApp) else None
+    val firstArg = if (args.isEmpty) null else args.head
+    val singleArgAsInfix = if (isSingleArg) asInfixApp(firstArg) else null
 
     implicit val clauseSiteFlags: ClauseSiteFlags = ClauseSiteFlags
       .atCallSite(leftOwner)
@@ -1490,7 +1507,8 @@ object SplitsAfterLeftParenOrBracket {
     val nlOnly = nlOpen && !singleLineOnly
 
     val oneline = binPack.isOneline
-    val afterFirstArgOneline = if (oneline) firstArg.map(tokenAfter) else None
+    val afterFirstArgOneline =
+      if (oneline && (firstArg ne null)) tokenAfter(firstArg) else null
 
     val (indentLen, bpIndentLen) = cfg.indent.getBinPackCallSites
 
@@ -1507,8 +1525,9 @@ object SplitsAfterLeftParenOrBracket {
           findToken(beforeClose, prev)(x => !RightParenOrBracket(x.left)),
       )
 
-    val (onelineCurryToken, onelinePolicy) = afterFirstArgOneline
-      .map(BinPackOneline.getPolicy(true, sjsExclude)).getOrElse((None, NoPolicy))
+    val (onelineCurryToken, onelinePolicy) =
+      if (afterFirstArgOneline eq null) (null, NoPolicy)
+      else BinPackOneline.getPolicy(true, sjsExclude)(afterFirstArgOneline)
 
     def baseNoSplit(implicit fileLine: FileLine) =
       Split(Space(cfg.spaces.inParentheses), 0)
@@ -1520,54 +1539,54 @@ object SplitsAfterLeftParenOrBracket {
         close,
         exclude = sjsExclude,
         noSyntaxNL = true,
-        killOnFail = Some(!dangleCloseDelim || sjsExclude.isEmpty),
+        killOnFail = MaybeBool(!dangleCloseDelim || sjsExclude.isEmpty),
       )
       else {
-        def noSingleArgIndents = oneline || singleArgAsInfix.isDefined ||
+        def noSingleArgIndents = oneline || (singleArgAsInfix ne null) ||
           !cfg.binPack.indentCallSiteSingleArg ||
-          !isBracket && getAssignAtSingleArgCallSite(args).isDefined
+          !isBracket && (getAssignAtSingleArgCallSite(args) ne null)
         val indent = Indent(bpIndentLen, close, Before)
         val noSplitIndents =
           if (isSingleArg && noSingleArgIndents) Nil
           else if (cfg.binPack.indentCallSiteOnce) {
             @tailrec
-            def iter(tree: Tree): Option[T] = tree.parent match {
+            def iter(tree: Tree): T = tree.parent match {
               case Some(p) =>
-                if (isArgClauseSite(p)) Some(getIndentTrigger(p))
-                else if (p.isAny[Tree.Block, Tree.WithBody]) None
+                if (isArgClauseSite(p)) getIndentTrigger(p)
+                else if (p.isAny[Tree.Block, Tree.WithBody]) null
                 else iter(p)
-              case _ => None
+              case _ => null
             }
             val trigger = iter(leftOwner)
-            Seq(trigger.fold(indent)(x => Indent.before(indent, x)))
+            Seq(if (trigger eq null) indent else Indent.before(indent, trigger))
           } else if (alignOpenDelim) getOpenParenAlignIndents(close)
           else Seq(indent)
 
         val nextComma =
-          if (firstArg.isEmpty) None
-          else if (!oneline) tokens.findTokenEx(ft)(xft =>
+          if (firstArg eq null) null
+          else if (!oneline) tokens.findTokenEx(xft =>
             xft.right match {
               case close.left | _: T.RightBrace | _: T.RightArrow => null
               case _: T.Comma => Right(next(xft))
               case _: T.LeftBrace => Left(matchingRight(xft))
               case _ => Left(next(xft))
             },
-          ).toOption
-          else if (isSingleArg) None
-          else afterFirstArgOneline.map(next)
-        val opt = nextComma.getOrElse(getSlbEndOnLeft(close))
+          )(ft)
+          else if (isSingleArg || (afterFirstArgOneline eq null)) null
+          else next(afterFirstArgOneline)
+        val opt = if (nextComma ne null) nextComma else getSlbEndOnLeft(close)
 
         val slbArg = oneline && !noSplitIndents.exists(_.hasStateColumn)
-        val slbPolicy: Policy = (if (slbArg) nextComma else None)
-          .map(SingleLineBlock(_, noSyntaxNL = true, exclude = sjsExclude))
+        val slbPolicy: Policy = Policy ? (slbArg && (nextComma ne null)) &&
+          SingleLineBlock(nextComma, noSyntaxNL = true, exclude = sjsExclude)
         val noSplitPolicy = slbPolicy ==> onelinePolicy & penalizeNewlinesPolicy
         val indentPolicy = Policy ? noSplitIndents.isEmpty || {
           def unindentBraces = insideBlock(getEndOfBlock(_) {
-            case FT(_: T.LeftBrace, _, _) => Some(true)
+            case FT(_: T.LeftBrace, _, _) => MaybeBool.True
             case FT(_: T.LeftParen, _, m) // don't unindent someone else's blocks
                 if isArgClauseSite(m.leftOwner) &&
-                  getArgs(m.leftOwner).lengthCompare(1) > 0 => Some(false)
-            case _ => None
+                  getArgs(m.leftOwner).lengthCompare(1) > 0 => MaybeBool.False
+            case _ => MaybeBool.Maybe
           })(ft, close)
           def unindentPolicy = Policy ? (isSingleArg || sjsOneline) &&
             unindentAtExclude(bpIndentLen)(
@@ -1585,16 +1604,17 @@ object SplitsAfterLeftParenOrBracket {
         }
         val optLite = cfg.newlines.keep && preferConfigStyle && !isSingleArg
         val kof = cfg.newlines.keep && preferConfigStyle && isSingleArg &&
-          !dangleCloseDelim && singleArgAsInfix.isEmpty && !flags.scalaJsStyle
+          !dangleCloseDelim && (singleArgAsInfix eq null) && !flags.scalaJsStyle
         baseNoSplit
           .withOptimalToken(opt, recurseOnly = optLite, killOnFail = kof)
           .withPolicy(noSplitPolicy & indentPolicy & noNLPolicy())
           .withIndents(noSplitIndents)
       }
 
-    def avoidNlClosedOnOpenNo = onelineCurryToken.exists(x =>
-      if (x.right.is[T.Dot]) onelinePolicy.isEmpty else !flags.scalaJsStyle,
-    )
+    def avoidNlClosedOnOpenNo = (onelineCurryToken ne null) && {
+      if (onelineCurryToken.right.is[T.Dot]) onelinePolicy.isEmpty
+      else !flags.scalaJsStyle
+    }
     val nlClosedOnOpenEffective = nlCloseOnOpen match {
       case NlClosedOnOpen.No if avoidNlClosedOnOpenNo =>
         val forceCfg = preferConfigStyle && !flags.literalArgList
@@ -1623,7 +1643,7 @@ object SplitsAfterLeftParenOrBracket {
     val nlSplit = Split(nlMod, bracketPenalty * (if (oneline) 4 else 2))
       .withSingleLineNoOptimal(close, ignore = !singleLineOnly)
       .andPolicy(Policy ? singleLineOnly || nlPolicy & penalizeNewlinesPolicy)
-      .andPolicy(singleArgAsInfix.map(InfixSplits(_, ft).nlPolicy))
+      .andPolicy(singleArgAsInfix &&& InfixSplits(singleArgAsInfix, ft).nlPolicy)
     Seq(noSplit, nlSplit)
 
   }
@@ -1642,17 +1662,16 @@ object SplitsAfterLeftParenOrBracket {
       implicit val clauseSiteFlags: ClauseSiteFlags = ClauseSiteFlags
         .atDefnSite(leftOwner)
 
-      val bracketPenalty =
-        if (isBracket) Some(Constants.BracketPenalty) else None
-      val penalizeBrackets = bracketPenalty
-        .map(p => PenalizeAllNewlines(close, p + 3))
-
+      val bracketPenalty = if (isBracket) Constants.BracketPenalty else 1
+      val penalizeBrackets =
+        if (isBracket) PenalizeAllNewlines(close, bracketPenalty + 3)
+        else Policy.NoPolicy
       val firstArg = optimizationEntities.argument
-      val nextComma = firstArg.flatMap { x =>
+      val nextComma = firstArg &&& {
         val ok = isSeqMulti(getArgs(leftOwner))
-        if (ok) findFirstOnRight[T.Comma](getLast(x), close) else None
+        if (ok) findFirstOnRight[T.Comma](getLast(firstArg), close) else null
       }
-      val nextCommaOneline = if (binPack.isOneline) nextComma else None
+      val nextCommaOneline = if (binPack.isOneline) nextComma else null
 
       val flags = getBinpackDefnSiteFlags(ft, prev(close))
       val (nlOnly, nlCloseOnOpen) = flags.nlOpenClose()
@@ -1660,31 +1679,31 @@ object SplitsAfterLeftParenOrBracket {
       val slbOrNL = nlOnly || noNLPolicy == null
 
       val rightIsComment = right.is[T.Comment]
-      def getNoSplit(slbEnd: Option[FT])(implicit fileLine: FileLine) = {
+      def getNoSplit(slbEnd: FT)(implicit fileLine: FileLine) = {
         val mod = if (rightIsComment) Space.orNL(noBreak) else noSplitMod
-        slbEnd.fold(Split(mod, 0))(x =>
-          Split(mod, 0).withOptimalToken(x, killOnFail = true)
-            .withPolicy(SingleLineBlock(x, okSLC = true, noSyntaxNL = true)),
-        )
+        if (slbEnd eq null) Split(mod, 0)
+        else Split(mod, 0).withOptimalToken(slbEnd, killOnFail = true)
+          .withPolicy(SingleLineBlock(slbEnd, okSLC = true, noSyntaxNL = true))
       }
 
       val noSplit =
         if (nlOnly) Split.ignored
-        else if (slbOrNL) getNoSplit(Some(close))
+        else if (slbOrNL) getNoSplit(close)
         else {
-          val opensPolicy = bracketPenalty.map(p =>
-            Policy.beforeLeft(close, "PENBP[") {
+          val opensPolicy =
+            if (isBracket) Policy.beforeLeft(close, "PENBP[") {
               case Decision(ftd @ FT(o: T.LeftBracket, _, m), s)
                   if isParamClauseSite(m.leftOwner) && styleMap.at(o)
                     .binPack.bracketDefnSite.exists(_ != BinPack.Site.Never) =>
-                if (isRightCommentThenBreak(ftd)) s else s.penalizeNL(p)
-            },
-          )
-          getNoSplit(nextComma.map(getSlbEndOnLeft))
+                if (isRightCommentThenBreak(ftd)) s
+                else s.penalizeNL(bracketPenalty)
+            }
+            else Policy.NoPolicy
+          getNoSplit(nextComma.nnMap(getSlbEndOnLeft))
             .andPolicy((opensPolicy | penalizeBrackets) & noNLPolicy())
         }
 
-      def nlCost = bracketPenalty.getOrElse(1)
+      def nlCost = bracketPenalty
       val nlMod = Space.orNL(rightIsComment && nlOnly && noBreak)
       def getDanglePolicy(implicit fileLine: FileLine) =
         decideNewlinesOnlyBeforeClose(close)
@@ -1694,8 +1713,9 @@ object SplitsAfterLeftParenOrBracket {
         case NlClosedOnOpen.Yes => getDanglePolicy
         case NlClosedOnOpen.No => NoPolicy
       }
-      val nlOnelinePolicy = nextCommaOneline
-        .map(x => splitOneArgPerLineAfterCommaOnBreak(next(x)))
+      val nlOnelinePolicy =
+        if (nextCommaOneline eq null) Policy.NoPolicy
+        else splitOneArgPerLineAfterCommaOnBreak(next(nextCommaOneline))
 
       val (indentLen, bpIndentLen) = cfg.indent.getBinPackDefnSites(leftOwner)
       val nlIndentLen =
@@ -1745,15 +1765,19 @@ object SplitsAfterLeftParenOrBracket {
     }
 
     // XXX: sometimes we have zero args, so multipleArgs != !singleArgument
-    val (onlyArgument, enclosedOnlyArgumentHead, multipleArgs, notTooManyArgs) =
-      args match {
-        case arg :: Nil =>
-          val onlyArgument = TreeOps.getBlockStat(arg)
-          val enclosedHead = getHeadIfEnclosed(onlyArgument)
-          (onlyArgument, enclosedHead, false, false)
-        case _ :: rest => (null, None, true, rest.lengthCompare(100) < 0)
-        case _ => (null, None, false, false)
-      }
+    var onlyArgument: Tree = null
+    var enclosedOnlyArgumentHead: FT = null
+    var multipleArgs = false
+    var notTooManyArgs = false
+    args match {
+      case arg :: Nil =>
+        onlyArgument = TreeOps.getBlockStat(arg)
+        enclosedOnlyArgumentHead = getHeadIfEnclosed(onlyArgument)
+      case _ :: rest =>
+        multipleArgs = true
+        notTooManyArgs = rest.lengthCompare(100) < 0
+      case _ =>
+    }
 
     val bracketCoef = if (isBracket) Constants.BracketPenalty else 1
     val mustDangleForTrailingCommas = getMustDangleForTrailingCommas(beforeClose)
@@ -1780,9 +1804,9 @@ object SplitsAfterLeftParenOrBracket {
       if (defnSite) cfg.newlines.isBeforeOpenParenDefnSite
       else cfg.newlines.isBeforeOpenParenCallSite
     val optimalOpt =
-      if (isBeforeOpenParen || !defnSite || isBracket) None
+      if (isBeforeOpenParen || !defnSite || isBracket) null
       else defnSiteOptimalToken(leftOwner)
-    val optimal: FT = getSlbEndOnLeft(optimalOpt.getOrElse(close))
+    val optimal: FT = getSlbEndOnLeft(optimalOpt ?? close)
 
     val wouldDangle = onlyConfigStyle || mustDangleForTrailingCommas ||
       dangleCloseDelim || closeBreak && beforeClose.left.is[T.Comment]
@@ -1814,20 +1838,24 @@ object SplitsAfterLeftParenOrBracket {
     val noSplitsForAssign = rightIsCommentWithBreak || defnSite || isBracket ||
       !sourceIgnored && configStyleFlag && hasBreak
     val splitsForAssign =
-      if (noSplitsForAssign) None
-      else getAssignAtSingleArgCallSite(args).map { assign =>
-        val breakToken = nextNonCommentSameLine(assign.rhs match {
-          case b: Term.Block if isEnclosedInBraces(b) => getHead(b)
-          case x => tokenBefore(x)
-        })
-        val newlineAfterAssignDecision = Policy ? newlinePolicy.isEmpty ||
-          decideNewlinesOnlyAfterToken(breakToken)
-        Seq(
-          Split(Newline, nestedPenalty + Constants.ExceedColumnPenalty)
-            .withPolicy(newlinePolicy).withIndent(indent),
-          Split(NoSplit, nestedPenalty).withSingleLineNoOptimal(breakToken)
-            .andPolicy(newlinePolicy & newlineAfterAssignDecision),
-        )
+      if (noSplitsForAssign) Seq.empty
+      else {
+        val assign = getAssignAtSingleArgCallSite(args)
+        if (assign eq null) Seq.empty
+        else {
+          val breakToken = nextNonCommentSameLine(assign.rhs match {
+            case b: Term.Block if isEnclosedInBraces(b) => getHead(b)
+            case x => tokenBefore(x)
+          })
+          val newlineAfterAssignDecision = Policy ? newlinePolicy.isEmpty ||
+            decideNewlinesOnlyAfterToken(breakToken)
+          Seq(
+            Split(Newline, nestedPenalty + Constants.ExceedColumnPenalty)
+              .withPolicy(newlinePolicy).withIndent(indent),
+            Split(NoSplit, nestedPenalty).withSingleLineNoOptimal(breakToken)
+              .andPolicy(newlinePolicy & newlineAfterAssignDecision),
+          )
+        }
       }
 
     val excludeBlocks = cfg.newlines.source match {
@@ -1836,15 +1864,15 @@ object SplitsAfterLeftParenOrBracket {
         insideBlock[T.LeftBracket](excludeBeg, close)
       case _ if multipleArgs => TokenRanges.empty
       case Newlines.unfold
-          if leftOwnerIsEnclosed || enclosedOnlyArgumentHead.forall(_ eq ft) =>
-        TokenRanges.empty
+          if leftOwnerIsEnclosed || (enclosedOnlyArgumentHead eq null) ||
+            (enclosedOnlyArgumentHead eq ft) => TokenRanges.empty
       case Newlines.fold if (onlyArgument match {
             case _: Tree.WithCond | _: Term.TryClause | _: Term.ForClause =>
-              enclosedOnlyArgumentHead.isEmpty
+              enclosedOnlyArgumentHead eq null
             case _ => false
           }) => TokenRanges.empty
       case Newlines.fold if (onlyArgument ne null) && {
-            enclosedOnlyArgumentHead.isDefined ||
+            (enclosedOnlyArgumentHead ne null) ||
             isTreeEndingInArgumentClause(onlyArgument)
           } =>
         if (onlyArgument eq leftOwner) TokenRanges(TokenRange(ft, close))
@@ -1883,7 +1911,7 @@ object SplitsAfterLeftParenOrBracket {
       else (0, decideNewlinesOnlyAfterToken(afterOpen))
 
     val splitsNoNL =
-      if (noSplitMod == null) Seq.empty
+      if (noSplitMod == null) Nil
       else if (onlyConfigStyle) Seq(
         Split(noSplitMod, 0).withPolicy(oneArgOneLine & implicitPolicy)
           .withOptimalToken(afterOpen, killOnFail = true)
@@ -1911,10 +1939,10 @@ object SplitsAfterLeftParenOrBracket {
               else if (preferNoSplit && splitsForAssign.isEmpty) singleLine(2)
               else if (
                 wouldDangle || optimalIsComment && isBracket ||
-                sourceIgnored &&
-                configStyleFlag && enclosedOnlyArgumentHead.isEmpty
+                sourceIgnored && configStyleFlag &&
+                (enclosedOnlyArgumentHead eq null)
               ) getSlb
-              else if (splitsForAssign.isDefined) singleLine(3)
+              else if (splitsForAssign.nonEmpty) singleLine(3)
               else singleLine(10)
             val kof = (cfg.newlines.keep || excludeBlocks.isEmpty) &&
               needDifferentFromOneArgPerLine
@@ -1941,7 +1969,7 @@ object SplitsAfterLeftParenOrBracket {
         splitsNoNL.nonEmpty &&
         (alignTuple ||
           !(onlyConfigStyle || multipleArgs || splitsForAssign.isEmpty))
-      ) Seq.empty
+      ) Nil
       else {
         val cost =
           if (forceConfigStyle || rightIsCommentWithBreak)
@@ -1957,16 +1985,15 @@ object SplitsAfterLeftParenOrBracket {
             val policy =
               if (!noSplitForNL) newlinePolicy
               else decideNewlinesOnlyBeforeToken(matchingRight(ft))
+            val infix = asInfixApp(onlyArgument)
             Split(NoSplit.orNL(noSplitForNL), cost, policy)
               .andPolicy(Policy ? noConfigStyle && singleLine(4))
-              .andPolicy(asInfixApp(onlyArgument).map(
-                InfixSplits(_, ft).nlPolicy,
-              ))
+              .andPolicy(infix &&& InfixSplits(infix, ft).nlPolicy)
           }
         Seq(split.withIndent(indent, ignore = !split.isNL))
       }
 
-    splitsNoNL ++ splitsNL ++ splitsForAssign.getOrElse(Seq.empty)
+    splitsNoNL ++ splitsNL ++ splitsForAssign
   }
 }
 
@@ -1975,30 +2002,43 @@ object SplitsAfterLeftParen extends Splits {
       ft: FT,
       fo: FormatOps,
       cfg: ScalafmtConfig,
-  ): Seq[Split] = SplitsAfterLeftParenOrBracket.get1.orElse(getLambdaAsSingleArg)
-    .orElse(get1).orElse(SplitsAfterLeftParenOrBracket.get2(isBracket = false))
-    .getOrElse(get2)
+  ): Seq[Split] = {
+    var splits = SplitsAfterLeftParenOrBracket.get1
+    if (splits ne null) return splits
+    splits = getLambdaAsSingleArg
+    if (splits ne null) return splits
+    splits = get1
+    if (splits ne null) return splits
+    splits = SplitsAfterLeftParenOrBracket.get2(isBracket = false)
+    if (splits ne null) return splits
+    get2
+  }
 
-  private def get1(implicit ft: FT, fo: FormatOps, cfg: ScalafmtConfig) = {
+  private def get1(implicit
+      ft: FT,
+      fo: FormatOps,
+      cfg: ScalafmtConfig,
+  ): Seq[Split] = {
     import fo._, tokens._, ft._
     right match {
       case _: T.RightParen =>
         val noNL = cfg.newlines.sourceIgnored || noBreak
-        Some(Seq(Split(NoSplit.orNL(noNL), 0)))
+        Seq(Split(NoSplit.orNL(noNL), 0))
       case _: T.Comment if (leftOwner match {
             case _: Lit.Unit => true
             case t: Member.SyntaxValuesClause => t.values.isEmpty
             case _ => false
-          }) && !hasBreakBeforeNonComment(ft) => Some(Seq(Split(Space, 0)))
-      case _ => None
+          }) && !hasBreakBeforeNonComment(ft) => Seq(Split(Space, 0))
+      case _ => null
     }
   }
 
   private def get2(implicit ft: FT, fo: FormatOps, cfg: ScalafmtConfig) =
-    getIfForWhile.getOrElse(ft.right match {
-      case _: T.LeftBrace => Seq(Split(NoSplit, 0))
-      case _ => getRest
-    })
+    getIfForWhile ??
+      (ft.right match {
+        case _: T.LeftBrace => Seq(Split(NoSplit, 0))
+        case _ => getRest
+      })
 
   private def getIfForWhile(implicit
       ft: FT,
@@ -2006,7 +2046,7 @@ object SplitsAfterLeftParen extends Splits {
       cfg: ScalafmtConfig,
   ) = {
     import fo._, tokens._, ft._
-    def impl(enclosedInBraces: => Boolean) = Some {
+    def impl(enclosedInBraces: => Boolean) = {
       val close = matchingLeft(ft)
       val indentLen = cfg.indent.ctrlSite.getOrElse(cfg.indent.callSite)
       val indent = Indent(indentLen, close, ExpiresOn.Before)
@@ -2031,10 +2071,10 @@ object SplitsAfterLeftParen extends Splits {
       ))
     }
     leftOwner match { // If/For/While/For with (
-      case t: Term.EnumeratorsBlock if getHeadOpt(t).contains(ft) => impl(false)
+      case t: Term.EnumeratorsBlock if getHead(t) eq ft => impl(false)
       case t: Tree.WithCond if !isTokenHeadOrBefore(left, t) =>
         impl(isEnclosedInBraces(t.cond))
-      case _ => None
+      case _ => null
     }
   }
 
@@ -2052,14 +2092,15 @@ object SplitsAfterLeftParen extends Splits {
         case _: T.KwIf => StateColumn
         case _: T.KwFor if !cfg.indent.yieldKeyword => StateColumn
         case _ =>
-          val needIndent = enclosed.forall {
-            case _: Term.ApplyInfix | _: Term.NewAnonymous => false
-            case Term.ArgClause((_: Term.ApplyInfix) :: Nil, _) => false
-            case _ => true
-          } && {
-            val pft = prevNonCommentSameLine(beforeClose)
-            (pft eq beforeClose) && beforeClose.left.is[T.Comment]
-          }
+          val needIndent =
+            (enclosed match {
+              case _: Term.ApplyInfix | _: Term.NewAnonymous => false
+              case Term.ArgClause((_: Term.ApplyInfix) :: Nil, _) => false
+              case _ => true
+            }) && {
+              val pft = prevNonCommentSameLine(beforeClose)
+              (pft eq beforeClose) && beforeClose.left.is[T.Comment]
+            }
           if (needIndent) cfg.indent.main else 0
       }
       Split.opt(getNoSplitAfterOpening(ft, commentNL = null), 0)
@@ -2082,12 +2123,12 @@ object SplitsAfterLeftParen extends Splits {
       case Newlines.keep =>
         Seq(if (hasBreak) newlineSplit(0, isConfig) else spaceSplit)
       case _ =>
-        val singleLine = enclosed.isEmpty || cfg.newlines.unfold
+        val singleLine = (enclosed eq null) || cfg.newlines.unfold
         Seq(
           if (!singleLine) spaceSplit
           else spaceSplitWithoutPolicy.withSingleLine(close).andPolicy(
-            InfixSplits.getSingleLineInfixPolicy(close),
-            ignore = !enclosed.exists(isInfixApp),
+            if ((enclosed eq null) || !isInfixApp(enclosed)) null
+            else InfixSplits.getSingleLineInfixPolicy(close),
           ),
           newlineSplit(10, forceDangle = true),
         )
@@ -2097,81 +2138,81 @@ object SplitsAfterLeftParen extends Splits {
   @tailrec
   private def getSingleFunctionArg(
       values: List[Tree],
-  )(implicit ftoks: FormatTokens): Option[Term.FunctionLike] = values match {
-    case (t: Term.FunctionLike) :: Nil => Some(t)
+  )(implicit ftoks: FormatTokens): Term.FunctionLike = values match {
+    case (t: Term.FunctionLike) :: Nil => t
     case (t: Term.Block) :: Nil if !ftoks.isEnclosedInBraces(t) =>
       getSingleFunctionArg(t.stats)
-    case _ => None
+    case _ => null
   }
 
   private def getLambdaAsSingleArg(implicit
       ft: FT,
       fo: FormatOps,
       cfg: ScalafmtConfig,
-  ) = {
+  ): Seq[Split] = {
     import fo._, tokens._, ft._
-    (leftOwner match {
+    val lambda = leftOwner match {
       case Term.ArgClause(v, None) => getSingleFunctionArg(v)
-      case _ => None
-    }).map { lambda =>
-      val close = matchingLeft(ft)
-      val beforeClose = prev(close)
-      val dangle = cfg.danglingParentheses.callSite
-      val newlinePolicy = Policy ? dangle && decideNewlinesOnlyBeforeClose(close)
-      val beforeParenLambdaParams = cfg.newlines.getBeforeParenLambdaParams
-      val noSplitMod =
-        if (
-          (beforeParenLambdaParams eq
-            Newlines.BeforeCurlyLambdaParams.always) ||
-          getMustDangleForTrailingCommas(beforeClose)
-        ) null
-        else getNoSplitAfterOpening(ft, commentNL = null)
+      case _ => null
+    }
+    if (lambda eq null) return null
 
-      def multilineSpaceSplit(implicit fileLine: FileLine): Split = {
-        val lambdaLeft: Option[FT] = functionExpire(lambda)._1 match {
-          case x @ FT(_: T.RightBrace, _, _) => matchingOptLeft(x)
-          case _ => None
-        }
+    val close = matchingLeft(ft)
+    val beforeClose = prev(close)
+    val dangle = cfg.danglingParentheses.callSite
+    val newlinePolicy = Policy ? dangle && decideNewlinesOnlyBeforeClose(close)
+    val beforeParenLambdaParams = cfg.newlines.getBeforeParenLambdaParams
+    val noSplitMod =
+      if (
+        (beforeParenLambdaParams eq Newlines.BeforeCurlyLambdaParams.always) ||
+        getMustDangleForTrailingCommas(beforeClose)
+      ) null
+      else getNoSplitAfterOpening(ft, commentNL = null)
 
-        val arrowFt = getFuncArrow(lambda).get
-        val lambdaIsABlock = lambdaLeft.exists(_.left eq arrowFt.right)
-        val lambdaToken =
-          nextNonCommentSameLine(if (lambdaIsABlock) next(arrowFt) else arrowFt)
-
-        val spacePolicy = SingleLineBlock(lambdaToken) ==> {
-          def before = Policy.onlyFor(beforeClose, "NODANGLE") { _ =>
-            val bc = beforeClose.left
-            if (bc.is[T.Comment])
-              if (bc.text.startsWith("//")) Nil else Seq(Split(Space, 0))
-            else Seq(Split(Space(cfg.spaces.inParentheses), 0))
-          }
-          Policy ? lambdaIsABlock ||
-          penalizeOneNewline(lambdaToken, 1) & Policy.RelayOnSplit.by(
-            Policy.End <= lambdaLeft.getOrElse(close),
-          )((s, _) => s.isNL)(before)(newlinePolicy)
-        }
-        Split(noSplitMod, 0, spacePolicy)
-          .withOptimalToken(lambdaToken, killOnFail = true)
+    def multilineSpaceSplit(implicit fileLine: FileLine): Split = {
+      val lambdaLeft: FT = functionExpire(lambda)._1 match {
+        case x @ FT(_: T.RightBrace, _, _) => matchingLeftOrNull(x)
+        case _ => null
       }
 
-      val indentLen =
-        if (dangle || cfg.binPack.callSite == BinPack.Site.Never)
-          cfg.indent.callSite
-        else cfg.indent.getBinPackCallSite
+      val arrowFt = getFuncArrow(lambda)
+      val lambdaIsABlock = lambdaLeft.nnHas(_.left eq arrowFt.right)
+      val lambdaToken =
+        nextNonCommentSameLine(if (lambdaIsABlock) next(arrowFt) else arrowFt)
 
-      if (noSplitMod == null)
-        Seq(Split(Newline, 0, newlinePolicy).withIndent(indentLen, close, Before))
-      else {
-        val newlinePenalty = 3 + nestedApplies(leftOwner)
-        val noMultiline = beforeParenLambdaParams eq
-          Newlines.BeforeCurlyLambdaParams.multiline
-        Seq(
-          if (noMultiline) Split(noSplitMod, 0).withSingleLine(close)
-          else multilineSpaceSplit,
-          Split(Newline, newlinePenalty, newlinePolicy)
-            .withIndent(indentLen, close, Before),
-        )
+      val spacePolicy = SingleLineBlock(lambdaToken) ==> {
+        def before = Policy.onlyFor(beforeClose, "NODANGLE") { _ =>
+          val bc = beforeClose.left
+          if (bc.is[T.Comment])
+            if (bc.text.startsWith("//")) Nil else Seq(Split(Space, 0))
+          else Seq(Split(Space(cfg.spaces.inParentheses), 0))
+        }
+        Policy ? lambdaIsABlock || penalizeOneNewline(lambdaToken, 1) & {
+          val exp = Policy.End <= lambdaLeft ?? close
+          Policy.RelayOnSplit.by(exp)((s, _) => s.isNL)(before)(newlinePolicy)
+        }
       }
+      Split(noSplitMod, 0, spacePolicy)
+        .withOptimalToken(lambdaToken, killOnFail = true)
+    }
+
+    val indentLen =
+      if (dangle || cfg.binPack.callSite == BinPack.Site.Never)
+        cfg.indent.callSite
+      else cfg.indent.getBinPackCallSite
+
+    if (noSplitMod == null)
+      Seq(Split(Newline, 0, newlinePolicy).withIndent(indentLen, close, Before))
+    else {
+      val newlinePenalty = 3 + nestedApplies(leftOwner)
+      val noMultiline = beforeParenLambdaParams eq
+        Newlines.BeforeCurlyLambdaParams.multiline
+      Seq(
+        if (noMultiline) Split(noSplitMod, 0).withSingleLine(close)
+        else multilineSpaceSplit,
+        Split(Newline, newlinePenalty, newlinePolicy)
+          .withIndent(indentLen, close, Before),
+      )
     }
   }
 }
@@ -2181,9 +2222,13 @@ object SplitsAfterLeftBracket extends Splits {
       ft: FT,
       fo: FormatOps,
       cfg: ScalafmtConfig,
-  ): Seq[Split] = SplitsAfterLeftParenOrBracket.get1
-    .orElse(SplitsAfterLeftParenOrBracket.get2(isBracket = true))
-    .getOrElse(Seq(Split(NoSplit, 0)))
+  ): Seq[Split] = {
+    var splits = SplitsAfterLeftParenOrBracket.get1
+    if (splits ne null) return splits
+    splits = SplitsAfterLeftParenOrBracket.get2(isBracket = true)
+    if (splits ne null) return splits
+    Seq(Split(NoSplit, 0))
+  }
 }
 
 object SplitsAfterMatch extends Splits {
@@ -2197,7 +2242,7 @@ object SplitsAfterMatch extends Splits {
       val indentLen = cfg.indent.matchSite.fold(0)(_ - cfg.indent.main)
       def expire = getLastNonTrivial(leftOwner) // should be rbrace
       Seq(Split(Space, 0).withIndent(indentLen, expire, ExpiresOn.Before))
-    } else Seq.empty
+    } else Nil
   }
 }
 
@@ -2255,20 +2300,19 @@ object SplitsBeforeColon extends Splits {
             left.is[T.Comment] && hasBreak =>
         val expire = getLastNonTrivial(returnType)
         val sameLineSplit = Space(endsWithSymbolIdent(left))
-        val bopSplits = cfg.newlines.getBeforeOpenParenDefnSite.map { x =>
+        cfg.newlines.getBeforeOpenParenDefnSite.nnMap { x =>
           val ob = OptionalBraces.at(nextAfterNonComment(expire))
           def extraIfBody = cfg.indent.extraBeforeOpenParenDefnSite
           val indent =
             if (ob) cfg.indent.getSignificant + extraIfBody
             else cfg.indent.main +
-              (if (defDefBody(rightOwner).isEmpty) 0 else extraIfBody)
+              (if (defDefBody(rightOwner) eq null) 0 else extraIfBody)
           Seq(
             Split(sameLineSplit, 0).onlyIf(noBreak || x.ne(Newlines.keep))
               .withSingleLine(expire),
             Split(Newline, 1).withIndent(indent, expire, After),
           )
-        }
-        bopSplits.getOrElse {
+        } ?? {
           def penalizeNewlines(extra: Int)(implicit fileLine: FileLine) =
             PenalizeAllNewlines(expire, Constants.BracketPenalty + extra)
           val indent = cfg.indent.getDefnSite(leftOwner)
@@ -2346,68 +2390,66 @@ object SplitsAfterComma extends Splits {
     } else {
       val nlMod = Newline2x(ft)
 
-      def forBinPack(binPack: BinPack.Site, callSite: Boolean) =
-        if (binPack eq BinPack.Site.Never) None
-        else optimizationEntities.argument.map { nextArg =>
-          val lastFT = getLast(nextArg)
-          val oneline = binPack.isOneline
-          val afterNextArg = nextNonComment(lastFT)
-          val nextCommaOrParen = afterNextArg.right match {
-            case _: T.Comma | _: T.RightParen | _: T.RightBracket =>
-              Some(afterNextArg)
-            case _ => None
-          }
-          def getEndOfResultType(cp: FT) =
-            if (
-              cp.right.is[T.Comma] || !cfg.newlines.avoidInResultType ||
-              cfg.newlines.sometimesBeforeColonInMethodReturnType
-            ) None
-            else {
-              val nft = findToken(next(cp), next)(x =>
-                x.right match {
-                  case _: T.Comment => x.hasBreak
-                  case _: T.RightParen | _: T.RightBracket => false
-                  case _ => true
-                },
-              )
-              if (nft.right.is[T.Colon]) colonDeclType(nft.meta.rightOwner)
-                .flatMap(getLastNonTrivialOpt) // could be empty tree
-              else None
-            }
-
-          val noSpace = nlMod.isDouble || cfg.newlines.keepBreak(hasBreak)
-          val noSjsExclude = (binPack ne BinPack.Site.OnelineSjs) ||
-            noSpace && (!oneline || nextCommaOrParen.isEmpty)
-          val sjsExclude =
-            if (noSjsExclude) TokenRanges.empty
-            else insideBracesBlock(ft, lastFT)
-          val onelinePolicy = Policy ? oneline &&
-            nextCommaOrParen
-              .map(BinPackOneline.getPolicy(callSite, sjsExclude)(_)._2)
-
-          val indentOncePolicy = Policy ?
-            (callSite && cfg.binPack.indentCallSiteOnce) && {
-              val trigger = getIndentTrigger(leftOwner)
-              Policy.onLeft(lastFT, prefix = "IND1") {
-                case Decision(FT(LeftParenOrBracket(), _, m), s)
-                    if isArgClauseSite(m.leftOwner) =>
-                  s.map(x => if (x.isNL) x else x.switch(trigger, true))
-              }
-            }
-          val nlSplit = Split(nlMod, 1, onelinePolicy & indentOncePolicy)
-          val noSplit =
-            if (noSpace) Split.ignored
-            else {
-              val end = getSlbEndOnLeft(
-                nextCommaOrParen.flatMap(getEndOfResultType).getOrElse(lastFT),
-              )
-              val slbPolicy =
-                SingleLineBlock(end, exclude = sjsExclude, noSyntaxNL = true)
-              Split(Space, 0, slbPolicy ==> onelinePolicy)
-                .withOptimalToken(end, killOnFail = sjsExclude.isEmpty)
-            }
-          Seq(noSplit, nlSplit)
+      def forBinPack(binPack: BinPack.Site, callSite: Boolean): Seq[Split] = {
+        if (binPack eq BinPack.Site.Never) null
+        else optimizationEntities.argument
+      }.nnMap { nextArg =>
+        val lastFT = getLast(nextArg)
+        val oneline = binPack.isOneline
+        val afterNextArg = nextNonComment(lastFT)
+        val nextCommaOrParen = afterNextArg.right match {
+          case _: T.Comma | _: T.RightParen | _: T.RightBracket => afterNextArg
+          case _ => null
         }
+        def getEndOfResultType(cp: FT) =
+          if (
+            cp.right.is[T.Comma] || !cfg.newlines.avoidInResultType ||
+            cfg.newlines.sometimesBeforeColonInMethodReturnType
+          ) null
+          else {
+            val nft = findToken(next(cp), next)(x =>
+              x.right match {
+                case _: T.Comment => x.hasBreak
+                case _: T.RightParen | _: T.RightBracket => false
+                case _ => true
+              },
+            )
+            if (!nft.right.is[T.Colon]) null // could be empty tree
+            else colonDeclType(nft.meta.rightOwner).nnMap(getLastNonTrivial)
+          }
+
+        val noSpace = nlMod.isDouble || cfg.newlines.keepBreak(hasBreak)
+        val onelineWithNextCommaOrParen = oneline && (nextCommaOrParen ne null)
+        val noSjsExclude = (binPack ne BinPack.Site.OnelineSjs) ||
+          noSpace && !onelineWithNextCommaOrParen
+        val sjsExclude =
+          if (noSjsExclude) TokenRanges.empty else insideBracesBlock(ft, lastFT)
+        val onelinePolicy = Policy ? onelineWithNextCommaOrParen &&
+          BinPackOneline.getPolicy(callSite, sjsExclude)(nextCommaOrParen)._2
+
+        val indentOncePolicy = Policy ?
+          (callSite && cfg.binPack.indentCallSiteOnce) && {
+            val trigger = getIndentTrigger(leftOwner)
+            Policy.onLeft(lastFT, prefix = "IND1") {
+              case Decision(FT(LeftParenOrBracket(), _, m), s)
+                  if isArgClauseSite(m.leftOwner) =>
+                s.map(x => if (x.isNL) x else x.switch(trigger, true))
+            }
+          }
+        val nlSplit = Split(nlMod, 1, onelinePolicy & indentOncePolicy)
+        val noSplit =
+          if (noSpace) Split.ignored
+          else {
+            val end = getSlbEndOnLeft(
+              nextCommaOrParen.nnMap(getEndOfResultType) ?? lastFT,
+            )
+            val slbPolicy =
+              SingleLineBlock(end, exclude = sjsExclude, noSyntaxNL = true)
+            Split(Space, 0, slbPolicy ==> onelinePolicy)
+              .withOptimalToken(end, killOnFail = sjsExclude.isEmpty)
+          }
+        Seq(noSplit, nlSplit)
+      }
 
       def defaultSplits(indent: Length, allowKeepNL: Boolean = true)(implicit
           fileLine: FileLine,
@@ -2433,7 +2475,7 @@ object SplitsAfterComma extends Splits {
       }
 
       cfg.binPack.siteFor(leftOwner).fold(altSplits) { case (bp, isCallSite) =>
-        forBinPack(bp, isCallSite).getOrElse(defaultSplits(0))
+        forBinPack(bp, isCallSite) ?? defaultSplits(0)
       }
     }
   }
@@ -2459,7 +2501,7 @@ object SplitsBeforeViewbound extends Splits {
     import fo._, ft._
     rightOwner match {
       case tb: Type.Bounds => getSplitsForTypeBounds(Space, tb, tb.view)
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -2477,9 +2519,12 @@ object SplitsBeforeSubtype extends Splits {
     import fo._, tokens._, ft._
     rightOwner match {
       case tb: Type.Bounds =>
-        val boundEnd = tb.hi.map(getLastNonTrivial)
+        val boundEnd = tb.hi match {
+          case Some(t) => getLastNonTrivial(t)
+          case None => null
+        }
         getSplitsForTypeBounds(Space, tb, boundEnd)
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -2493,9 +2538,12 @@ object SplitsBeforeSupertype extends Splits {
     import fo._, tokens._, ft._
     rightOwner match {
       case tb: Type.Bounds =>
-        val boundEnd = tb.lo.map(getLastNonTrivial)
+        val boundEnd = tb.lo match {
+          case Some(t) => getLastNonTrivial(t)
+          case None => null
+        }
         getSplitsForTypeBounds(Space, tb, boundEnd)
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -2505,15 +2553,16 @@ object SplitsBeforeDot extends Splits {
       ft: FT,
       fo: FormatOps,
       cfg: ScalafmtConfig,
-  ): Seq[Split] = Select.onRightOpt(ft)(fo.tokens) match {
-    case Some(x)
-        if cfg.newlines.keep || !x.tree.is[Term.Select] ||
-          findTreeWithParent(x.tree) {
-            case _: Term.ArgClause => None
-            case _: Type.Select | _: Importer | _: Pkg => Some(true)
-            case _: Term.Select | _: Member.Apply => None
-            case _ => Some(false)
-          }.isEmpty => getSelect(x)
+  ): Seq[Split] = Select.onRightOrNull(ft)(fo.tokens) match {
+    case x
+        if (x ne null) &&
+          (cfg.newlines.keep || !x.tree.is[Term.Select] ||
+            (findTreeWithParent(x.tree) {
+              case _: Term.ArgClause => MaybeBool.Maybe
+              case _: Type.Select | _: Importer | _: Pkg => MaybeBool.True
+              case _: Term.Select | _: Member.Apply => MaybeBool.Maybe
+              case _ => MaybeBool.False
+            } eq null)) => getSelect(x)
     case _ => Seq(Split(NoSplit, 0))
   }
 
@@ -2533,8 +2582,8 @@ object SplitsBeforeDot extends Splits {
         case p: Term.Apply => isFewerBraces(p)
         case p: Term.MatchLike => getHead(p.casesBlock).leftOwner ne
             p.casesBlock
-        case p: Term.NewAnonymous => getHeadOpt(p.templ.body)
-            .exists(_.left.is[T.Colon])
+        case p: Term.NewAnonymous => getHead(p.templ.body)
+            .nnHas(_.left.is[T.Colon])
         case _: Term.ForClause | _: Term.ApplyInfix | _: Term.SelectPostfix =>
           true
         case _ => false
@@ -2542,31 +2591,32 @@ object SplitsBeforeDot extends Splits {
     val fewerBracesLike = checkFewerBraces(thisSelect.qual)
     val indentFewerBraces = cfg.getFewerBraces()
     val noIndentFewerBraces =
-      if (nextSelect.isEmpty) indentFewerBraces != Indents.FewerBraces.always
+      if (nextSelect eq null) indentFewerBraces != Indents.FewerBraces.always
       else indentFewerBraces == Indents.FewerBraces.never
 
     val nlOnly = fewerBracesLike ||
       cfg.newlines.sourceIgnored && afterComment && hasBreak ||
-      prevApply.exists(x => getHead(x.argClause).left.is[T.Colon])
+      (prevApply ne null) && getHead(prevApply.argClause).left.is[T.Colon]
     val expire = getLastExceptParen(expireTree)
     val indentLen = cfg.indent.main
 
-    val nextDotOpt = nextSelect.map(ns => tokenBefore(ns.nameFt))
-    val beforeNextDotOpt = nextDotOpt.map(prev)
+    val nextDotOpt = nextSelect &&& tokenBefore(nextSelect.nameFt)
+    val beforeNextDotOpt = nextDotOpt.nnMap(prev)
     val nextFewerBraces = nextSelect match {
-      case None => if (checkFewerBraces(expireTree)) Some(expire) else None
-      case Some(ns) => if (checkFewerBraces(ns.qual)) nextDotOpt else None
+      case null => if (checkFewerBraces(expireTree)) expire else null
+      case ns => if (checkFewerBraces(ns.qual)) nextDotOpt else null
     }
 
-    def forcedBreakOnNextDotPolicy(implicit fileLine: FileLine) =
-      beforeNextDotOpt.map(decideNewlinesOnlyAfterToken(_))
+    def forcedBreakOnNextDotPolicy(implicit fileLine: FileLine) = Policy ?
+      (beforeNextDotOpt eq null) ||
+      decideNewlinesOnlyAfterToken(beforeNextDotOpt)
     def getClassicNonFirstBreakOnDot(dot: FT): Policy = Policy
       .onlyFor(dot, "NEXTSEL2NL") { s =>
         val filtered = s.flatMap { x =>
           val y = x.activateFor(SplitTag.SelectChainSecondNL)
           if (y.isActive) Some(y) else None
         }
-        if (filtered.isEmpty) Seq.empty
+        if (filtered.isEmpty) Nil
         else {
           val minCost = math.max(0, filtered.map(_.costWithPenalty).min - 1)
           filtered.map { x =>
@@ -2576,8 +2626,9 @@ object SplitsBeforeDot extends Splits {
           }
         }
       }
-    def classicNonFirstBreakOnNextDot: Policy = beforeNextDotOpt
-      .map(getClassicNonFirstBreakOnDot)
+    def classicNonFirstBreakOnNextDot: Policy = Policy ?
+      (beforeNextDotOpt ne null) &&
+      getClassicNonFirstBreakOnDot(beforeNextDotOpt)
 
     def getSlbEnd() = {
       val nft = nextNonCommentSameLineAfter(ft)
@@ -2592,12 +2643,15 @@ object SplitsBeforeDot extends Splits {
       case Newlines.classic =>
         def getNlMod = {
           val endSelect = nextFewerBraces match {
-            case Some(x) => if (noIndentFewerBraces) Some(x) else None
-            case None =>
-              Some(nextSelect.fold(expire)(ns => getLastNonTrivial(ns.qual)))
+            case null =>
+              if (nextSelect eq null) expire
+              else getLastNonTrivial(nextSelect.qual)
+            case x => if (noIndentFewerBraces) x else null
           }
-          val altIndent = endSelect.map(Indent(-indentLen, _, After))
-          Newline.withAlt(modSpace.withIndentOpt(altIndent))
+          val altIndent =
+            if (endSelect eq null) Indent.empty
+            else Indent(-indentLen, endSelect, After)
+          Newline.withAlt(modSpace.withIndent(altIndent))
         }
 
         val prevChain = inSelectChain(prevSelect, thisSelect, expireTree)
@@ -2609,7 +2663,7 @@ object SplitsBeforeDot extends Splits {
           ).onlyFor(SplitTag.SelectChainSecondNL)
         if (canStartSelectChain(thisSelect, nextSelect, expireTree)) {
           val chainExpire =
-            if (nextSelect.isEmpty) thisSelect.nameFt else expire
+            if (nextSelect eq null) thisSelect.nameFt else expire
           val nestedPenalty = nestedSelect(rightOwner) + nestedApplies(leftOwner)
           // This policy will apply to both the space and newline splits, otherwise
           // the newline is too cheap even it doesn't actually prevent other newlines.
@@ -2621,7 +2675,7 @@ object SplitsBeforeDot extends Splits {
           val chainLengthPenalty =
             if (
               cfg.newlines.penalizeSingleSelectMultiArgList &&
-              nextSelect.isEmpty
+              (nextSelect eq null)
             )
               // penalize by the number of arguments in the rhs open apply.
               // I know, it's a bit arbitrary, but my manual experiments seem
@@ -2695,14 +2749,14 @@ object SplitsBeforeDot extends Splits {
               .withSingleLine(slbEnd, noSyntaxNL = noSyntaxNL),
             Split(nlMod, 1, nlPolicy),
           )
-        if (prevSelect.isEmpty && nextSelect.isEmpty) splits()(getSlbEnd())
+        if ((prevSelect eq null) && (nextSelect eq null)) splits()(getSlbEnd())
         else splits(forcedBreakOnNextDotPolicy)(expire, noSyntaxNL = true)
 
       case Newlines.fold =>
         def nlSplitBase(cost: Int, policy: Policy = NoPolicy)(implicit
             fileLine: FileLine,
         ) = Split(Newline.withAlt(modSpace, noAltIndent = true), cost, policy)
-        if (nextFewerBraces.exists(_ ne expire)) {
+        if ((nextFewerBraces ne null) && (nextFewerBraces ne expire)) {
           val policy: Policy = forcedBreakOnNextDotPolicy
           if (nlOnly) Seq(nlSplitBase(0).withPolicy(policy))
           else {
@@ -2710,19 +2764,22 @@ object SplitsBeforeDot extends Splits {
             Seq(noSplit, nlSplitBase(1, policy))
           }
         } else if (!nlOnly) {
-          val end = nextSelect.fold(expire)(x => getLastNonTrivial(x.qual))
-          val bracketsToo = nextSelect.forall(_.qual.is[Term.ApplyType]) &&
+          val end =
+            if (nextSelect eq null) expire
+            else getLastNonTrivial(nextSelect.qual)
+          val bracketsToo = nextSelect.orHas(_.qual.is[Term.ApplyType]) &&
             (cfg.binPack.callSiteFor(isBracket = true) ne BinPack.Site.Never)
           val exclude =
             insideBracesBlock(ft, end, parens = true, brackets = bracketsToo)
               .excludeCloseDelim
           def arrowOwner(tree: Tree): Boolean = tree.is[Member.Function] &&
-            findTreeWithParent(tree) {
-              case _: Member.Apply => Some(true)
-              case p: Term.ArgClause if !isSeqSingle(p.values) => Some(false)
-              case p: Tree.Block if !isSeqSingle(p.stats) => Some(false)
-              case _ => None
-            }.isDefined
+            (findTreeWithParent(tree) {
+              case _: Member.Apply => MaybeBool.True
+              case p: Term.ArgClause if !isSeqSingle(p.values) =>
+                MaybeBool.False
+              case p: Tree.Block if !isSeqSingle(p.stats) => MaybeBool.False
+              case _ => MaybeBool.Maybe
+            } ne null)
           val arrowPolicy = exclude.ranges
             .foldLeft(Policy.noPolicy) { case (res, tr) =>
               val policy = Policy.onRight(tr.rt, "PNL+DOTARR") {
@@ -2745,13 +2802,13 @@ object SplitsBeforeDot extends Splits {
         } else Seq(nlSplitBase(0))
     }
 
-    val delayedBreakPolicyOpt = nextSelect.map { selectLike =>
-      val tree = selectLike.tree
-      Policy.beforeLeft(selectLike.nameFt, "NEXTSEL1NL") {
+    val delayedBreakPolicyOpt = Policy ? (nextSelect ne null) && {
+      val tree = nextSelect.tree
+      Policy.beforeLeft(nextSelect.nameFt, "NEXTSEL1NL") {
         case Decision(FT(_, _: T.Dot, m), s) if m.rightOwner eq tree =>
           SplitTag.SelectChainFirstNL.activateOnly(s)
         case Decision(FT(_, _: T.Comment, m), s)
-            if m.rightOwner.eq(tree) && nextFewerBraces.isEmpty &&
+            if m.rightOwner.eq(tree) && (nextFewerBraces eq null) &&
               s.exists(_.isNeededFor(SplitTag.SelectChainFirstNL)) =>
           SplitTag.SelectChainFirstNL.activateOnly(s)
       }
@@ -2771,18 +2828,18 @@ object SplitsBeforeDot extends Splits {
       ) // will break
         baseSplits.map(_.withIndent(nlIndent).andFirstPolicy(nlPolicy))
       else {
-        val spcIndent = nextFewerBraces.fold(Indent.empty)(x =>
-          if (noIndentFewerBraces) Indent.Empty
-          else if (nextSelect.isEmpty) nlIndent
-          else Indent(indentLen, x, Before),
-        )
+        val spcIndent =
+          if (nextFewerBraces eq null) Indent.empty
+          else if (noIndentFewerBraces) Indent.Empty
+          else if (nextSelect eq null) nlIndent
+          else Indent(indentLen, nextFewerBraces, Before)
         baseSplits.map(s =>
           if (s.isNL) s.withIndent(nlIndent).andFirstPolicy(nlPolicy)
           else s.withIndent(spcIndent).andFirstPolicy(spcPolicy),
         )
       }
 
-    if (prevSelect.isEmpty) splits
+    if (prevSelect eq null) splits
     else baseSplits ++ splits.map(_.onlyFor(SplitTag.SelectChainFirstNL))
   }
 }
@@ -2799,7 +2856,7 @@ object SplitsAfterAt extends Splits {
       case _: T.Symbolic => Seq(Split(NoSplit, 0))
       // Add space if right starts with a symbol
       case r: T.Ident => Seq(Split(identModification(r), 0))
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -2810,7 +2867,7 @@ object SplitsBeforeAt extends Splits {
       fo: FormatOps,
       cfg: ScalafmtConfig,
   ): Seq[Split] = // For annotations, see #183 for discussion on this.
-    if (ft.rightOwner.is[Pat.Bind]) Seq(Split(Space, 0)) else Seq.empty
+    if (ft.rightOwner.is[Pat.Bind]) Seq(Split(Space, 0)) else Nil
 }
 
 object SplitsAfterIdent extends Splits {
@@ -2842,7 +2899,7 @@ object SplitsAfterIdent extends Splits {
               case _ => false
             }
             Seq(Split(Space(useSpace), 0))
-          case _ => Seq.empty
+          case _ => Nil
         }
       case t: Pat.Alternative if getIdent == "|" => // Pattern alternatives
         if (cfg.newlines.keep) Seq(Split(Space.orNL(noBreak), 0))
@@ -2867,7 +2924,7 @@ object SplitsAfterIdent extends Splits {
         Seq(Split(Space(cfg.spaces.inByNameTypes && !right.is[T.LeftBrace]), 0))
       case _: Mod.ParamsType => SplitsAfterImplicit.get
       case _: Term.SplicedMacroLike => SplitsNoSplit.get
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -2895,9 +2952,9 @@ object SplitsBeforeIdent extends Splits {
       case t: Name => t.parent match {
           case Some(p: Member.Infix) if p.op eq t => insideInfixSplit(p)
 //          case _ if left.is[T.Dot] => Seq(Split(NoSplit, 0))
-          case _ => Seq.empty
+          case _ => Nil
         }
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -2910,7 +2967,7 @@ object SplitsBeforeExtends extends Splits {
   ): Seq[Split] = ft.rightOwner match {
     case t: Defn.EnumCase => getEnumCase(t)
     case t: Template => getTemplate(t)
-    case _ => Seq.empty
+    case _ => Nil
   }
 
   def getEnumCase(
@@ -2920,7 +2977,7 @@ object SplitsBeforeExtends extends Splits {
     binPackParentConstructorSplits(
       true,
       Set(rightOwner),
-      enumCase.inits.headOption,
+      enumCase.inits.headOrNull,
       getLast(rightOwner),
       cfg.indent.extendSite,
       enumCase.inits.lengthCompare(1) > 0,
@@ -2973,7 +3030,7 @@ object SplitsBeforeWith extends Splits {
       case t @ WithChain(top) => binPackParentConstructorSplits(
           !t.lhs.is[Type.With],
           withChain(top).toSet,
-          Some(t.rhs),
+          t.rhs,
           getLast(top),
           cfg.indent.main,
         )
@@ -3010,12 +3067,12 @@ object SplitsAfterIf extends Splits {
         )
         val mlSplitOpt = OptionalBraces
           .indentAndBreakBeforeCtrl[T.KwThen](t.cond, mlSplitBase)
-        Seq(slb, mlSplitOpt.getOrElse(mlSplitBase))
+        Seq(slb, mlSplitOpt ?? mlSplitBase)
 
       case _: Case if cfg.newlines.keepBreak(nextNonCommentSameLine(ft)) =>
         Seq(Split(Newline, 0))
 
-      case t: Term.Name if t.parent.is[Term.EndMarker] => Seq.empty
+      case t: Term.Name if t.parent.is[Term.EndMarker] => Nil
 
       case _ => Seq(Split(Space, 0))
     }
@@ -3077,7 +3134,7 @@ object SplitsBeforeIf extends Splits {
           .withPolicy(penalizeNewlineByNesting(next(ft), arrow))
         Seq(noSplit, nlSplit)
 
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -3095,21 +3152,21 @@ object SplitsAfterForWhile extends Splits {
         val onlyNL = cfg.newlines.keepBreak(hasBreak)
         Split(Newline.orMod(onlyNL, spaceMod), 0)
       }
-      val split = (leftOwner match {
+      val split = leftOwner match {
         // block expr case is handled in OptionalBraces.WhileImpl
         case t: Term.While => OptionalBraces
             .indentAndBreakBeforeCtrl[T.KwDo](t.expr, splitBase)
         // below, multi-enum cases are handled in OptionalBraces.ForImpl
-        case t: Term.For => getSingleElement(t.enumsBlock).flatMap(
-            OptionalBraces.indentAndBreakBeforeCtrl[T.KwDo](_, splitBase),
+        case t: Term.For => getSingleElement(t.enumsBlock).nnMap(x =>
+            OptionalBraces.indentAndBreakBeforeCtrl[T.KwDo](x, splitBase),
           )
-        case t: Term.ForYield => getSingleElement(t.enumsBlock).flatMap(
-            OptionalBraces.indentAndBreakBeforeCtrl[T.KwYield](_, splitBase),
+        case t: Term.ForYield => getSingleElement(t.enumsBlock).nnMap(x =>
+            OptionalBraces.indentAndBreakBeforeCtrl[T.KwYield](x, splitBase),
           )
-        case _ => None
-      }).getOrElse(Split(spaceMod, 0))
-      Seq(split)
-    } else Seq.empty
+        case _ => null
+      }
+      Seq(split ?? Split(spaceMod, 0))
+    } else Nil
   }
 }
 
@@ -3120,7 +3177,7 @@ object SplitsBeforeWhile extends Splits {
       cfg: ScalafmtConfig,
   ): Seq[Split] = {
     import ft._
-    if (!rightOwner.is[Term.Do]) Seq.empty
+    if (!rightOwner.is[Term.Do]) Nil
     else if (hasBlankLine) Seq(Split(Newline2x, 0))
     else {
       val nlOnly = left.is[T.RightBrace] &&
@@ -3161,7 +3218,7 @@ object SplitsAfterDo extends Splits {
         getWithBody(t)(eft =>
           Seq(Split(Newline, 1).withIndent(cfg.indent.main, eft, ExpiresOn.After)),
         )
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 
@@ -3172,7 +3229,7 @@ object SplitsAfterDo extends Splits {
     val eft = getLast(t.body)
     if (
       t.body.is[Tree.Block] && right.is[T.LeftBrace] &&
-      matchingOptRight(ft).exists(_.idx >= eft.idx)
+      { val m = matchingRightOrNull(ft); (m ne null) && m.idx >= eft.idx }
     ) Seq(Split(Space, 0))
     else ifNotBlock(eft)
   }
@@ -3200,8 +3257,7 @@ object SplitsBeforeDo extends Splits {
       ft: FT,
       fo: FormatOps,
       cfg: ScalafmtConfig,
-  ): Seq[Split] =
-    if (ft.rightOwner.is[Term.Do]) Seq.empty else SplitsBeforeThenDo.get
+  ): Seq[Split] = if (ft.rightOwner.is[Term.Do]) Nil else SplitsBeforeThenDo.get
 }
 
 object SplitsAfterElse extends Splits {
@@ -3233,7 +3289,7 @@ object SplitsAfterElse extends Splits {
             Split(Space, 0).withSingleLineNoOptimal(expire),
           )(nlSplitFunc)
         }
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 }
@@ -3277,7 +3333,7 @@ object SplitsAfterCase extends Splits {
       case c: Case => getCaseTree(getCaseArrow(c), c)
       case tc: TypeCase => getCaseTree(getCaseArrow(tc), tc)
 
-      case _ => Seq.empty
+      case _ => Nil
     }
   }
 
@@ -3296,12 +3352,12 @@ object SplitsAfterCase extends Splits {
         case Comments.IndentTrailingInCaseBody.none => nft
         case Comments.IndentTrailingInCaseBody.more => // find last blank or non-comment
           var bft: FT = null
-          findTokenEx(nft) { xft =>
+          findTokenEx { xft =>
             if (xft.hasBlankLine) bft = xft
             if (xft.right.is[T.Comment] && (commentOwner eq xft.rightOwner))
               Left(next(xft))
             else Right(if ((bft eq null) || notNextCase(xft)) xft else bft)
-          }.getOrElse(nft)
+          }(nft) ?? nft
         case Comments.IndentTrailingInCaseBody.less => // find first blank or non-comment
           findToken(nft, next)(xft =>
             !xft.right.is[T.Comment] || (commentOwner ne xft.rightOwner) ||
@@ -3318,10 +3374,11 @@ object SplitsAfterCase extends Splits {
         // postArrowFt points to non-comment after arrowFt
         // possibly on next line without intervening comments
         implicit val beforeMultiline = cfg.newlines.getBeforeMultiline
-        getClosingIfCaseBodyEnclosedAsBlock(postArrow, owner).fold(
+        val rparen = getClosingIfCaseBodyEnclosedAsBlock(postArrow, owner)
+        if (rparen eq null)
           Policy ? beforeMultiline.in(Newlines.fold, Newlines.keep) ||
-            defaultPolicy,
-        ) { rparen =>
+          defaultPolicy
+        else {
           val lparen = next(postArrow)
           val postParen = nextNonCommentSameLine(lparen)
           val indent = cfg.indent.main
@@ -3369,7 +3426,7 @@ object SplitsAfterTryCatchFinally {
       f: Term.TryClause => Tree,
   )(implicit ft: FT, fo: FormatOps, cfg: ScalafmtConfig): Seq[Split] =
     ft.leftOwner match {
-      case _: Term.Name => Seq.empty // exclude end marker
+      case _: Term.Name => Nil // exclude end marker
       case t: Term.TryClause => getWithBody(f(t))
       case t => getWithBody(t)
     }
@@ -3380,8 +3437,9 @@ object SplitsAfterTryCatchFinally {
     import fo._, tokens._
     val end = getLast(body)
     val nft = nextNonComment(ft)
-    val inBraces = body.is[Tree.Block] && nft.right.is[T.LeftBrace] &&
-      matchingOptRight(nft).exists(_.idx >= end.idx)
+    val inBraces = body.is[Tree.Block] && nft.right.is[T.LeftBrace] && {
+      val m = matchingRightOrNull(nft); (m ne null) && m.idx >= end.idx
+    }
     if (inBraces) Seq(Split(Space, 0))
     else {
       val indent = Indent(cfg.indent.main, end, ExpiresOn.After)
@@ -3409,7 +3467,7 @@ object SplitsBeforeCatchFinally extends Splits {
     import ft._
     val ok = cfg.newlines.alwaysBeforeElseAfterCurlyIf ||
       !(left.is[T.RightBrace] && isCurlyWithNextKeyword(ft, ft))
-    if (ok) Seq(Split(Newline2x(hasBlankLine), 0)) else Seq.empty
+    if (ok) Seq(Split(Newline2x(hasBlankLine), 0)) else Nil
   }
 }
 
@@ -3439,19 +3497,20 @@ object SplitsAfterYield extends Splits {
   ): Seq[Split] = {
     import fo._, tokens._, ft._
     (leftOwner match {
-      case t: Term.ForYield => Some(TreeOps.getBlockStat(t.body))
-      case _ => None
-    }).fold(Seq.empty[Split]) {
+      case t: Term.ForYield => TreeOps.getBlockStat(t.body)
+      case _ => null
+    }) match {
+      case null => Nil
       case b: Term.PartialFunction
           if dialect.allowSignificantIndentation &&
             nextNonComment(ft).right.is[T.KwCase] =>
         val split = Split(Newline, 0)
           .withIndent(cfg.indent.getSignificant, getLast(b), ExpiresOn.After)
         Seq(split)
-      case b: Tree.Block
-          if right.is[T.LeftBrace] &&
-            matchingOptRight(ft).exists(_.idx >= getLast(b).idx) =>
-        Seq(Split(Space, 0))
+      case b: Tree.Block if right.is[T.LeftBrace] && {
+            val m = matchingRightOrNull(ft);
+            (m ne null) && m.idx >= getLast(b).idx
+          } => Seq(Split(Space, 0))
       case b =>
         val lastToken = getLast(b)
         val indent = Indent(cfg.indent.main, lastToken, ExpiresOn.After)
@@ -3492,7 +3551,7 @@ object SplitsAfterXmlSpliceStart extends Splits {
   ): Seq[Split] =
     if (cfg.xmlLiterals.assumeFormatted) fo
       .withIndentOnXmlSpliceStart(ft, Seq(Split(NoSplit, 0)))
-    else Seq.empty
+    else Nil
 }
 
 object SplitsAfterCommentLowPriority extends Splits {
@@ -3516,29 +3575,30 @@ object SplitsBeforeCommentLowPriority extends Splits {
     def baseSplit(implicit fileLine: FileLine) = Split(mod, 0)
 
     val nearbyDot =
-      if (nft.right.is[T.Dot]) Some(nft)
+      if (nft.right.is[T.Dot]) nft
       else {
         val pft = prevBeforeNonComment(ft)
-        if (pft.right.is[T.Dot]) Some(pft) else None
+        if (pft.right.is[T.Dot]) pft else null
       }
-    val selectLikeOpt = nearbyDot.flatMap(Select.onRightOpt)
+    val selectLike = nearbyDot.nnMap(Select.onRightOrNull)
 
-    selectLikeOpt.fold {
-      val infixSplits = nft.rightOwner match {
-        case t: Name if nft.right.is[T.Ident] =>
-          t.parent match {
-            case Some(p: Member.Infix) if p.op eq t => insideInfixSplit(p)
-            case _ => Seq.empty
-          }
-        case _ => Seq.empty
-      }
-      if (infixSplits.isEmpty) Seq(baseSplit) else infixSplits
-    } { t =>
-      val noIndent = nearbyDot.exists(_.idx <= ft.idx)
-      def split(implicit fileLine: FileLine) = baseSplit
-        .withIndent(cfg.indent.main, nft, ExpiresOn.After, ignore = noIndent)
-      if (Select.prev(t, cfg.newlines.encloseSelectChains).isEmpty) Seq(split)
-      else Seq(baseSplit, split.onlyFor(SplitTag.SelectChainFirstNL))
+    selectLike match {
+      case null =>
+        val infixSplits = nft.rightOwner match {
+          case t: Name if nft.right.is[T.Ident] =>
+            t.parent match {
+              case Some(p: Member.Infix) if p.op eq t => insideInfixSplit(p)
+              case _ => Nil
+            }
+          case _ => Nil
+        }
+        if (infixSplits.isEmpty) Seq(baseSplit) else infixSplits
+      case t =>
+        val noIndent = (nearbyDot ne null) && nearbyDot.idx <= ft.idx
+        def split(implicit fileLine: FileLine) = baseSplit
+          .withIndent(cfg.indent.main, nft, ExpiresOn.After, ignore = noIndent)
+        if (Select.prev(t, cfg.newlines.encloseSelectChains) eq null) Seq(split)
+        else Seq(baseSplit, split.onlyFor(SplitTag.SelectChainFirstNL))
     }
   }
 }
@@ -3560,8 +3620,9 @@ object SplitsAfterImplicit extends Splits {
     import fo._, tokens._, ft._
     val ok = cfg.binPack.defnSite == BinPack.Site.Never &&
       !cfg.verticalMultiline.atDefnSite && !right.is[T.Comment]
-    val params = if (ok) TreeOps.getImplicitParamList(leftOwner) else None
-    params.fold(Seq.empty[Split]) { params =>
+    val params = if (ok) TreeOps.getImplicitParamList(leftOwner) else null
+    if (params eq null) Nil
+    else {
       val spaceSplit =
         if (cfg.newlines.forceAfterImplicitParamListModifier) Split.ignored
         else Split(Space, 0).withPolicy(
@@ -3581,7 +3642,7 @@ object SplitsAfterDot extends Splits {
   ): Seq[Split] =
     if (existsParentOfType[ImportExportStat](ft.rightOwner))
       Seq(Split(NoSplit, 0))
-    else Seq.empty
+    else Nil
 }
 
 object SplitsAfterDotLowPriority extends Splits {
@@ -3590,7 +3651,7 @@ object SplitsAfterDotLowPriority extends Splits {
       fo: FormatOps,
       cfg: ScalafmtConfig,
   ): Seq[Split] =
-    if (!ft.right.isAny[T.Ident, T.KwType, T.KwThis, T.KwSuper]) Seq.empty
+    if (!ft.right.isAny[T.Ident, T.KwType, T.KwThis, T.KwSuper]) Nil
     else Seq(Split(NoSplit, 0))
 }
 
@@ -3625,7 +3686,7 @@ object SplitsWithOptionalNL extends Splits {
           val noNL = !cfg.newlines.annotation || noBreak
           Seq(Split(Space.orNL(noNL), 0))
       }
-    } else Seq.empty
+    } else Nil
   }
 }
 
@@ -3652,7 +3713,8 @@ object SplitsAfterOptionalBracesKeyword extends Splits {
       cfg: ScalafmtConfig,
   ): Seq[Split] = {
     import fo.tokens
-    OptionalBraces.get(ft).flatMap(_.splits).getOrElse(Seq.empty)
+    val ob = OptionalBraces.get(ft)
+    if (ob eq null) Nil else ob.splits
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/State.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.internal
+package org.scalafmt
+package internal
 
 import org.scalafmt.config.{Comments, Indents, Newlines, ScalafmtConfig}
 import org.scalafmt.util.PolicyOps
@@ -129,19 +130,19 @@ final class State(
       val initialModExt = initialNextSplit.modExt
       val nextPushes = getUnexpired(initialModExt)
       val initIndent = Indent.getIndent(nextPushes)
-      initialModExt.altOpt.flatMap(alt =>
-        if (tok.left.is[T.Comment]) None
-        else if (initIndent < alt.mod.length + column) None
-        else if (initialModExt.noAltIndent) Some(alt)
-        else Some(alt.withIndents(initialModExt.indents)),
+      initialModExt.alt.nnMap(alt =>
+        if (tok.left.is[T.Comment]) null
+        else if (initIndent < alt.mod.length + column) null
+        else if (initialModExt.noAltIndent) alt
+        else alt.withIndents(initialModExt.indents),
       ) match {
-        case Some(alt) =>
+        case null =>
+          nextIndent = initIndent
+          nextIndents = nextPushes
+        case alt =>
           nextIndents = getUnexpired(alt)
           nextIndent = Indent.getIndent(nextIndents)
           nextSplit = initialNextSplit.withMod(alt)
-        case None =>
-          nextIndent = initIndent
-          nextIndents = nextPushes
       }
     }
 
@@ -249,12 +250,13 @@ final class State(
         val isComment = ft.right.is[T.Comment]
         /* we only delay penalty for overflow tokens which are part of a
          * statement that started at the beginning of the current line */
-        val startFtOpt =
-          if (!State.allowSplitForLineStart(nextSplit, ft, isComment)) None
+        val startFt =
+          if (!State.allowSplitForLineStart(nextSplit, ft, isComment)) null
           else lineStartsStatement(isComment)
-        val delay = startFtOpt.exists {
-          case xft @ FT(_, _: T.Interpolation.Start, _) => tokens
-              .matchingRight(xft).left ne ft.right
+        val delay = startFt match {
+          case null => false
+          case FT(_, _: T.Interpolation.Start, _) => tokens
+              .matchingRight(startFt).left ne ft.right
           case _ => true
         }
         // if delaying, estimate column if the split had been a newline
@@ -294,29 +296,28 @@ final class State(
     *   [[State.allowSplitForLineStart]] which tokens can be traversed.
     */
   @tailrec
-  private def getLineStartOwner(isComment: Boolean)(implicit
-      style: ScalafmtConfig,
-      tokens: FormatTokens,
-  ): Option[(FT, Tree)] = {
+  private def getLineStartOwner(
+      isComment: Boolean,
+  )(implicit style: ScalafmtConfig, tokens: FormatTokens): (FT, Tree) = {
     val ft = tokens(depth)
-    if (ft.meta.left.hasNL) None
+    if (ft.meta.left.hasNL) null
     else if (!split.isNL) {
       val ok = (prev ne State.start) &&
         State.allowSplitForLineStart(split, ft, isComment)
-      if (ok) prev.getLineStartOwner(isComment) else None
+      if (ok) prev.getLineStartOwner(isComment) else null
     } else {
-      def startsWithLeft(tree: Tree): Boolean = tokens.getHeadOpt(tree)
-        .contains(ft)
-      def optionIfStartsWithLeft(tree: Tree): Option[Tree] = Some(tree)
-        .filter(startsWithLeft)
-      val owner = optionIfStartsWithLeft(ft.meta.rightOwner)
-        .orElse(optionIfStartsWithLeft(ft.meta.leftOwner))
-      owner.map { x =>
-        val y = x.parent.flatMap(p =>
-          if (!startsWithLeft(p)) None
-          else findTreeWithParentSimple(p, false)(startsWithLeft),
-        )
-        (ft, y.getOrElse(x))
+      def startsWithLeft(tree: Tree): Boolean = tokens.getHead(tree) eq ft
+      val owner =
+        if (startsWithLeft(ft.rightOwner)) ft.rightOwner
+        else if (startsWithLeft(ft.leftOwner)) ft.leftOwner
+        else null
+      owner &&& {
+        val y = owner.parent match {
+          case Some(p) if startsWithLeft(p) =>
+            findTreeWithParentSimple(p, false)(startsWithLeft)
+          case _ => null
+        }
+        (ft, y ?? owner)
       }
     }
   }
@@ -327,20 +328,17 @@ final class State(
   private def lineStartsStatement(isComment: Boolean)(implicit
       style: ScalafmtConfig,
       tokens: FormatTokens,
-  ): Option[FT] = getLineStartOwner(isComment)
-    .flatMap { case (lineFt, lineOwner) =>
-      val ft = tokens(depth)
-      val ok =
-        // comment could be preceded by a comma
-        isComment && ft.left.is[T.Comma] &&
-          (tokens.prev(ft).meta.leftOwner match {
-            case `lineOwner` => true
-            case t: Member.SyntaxValuesClause => t.parent.contains(lineOwner)
-            case _ => false
-          }) || findTreeOrParentSimple(ft.meta.leftOwner)(_ eq lineOwner)
-            .isDefined
-      if (ok) Some(lineFt) else None
-    }
+  ): FT = getLineStartOwner(isComment).nnMap { case (lineFt, lineOwner) =>
+    val ft = tokens(depth)
+    // comment could be preceded by a comma
+    val ok = isComment && ft.left.is[T.Comma] &&
+      (tokens.prev(ft).meta.leftOwner match {
+        case `lineOwner` => true
+        case t: Member.SyntaxValuesClause => t.parent.contains(lineOwner)
+        case _ => false
+      }) || (findTreeOrParentSimple(ft.meta.leftOwner)(_ eq lineOwner) ne null)
+    if (ok) lineFt else null
+  }
 
   private def getRelativeToLhsLastLineEnd(
       isNL: Boolean,
@@ -601,7 +599,7 @@ object State {
 
   @inline
   private def isWithinInterpolation(tree: Tree): Boolean =
-    findTreeOrParentSimple(tree)(isInterpolation).isDefined
+    findTreeOrParentSimple(tree)(isInterpolation) ne null
 
   private val nullFT = FT(null, null, null)
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/package.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/package.scala
@@ -1,0 +1,71 @@
+package org
+
+package object scalafmt {
+
+  private[scalafmt] implicit class ImplicitSeq[T >: Null <: AnyRef](
+      private val obj: Seq[T],
+  ) extends AnyVal {
+    def headOrNull: T = if (obj.isEmpty) null else obj.head
+    def lastOrNull: T = if (obj.isEmpty) null else obj.last
+  }
+
+  private[scalafmt] implicit class ImplicitIterator[T >: Null <: AnyRef](
+      private val obj: Iterator[T],
+  ) extends AnyVal {
+    def findOrNull(pred: T => Boolean): T = {
+      while (obj.hasNext) {
+        val a = obj.next()
+        if (pred(a)) return a
+      }
+      null
+    }
+  }
+
+  private[scalafmt] implicit class ImplicitIterable[T >: Null <: AnyRef](
+      private val obj: Iterable[T],
+  ) extends AnyVal {
+    def findOrNull(pred: T => Boolean): T = obj.iterator.findOrNull(pred)
+  }
+
+  // receiver bound `<: AnyRef` (not just `>: Null`) so a value-type receiver
+  // (e.g. a Boolean) can't box to `Any` and silently misbehave -- these are
+  // reference-only. (`B` stays `>: Null` so side-effecting `?&&`/`&&&` whose
+  // function returns Unit still work.)
+  private[scalafmt] implicit class ImplicitNullable[A >: Null <: AnyRef](
+      private val obj: A,
+  ) extends AnyVal {
+    def ??(or: => A): A = if (obj != null) obj else or
+    def &&&[B >: Null](or: => B): B = if (obj == null) null else or
+    def ===(or: => A): Boolean = (obj ne null) && (obj eq or)
+    def =!=(or: => A): Boolean = !(obj === or)
+    def nnIf(pred: A => Boolean): A =
+      if (obj != null && pred(obj)) obj else null
+    def orHas(pred: A => Boolean): Boolean = obj == null || pred(obj)
+    def nnHas(pred: A => Boolean): Boolean = obj != null && pred(obj)
+    def nnMap[B >: Null](f: A => B): B = if (obj == null) null else f(obj)
+    def nnFor(f: A => Unit): Unit = if (obj != null) f(obj)
+    def nnFold[B](or: => B)(f: A => B): B = if (obj == null) or else f(obj)
+    def nnMapOr[B](f: A => B)(or: => B): B = if (obj == null) or else f(obj)
+  }
+
+  sealed trait MaybeBool {
+    def asBoolean: Boolean
+    def getBoolean(or: Boolean): Boolean
+  }
+  object MaybeBool {
+    def apply(b: Boolean): MaybeBool = if (b) True else False
+    case object True extends MaybeBool {
+      def asBoolean: Boolean = true
+      def getBoolean(or: Boolean): Boolean = true
+    }
+    case object False extends MaybeBool {
+      def asBoolean: Boolean = false
+      def getBoolean(or: Boolean): Boolean = false
+    }
+    case object Maybe extends MaybeBool {
+      def asBoolean: Boolean = ???
+      def getBoolean(or: Boolean): Boolean = or
+    }
+  }
+
+}

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config.RewriteSettings
 import org.scalafmt.util.InfixApp
@@ -14,8 +15,7 @@ object AvoidInfix extends RewriteFactory {
   override def hasChanged(v1: RewriteSettings, v2: RewriteSettings): Boolean =
     v2.avoidInfix ne v1.avoidInfix
 
-  override def create(implicit ctx: RewriteCtx): Option[RewriteSession] =
-    Some(new AvoidInfix)
+  override def create(implicit ctx: RewriteCtx): RewriteSession = new AvoidInfix
 
 }
 
@@ -37,14 +37,14 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
     case x: Term.SelectPostfix if !cfg.excludePostfix =>
       rewriteImpl(x.qual, Right(x.name))
     case x: Term.Match => noDotMatch(x)
-        .foreach(op => rewriteImpl(x.expr, Left(op), null))
+        .nnFor(op => rewriteImpl(x.expr, Left(op), null))
     case _ =>
   }
 
-  private def noDotMatch(t: Term.Match): Option[T] =
+  private def noDotMatch(t: Term.Match): T =
     if (allowMatchAsOperator && t.mods.isEmpty && !cfg.excludeMatch) ctx
       .tokenTraverser.prevNonTrivialToken(t.casesBlock.tokens.head)
-    else None
+    else null
 
   private def rewriteImpl(
       lhs: Term,
@@ -60,16 +60,17 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
       (lhs match {
         case t: Term.ApplyInfix => checkMatchingInfix(t.lhs, t.op.value, t.arg)
         case t: Term.Match => noDotMatch(t) match {
-            case None => false
-            case Some(kw) => checkMatchingInfix(t.expr, kw.text, t.casesBlock)
+            case null => false
+            case kw => checkMatchingInfix(t.expr, kw.text, t.casesBlock)
           }
         case _ => false
       })
 
-    if (!checkMatchingInfix(lhs, op.fold(_.text, _.value), rhs, Some(lhsIsOK)))
-      return
+    if (
+      !checkMatchingInfix(lhs, op.fold(_.text, _.value), rhs, MaybeBool(lhsIsOK))
+    ) return
     if (!ctx.dialect.allowTryWithAnyExpr)
-      if (beforeLhsHead.exists(_.is[T.KwTry])) return
+      if (beforeLhsHead.nnHas(_.is[T.KwTry])) return
 
     val builder = Seq.newBuilder[TokenPatch]
 
@@ -93,7 +94,8 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
         }
       // move the left paren if enclosed, else enclose
       val (argsHead, argsLast) = ends(rhs)
-      def rhsWrapped = ctx.getMatchingOpt(argsHead).exists(_.end >= argsLast.end)
+      def rhsWrapped = ctx.getMatchingOrNull(argsHead)
+        .nnHas(_.end >= argsLast.end)
       val shouldMoveOpenDelim = rhs match {
         case _: Lit.Unit => ctx.dialect.allowEmptyInfixArgs
         case ac: Term.ArgClause => ac.values match {
@@ -133,7 +135,7 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
       lhs: Term,
       op: String,
       rhs: Tree,
-      lhsIsOK: => Option[Boolean] = None,
+      lhsIsOK: => MaybeBool = MaybeBool.Maybe,
   ): Boolean = InfixApp.isLeftAssoc(op) && cfg.matches(lhs.text, op) &&
     (rhs match {
       case ac @ Term.ArgClause(arg :: Nil, _) if !isWrapped(ac) =>
@@ -142,19 +144,15 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
     }) &&
     (lhs match {
       case lhs: Term.ApplyInfix if hasPlaceholder(lhs, includeArg = true) =>
-        lhsIsOK match {
-          case Some(x) => x
-          case None => isWrapped(lhs) ||
-            checkMatchingInfix(lhs.lhs, lhs.op.value, lhs.arg)
-        }
+        val ok = lhsIsOK
+        if (ok ne MaybeBool.Maybe) ok.asBoolean
+        else isWrapped(lhs) || checkMatchingInfix(lhs.lhs, lhs.op.value, lhs.arg)
       case lhs: Term.Match if hasPlaceholder(lhs, includeArg = true) =>
-        lhsIsOK match {
-          case Some(x) => x
-          case None if isWrapped(lhs) => true
-          case None => noDotMatch(lhs) match {
-              case None => false
-              case Some(op) => checkMatchingInfix(lhs.expr, op.text, null)
-            }
+        val ok = lhsIsOK
+        if (ok ne MaybeBool.Maybe) ok.asBoolean
+        else isWrapped(lhs) || {
+          val op = noDotMatch(lhs)
+          (op ne null) && checkMatchingInfix(lhs.expr, op.text, null)
         }
       case _ => true
     })
@@ -163,10 +161,9 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
   private def isMatching(head: T, last: => T): Boolean = head.is[T.LeftParen] &&
     ctx.isMatching(head, last)
 
-  private def isWrapped(head: T, last: T, beforeHead: => Option[T]): Boolean =
-    isMatching(head, last) || beforeHead.exists(
-      isMatching(_, ctx.tokenTraverser.nextNonTrivialToken(last).orNull),
-    )
+  private def isWrapped(head: T, last: T, beforeHead: => T): Boolean =
+    isMatching(head, last) ||
+      beforeHead.nnHas(isMatching(_, ctx.tokenTraverser.nextNonTrivialToken(last)))
 
   private def isWrapped(head: T, last: T): Boolean =
     isWrapped(head, last, ctx.tokenTraverser.prevNonTrivialToken(head))

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ConvertToNewScala3Syntax.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ConvertToNewScala3Syntax.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal._
@@ -31,7 +32,7 @@ private class ConvertToNewScala3Syntax(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = Option {
+  ): Replacement = {
     val flag = style.rewrite.scala3.newSyntax
     def pft = ftoks.prevNonComment(ft)
     def left = pft.left
@@ -120,12 +121,12 @@ private class ConvertToNewScala3Syntax(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = {
+  ): (Replacement, Replacement) = {
     def nextRight = ftoks.nextNonComment(ftoks.next(ft)).right
     ft.right match {
 
       case x: T.RightParen if left.isRemove =>
-        val rtRepl = ft.meta.rightOwner match {
+        (ft.meta.rightOwner match {
           case _: Term.If =>
             if (!nextRight.is[T.KwThen])
               replaceToken("then")(new T.KwThen(x.input, x.dialect, x.start))
@@ -136,17 +137,14 @@ private class ConvertToNewScala3Syntax(implicit val ftoks: FormatTokens)
             else removeToken
           case t: Term.EnumeratorsBlock =>
             val needDo = t.parent.is[Term.For] && !nextRight.is[T.KwDo]
-            if (needDo) replaceToken("do", t.parent)(
+            if (needDo) replaceToken("do", t.parentOrNull)(
               new T.KwDo(x.input, x.dialect, x.start),
             )
             else removeToken
           case _ => null
-        }
-        if (rtRepl eq null) None
-        else Some {
-          val keep = session.rule[RemoveScala3OptionalBraces]
-            .forall(_.skipRightToBraces(left))
-          if (keep) (left, rtRepl)
+        }).nnMap { rtRepl =>
+          val r = session.rule[RemoveScala3OptionalBraces]
+          if (r.orHas(_.skipRightToBraces(left))) (left, rtRepl)
           else {
             val robLt = {
               implicit val ft: FT = ftoks(left.idx)
@@ -165,9 +163,9 @@ private class ConvertToNewScala3Syntax(implicit val ftoks: FormatTokens)
           }
         }
 
-      case _: T.RightBrace if left.isRemove => Some((left, removeToken))
+      case _: T.RightBrace if left.isRemove => (left, removeToken)
 
-      case _ => None
+      case _ => null
     }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/FormatTokensRewrite.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal._
@@ -85,9 +86,9 @@ class FormatTokensRewrite(
         val nextIdx = idx + 1
         val nextFt = ftoks.at(nextIdx)
         val rtMeta = nextFt.meta
-        mergeWhitespaceLeftToRight(ftOld.meta, rtMeta).foreach { bw =>
+        val bw = mergeWhitespaceLeftToRight(ftOld.meta, rtMeta)
+        if (bw ne null)
           arr(nextIdx) = nextFt.copy(meta = rtMeta.copy(between = bw))
-        }
       }
       repl.how match {
         case ReplacementType.Remove => remove(appended)
@@ -168,20 +169,21 @@ class FormatTokensRewrite(
       val formatOff = ft.meta.formatOff
       implicit val style = if (formatOff) null else styleMap.at(ft.right)
 
-      def applyRules: Option[Int] = session.applyRules(rules)
-      def afterRight(repl: Replacement, claimedIdx: => Int): Unit = repl
-        .afterRight.foreach(fx => afterRightIdxStack.prepend((claimedIdx, fx)))
+      def applyRules: Int = session.applyRules(rules)
+      def afterRight(repl: Replacement, claimedIdx: => Int): Unit = {
+        val fx = repl.afterRight
+        if (fx >= 0) afterRightIdxStack.prepend((claimedIdx, fx))
+      }
 
       ft.right match {
         case _: T.OpenDelim =>
           formatOffStack.prepend(formatOff)
           val ldelimIdxOpt =
-            if (formatOff) None
-            else session.claimedRule match {
-              case Some(c) => session.applyRule(c.rule)
-              case _ => applyRules
-            }
-          val ldelimIdx = ldelimIdxOpt.getOrElse(session.claim(null))
+            if (formatOff) -1
+            else session.claimedRule
+              .nnFold(applyRules)(c => session.applyRule(c.rule))
+          val ldelimIdx =
+            if (ldelimIdxOpt >= 0) ldelimIdxOpt else session.claim(null)
           leftDelimIndex.prepend(ldelimIdx)
 
         case _: T.CloseDelim =>
@@ -190,7 +192,7 @@ class FormatTokensRewrite(
           if (lfmtOff && formatOffStack.nonEmpty) formatOffStack.update(0, true)
           val left = tokens(ldelimIdx)
           if (left ne null) {
-            val ko = formatOff || session.claimedRule.exists(_.rule ne left.rule)
+            val ko = formatOff || session.claimedRule.nnHas(_.rule ne left.rule)
             if (ko) session(ldelimIdx) = null
             else left.onRightAndClaim(lfmtOff, ldelimIdx)
           }
@@ -199,7 +201,8 @@ class FormatTokensRewrite(
         // below, only non-paired tokens
 
         case _ if !formatOff =>
-          applyRules.foreach(tx => afterRight(tokens(tx), tx))
+          val tx = applyRules
+          if (tx >= 0) afterRight(tokens(tx), tx)
 
         case _: T.Comment => // formatOff gets set only by comment
           if (formatOffStack.nonEmpty) formatOffStack.update(0, true)
@@ -230,7 +233,7 @@ class FormatTokensRewrite(
         }
       ) {}
 
-      if (!formatOff) session.applyAppendRules(rules).foreach { repl =>
+      if (!formatOff) session.applyAppendRules(rules).nnFor { repl =>
         session.append(repl)
         afterRight(repl, tokens.length - 1)
       }
@@ -256,13 +259,13 @@ object FormatTokensRewrite {
         ft: FT,
         session: Session,
         style: ScalafmtConfig,
-    ): Option[Replacement]
+    ): Replacement
     // act on or modify only ft.right; process close (right) delim
     def onRight(left: Replacement, hasFormatOff: Boolean)(implicit
         ft: FT,
         session: Session,
         style: ScalafmtConfig,
-    ): Option[(Replacement, Replacement)]
+    ): (Replacement, Replacement)
 
     protected final def removeToken(implicit
         ft: FT,
@@ -279,20 +282,20 @@ object FormatTokensRewrite {
 
     protected final def replaceToken(
         text: String,
-        owner: Option[Tree] = None,
+        owner: Tree = null,
         claim: Iterable[Int] = Nil,
         rtype: ReplacementType = ReplacementType.Replace,
-        afterRight: Option[Int] = None,
+        afterRight: Int = -1,
     )(tok: T)(implicit ft: FT, style: ScalafmtConfig): Replacement = {
       val mOld = ft.meta.right
-      val mNew = mOld.copy(text = text, owner = owner.getOrElse(mOld.owner))
+      val mNew = mOld.copy(text = text, owner = owner ?? mOld.owner)
       val ftNew = ft.copy(right = tok, meta = ft.meta.copy(right = mNew))
       Replacement(this, ftNew, rtype, style, claim, afterRight)
     }
 
     protected final def replaceTokenBy(
         text: String,
-        owner: Option[Tree] = None,
+        owner: Tree = null,
         claim: Iterable[Int] = Nil,
         rtype: ReplacementType = ReplacementType.Replace,
     )(f: T => T)(implicit ft: FT, style: ScalafmtConfig): Replacement =
@@ -312,7 +315,7 @@ object FormatTokensRewrite {
         ft: FT,
         session: Session,
         style: ScalafmtConfig,
-    ): Option[Replacement]
+    ): Replacement
   }
 
   private[rewrite] trait RuleFactory {
@@ -400,33 +403,32 @@ object FormatTokensRewrite {
       }
     }
 
-    def getClaimed(ftIdx: Int): Option[(Int, Replacement)] =
-      claimed.get(ftIdx) match {
-        case Some(x) =>
-          val repl = tokens(x)
-          val ok = (repl eq null) || repl.idx == ftIdx
-          if (ok) Some((x, repl)) else None
-        case _ => None
-      }
+    def getClaimed(ftIdx: Int): (Int, Replacement) = claimed.get(ftIdx) match {
+      case Some(x) =>
+        val repl = tokens(x)
+        val ok = (repl eq null) || repl.idx == ftIdx
+        if (ok) (x, repl) else null
+      case _ => null
+    }
 
     @inline
-    def claimedRule(implicit ft: FT): Option[Replacement] =
-      claimedRule(ft.meta.idx)
+    def claimedRule(implicit ft: FT): Replacement = claimedRule(ft.meta.idx)
 
     @inline
-    def claimedRuleOnLeft(ft: FT): Option[Replacement] =
-      claimedRule(ft.meta.idx - 1)
+    def claimedRuleOnLeft(ft: FT): Replacement = claimedRule(ft.meta.idx - 1)
 
     @inline
-    def claimedRule(ftIdx: Int): Option[Replacement] = claimed.get(ftIdx)
-      .map(tokens.apply).filter(_ ne null)
+    def claimedRule(ftIdx: Int): Replacement = claimed.get(ftIdx) match {
+      case Some(idx) => tokens(idx)
+      case _ => null
+    }
 
     @inline
     def claim(repl: Replacement)(implicit ft: FT): Int = {
       if (repl ne null) repl.how match {
         case rt: ReplacementType.RemoveAndResurrect =>
           getClaimed(rt.idx) match {
-            case Some((oidx, x)) if x != null && x.isRemove =>
+            case (oidx, x) if x != null && x.isRemove =>
               this(oidx) = repl.copy(ft = repl.ft.withIdx(rt.idx))
             case _ =>
           }
@@ -459,24 +461,26 @@ object FormatTokensRewrite {
 
     private[FormatTokensRewrite] def applyRule(
         attemptedRule: Rule,
-    )(implicit ft: FT, style: ScalafmtConfig): Option[Int] =
-      if (attemptedRule.enabled) attemptedRule.onToken.map { repl =>
-        val idx = claim(repl)
-        repl.claim.foreach(claimed.getOrElseUpdate(_, idx))
-        idx
-      }
-      else None
+    )(implicit ft: FT, style: ScalafmtConfig): Int =
+      if (attemptedRule.enabled) {
+        val repl = attemptedRule.onToken
+        if (repl eq null) -1
+        else {
+          val idx = claim(repl)
+          repl.claim.foreach(claimed.getOrElseUpdate(_, idx))
+          idx
+        }
+      } else -1
 
     private[FormatTokensRewrite] def applyRules(
         rules: Seq[Rule],
-    )(implicit ft: FT, style: ScalafmtConfig): Option[Int] = {
+    )(implicit ft: FT, style: ScalafmtConfig): Int = {
       @tailrec
-      def iter(remainingRules: Seq[Rule]): Option[Int] = remainingRules match {
-        case r +: rs => applyRule(r) match {
-            case None => iter(rs)
-            case x => x
-          }
-        case _ => None
+      def iter(remainingRules: Seq[Rule]): Int = remainingRules match {
+        case r +: rs =>
+          val res = applyRule(r)
+          if (res >= 0) res else iter(rs)
+        case _ => -1
       }
       iter(rules)
     }
@@ -484,31 +488,35 @@ object FormatTokensRewrite {
     @tailrec
     private[FormatTokensRewrite] final def applyAppendRules(
         rules: Seq[Rule],
-    )(implicit ft: FT, style: ScalafmtConfig): Option[Replacement] = rules match {
+    )(implicit ft: FT, style: ScalafmtConfig): Replacement = rules match {
       case r +: rs => r match {
           case r: RuleWithAppend if r.enabled =>
             val res = r.appendOnToken
-            if (res.isEmpty) applyAppendRules(rs) else res
+            if (res eq null) applyAppendRules(rs) else res
           case _ => applyAppendRules(rs)
         }
-      case _ => None
+      case _ => null
     }
 
-    def rule[A <: Rule](implicit
+    def rule[A >: Null <: Rule](implicit
         tag: ClassTag[A],
         sc: ScalafmtConfig,
-    ): Option[A] = {
-      val ruleOpt = rules.find(tag.runtimeClass.isInstance)
-      ruleOpt.map(_.asInstanceOf[A]).filter(_.enabled)
+    ): A = rules.find(tag.runtimeClass.isInstance) match {
+      case Some(x) =>
+        val rule = x.asInstanceOf[A]
+        if (rule.enabled) rule else null
+      case _ => null
     }
 
-    def isRemovedOnLeftOpt(x: FT): Option[Boolean] = {
+    def isRemovedOnLeftOpt(x: FT): MaybeBool = {
       val ftIdx = x.meta.idx - 1
-      claimedRule(ftIdx).filter(_.idx == ftIdx).map(_.isRemove)
+      val repl = claimedRule(ftIdx)
+      if ((repl eq null) || repl.idx != ftIdx) MaybeBool.Maybe
+      else MaybeBool(repl.isRemove)
     }
 
     def isRemovedOnLeft(x: FT, ok: Boolean): Boolean = isRemovedOnLeftOpt(x)
-      .contains(ok)
+      .getBoolean(!ok) == ok
 
   }
 
@@ -519,7 +527,7 @@ object FormatTokensRewrite {
       style: ScalafmtConfig,
       // list of FT indices, with the claimed token on the **right**
       claim: Iterable[Int] = Nil,
-      afterRight: Option[Int] = None,
+      afterRight: Int = -1,
   ) extends WithSpan {
     def getSpanDelta(implicit session: Session): Int = how.getSpanDelta(ft)
     def copySpanFrom(other: WithSpan, span: Int = 0, gap: Int = 0): Unit = {
@@ -536,8 +544,8 @@ object FormatTokensRewrite {
         ft: FT,
         session: Session,
         style: ScalafmtConfig,
-    ): Option[(Replacement, Replacement)] =
-      if (rule.enabled) rule.onRight(this, hasFormatOff) else None
+    ): (Replacement, Replacement) =
+      if (rule.enabled) rule.onRight(this, hasFormatOff) else null
 
     private[FormatTokensRewrite] def onRightOrNull(
         hasFormatOff: Boolean,
@@ -545,7 +553,7 @@ object FormatTokensRewrite {
         ft: FT,
         session: Session,
         style: ScalafmtConfig,
-    ): (Replacement, Replacement) = onRight(hasFormatOff).getOrElse((null, null))
+    ): (Replacement, Replacement) = onRight(hasFormatOff) ?? (null, null)
 
     def onRightAndClaim(hasFormatOff: Boolean, leftIdx: Int)(implicit
         ft: FT,
@@ -589,23 +597,20 @@ object FormatTokensRewrite {
     }
   }
 
-  private def mergeWhitespaceLeftToRight(
-      lt: FT.Meta,
-      rt: FT.Meta,
-  ): Option[Array[T]] = {
+  private def mergeWhitespaceLeftToRight(lt: FT.Meta, rt: FT.Meta): Array[T] = {
     import FT.isNL
     val rtBW = rt.between
     val rtNumNL = rt.newlinesBetween
-    if (rtNumNL >= 2) None // right has a blank line, nothing to get from left
+    if (rtNumNL >= 2) null // right has a blank line, nothing to get from left
     else {
       val ltBW = lt.between
-      if (rtNumNL >= lt.newlinesBetween) None // right has at least as many newlines
+      if (rtNumNL >= lt.newlinesBetween) null // right has at least as many newlines
       else {
         // left has more newlines than right (so it's non-empty)
         /* for special comment handling: if right ends in a newline, we must
          * end in a newline as well; otherwise, append at least one space */
         val rtEndsInNL = rtNumNL != 0 && isNL(rtBW.last)
-        if (rtEndsInNL == isNL(ltBW.last)) Some(ltBW)
+        if (rtEndsInNL == isNL(ltBW.last)) ltBW
         else {
           val numNL = math.min(2, ltBW.count(isNL))
           val arr = new Array[T](numNL + (if (rtEndsInNL) 0 else 1))
@@ -616,7 +621,7 @@ object FormatTokensRewrite {
             val lastNL = arr(numNL - 1)
             new T.Space(lastNL.input, lastNL.dialect, lastNL.start + 1)
           }
-          Some(arr)
+          arr
         }
       }
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config._
 import org.scalafmt.util._
@@ -35,8 +36,8 @@ object Imports extends RewriteFactory {
 
     def noGroups: Boolean = sort.eq(Sort.none) && numGroups == 0
 
-    def group(str: String): Int = regex.find(_._1.matcher(str).matches())
-      .fold(numGroups)(_._2)
+    def group(str: String): Int = regex.findOrNull(_._1.matcher(str).matches())
+      .nnFold(numGroups)(_._2)
   }
 
   object Settings {
@@ -72,14 +73,14 @@ object Imports extends RewriteFactory {
   override def hasChanged(v1: RewriteSettings, v2: RewriteSettings): Boolean =
     v1.imports ne v2.imports
 
-  override def create(implicit ctx: RewriteCtx): Option[RewriteSession] = {
+  override def create(implicit ctx: RewriteCtx): RewriteSession = {
     val settings = ctx.style.rewrite.imports
     val selectors = ctx.style.importSelectorsRewrite
-    if (selectors eq Newlines.unfold) Some(new ExpandFull)
-    else if (selectors eq Newlines.fold) Some(new Fold)
-    else if (settings.numGroups != 0) Some(new ExpandPart)
-    else if (settings.sort ne Sort.none) Some(new ExpandNone)
-    else None
+    if (selectors eq Newlines.unfold) new ExpandFull
+    else if (selectors eq Newlines.fold) new Fold
+    else if (settings.numGroups != 0) new ExpandPart
+    else if (settings.sort ne Sort.none) new ExpandNone
+    else null
   }
 
   private val allImportRules: Set[Rewrite] =
@@ -137,7 +138,7 @@ object Imports extends RewriteFactory {
       raw: String,
       importees: Seq[Importee],
       commentsBefore: Seq[T] = Seq.empty,
-      commentAfter: Option[T] = None,
+      commentAfter: T = null,
   )
 
   private class Grouping(
@@ -396,9 +397,10 @@ object Imports extends RewriteFactory {
           sb.append(x.text).appendNL
         }
         sb.append(selectorString)
-        commentAfter.foreach(x => sb.append(' ').append(x.text).appendNL)
+        if (commentAfter ne null) sb.append(' ').append(commentAfter.text)
+          .appendNL
         val pretty = sb.append('}').result()
-        val hadComments = commentsBefore.nonEmpty || commentAfter.isDefined
+        val hadComments = commentsBefore.nonEmpty || (commentAfter ne null)
         Selectors(
           pretty,
           if (needRaw && hadComments) s"{$selector}" else pretty,
@@ -435,9 +437,9 @@ object Imports extends RewriteFactory {
           }
           sb.append(selectorString)
           if (index != selectorCount) sb.append(',')
-          commentAfter.foreach { x =>
+          if (commentAfter ne null) {
             hadComments = true
-            sb.append(' ').append(x).appendNL
+            sb.append(' ').append(commentAfter).appendNL
           }
         }
         val pretty = sb.append('}').result()
@@ -489,24 +491,21 @@ object Imports extends RewriteFactory {
       ctx.tokenTraverser.nextNonTrivialToken(x.tokens.last).is[T.RightArrow],
     )
 
-    protected final def getCommentsAround(tree: Tree): (Seq[T], Option[T]) = {
-      val tokens = tree.tokens
-      val beg = getCommentsBefore(tokens)
-      val end = getCommentAfter(tokens)
-      beg -> end
-    }
+    protected final def getCommentsAround(tree: Tree): (Seq[T], T) =
+      getCommentsBefore(tree.tokens) -> getCommentAfter(tree)
 
     protected final def getCommentsBefore(tok: T): Seq[T] = {
       var hadLf = false
       val slc = new ListBuffer[T]
       ctx.tokenTraverser.findAtOrBefore(ctx.getIndex(tok) - 1) {
         case t: T.AtEOL =>
-          if (hadLf || t.newlines > 1) Some(true) else { hadLf = true; None }
+          if (hadLf || t.newlines > 1) MaybeBool.True
+          else { hadLf = true; MaybeBool.Maybe }
         case t: T.Comment if TokenOps.isSingleLineIfComment(t) =>
-          slc.prepend(t); hadLf = false; None
-        case _: T.Whitespace => None
-        case _: T.LeftBrace => Some(false)
-        case _ => if (!hadLf && slc.nonEmpty) slc.remove(0); Some(false)
+          slc.prepend(t); hadLf = false; MaybeBool.Maybe
+        case _: T.Whitespace => MaybeBool.Maybe
+        case _: T.LeftBrace => MaybeBool.False
+        case _ => if (!hadLf && slc.nonEmpty) slc.remove(0); MaybeBool.False
       }
       slc.result()
     }
@@ -514,15 +513,15 @@ object Imports extends RewriteFactory {
     protected final def getCommentsBefore(tokens: Tokens): Seq[T] =
       getCommentsBefore(tokens.head)
 
-    protected final def getCommentAfter(tok: T): Option[T] = ctx.tokenTraverser
+    protected final def getCommentAfter(tok: T): T = ctx.tokenTraverser
       .findAtOrAfter(ctx.getIndex(tok) + 1) {
-        case _: T.HSpace | _: T.Comma => None
-        case t: T.Comment => Some(TokenOps.isSingleLineIfComment(t))
-        case _ => Some(false)
+        case _: T.HSpace | _: T.Comma => MaybeBool.Maybe
+        case t: T.Comment => MaybeBool(TokenOps.isSingleLineIfComment(t))
+        case _ => MaybeBool.False
       }
 
-    protected final def getCommentAfter(tokens: Tokens): Option[T] =
-      getCommentAfter(tokens.last)
+    protected final def getCommentAfter(tree: Tree): T =
+      getCommentAfter(tree.tokens.last)
 
     private val eol = LineEndings
       .eol(ctx.style.lineEndings.contains(LineEndings.windows))
@@ -598,7 +597,7 @@ object Imports extends RewriteFactory {
           val pTokens = p.tokens
           val isHead = newSeen.contains(1)
           val isLast = newSeen.contains(p.importees.length)
-          if (isLast) getCommentAfter(pTokens).foreach(appendTailComment)
+          if (isLast) getCommentAfter(p).nnFor(appendTailComment)
           p.parent match {
             case Some(pp: ImportExportStat) =>
               if (isHead && pp.importers.headOption.contains(p))
@@ -634,13 +633,16 @@ object Imports extends RewriteFactory {
             importees.foreach(processImporteeComments(appendTailComment))
             commentsBefore.foreach(appendComment)
             val commentsAfter = commentsAfterBuilder.result().iterator
-            val trailingComment = commentAfter.orElse(commentsAfter.nextOption())
+            val trailingComment = commentAfter ?? {
+              if (commentsAfter.hasNext) commentsAfter.next() else null
+            }
             commentsAfter.foreach(comment =>
-              if (!commentAfter.contains(comment)) appendComment(comment),
+              if (commentAfter ne comment) appendComment(comment),
             )
             appendIndent()
             sb.append(stat)
-            trailingComment.foreach(x => sb.append(' ').append(x.text))
+            if (trailingComment ne null) sb.append(' ')
+              .append(trailingComment.text)
             sb.appendNL
           }
         }
@@ -661,7 +663,7 @@ object Imports extends RewriteFactory {
       val lastTok = x.last.tokens.last
       (
         getCommentsBefore(headTok).headOption.getOrElse(headTok),
-        getCommentAfter(lastTok).getOrElse(lastTok),
+        getCommentAfter(lastTok) ?? lastTok,
       )
     }
 
@@ -938,7 +940,7 @@ object Imports extends RewriteFactory {
 }
 
 abstract class ShouldUseImports extends RewriteFactory {
-  override final def create(implicit ctx: RewriteCtx): Option[RewriteSession] =
+  override final def create(implicit ctx: RewriteCtx): RewriteSession =
     throw new NotImplementedError("should use Imports")
 }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/PreferCurlyFors.scala
@@ -1,10 +1,13 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal._
 
 import scala.meta._
 import scala.meta.tokens.{Token => T}
+
+import scala.annotation.tailrec
 
 import metaconfig._
 
@@ -69,57 +72,59 @@ private class PreferCurlyFors(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = Option {
-    ft.right match {
-      case x: T.LeftParen if (ft.meta.rightOwner match {
-            case t: Term.EnumeratorsBlock if hasMultipleNonGuardEnums(t) =>
-              style.dialect.allowInfixOperatorAfterNL || hasNoLeadingInfix(t)
-            case _ => false
-          }) => replaceToken("{")(new T.LeftBrace(x.input, x.dialect, x.start))
+  ): Replacement = ft.right match {
+    case x: T.LeftParen if (ft.meta.rightOwner match {
+          case t: Term.EnumeratorsBlock if hasMultipleNonGuardEnums(t) =>
+            style.dialect.allowInfixOperatorAfterNL || hasNoLeadingInfix(t)
+          case _ => false
+        }) => replaceToken("{")(new T.LeftBrace(x.input, x.dialect, x.start))
 
-      case _: T.Semicolon
-          if !settings.removeTrailingSemicolonsOnly ||
-            hasBreakAfterRightBeforeNonComment(ft) =>
-        ft.meta.rightOwner match {
-          case t: Term.EnumeratorsBlock
-              if nextNonCommentAfter(ft).right.is[T.KwIf] || {
-                val parenOrBrace = tokenJustBefore(t)
-                parenOrBrace.right.is[T.LeftBrace] ||
-                session.claimedRule(parenOrBrace).exists(_.rule eq this)
-              } => removeToken
-          case _ => null
-        }
+    case _: T.Semicolon
+        if !settings.removeTrailingSemicolonsOnly ||
+          hasBreakAfterRightBeforeNonComment(ft) =>
+      ft.meta.rightOwner match {
+        case t: Term.EnumeratorsBlock
+            if nextNonCommentAfter(ft).right.is[T.KwIf] || {
+              val parenOrBrace = tokenJustBefore(t)
+              parenOrBrace.right.is[T.LeftBrace] ||
+              session.claimedRule(parenOrBrace).nnHas(_.rule eq this)
+            } => removeToken
+        case _ => null
+      }
 
-      case _ => null
-    }
+    case _ => null
   }
 
   override def onRight(left: Replacement, hasFormatOff: Boolean)(implicit
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = ft.right match {
+  ): (Replacement, Replacement) = ft.right match {
     case x: T.RightParen
         if left.how == ReplacementType.Replace &&
           left.ft.right.is[T.LeftBrace] =>
       val right = replaceToken("}")(new T.RightBrace(x.input, x.dialect, x.start))
-      Some((left, right))
-    case _ => None
+      (left, right)
+    case _ => null
   }
 
-  private def hasNoLeadingInfix(t: Term.EnumeratorsBlock)(implicit
-      head: FT,
-  ): Boolean = findTokenWith(nextNonCommentAfter(head), next)(ft =>
-    ft.meta.rightOwner match {
+  private def hasNoLeadingInfix(
+      t: Term.EnumeratorsBlock,
+  )(implicit head: FT): Boolean = {
+    @tailrec
+    def iter(ft: FT): Boolean = ft.meta.rightOwner match {
       case ro: Name if (ro.parent match {
             case Some(p: Member.Infix)
                 if (p.op eq ro) && ft.right.is[T.Ident] =>
               prevNonCommentSameLine(ft).hasBreak
             case _ => false
-          }) => Some(false)
-      case `t` if ft.right.is[T.RightParen] => Some(true) // closing delimiter
-      case _ => None
-    },
-  ).contains(true)
+          }) => false
+      case `t` if ft.right.is[T.RightParen] => true // closing delimiter
+      case _ =>
+        val nextFt = next(ft)
+        (nextFt ne ft) && iter(nextFt)
+    }
+    iter(nextNonCommentAfter(head))
+  }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ProcedureSyntax.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ProcedureSyntax.scala
@@ -6,8 +6,8 @@ import scala.meta._
 import scala.meta.tokens.{Token => T}
 
 object ProcedureSyntax extends RewriteFactory {
-  override def create(implicit ctx: RewriteCtx): Option[RewriteSession] =
-    if (ctx.dialect.allowProcedureSyntax) Some(new ProcedureSyntax) else None
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    if (ctx.dialect.allowProcedureSyntax) new ProcedureSyntax else null
 }
 
 class ProcedureSyntax private (implicit ctx: RewriteCtx)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config._
 import org.scalafmt.internal._
@@ -43,18 +44,18 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
       stat: Tree,
   )(implicit ftoks: FormatTokens): Boolean = {
     @tailrec
-    def stripTopBlock(tree: Tree): Option[Tree] = tree match {
+    def stripTopBlock(tree: Tree): Tree = tree match {
       case Term.Block(s :: Nil)
           if (tree ne stat) || !ftoks.tokenAfter(s).right.is[T.Semicolon] =>
         stripTopBlock(s)
-      case _: Term.Block => None
+      case _: Term.Block => null
       /* guard for statements requiring a wrapper block
        * "foo { x => y; z }" can't become "foo(x => y; z)"
        * "foo { x1 => x2 => y; z }" can't become "foo(x1 => x2 => y; z)"
        */
       case t: Term.FunctionLike =>
-        if (needParensAroundParams(t)) None else stripTopBlock(t.body)
-      case _ => Some(tree)
+        if (needParensAroundParams(t)) null else stripTopBlock(t.body)
+      case _ => tree
     }
     @tailrec
     def iter(trees: List[Tree]): Boolean = trees match {
@@ -72,7 +73,7 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
         }
       case _ => true
     }
-    stripTopBlock(stat).exists(t => iter(t :: Nil))
+    stripTopBlock(stat).nnHas(t => iter(t :: Nil))
   }
 
   private def checkApply(t: Tree): Boolean = t.parent match {
@@ -88,7 +89,7 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
         b.parent.exists(ftoks.getLast(_) eq rb)
       case f: Term.FunctionLike => checkApply(f) && canRewriteStatWithParens(f)
       case t @ Term.ArgClause(arg :: Nil, _) => isParentAnApply(t) &&
-        ftoks.getDelimsIfEnclosed(t).exists(_._2 eq rb) &&
+        ftoks.getDelimsIfEnclosed(t).nnHas(_._2 eq rb) &&
         canRewriteStatWithParens(arg)
       case _ => false
     })
@@ -98,7 +99,7 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
 
   private[scalafmt] def isLeftParenReplacedWithBraceOnLeft(pft: FT)(implicit
       session: Session,
-  ): Boolean = session.claimedRuleOnLeft(pft).exists(isReplacedWithBrace)
+  ): Boolean = session.claimedRuleOnLeft(pft).nnHas(isReplacedWithBrace)
 
   private def okLineSpan(tree: Tree)(implicit style: ScalafmtConfig): Boolean =
     getTreeLineSpan(tree) <= settings.maxBreaks
@@ -117,10 +118,10 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
   )(implicit style: ScalafmtConfig): Boolean =
     isDefnBodiesEnabled(noParams = false) &&
       (getTreeSingleStat(b) match {
-        case Some(_: Term.PartialFunction) => false
-        case Some(_: Term.Block) => true
-        case Some(s) => okLineSpan(s)
-        case _ => okIfMultipleStats
+        case _: Term.PartialFunction => false
+        case _: Term.Block => true
+        case null => okIfMultipleStats
+        case s => okLineSpan(s)
       })
 
   @inline
@@ -130,7 +131,7 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
 
   private def getSingleStatIfLineSpanOk(b: Term.Block)(implicit
       style: ScalafmtConfig,
-  ): Option[Stat] = getBlockSingleStat(b).filter(okLineSpan(_))
+  ): Stat = getBlockSingleStat(b).nnIf(okLineSpan(_))
 
   @tailrec
   private[rewrite] def okCommentBeforeClose(
@@ -161,17 +162,17 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = Option(ft.right match {
+  ): Replacement = ft.right match {
     case _: T.LeftBrace => onLeftBrace
     case _: T.LeftParen => onLeftParen
     case _ => null
-  })
+  }
 
   override def onRight(left: Replacement, hasFormatOff: Boolean)(implicit
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = {
+  ): (Replacement, Replacement) = {
     def okBeforeBrace = {
       val pft = ftoks.prevNonComment(ft)
       def isRemoved = session.isRemovedOnLeft(pft, ok = true)
@@ -181,24 +182,24 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
         case _ => true
       }
     }
-    Option(ft.right match {
+    ft.right match {
       case _: T.RightBrace if okBeforeBrace => onRightBrace(left)
       case _: T.RightParen => onRightParen(left, hasFormatOff)
       case _ => null
-    })
+    }
   }
 
   private def onLeftParen(implicit ft: FT, style: ScalafmtConfig): Replacement = {
     val rt = ft.right
 
-    def replaceWithBrace(claim: List[Int] = Nil, owner: Option[Tree] = None) = {
+    def replaceWithBrace(claim: List[Int] = Nil, owner: Tree = null) = {
       val lb = new T.LeftBrace(rt.input, rt.dialect, rt.start)
       replaceToken("{", owner = owner, claim = claim)(lb)
     }
 
     ft.rightOwner match {
       case ta @ Term.ArgClause(arg :: Nil, None)
-          if !ta.parent.is[Init] && getOpeningParen(ta).contains(rt) =>
+          if !ta.parent.is[Init] && (getOpeningParen(ta) eq rt) =>
         val lp = ftoks.next(ft)
         def useDelim = settings.oneStatApply.changeDelim(lp, ftoks.getLast(ta))
         def shouldReplaceWithBrace(s: Stat): Boolean = s match {
@@ -212,11 +213,11 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
             case FT(lt, _: T.LeftBrace, m) =>
               val claim = m.idx :: claimToo
               if (lt eq rt) removeToken(claim = claim)
-              else replaceWithBrace(owner = Some(m.rightOwner), claim = claim)
-            case _ => replaceWithBrace(owner = Some(arg), claim = claimToo)
+              else replaceWithBrace(owner = m.rightOwner, claim = claim)
+            case _ => replaceWithBrace(owner = arg, claim = claimToo)
           }
         def rewriteFunction(f: Term.FunctionLike)(shouldMoveBrace: => Boolean) =
-          getBlockToReplaceAsFuncBodyInSingleArgApply(ta, f).fold(
+          getBlockToReplaceAsFuncBodyInSingleArgApply(ta, f).nnFold(
             if (!shouldMoveBrace) null
             else if (f eq arg) replaceWithBrace()
             else replaceWithNextBrace(),
@@ -250,9 +251,8 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
                   case _ => blockCantBeStripped || blockWontBeStripped
                 })
             getTreeSingleExpr(b) match {
-              case Some(f: Term.FunctionLike) =>
-                rewriteFunction(f)(shouldMoveBrace(f))
-              case Some(s: Term) if !shouldMoveBrace(s) => null
+              case f: Term.FunctionLike => rewriteFunction(f)(shouldMoveBrace(f))
+              case s: Term if !shouldMoveBrace(s) => null
               case _ => replaceWithNextBrace()
             }
           case f: Term.FunctionLike =>
@@ -271,15 +271,13 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       style: ScalafmtConfig,
   ): (Replacement, Replacement) = left.how match {
     case ReplacementType.Remove =>
-      getRightBraceBeforeRightParen(shouldBeRemoved = false).map { rb =>
+      getRightBraceBeforeRightParen(shouldBeRemoved = false).nnMap { rb =>
         ft.rightOwner match {
-          case ac: Term.ArgClause => ftoks.matchingOptLeft(rb).foreach(lbr =>
-              session.rule[RemoveScala3OptionalBraces].foreach { r =>
+          case ac: Term.ArgClause => ftoks.matchingLeftOrNull(rb).nnFor(lbr =>
+              session.rule[RemoveScala3OptionalBraces].nnFor { r =>
                 val lb = ftoks.prev(lbr)
-                session.getClaimed(lb.idx).foreach { case (leftIdx, lbRepl) =>
-                  val orepl = if (lbRepl ne null) lbRepl else left
-                  val repl = r.onLeftForArgClause(lb, orepl)(ac)
-                  if (null ne repl) {
+                session.getClaimed(lb.idx).nnFor { case (leftIdx, lbRepl) =>
+                  r.onLeftForArgClause(lb, lbRepl ?? left)(ac).nnFor { repl =>
                     implicit val ft: FT = ftoks.prev(rb)
                     repl.advanceSpan(ft) // instead of removing from session
                     repl.onRightAndClaim(hasFormatOff, leftIdx)
@@ -290,18 +288,18 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
           case _ =>
         }
         (left, removeToken)
-      }.orNull
+      }
 
     case ReplacementType.Replace if left.ft.right.is[T.LeftBrace] =>
       // this also removes any trailing commas, so can't be conditionally invoked
       val pftOpt = getRightBraceBeforeRightParen(shouldBeRemoved = true)
       def replaceWithBrace(rb: T, rtype: ReplacementType, startOff: Int = 0) = {
-        val rbo = Some(left.ft.rightOwner)
+        val rbo = left.ft.rightOwner
         left -> replaceToken("}", owner = rbo, rtype = rtype)(
           new T.RightBrace(rb.input, rb.dialect, rb.start + startOff),
         )
       }
-      def replaceIfAfterRightBrace = pftOpt.map { pft =>
+      def replaceIfAfterRightBrace = pftOpt.nnMap { pft =>
         val rb = pft.left
         // move right to the end of the function
         val rType = new ReplacementType.RemoveAndResurrect(pft.idx - 1)
@@ -310,23 +308,21 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       }
       (ft.rightOwner match {
         case ac: Term.ArgClause => session.rule[RemoveScala3OptionalBraces]
-            .flatMap { r =>
+            .nnMap { r =>
               val repl = r.onLeftForArgClause(left.ft, left)(ac)
-              if (repl eq null) None else repl.onRight(hasFormatOff)
-            }.orElse(
-              if (left.claim.nonEmpty) None
-              else Some(replaceWithBrace(ft.right, ReplacementType.Replace)),
-            )
-        case _ => None
-      }).getOrElse(
-        replaceIfAfterRightBrace.orNull, // don't know how to Replace
-      )
+              if (repl eq null) null else repl.onRight(hasFormatOff)
+            } ?? {
+            if (left.claim.nonEmpty) null
+            else replaceWithBrace(ft.right, ReplacementType.Replace)
+          }
+        case _ => null
+      }) ?? replaceIfAfterRightBrace // don't know how to Replace
     case _ => null
   }
 
   private def getRightBraceBeforeRightParen(
       shouldBeRemoved: Boolean,
-  )(implicit ft: FT, session: Session, style: ScalafmtConfig): Option[FT] = {
+  )(implicit ft: FT, session: Session, style: ScalafmtConfig): FT = {
     @inline
     def isRemovedOnLeft(xft: FT): Boolean = session
       .isRemovedOnLeft(xft, ok = true)
@@ -340,15 +336,17 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
     val pft = ftoks.prevNonComment(ft)
     val ok =
       if (pft.left.is[T.Comma]) // looks like trailing comma
-        checkBrace(ftoks.prevNonCommentBefore(pft)) &&
-        session.isRemovedOnLeftOpt(pft).getOrElse {
-          val crt = ftoks.prev(pft)
-          val crepl = Replacement(this, crt, ReplacementType.Remove, style)
-          session.claim(crepl)(crt)
-          true
+        checkBrace(ftoks.prevNonCommentBefore(pft)) && {
+          val ok = session.isRemovedOnLeftOpt(pft)
+          if (ok eq MaybeBool.Maybe) {
+            val crt = ftoks.prev(pft)
+            val crepl = Replacement(this, crt, ReplacementType.Remove, style)
+            session.claim(crepl)(crt)
+          }
+          ok ne MaybeBool.False
         }
       else checkBrace(pft)
-    if (ok) Some(pft) else None
+    if (ok) pft else null
   }
 
   private def onLeftBrace(implicit
@@ -374,11 +372,11 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
             removeToken
           case _: T.LeftBrace
               if owner.parent.contains(pft.leftOwner) && okLineSpan(t) &&
-                findTreeWithParentEx(owner) {
-                  case p: Term.Block => Some(p)
-                  case _: Term.ArgClause => None
-                  case _ => Some(null)
-                }.isEmpty => removeToken
+                (findTreeWithParentEx(owner) {
+                  case p: Term.Block => p
+                  case _: Term.ArgClause => Tree.NoTree
+                  case _ => null
+                } eq null) => removeToken
           case _ => null
         }
       case t: Term.Block => t.parent match {
@@ -389,15 +387,15 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
               .changeDelim(head, ftoks.getLast(p)) eq T.LeftParen
             if (head.left ne ft.right) { // it was a left paren
               val keepBrace = session.claimedRuleOnLeft(head)
-                .exists(_.isRemove) || !useParens && !okLineSpan(t)
+                .nnHas(_.isRemove) || !useParens && !okLineSpan(t)
               if (keepBrace) null else removeToken
             } else // arg clause is this block
-            if (useParens) replaceTokenBy("(", Some(p))(x =>
+            if (useParens) replaceTokenBy("(", p)(x =>
               new T.LeftParen(x.input, x.dialect, x.start),
             )
             else null
           case Some(f: Term.FunctionLike)
-              if getBlockToReplaceAsFuncBodyIfInSingleArgApply(f).exists {
+              if getBlockToReplaceAsFuncBodyIfInSingleArgApply(f).nnHas {
                 case (_, xft) => xft.idx <= ft.idx + 1
               } => removeToken
           case Some(_: Term.Interpolate) => handleInterpolation
@@ -422,7 +420,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
             okLineSpan(t) =>
         val prevIsEquals = ftoks.prevNonComment(ft).left.is[T.Equals]
         if (prevIsEquals) removeToken
-        else replaceTokenBy("=", t.parent)(x =>
+        else replaceTokenBy("=", t.parentOrNull)(x =>
           new T.Equals(x.input, x.dialect, x.start),
         )
       case _ => null
@@ -460,8 +458,8 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
                   okCommentBeforeClose(ft) &&
                   !elseAfterRightBraceThenpOnLeft) => (left, removeToken)
           case ReplacementType.Replace => left.ft.right match {
-              case _: T.LeftParen => left -> replaceTokenBy(")", t.parent)(x =>
-                  new T.RightParen(x.input, x.dialect, x.start),
+              case _: T.LeftParen => left -> replaceTokenBy(")", t.parentOrNull)(
+                  x => new T.RightParen(x.input, x.dialect, x.start),
                 )
               case _: T.Equals if okSemicolon(t) || okCommentBeforeClose(ft) =>
                 (left, removeToken)
@@ -501,10 +499,10 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
     })
   }
 
-  private def getOpeningParen(t: Term.ArgClause): Option[T.LeftParen] =
+  private def getOpeningParen(t: Term.ArgClause): T.LeftParen =
     ftoks.getHead(t).left match {
-      case lp: T.LeftParen => Some(lp)
-      case _ => None
+      case lp: T.LeftParen => lp
+      case _ => null
     }
 
   // single-arg apply of a lambda
@@ -513,47 +511,40 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
   private def getBlockToReplaceAsFuncBodyInSingleArgApply(
       ta: Term.ArgClause,
       func: Term.FunctionLike,
-  )(implicit
-      style: ScalafmtConfig,
-      ftoks: FormatTokens,
-  ): Option[(Term.Block, FT)] = {
+  )(implicit style: ScalafmtConfig, ftoks: FormatTokens): (Term.Block, FT) = {
     @tailrec
-    def iter(body: Tree): Option[(Term.Block, FT)] = body match {
+    def iter(body: Tree): (Term.Block, FT) = body match {
       case b: Term.Block => ftoks.getDelimsIfEnclosed(b) match {
-          case Some((lb, _)) =>
-            if (!lb.left.is[T.LeftBrace]) None
+          case (lb, _) =>
+            if (!lb.left.is[T.LeftBrace]) null
             else {
               val lbo = lb.leftOwner
-              if (lbo eq b) Some((b, lb)) else iter(lbo)
+              if (lbo eq b) (b, lb) else iter(lbo)
             }
-          case None => b.stats match {
+          case null => b.stats match {
               case (s: Term) :: Nil => iter(s)
-              case _ => None
+              case _ => null
             }
         }
       case f: Term.FunctionLike if !needParensAroundParams(f) => iter(f.body)
-      case _ => None
+      case _ => null
     }
 
     val ok = isDefnBodiesEnabled(noParams = false) && isParentAnApply(ta)
-    if (ok) iter(func.body) else None
+    if (ok) iter(func.body) else null
   }
 
   private def getBlockToReplaceAsFuncBodyIfInSingleArgApply(
       func: Term.FunctionLike,
-  )(implicit
-      style: ScalafmtConfig,
-      ftoks: FormatTokens,
-  ): Option[(Term.Block, FT)] = {
+  )(implicit style: ScalafmtConfig, ftoks: FormatTokens): (Term.Block, FT) = {
     @tailrec
-    def iter(t: Tree, f: Term.FunctionLike): Option[(Term.Block, FT)] =
-      t.parent match {
-        case Some(p @ Term.ArgClause(_ :: Nil, _)) =>
-          getBlockToReplaceAsFuncBodyInSingleArgApply(p, f)
-        case Some(p: Term.Block) => iter(p, f)
-        case Some(p: Term.FunctionLike) => iter(p, p)
-        case _ => None
-      }
+    def iter(t: Tree, f: Term.FunctionLike): (Term.Block, FT) = t.parent match {
+      case Some(p @ Term.ArgClause(_ :: Nil, _)) =>
+        getBlockToReplaceAsFuncBodyInSingleArgApply(p, f)
+      case Some(p: Term.Block) => iter(p, f)
+      case Some(p: Term.FunctionLike) => iter(p, p)
+      case _ => null
+    }
     iter(func, func)
   }
 
@@ -566,7 +557,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
   )(implicit style: ScalafmtConfig): Boolean = t.parent match {
     case Some(p: Term.ArgClause) => p.parent match {
         case Some(_: Init) => okToRemoveAroundFunctionBody(t.body, false)
-        case Some(_: Term.Apply) => getOpeningParen(p).isDefined &&
+        case Some(_: Term.Apply) => (getOpeningParen(p) ne null) &&
           okToRemoveAroundFunctionBody(t.body, p.values)
         case _ => false
       }
@@ -601,13 +592,14 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
         val nrft = ftoks.nextNonComment(rft)
         !nrft.right.is[T.Ident] || !isInfixOp(nrft.rightOwner) ||
         wasNonComment && style.newlines.infix.sourceIgnoredAt(nrft)(p) ||
-        findTreeWithParent(p) { // check if infix is in parens
-          case pp: Member.ArgClause => ftoks.getClosingIfWithinParensOrBraces(pp)
-              .map(_.isRight)
-          case _: Member.Infix => None
-          case _: Tree.Block => Some(false)
-          case pp => Some(ftoks.isEnclosedWithinParens(pp))
-        }.isDefined
+        (findTreeWithParent(p) { // check if infix is in parens
+          case pp: Member.ArgClause =>
+            val res = ftoks.getClosingIfWithinParensOrBraces(pp)
+            if (res eq null) MaybeBool.Maybe else MaybeBool(res.isRight)
+          case _: Member.Infix => MaybeBool.Maybe
+          case _: Tree.Block => MaybeBool.False
+          case pp => MaybeBool(ftoks.isEnclosedWithinParens(pp))
+        } ne null)
       }
       val prft = ftoks.prev(rft)
       prft.left match {
@@ -628,14 +620,13 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
         // Leave this alone for now.
         // In future there should be an option to surround such expressions with parens instead of braces
         if (isSeqMulti(t.values)) okToRemoveBlockWithinApply(b)
-        else ftoks.getDelimsIfEnclosed(t).exists { case (ldelim, _) =>
+        else ftoks.getDelimsIfEnclosed(t).nnHas { case (ldelim, _) =>
           def isArgDelimRemoved = session.isRemovedOnLeft(ldelim, ok = true)
           ldelim.left match {
             case lb: T.LeftBrace => (ft.right ne lb) && !isArgDelimRemoved // arg clause has separate braces
-            case _: T.LeftParen => session.claimedRuleOnLeft(ldelim) match {
-                case Some(x) => isReplacedWithBrace(x) // this brace replaces paren
-                case None => okLineSpan(b) && canRewriteStatWithParens(b)
-              }
+            case _: T.LeftParen => session.claimedRuleOnLeft(ldelim).nnFold(
+                okLineSpan(b) && canRewriteStatWithParens(b),
+              )(isReplacedWithBrace) // this brace replaces paren
             case _ => false
           }
         }
@@ -685,14 +676,14 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
   )(implicit ft: FT, classifier: Classifier[Tree, A]): Boolean =
     !ftoks.next(ft).right.is[T.Comment] &&
       (getTreeSingleExpr(b) match {
-        case Some(x: Term.Name) => Chars
+        case x: Term.Name => Chars
             .isTypeMask(Chars.scalaLetterTypeMask)(x.text.codePointAt(0))
         case _ => false
       }) && existsParentOfType[A](p)
 
   private def checkBlockAsBody(b: Term.Block, rhs: Tree, noParams: => Boolean)(
       implicit style: ScalafmtConfig,
-  ): Boolean = rhs.eq(b) && getSingleStatIfLineSpanOk(b).exists(innerOk(b)) &&
+  ): Boolean = rhs.eq(b) && getSingleStatIfLineSpanOk(b).nnHas(innerOk(b)) &&
     isDefnBodiesEnabled(noParams)
 
   private def innerOk(b: Term.Block)(s: Stat): Boolean = s match {
@@ -707,7 +698,8 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
 
   private def okToRemoveBlockWithinApply(b: Term.Block)(implicit
       style: ScalafmtConfig,
-  ): Boolean = getSingleStatIfLineSpanOk(b).exists {
+  ): Boolean = getSingleStatIfLineSpanOk(b) match {
+    case null => false
     case f: Term.FunctionLike => !needParensAroundParams(f) && {
         val fb = f.body
         !fb.is[Term.Block] ||
@@ -724,7 +716,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
   private def shouldRemoveSingleStatBlock(
       b: Term.Block,
   )(implicit ft: FT, style: ScalafmtConfig, session: Session): Boolean =
-    getSingleStatIfLineSpanOk(b).exists { stat =>
+    getSingleStatIfLineSpanOk(b).nnHas { stat =>
       import style.dialect
       @tailrec
       def keepForParent(tree: Tree): Boolean = tree match {
@@ -733,24 +725,25 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
             case _ => true
           }
         case _: Term.TryClause =>
-          def matching(tok: T) = ftoks.matchingOptLeft(ftoks(tok))
+          def matching(tok: T) = ftoks.matchingLeftOrNull(ftoks(tok))
           // "try (x).y" or "try { x }.y" isn't supported until scala 2.13
           // same is true with "try (a, b)" and "try ()"
           // return true if rewrite is not OK
           // inside exists, return true if rewrite is OK
           !stat.tokens.headOption.exists {
             case x: T.LeftParen => matching(x) match {
-                case Some(y) if y.left ne stat.tokens.last =>
-                  session.rule[RedundantParens].exists(
-                    _.onToken(ftoks(x, -1), session, style).exists(_.isRemove),
+                case null => true
+                case y if y.left ne stat.tokens.last =>
+                  session.rule[RedundantParens].nnHas(
+                    _.onToken(ftoks(x, -1), session, style).nnHas(_.isRemove),
                   )
-                case Some(_) if !style.dialect.allowTryWithAnyExpr =>
+                case _ if !style.dialect.allowTryWithAnyExpr =>
                   !stat.isAny[Term.Tuple, Lit.Unit]
                 case _ => true
               }
             case x: T.LeftBrace => matching(x) match {
-                case Some(y) if y.left ne stat.tokens.last =>
-                  findFirstTreeBetween(stat, x, y.left).exists {
+                case y if (y ne null) && (y.left ne stat.tokens.last) =>
+                  findFirstTreeBetween(stat, x, y.left) match {
                     case z: Term.Block => okToRemoveBlock(z)
                     case _ => false
                   }
@@ -813,13 +806,13 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
     )
     val rbOwner = ft.rightOwner
     findTreeWithParent(pft.leftOwner)(p =>
-      if (p eq rbOwner) Some(false)
+      if (p eq rbOwner) MaybeBool.False
       else p.parent match {
-        case None => Some(false)
-        case Some(pp: Term.If) if pp.thenp eq p => Some(true)
-        case _ => None
+        case None => MaybeBool.False
+        case Some(pp: Term.If) if pp.thenp eq p => MaybeBool.True
+        case _ => MaybeBool.Maybe
       },
-    ).isDefined
+    ) ne null
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantParens.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config.{RedundantParensSettings, ScalafmtConfig}
 import org.scalafmt.internal._
@@ -93,21 +94,21 @@ class RedundantParens(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = ft.right match {
-    case _: T.LeftParen if okToReplace => Some(removeToken)
-    case _ => None
+  ): Replacement = ft.right match {
+    case _: T.LeftParen if okToReplace => removeToken
+    case _ => null
   }
 
   override def onRight(left: Replacement, hasFormatOff: Boolean)(implicit
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] =
+  ): (Replacement, Replacement) =
     if (
       left.isRemove && RewriteTrailingCommas.checkIfPrevious &&
       RedundantBraces.okCommentBeforeClose(ft)
-    ) Some((left, removeToken))
-    else None
+    ) (left, removeToken)
+    else null
 
   private def okToReplaceWithCount(numParens: Int, tree: Tree, lpOuter: FT)(
       implicit style: ScalafmtConfig,
@@ -231,11 +232,11 @@ class RedundantParens(implicit val ftoks: FormatTokens)
               next @ FT(_, _: T.RightParen, _),
             ) => iter(ftoks.prev(prev), ftoks.next(next), cnt + 1)
         case _ => TreeOps
-            .findEnclosedBetweenParens(lt.right, rt.left, ft.meta.rightOwner)
-            .exists(okToReplaceWithCount(cnt, _, lt))
+            .findEnclosedBetweenParens(lt.right, rt.left, ft.rightOwner)
+            .nnHas(okToReplaceWithCount(cnt, _, lt))
       }
 
-    ftoks.matchingOptRight(ft).exists(rt => iter(ft, rt, 1))
+    ftoks.matchingRightOrNull(ft).nnHas(iter(ft, _, 1))
   }
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveEmptyDocstrings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveEmptyDocstrings.scala
@@ -21,16 +21,16 @@ object RemoveEmptyDocstrings
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = {
+  ): Replacement = {
     val skip = ft.right.is[T.Comment] &&
       FormatWriter.isEmptyDocstring(ft.meta.right.text)
-    if (skip) Some(removeToken) else None
+    if (skip) removeToken else null
   }
 
   override def onRight(lt: Replacement, hasFormatOff: Boolean)(implicit
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = None
+  ): (Replacement, Replacement) = null
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config._
 import org.scalafmt.internal._
@@ -41,92 +42,97 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = ft.right match {
-    case x: T.LeftBrace => Option {
-        ft.meta.rightOwner match {
-          case _ if ftoks.nextNonCommentAfter(ft).right.is[T.RightBrace] => null
-          case t: Term.Block if t.stats.nonEmpty =>
-            val pft = ftoks.prevNonComment(ft)
-            val removeRepl =
-              if (settings.isRemoveEnabled) onLeftForBlock(t, pft) else null
-            if (removeRepl ne null) removeRepl
-            else if (
-              isSingleStatBlock(t) && settings.isInsertEnabled &&
-              session.rule[RedundantBraces].nonEmpty &&
-              getOptionalBraces(pft).exists(_._3)
-            ) Replacement(this, ft, ReplacementType.Replace, style)
-            else null
-          case _ if !settings.isRemoveEnabled => null
-          case t: Template.Body if !t.isEmpty =>
-            if (t.parent.parent.is[Defn.Given]) removeToken
-            else replaceToken(":")(new T.Colon(x.input, x.dialect, x.start))
-          case t: Term.ArgClause => onLeftForArgClause(t)
-          case t: Term.PartialFunction => t.parent match {
-              case Some(p: Term.ArgClause) if (p.tokens.head match {
-                    case px: T.LeftBrace => px eq x
-                    case px: T.LeftParen =>
-                      shouldRewriteArgClauseWithLeftParen[RedundantBraces](px)
-                    case _ => false
-                  }) => onLeftForArgClause(p)
-              case _ => null
+  ): Replacement = ft.right match {
+    case x: T.LeftBrace => ft.meta.rightOwner match {
+        case _ if ftoks.nextNonCommentAfter(ft).right.is[T.RightBrace] => null
+        case t: Term.Block if t.stats.nonEmpty =>
+          val pft = ftoks.prevNonComment(ft)
+          val removeRepl =
+            if (settings.isRemoveEnabled) onLeftForBlock(t, pft) else null
+          if (removeRepl ne null) removeRepl
+          else if (
+            isSingleStatBlock(t) && settings.isInsertEnabled &&
+            (session.rule[RedundantBraces] ne null) && {
+              val triple = getOptionalBraces(pft)
+              (triple ne null) && triple._3
             }
-          case t: Term.EnumeratorsBlock
-              if allowOldSyntax || !t.parent.is[Term.For] || {
-                val rbFt = ftoks.matchingRight(ft)
-                ftoks.nextNonComment(rbFt).right.is[T.KwDo]
-              } => removeToken
-          case _: Tree.CasesBlock => removeToken
-          case _: Ctor.Block if ftoks.prevNonComment(ft).left.is[T.Equals] =>
-            removeToken
-          case _ => null
-        }
+          ) Replacement(this, ft, ReplacementType.Replace, style)
+          else null
+        case _ if !settings.isRemoveEnabled => null
+        case t: Template.Body if !t.isEmpty =>
+          if (t.parent.parent.is[Defn.Given]) removeToken
+          else replaceToken(":")(new T.Colon(x.input, x.dialect, x.start))
+        case t: Term.ArgClause => onLeftForArgClause(t)
+        case t: Term.PartialFunction => t.parent match {
+            case Some(p: Term.ArgClause) if (p.tokens.head match {
+                  case px: T.LeftBrace => px eq x
+                  case px: T.LeftParen =>
+                    shouldRewriteArgClauseWithLeftParen[RedundantBraces](px)
+                  case _ => false
+                }) => onLeftForArgClause(p)
+            case _ => null
+          }
+        case t: Term.EnumeratorsBlock
+            if allowOldSyntax || !t.parent.is[Term.For] || {
+              val rbFt = ftoks.matchingRight(ft)
+              ftoks.nextNonComment(rbFt).right.is[T.KwDo]
+            } => removeToken
+        case _: Tree.CasesBlock => removeToken
+        case _: Ctor.Block if ftoks.prevNonComment(ft).left.is[T.Equals] =>
+          removeToken
+        case _ => null
       }
-    case _ if !settings.isRemoveEnabled => None
+    case _ if !settings.isRemoveEnabled => null
     case _: T.LeftParen
         if !ftoks.nextNonCommentAfter(ft).right.is[T.RightParen] =>
       ft.meta.rightOwner match {
-        case t: Term.ArgClause => Option(onLeftForArgClause(t))
-        case _ => None
+        case t: Term.ArgClause => onLeftForArgClause(t)
+        case _ => null
       }
     case _: T.Colon if settings.isInsertEnabled => insertOnToken(isColon = true)
-    case _ => None
+    case _ => null
   }
 
   override def appendOnToken(implicit
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] =
-    if (!settings.isInsertEnabled || ft.right.is[T.Colon]) None
+  ): Replacement =
+    if (!settings.isInsertEnabled || ft.right.is[T.Colon]) null
     else insertOnToken(isColon = false)
 
   private[rewrite] def getOptionalBraces(ft: FT)(implicit
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(OptionalBraces, FT, Boolean)] = OptionalBraces.getWithBrace(
-    session.claimedRule(ft.idx - 1).flatMap(r =>
-      if (r.how eq ReplacementType.Replace) Some(r.ft.right) else None,
-    ).fold(ft)(x => ft.copy(left = x)),
-  )
+  ): (OptionalBraces, FT, Boolean) = OptionalBraces.getWithBrace {
+    val r = session.claimedRule(ft.idx - 1)
+    val left =
+      if ((r ne null) && (r.how eq ReplacementType.Replace)) r.ft.left else null
+    if (left eq null) ft else ft.copy(left = left)
+  }
 
   private def insertOnToken(isColon: Boolean)(implicit
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = getOptionalBraces(ftoks.next(ft))
-    .flatMap { case (ob, _, skip) =>
+  ): Replacement = getOptionalBraces(ftoks.next(ft))
+    .nnMap { case (ob, _, skip) =>
       val block = ob.block
-      if (skip) None
-      else if (block.parent.is[Case]) if (isColon) Some(removeToken) else None
-      else ftoks.getLastOpt(block).map { rb =>
-        val rt = ft.right
-        val lb = new T.LeftBrace(rt.input, rt.dialect, rt.start)
-        if (isColon) replaceToken("{", afterRight = Some(rb.idx))(lb)
+      if (skip) null
+      else if (block.parent.is[Case]) if (isColon) removeToken else null
+      else {
+        val rb = ftoks.getLast(block)
+        if (rb eq null) null
         else {
-          val meta = ft.meta
-            .copy(right = ft.meta.right.copy(text = "{", owner = block))
-          val how = appendTokensType(ft.copy(right = lb, meta = meta))
-          Replacement(this, ft, how, style, afterRight = Some(rb.idx))
+          val rt = ft.right
+          val lb = new T.LeftBrace(rt.input, rt.dialect, rt.start)
+          if (isColon) replaceToken("{", afterRight = rb.idx)(lb)
+          else {
+            val meta = ft.meta
+              .copy(right = ft.meta.right.copy(text = "{", owner = block))
+            val how = appendTokensType(ft.copy(right = lb, meta = meta))
+            Replacement(this, ft, how, style, afterRight = rb.idx)
+          }
         }
       }
     }
@@ -135,7 +141,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = {
+  ): (Replacement, Replacement) = {
     val toBraces = left.how match {
       case ReplacementType.Replace => left.ft.right.is[T.LeftBrace]
       case rt: ReplacementType.AppendAfter => rt.ft.right.is[T.LeftBrace]
@@ -150,7 +156,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = {
+  ): (Replacement, Replacement) = {
     val nextFt = ftoks.nextNonCommentAfter(ft)
     val notOkToRewrite = hasFormatOff || { // can't force significant indentation
       val cfg = settings
@@ -181,19 +187,21 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
         case _ => false
       })
     ft.right match {
-      case _ if notOkToRewrite => None
+      case _ if notOkToRewrite => null
       case _: T.RightParen if RewriteTrailingCommas.checkIfPrevious =>
-        Some((left, removeToken))
+        (left, removeToken)
       case x: T.RightBrace =>
         val replacement = ft.meta.rightOwner match {
           case t: Term.EnumeratorsBlock
               if allowOldSyntax && t.parent.is[Term.For] &&
                 !nextFt.right.is[T.KwDo] =>
-            replaceToken("do", t.parent)(new T.KwDo(x.input, x.dialect, x.start))
+            replaceToken("do", t.parentOrNull)(
+              new T.KwDo(x.input, x.dialect, x.start),
+            )
           case _ => removeToken
         }
-        Some((left, replacement))
-      case _ => None
+        (left, replacement)
+      case _ => null
     }
   }
 
@@ -230,22 +238,21 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = {
+  ): (Replacement, Replacement) = {
     val notOkToRewrite = skipRightToBraces(left)
     // had the braces already but RedundantBraces is on
     val maybeKeep =
       (left.how eq ReplacementType.Replace) && (ftoks(left.idx) eq left.ft)
     if (maybeKeep)
-      if (notOkToRewrite) session.rule[RedundantBraces].flatMap { r =>
-        val rbRepl = {
+      if (notOkToRewrite) session.rule[RedundantBraces].nnMap(r =>
+        {
           implicit val ft: FT = left.ft
           implicit val style: ScalafmtConfig = left.style
           r.onLeftBrace(ft.rightOwner)
-        }
-        if (rbRepl eq null) None else r.onRight(rbRepl, hasFormatOff)
-      }
-      else None
-    else if (notOkToRewrite) None
+        }.nnMap(r.onRight(_, hasFormatOff)),
+      )
+      else null
+    else if (notOkToRewrite) null
     else {
       val rt = ft.right
       val rbt = new T.RightBrace(rt.input, rt.dialect, rt.end)
@@ -255,7 +262,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       }
       val rbmeta = lb.meta.copy(right = lb.meta.right.copy(text = "}"))
       val replType = appendTokensType(FT(rt, rbt, rbmeta))
-      Some((left, Replacement(this, ft, replType, style)))
+      (left, Replacement(this, ft, replType, style))
     }
   }
 
@@ -264,7 +271,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Replacement = tree.parent.orNull match {
+  ): Replacement = tree.parentOrNull match {
     case null => null
     case t: Term.Block
         if (pft.meta.leftOwner eq t) && pft.left.is[T.LeftBrace] &&
@@ -316,10 +323,10 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
 
   private def shouldRewriteArgClauseWithLeftParen[A <: Rule](
       lp: T,
-  )(implicit ft: FT, session: Session, tag: ClassTag[A]) = {
+  )(implicit ft: FT, session: Session, tag: ClassTag[A]): Boolean = {
     val prevFt = ftoks.prevNonComment(ft)
     prevFt.left.eq(lp) && session.claimedRule(prevFt.meta.idx - 1)
-      .exists(x => tag.runtimeClass.isInstance(x.rule))
+      .nnHas(x => tag.runtimeClass.isInstance(x.rule))
   }
 
   private[rewrite] def onLeftForArgClause(

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveSemicolons.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveSemicolons.scala
@@ -27,7 +27,7 @@ class RemoveSemicolons(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = {
+  ): Replacement = {
     val skip = ft.right.is[T.Semicolon] &&
       (ft.rightOwner match {
         case t: Term.EnumeratorsBlock => t.enums.lengthCompare(1) == 0 ||
@@ -36,13 +36,13 @@ class RemoveSemicolons(implicit val ftoks: FormatTokens)
         case _: Tree.Block | _: Case => true
         case _ => false
       })
-    if (skip) Some(removeToken) else None
+    if (skip) removeToken else null
   }
 
   override def onRight(lt: Replacement, hasFormatOff: Boolean)(implicit
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = None
+  ): (Replacement, Replacement) = null
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Rewrite.scala
@@ -1,7 +1,8 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config.{RewriteSettings, ScalafmtConfig}
-import org.scalafmt.internal.FormatWriter
+import org.scalafmt.internal._
 import org.scalafmt.util.{TokenOps, TokenTraverser, TreeOps}
 
 import scala.meta.tokens.{Token => T}
@@ -25,10 +26,10 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
     .getMatchingDelims(tokens)(TokenOps.hash)(identity)
 
   @inline
-  def getMatchingOpt(a: T): Option[T] = matchingParens.get(TokenOps.hash(a))
+  def getMatchingOrNull(a: T): T = matchingParens.get(TokenOps.hash(a))
 
   @inline
-  def isMatching(a: T, b: => T): Boolean = getMatchingOpt(a).exists(_ eq b)
+  def isMatching(a: T, b: => T): Boolean = getMatchingOrNull(a).nnHas(_ eq b)
 
   @inline
   def getIndex(token: T): Int = tokenTraverser.getIndex(token)
@@ -52,22 +53,20 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
 
   def onlyWhitespaceBefore(index: Int): Boolean = tokenTraverser
     .findAtOrBefore(index - 1) {
-      case _: T.AtEOL | _: T.BOF => Some(true)
-      case _: T.Whitespace => None
-      case _ => Some(false)
-    }.isDefined
+      case _: T.AtEOL | _: T.BOF => MaybeBool.True
+      case _: T.Whitespace => MaybeBool.Maybe
+      case _ => MaybeBool.False
+    } ne null
 
-  def findNonWhitespaceWith(
-      f: (T => Option[Boolean]) => Option[T],
-  ): Option[(T, Option[T.AtEOL])] = {
-    var lf: Option[T.AtEOL] = None
+  def findNonWhitespaceWith(f: (T => MaybeBool) => T): (T, T.AtEOL) = {
+    var lf: T.AtEOL = null
     val nonWs = f {
       case t: T.AtEOL =>
-        if (lf.nonEmpty) Some(false) else { lf = Some(t); None }
-      case _: T.Whitespace => None
-      case _ => Some(true)
+        if (lf ne null) MaybeBool.False else { lf = t; MaybeBool.Maybe }
+      case _: T.Whitespace => MaybeBool.Maybe
+      case _ => MaybeBool.True
     }
-    nonWs.map((_, lf))
+    if (nonWs eq null) null else (nonWs, lf)
   }
 
   // end is inclusive
@@ -77,9 +76,9 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
     case t: T.AtEOL =>
       if (t.newlines > 1) builder += TokenPatch.Replace(t, t.text.stripLineEnd)
       else builder += TokenPatch.Remove(t)
-      Some(false)
-    case _: T.HSpace => None
-    case _ => Some(false)
+      MaybeBool.False
+    case _: T.HSpace => MaybeBool.Maybe
+    case _ => MaybeBool.False
   }
 
 }
@@ -87,7 +86,7 @@ case class RewriteCtx(style: ScalafmtConfig, input: Input, tree: Tree) {
 trait Rewrite
 
 abstract class RewriteFactory extends Rewrite {
-  def create(implicit ctx: RewriteCtx): Option[RewriteSession]
+  def create(implicit ctx: RewriteCtx): RewriteSession
   def hasChanged(v1: RewriteSettings, v2: RewriteSettings): Boolean = false
 }
 
@@ -123,13 +122,20 @@ object Rewrite {
 
   val default: Seq[Rewrite] = name2rewrite.values.toSeq
 
-  def apply(input: Input, style: ScalafmtConfig): Option[String] = {
+  def apply(input: Input, style: ScalafmtConfig): String = {
     val rewrites = style.rewrite.rewriteFactoryRules
-    if (rewrites.isEmpty) None
+    if (rewrites.isEmpty) null
     else style.runner.parse(input) match {
       case Parsed.Success(ast) =>
         val ctx = RewriteCtx(style, input, ast)
-        val rewriteSessions = rewrites.flatMap(_.create(ctx)).toArray
+        val rewriteSessions = {
+          val arr = Array.newBuilder[RewriteSession]
+          rewrites.foreach { x =>
+            val session = x.create(ctx)
+            if (session ne null) arr += session
+          }
+          arr.result()
+        }
         val traverser = new SimpleTraverser {
           override def apply(tree: Tree): Unit = {
             rewriteSessions.foreach(_.rewrite(tree))
@@ -137,8 +143,8 @@ object Rewrite {
           }
         }
         traverser(ast)
-        Some(ctx.applyPatches)
-      case _ => None
+        ctx.applyPatches
+      case _ => null
     }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteLiterals.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteLiterals.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.rewrite
+package org.scalafmt
+package rewrite
 
 import org.scalafmt.config._
 import org.scalafmt.internal._
@@ -25,7 +26,7 @@ object RewriteLiterals extends Rewrite with FormatTokensRewrite.RuleFactory {
       str: String,
       suffixLower: Char,
       suffixCase: Literals.FloatingPoint => Literals.Case,
-  )(implicit style: ScalafmtConfig): Option[String] = {
+  )(implicit style: ScalafmtConfig): String = {
     val fpFilter = fpStyle.filter
 
     val lastCh = str.last
@@ -34,18 +35,18 @@ object RewriteLiterals extends Rewrite with FormatTokensRewrite.RuleFactory {
     val skip = fpFilter.needSuffix && !hasSuffix ||
       fpFilter.minTotalDigits >
       str.length - (if (hasSuffix) 1 else 0) - (if (signum < 0) 1 else 0)
-    if (skip) return None
+    if (skip) return null
 
     val jsb = new lang.StringBuilder()
     def result() =
-      if (jsb.length() == 0) None
+      if (jsb.length() == 0) null
       else {
         if (hasSuffix) jsb.append(suffixCase(fpStyle).process(lastCh))
-        Some(jsb.toString)
+        jsb.toString
       }
 
     if (signum == 0) {
-      if (fpFilter.minSignificantDigits > 1) return None
+      if (fpFilter.minSignificantDigits > 1) return null
       jsb.append('0')
       if (!hasSuffix) jsb.append(".0")
       return result()
@@ -53,7 +54,7 @@ object RewriteLiterals extends Rewrite with FormatTokensRewrite.RuleFactory {
 
     val stripped = value.underlying().stripTrailingZeros()
     val digits = stripped.unscaledValue().abs().toString
-    if (fpFilter.minSignificantDigits > digits.length) return None
+    if (fpFilter.minSignificantDigits > digits.length) return null
 
     val fpFormat = fpStyle.format
     val separators =
@@ -145,25 +146,25 @@ class RewriteLiterals(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = ft.right match {
+  ): Replacement = ft.right match {
     // if we replace, set end to be equal to start, that way we'll know it was rewritten
     case x @ Constant.Float(v) =>
       prettyPrintFloatingPoint(v, ft.meta.right.text, 'f', _.float)
-        .map(replaceToken(_)(
+        .nnMap(replaceToken(_)(
           new Constant.Float(x.input, x.dialect, x.start, x.start, v),
         ))
     case x @ Constant.Double(v) =>
       prettyPrintFloatingPoint(v, ft.meta.right.text, 'd', _.double)
-        .map(replaceToken(_)(
+        .nnMap(replaceToken(_)(
           new Constant.Double(x.input, x.dialect, x.start, x.start, v),
         ))
-    case _ => None
+    case _ => null
   }
 
   override def onRight(left: Replacement, hasFormatOff: Boolean)(implicit
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = None
+  ): (Replacement, Replacement) = null
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RewriteTrailingCommas.scala
@@ -48,7 +48,7 @@ private class RewriteTrailingCommas(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[Replacement] = if (shouldRemove(ft)) Some(removeToken) else None
+  ): Replacement = if (shouldRemove(ft)) removeToken else null
 
   private[rewrite] def shouldRemove(ft: FT): Boolean = ft.right.is[T.Comma] &&
     // comma and paren/bracket/brace should generally have the same owner
@@ -61,6 +61,6 @@ private class RewriteTrailingCommas(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Option[(Replacement, Replacement)] = None
+  ): (Replacement, Replacement) = null
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -10,8 +10,8 @@ object SortModifiers extends RewriteFactory {
   override def hasChanged(v1: RewriteSettings, v2: RewriteSettings): Boolean =
     v2.sortModifiers ne v1.sortModifiers
 
-  override def create(implicit ctx: RewriteCtx): Option[RewriteSession] =
-    Some(new SortModifiers)
+  override def create(implicit ctx: RewriteCtx): RewriteSession =
+    new SortModifiers
 }
 
 class SortModifiers(implicit ctx: RewriteCtx) extends RewriteSession {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/PolicyOps.scala
@@ -104,7 +104,7 @@ object PolicyOps {
 
   final class DecideNewlinesOnlyBeforeToken private (
       val token: FT,
-      split: Option[Split],
+      split: Split,
       val rank: Int,
       ifAny: Boolean,
   )(implicit fileLine: FileLine)
@@ -112,35 +112,31 @@ object PolicyOps {
     override val noDequeue: Boolean = false
     override def terminal: Boolean = false
     override val prefix: String = "NB"
-    override val f: Policy.Pf = split match {
-      case Some(s) => {
+    override val f: Policy.Pf =
+      if (split ne null) {
         case d: Decision if d.formatToken.right eq token.left =>
-          d.onlyNewlinesWithFallback(s)
+          d.onlyNewlinesWithFallback(split)
       }
-      case _ if ifAny => {
+      else if (ifAny) {
         case d: Decision if d.formatToken.right eq token.left =>
           d.onlyNewlinesIfAvailable
       }
-      case _ => {
+      else {
         case d: Decision if d.formatToken.right eq token.left =>
           d.onlyNewlinesWithoutFallback
       }
-    }
   }
 
   object DecideNewlinesOnlyBeforeToken {
-    def apply(
-        token: FT,
-        split: Option[Split],
-        rank: Int = 0,
-        ifAny: Boolean = false,
-    )(implicit fileLine: FileLine): Policy = Policy.End < token ==>
+    def apply(token: FT, split: Split, rank: Int = 0, ifAny: Boolean = false)(
+        implicit fileLine: FileLine,
+    ): Policy = Policy.End < token ==>
       new DecideNewlinesOnlyBeforeToken(token, split, rank, ifAny) <= token
   }
 
   final class DecideNewlinesOnlyAfterToken private (
       val token: FT,
-      split: Option[Split],
+      split: Split,
       val rank: Int,
       ifAny: Boolean,
   )(implicit fileLine: FileLine)
@@ -148,28 +144,24 @@ object PolicyOps {
     override val noDequeue: Boolean = false
     override def terminal: Boolean = false
     override val prefix: String = "NA"
-    override val f: Policy.Pf = split match {
-      case Some(s) => {
+    override val f: Policy.Pf =
+      if (split ne null) {
         case d: Decision if d.formatToken eq token =>
-          d.onlyNewlinesWithFallback(s)
+          d.onlyNewlinesWithFallback(split)
       }
-      case _ if ifAny => {
+      else if (ifAny) {
         case d: Decision if d.formatToken eq token => d.onlyNewlinesIfAvailable
       }
-      case _ => {
+      else {
         case d: Decision if d.formatToken eq token =>
           d.onlyNewlinesWithoutFallback
       }
-    }
   }
 
   object DecideNewlinesOnlyAfterToken {
-    def apply(
-        token: FT,
-        split: Option[Split],
-        rank: Int = 0,
-        ifAny: Boolean = false,
-    )(implicit fileLine: FileLine): Policy = Policy.End <= token ==>
+    def apply(token: FT, split: Split, rank: Int = 0, ifAny: Boolean = false)(
+        implicit fileLine: FileLine,
+    ): Policy = Policy.End <= token ==>
       new DecideNewlinesOnlyAfterToken(token, split, rank, ifAny) >= token
   }
 
@@ -209,7 +201,7 @@ object PolicyOps {
 
   def decideNewlinesOnlyBeforeClose(split: Split, rank: Int = 0)(close: FT)(
       implicit fileLine: FileLine,
-  ): Policy = DecideNewlinesOnlyBeforeToken(close, Option(split), rank)
+  ): Policy = DecideNewlinesOnlyBeforeToken(close, split, rank)
 
   def decideNewlinesOnlyBeforeCloseOnBreak(close: FT)(implicit
       fileLine: FileLine,
@@ -226,7 +218,7 @@ object PolicyOps {
   def decideNewlinesOnlyBeforeToken(rank: Int, ifAny: Boolean = false)(
       token: FT,
   )(implicit fileLine: FileLine): Policy =
-    DecideNewlinesOnlyBeforeToken(token, None, rank = rank, ifAny = ifAny)
+    DecideNewlinesOnlyBeforeToken(token, null, rank = rank, ifAny = ifAny)
 
   def decideNewlinesOnlyAfterClose(close: FT)(implicit
       fileLine: FileLine,
@@ -239,7 +231,7 @@ object PolicyOps {
 
   def decideNewlinesOnlyAfterClose(split: Split, rank: Int = 0)(close: FT)(
       implicit fileLine: FileLine,
-  ): Policy = DecideNewlinesOnlyAfterToken(close, Option(split), rank)
+  ): Policy = DecideNewlinesOnlyAfterToken(close, split, rank)
 
   def decideNewlinesOnlyAfterToken(token: FT)(implicit
       fileLine: FileLine,
@@ -248,7 +240,7 @@ object PolicyOps {
   def decideNewlinesOnlyAfterToken(rank: Int, ifAny: Boolean = false)(
       token: FT,
   )(implicit fileLine: FileLine): Policy =
-    DecideNewlinesOnlyAfterToken(token, None, rank = rank, ifAny = ifAny)
+    DecideNewlinesOnlyAfterToken(token, null, rank = rank, ifAny = ifAny)
 
   def unindentAtExclude(indent: Int)(exclude: TokenRanges): Policy = exclude
     .ranges.foldLeft(Policy.noPolicy) { case (policy, range) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -56,10 +56,10 @@ class StyleMap(tokens: FormatTokens, initStyle: ScalafmtConfig) {
               opensLiteralArgumentList(ft)(curr) =>
           forcedBinPack += ft.meta.leftOwner
           changeStyle(setBinPack(curr, callSite = BinPack.Site.Always))
-            .foreach(x =>
-              tokens.matchingOptLeft(ft)
-                .foreach(y => disableBinPack.update(y.idx, x.binPack.callSite)),
-            )
+            .foreach { x =>
+              val y = tokens.matchingLeftOrNull(ft)
+              if (y ne null) disableBinPack.update(y.idx, x.binPack.callSite)
+            }
         case _: T.RightParen => disableBinPack.remove(ft.idx)
             .foreach(x => changeStyle(setBinPack(curr, callSite = x)))
         case _ =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.util
+package org.scalafmt
+package util
 
 import org.scalafmt.config.ScalafmtConfig
 import org.scalafmt.internal._
@@ -52,11 +53,10 @@ object TokenOps {
   def findLastVisibleTokenIndex(tokens: Tokens): Int = tokens
     .rskipIf(_.isAny[T.Whitespace, T.EOF], tokens.length - 1)
 
-  def findLastVisibleTokenOpt(tokens: Tokens): Option[T] = {
+  def findLastVisibleTokenOrNull(tokens: Tokens): T = {
     val idx = findLastVisibleTokenIndex(tokens)
-    if (idx < 0) None else Some(tokens(idx))
+    if (idx < 0) null else tokens(idx)
   }
-
   def findLastVisibleToken(tokens: Tokens): T =
     tokens(findLastVisibleTokenIndex(tokens).max(0))
 
@@ -124,25 +124,30 @@ object TokenOps {
 
   def getIndentTrigger(tree: Tree): T = tree.tokens.head
 
-  def getEndOfBlock(ft: FT)(f: FT => Option[Boolean])(implicit
-      style: ScalafmtConfig,
-      ftoks: FormatTokens,
-  ): Option[(FT, Boolean)] = ft.left match {
-    case _: T.OpenDelim => f(ft)
-        .flatMap(ok => ftoks.matchingOptLeft(ft).map(_ -> ok))
-    case _ => OptionalBraces.get(ft).flatMap(ob =>
-        ftoks.getLastOpt(ob.block).map(ftoks.nextNonCommentSameLine(_) -> true),
-      )
-  }
+  def getEndOfBlock(ft: FT)(
+      f: FT => MaybeBool,
+  )(implicit style: ScalafmtConfig, ftoks: FormatTokens): (FT, Boolean) =
+    ft.left match {
+      case _: T.OpenDelim =>
+        val ok = f(ft)
+        if (ok eq MaybeBool.Maybe) null
+        else ftoks.matchingLeftOrNull(ft).nnMap(_ -> ok.asBoolean)
+      case _ => OptionalBraces.get(ft).nnMap { ob =>
+          val last = ftoks.getLast(ob.block)
+          if (last eq null) null else ftoks.nextNonCommentSameLine(last) -> true
+        }
+    }
 
   def getEndOfBlock(ft: FT, parens: => Boolean, brackets: => Boolean = false)(
       implicit
       style: ScalafmtConfig,
       ftoks: FormatTokens,
-  ): Option[(FT, Boolean)] = getEndOfBlock(ft) {
-    case FT(_: T.LeftParen, _, _) => if (parens) Some(true) else None
-    case FT(_: T.LeftBracket, _, _) => if (brackets) Some(true) else None
-    case _ => Some(true)
+  ): (FT, Boolean) = getEndOfBlock(ft) {
+    case FT(_: T.LeftParen, _, _) =>
+      if (parens) MaybeBool.True else MaybeBool.Maybe
+    case FT(_: T.LeftBracket, _, _) =>
+      if (brackets) MaybeBool.True else MaybeBool.Maybe
+    case _ => MaybeBool.True
   }
 
   def insideBlock[A](start: FT, end: FT)(implicit
@@ -153,7 +158,7 @@ object TokenOps {
   def insideBlock(start: FT, end: FT, matches: FT => Boolean)(implicit
       ftoks: FormatTokens,
   ): TokenRanges = insideBlock(x =>
-    if (matches(x)) ftoks.matchingOptLeft(x).map(_ -> true) else None,
+    if (!matches(x)) null else ftoks.matchingLeftOrNull(x).nnMap(_ -> true),
   )(start, end)
 
   def insideBracesBlock(
@@ -167,20 +172,20 @@ object TokenOps {
     )(start, end)
 
   def insideBlock(
-      matches: FT => Option[(FT, Boolean)],
+      matches: FT => (FT, Boolean),
   )(start: FT, end: FT)(implicit ftoks: FormatTokens): TokenRanges = {
     var result = TokenRanges.empty
 
     @tailrec
     def run(tok: FT): Unit = if (tok.idx < end.idx) {
-      val nextTokOpt = matches(tok).flatMap { case (closeFt, keep) =>
-        if (tok.left.start >= closeFt.left.end) None
+      val nextTokOpt = matches(tok).nnMap { case (closeFt, keep) =>
+        if (tok.left.start >= closeFt.left.end) null
         else {
           if (keep) result = result.append(TokenRange(tok, closeFt))
-          Some(closeFt)
+          closeFt
         }
       }
-      val nextTok = nextTokOpt.getOrElse(ftoks.next(tok))
+      val nextTok = if (nextTokOpt ne null) nextTokOpt else ftoks.next(tok)
       if (nextTok ne tok) run(nextTok)
     }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.util
+package org.scalafmt
+package util
 
 import org.scalafmt.config.ScalafmtConfig
 
@@ -41,8 +42,6 @@ class TokenTraverser(tokens: Tokens, input: Input)(implicit
 
   @inline
   def getIndex(token: T): Int = tok2idx(token)
-  @inline
-  def getIndexOpt(token: T): Option[Int] = tok2idx.get(token)
 
   def nextToken(token: T): T = tok2idx.get(token) match {
     case Some(i) if i < tokens.length - 1 => tokens(i + 1)
@@ -54,10 +53,10 @@ class TokenTraverser(tokens: Tokens, input: Input)(implicit
     case _ => token
   }
 
-  def nextNonTrivialToken(token: T): Option[T] =
+  def nextNonTrivialToken(token: T): T =
     findAfter(token)(TokenTraverser.isTrivialPred)
 
-  def prevNonTrivialToken(token: T): Option[T] =
+  def prevNonTrivialToken(token: T): T =
     findBefore(token)(TokenTraverser.isTrivialPred)
 
   /** Find a token after the given one. The search stops when the predicate
@@ -65,37 +64,43 @@ class TokenTraverser(tokens: Tokens, input: Input)(implicit
     * @return
     *   Some(token) if the predicate returned Some(true), else None.
     */
-  def findAfter(token: T)(predicate: T => Option[Boolean]): Option[T] = tok2idx
-    .get(token).flatMap(x => findAtOrAfter(x + 1)(predicate))
+  def findAfter(token: T)(predicate: T => MaybeBool): T =
+    tok2idx.get(token) match {
+      case Some(x) => findAtOrAfter(x + 1)(predicate)
+      case None => null
+    }
 
   /** Find a token before the given one. The search stops when the predicate
     * returns Some value (or the end is reached).
     * @return
     *   Some(token) if the predicate returned Some(true), else None.
     */
-  def findBefore(token: T)(predicate: T => Option[Boolean]): Option[T] = tok2idx
-    .get(token).flatMap(x => findAtOrBefore(x - 1)(predicate))
+  def findBefore(token: T)(predicate: T => MaybeBool): T =
+    tok2idx.get(token) match {
+      case Some(x) => findAtOrBefore(x - 1)(predicate)
+      case None => null
+    }
 
   @tailrec
-  final def findAtOrAfter(off: Int)(pred: T => Option[Boolean]): Option[T] =
-    if (off >= tokens.length) None
+  final def findAtOrAfter(off: Int)(pred: T => MaybeBool): T =
+    if (off >= tokens.length) null
     else {
       val token = tokens(off)
       pred(token) match {
-        case Some(true) => Some(token)
-        case Some(false) => None
+        case MaybeBool.True => token
+        case MaybeBool.False => null
         case _ => findAtOrAfter(off + 1)(pred)
       }
     }
 
   @tailrec
-  final def findAtOrBefore(off: Int)(pred: T => Option[Boolean]): Option[T] =
-    if (off < 0) None
+  final def findAtOrBefore(off: Int)(pred: T => MaybeBool): T =
+    if (off < 0) null
     else {
       val token = tokens(off)
       pred(token) match {
-        case Some(true) => Some(token)
-        case Some(false) => None
+        case MaybeBool.True => token
+        case MaybeBool.False => null
         case _ => findAtOrBefore(off - 1)(pred)
       }
     }
@@ -111,7 +116,7 @@ class TokenTraverser(tokens: Tokens, input: Input)(implicit
 
 object TokenTraverser {
 
-  private def isTrivialPred(token: T): Option[Boolean] =
-    if (token.is[T.Trivia]) None else Some(true)
+  private def isTrivialPred(token: T): MaybeBool =
+    if (token.is[T.Trivia]) MaybeBool.Maybe else MaybeBool.True
 
 }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeExtractors.scala
@@ -9,9 +9,9 @@ object InfixApp {
     @inline
     def precedence: Int = InfixApp.getPrecedence(tree.op.value)
 
-    def singleArg: Option[Tree] = tree.arg match {
+    def singleArg: Tree = tree.arg match {
       case x: Member.ArgClause => TreeOps.getSingleElement(x.values)
-      case x => Some(x)
+      case x => x
     }
 
     def args: Seq[Tree] = tree.arg match {
@@ -19,15 +19,17 @@ object InfixApp {
       case arg => arg :: Nil
     }
 
-    def nestedInfixApps: Seq[Member.Infix] = (tree.lhs :: singleArg.toList)
+    def nestedInfixApps: Iterable[Member.Infix] = (tree.lhs :: singleArg :: Nil)
       .collect { case x: Member.Infix => x }
 
   }
 
-  def unapply(tree: Tree): Option[Member.Infix] = tree match {
-    case t: Member.Infix => Some(t)
-    case _ => None
+  def get(tree: Tree): Member.Infix = tree match {
+    case t: Member.Infix => t
+    case _ => null
   }
+
+  def unapply(tree: Tree): Option[Member.Infix] = Option(get(tree))
 
   // https://scala-lang.org/files/archive/spec/2.11/06-expressions.html#infix-operations
   // Operators ending in a colon `:' are right-associative. All other operators are left-associative.

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -1,4 +1,5 @@
-package org.scalafmt.util
+package org.scalafmt
+package util
 
 import org.scalafmt.Error
 import org.scalafmt.config._
@@ -39,51 +40,51 @@ object TreeOps {
   object SingleArgInBraces {
     def unapply(
         tree: Tree,
-    )(implicit ftoks: FormatTokens): Option[(FT, Term, FT)] = tree match {
+    )(implicit ftoks: FormatTokens): Option[(Term, (FT, FT))] = tree match {
       case t: Term.ArgClause => unapply(t)
       case _ => None
     }
     def unapply(tree: Term.ArgClause)(implicit
         ftoks: FormatTokens,
-    ): Option[(FT, Term, FT)] = getBraces(tree, tree.values)
+    ): Option[(Term, (FT, FT))] = Option(getBraces(tree))
+
+    @inline
+    private def getBraces(tree: Term.ArgClause)(implicit
+        ftoks: FormatTokens,
+    ): (Term, (FT, FT)) = getBraces(tree, tree.values)
 
     @inline
     private def getBraces[A <: Tree](tree: Tree, values: List[A])(implicit
         ftoks: FormatTokens,
-    ): Option[(FT, A, FT)] = values match {
-      case arg :: Nil => getBracesNested(tree, values).map { case (b, e) =>
-          (b, arg, e)
-        }
-      case _ => None
+    ): (A, (FT, FT)) = values match {
+      case arg :: Nil => getBracesNested(tree, values).nnMap((arg, _))
+      case _ => null
     }
 
     @inline
     private def getBracesNested(tree: Tree, values: List[Tree])(implicit
         ftoks: FormatTokens,
-    ): Option[(FT, FT)] = values match {
-      case _ :: Nil => ftoks.getBracesIfEnclosed(tree) match {
-          case None => tree.parent match {
-              case Some(p: Term.ArgClause) => getBracesNested(p, p.values)
-              case Some(p: Term.Block) => getBracesNested(p, p.stats)
-              case _ => None
-            }
-          case x => x
-        }
-      case _ => None
+    ): (FT, FT) = values match {
+      case _ :: Nil => ftoks.getBracesIfEnclosed(tree) ??
+          (tree.parent match {
+            case Some(p: Term.ArgClause) => getBracesNested(p, p.values)
+            case Some(p: Term.Block) => getBracesNested(p, p.stats)
+            case _ => null
+          })
+      case _ => null
     }
 
-    def orBlock(
-        tree: Tree,
-    )(implicit ftoks: FormatTokens): Option[(FT, Stat, FT)] = tree match {
-      case t: Term.ArgClause => unapply(t)
-      case t: Term.Block => getBraces(t, t.stats)
-      case _ => None
-    }
+    def orBlock(tree: Tree)(implicit ftoks: FormatTokens): (Stat, (FT, FT)) =
+      tree match {
+        case t: Term.ArgClause => getBraces(t)
+        case t: Term.Block => getBraces(t, t.stats)
+        case _ => null
+      }
 
     object OrBlock {
       def unapply(tree: Tree)(implicit
           ftoks: FormatTokens,
-      ): Option[(FT, Stat, FT)] = orBlock(tree)
+      ): Option[(Stat, (FT, FT))] = Option(orBlock(tree))
     }
   }
 
@@ -93,7 +94,7 @@ object TreeOps {
       case Some(p: Term.FunctionLike) => isBlockFunction(p)
       case Some(p @ Term.Block(`fun` :: Nil)) => ftoks.getHead(p).left
           .is[T.LeftBrace] || isBlockFunction(p)
-      case Some(SingleArgInBraces(_, `fun`, _)) => true
+      case Some(SingleArgInBraces(`fun`, _)) => true
       case _ => false
     }
 
@@ -103,17 +104,18 @@ object TreeOps {
 
   def isExprWithParentInBraces(expr: Tree)(parent: Tree)(implicit
       ftoks: FormatTokens,
-  ): Boolean = SingleArgInBraces.orBlock(parent).exists(_._2 eq expr)
+  ): Boolean = SingleArgInBraces.orBlock(parent).nnHas(_._1 eq expr)
 
   /** Finds matching delimiters [({})].
     *
     * Contains lookup keys in both directions, opening [({ and closing })].
     */
+  // java.util.HashMap so consumers can `get` a value-or-null without a `Some`
   def getMatchingDelims[K, V](
       coll: IndexedSeq[V],
-  )(key: V => K)(f: V => T): Map[K, V] = {
+  )(key: V => K)(f: V => T): java.util.HashMap[K, V] = {
     def show(tok: T): String = s"[${tok.end}]$tok"
-    val ret = Map.newBuilder[K, V]
+    val ret = new java.util.HashMap[K, V]
     var stack = List.empty[(T, V)]
     coll.foreach { elem =>
       f(elem) match {
@@ -128,8 +130,8 @@ object TreeOps {
             checkValidDelims(lt, rt),
             s"Mismatched delims (${show(lt)}, ${show(rt)})",
           )
-          ret += key(ltElem) -> elem
-          ret += key(elem) -> ltElem
+          ret.put(key(ltElem), elem)
+          ret.put(key(elem), ltElem)
           stack = stack.tail
         case _ =>
       }
@@ -137,8 +139,7 @@ object TreeOps {
     if (stack.nonEmpty) throw new IllegalArgumentException(
       stack.map { case (x, _) => show(x) }.mkString("Orphan delims: ", ", ", ""),
     )
-    val result = ret.result()
-    result
+    ret
   }
 
   def checkValidDelims(open: T, close: T): Boolean = open match {
@@ -161,110 +162,122 @@ object TreeOps {
 
   /** Returns first ancestor which matches the given predicate.
     */
-  def findTreeOrParent(
-      tree: Tree,
-  )(pred: Tree => Option[Boolean]): Option[Tree] = findTreeEx(tree)(t =>
-    pred(t) match {
-      case None => t.parent
-      case Some(true) => Some(null)
-      case Some(false) => None
-    },
-  )
+  def findTreeOrParent(tree: Tree)(predMaybe: Tree => MaybeBool): Tree =
+    findTreeEx(tree)(t =>
+      predMaybe(t) match {
+        case MaybeBool.Maybe => t.parentOrNoTree
+        case MaybeBool.True => null
+        case MaybeBool.False => Tree.NoTree
+      },
+    )
 
   /** Returns first tree which matches the given predicate. The predicate
     * returns None to indicate failure; or the tree to recurse to; if the tree
     * is null (or the same as current tree), the current tree is returned.
     */
   @tailrec
-  def findTreeEx(tree: Tree)(pred: Tree => Option[Tree]): Option[Tree] =
-    pred(tree) match {
-      case None => None
-      case Some(null | `tree`) => Some(tree)
-      case Some(r) => findTreeEx(r)(pred)
-    }
+  def findTreeEx(tree: Tree)(pred: Tree => Tree): Tree = pred(tree) match {
+    case Tree.NoTree => null
+    case null | `tree` => tree
+    case r => findTreeEx(r)(pred)
+  }
 
   def findTreeOrParentSimple(tree: Tree, flag: Boolean = true)(
       pred: Tree => Boolean,
-  ): Option[Tree] =
-    findTreeOrParent(tree)(x => if (pred(x) == flag) Some(true) else None)
+  ): Tree = findTreeOrParent(tree)(x =>
+    if (pred(x) == flag) MaybeBool.True else MaybeBool.Maybe,
+  )
 
   /** Returns first ancestor whose parent matches the given predicate. The
     * predicate returns None to continue with the parent, or the boolean match
     * flag, which terminates the search.
     */
-  def findTreeWithParent(tree: Tree)(
-      pred: Tree => Option[Boolean],
-  ): Option[Tree] = findTreeWithParentEx(tree)(t =>
-    pred(t) match {
-      case None => Some(t)
-      case Some(true) => Some(null)
-      case Some(false) => None
-    },
-  )
+  /** Returns (or `null`) the first ancestor whose parent matches the predicate
+    * (`None` = continue to parent, `Some(true)` = match-stop, `Some(false)` =
+    * fail). Walks the parent chain directly and returns `Tree`/`null` rather
+    * than going through `findTreeWithParentEx` with an `Option[Tree]` mapping
+    * lambda, which allocated a `Some` on every upward step (hot path).
+    */
+  def findTreeWithParent(tree: Tree)(pred: Tree => MaybeBool): Tree = {
+    var child = tree
+    var result: Tree = null
+    var searching = true
+    while (searching) child.parent match {
+      case None => searching = false
+      case Some(p) => pred(p) match {
+          case MaybeBool.Maybe => child = p
+          case MaybeBool.True => result = child; searching = false
+          case MaybeBool.False => searching = false
+        }
+    }
+    result
+  }
 
   /** Returns first ancestor whose parent matches the given predicate. The
     * predicate returns None to indicate failure; or the tree to recurse to; if
     * the recurse-to tree is null, the current tree is returned.
     */
   @tailrec
-  def findTreeWithParentEx(
-      tree: Tree,
-  )(pred: Tree => Option[Tree]): Option[Tree] = tree.parent match {
-    case None => None
-    case Some(p) => pred(p) match {
-        case None => None
-        case Some(null) => Some(tree)
-        case Some(r) => findTreeWithParentEx(r)(pred)
-      }
-  }
+  def findTreeWithParentEx(tree: Tree)(pred: Tree => Tree): Tree =
+    tree.parent match {
+      case None => null
+      case Some(p) => pred(p) match {
+          case Tree.NoTree => null
+          case null => tree
+          case r => findTreeWithParentEx(r)(pred)
+        }
+    }
 
   def findTreeWithParentSimple(tree: Tree, flag: Boolean = true)(
       pred: Tree => Boolean,
-  ): Option[Tree] =
-    findTreeWithParent(tree)(x => if (pred(x) == flag) Some(true) else None)
+  ): Tree = findTreeWithParent(tree)(x =>
+    if (pred(x) == flag) MaybeBool.True else MaybeBool.Maybe,
+  )
 
-  /** Returns first ancestor with a parent of a given type.
+  /** Returns first ancestor with a parent of a given type (or `null`).
     */
   def findTreeWithParentOfType[A <: Tree](tree: Tree)(implicit
       classifier: Classifier[Tree, A],
-  ): Option[Tree] = findTreeWithParentSimple(tree)(classifier.apply)
+  ): Tree = findTreeWithParentSimple(tree)(classifier.apply)
 
   /** Returns true if a matching ancestor of a given type exists.
     */
   @inline
   def existsParentOfType[A <: Tree](tree: Tree)(implicit
       classifier: Classifier[Tree, A],
-  ): Boolean = findTreeWithParentOfType[A](tree).isDefined
+  ): Boolean = findTreeWithParentOfType[A](tree) ne null
 
   @tailrec
-  def defDefBody(tree: Tree): Option[Tree] = tree match {
-    case d: Defn with Tree.WithBody => Some(d.body)
-    case d: Defn with Stat.WithTemplate => Some(d.templ.body)
-    case t: Ctor.Block => Some(t)
-    case t: Ctor.Secondary => Some(t.body)
+  def defDefBody(tree: Tree): Tree = tree match {
+    case d: Defn with Tree.WithBody => d.body
+    case d: Defn with Stat.WithTemplate => d.templ.body
+    case t: Ctor.Block => t
+    case t: Ctor.Secondary => t.body
     case _: Ctor.Primary | _: Pat.Var | _: Term.Name => tree.parent match {
         case Some(p) => defDefBody(p)
-        case _ => None
+        case _ => null
       }
-    case _ => None
+    case _ => null
   }
   @tailrec
-  def defDefBodyParent(tree: Tree): Option[Tree] = tree.parent match {
+  def defDefBodyParent(tree: Tree): Tree = tree.parent match {
     case Some(p: Member.ParamClauseGroup) => defDefBodyParent(p)
     case Some(p) => defDefBody(p)
-    case None => None
+    case None => null
   }
 
   // invoked ONLY for colon
-  def colonDeclType(tree: Tree): Option[Type] = tree match {
-    case d: Defn.Given => d.templ.inits.headOption.map(_.tpe)
-    case d: Tree.WithDeclTpe => Some(d.decltpe) // all are Decl or Defn
-    case d: Tree.WithDeclTpeOpt with Defn => d.decltpe
-    case _ => None
+  def colonDeclType(tree: Tree): Type = tree match {
+    case d: Defn.Given =>
+      val trees = d.templ.inits
+      if (trees.isEmpty) null else trees.head.tpe
+    case d: Tree.WithDeclTpe => d.decltpe // all are Decl or Defn
+    case d: Tree.WithDeclTpeOpt with Defn => d.decltpe.orNull
+    case _ => null
   }
 
   object ColonDeclType {
-    def unapply(tree: Tree): Option[Type] = colonDeclType(tree)
+    def unapply(tree: Tree): Option[Type] = Option(colonDeclType(tree))
   }
 
   def isParamClauseSite(tree: Tree): Boolean = tree match {
@@ -346,41 +359,40 @@ object TreeOps {
     math.max(res, treeDepth(t))
   }
 
-  def getSingleArgOnLeftBraceOnLeft(ft: FT)(implicit
-      ftoks: FormatTokens,
-  ): Option[(Term.ArgClause, Stat)] = ft.leftOwner match {
-    case ac: Term.ArgClause => (ac.values match {
+  def getSingleArgOnLeftBraceOnLeft[A >: Null](
+      f: (Term.ArgClause, Stat) => A,
+  )(ft: FT)(implicit ftoks: FormatTokens): A = ft.leftOwner match {
+    case ac: Term.ArgClause =>
+      val stat = ac.values match {
         case (t: Term.Block) :: Nil if ftoks.getHead(t) eq ft =>
           getBlockSingleStat(t)
-        case t :: Nil => Some(t)
-        case _ => None
-      }).map(x => (ac, x))
+        case t :: Nil => t
+        case _ => null
+      }
+      if (stat eq null) null else f(ac, stat)
     case t: Term => t.parent match {
         case Some(ac: Term.ArgClause) if ac.values.lengthCompare(1) == 0 =>
-          (t match {
+          val stat = t match {
             case t: Term.Block if ftoks.getHead(ac) eq ft =>
               getBlockSingleStat(t)
-            case _ => Some(t)
-          }).map(x => (ac, x))
-        case _ => None
+            case _ => t
+          }
+          if (stat eq null) null else f(ac, stat)
+        case _ => null
       }
-    case _ => None
+    case _ => null
   }
 
-  def getSingleArgLambdaPenalties(
-      ac: Term.ArgClause,
-      arg: Stat,
-  ): Option[(Int, Int)] =
-    if (arg.is[Term.FunctionLike]) Some((nestedApplies(ac), 2))
+  def getSingleArgLambdaPenalties(ac: Term.ArgClause, arg: Stat): (Int, Int) =
+    if (arg.is[Term.FunctionLike]) (nestedApplies(ac), 2)
     else ac.parent match {
-      case Some(p: Term.Apply) => Some((nestedApplies(p), treeDepth(p.fun)))
-      case _ => None
+      case Some(p: Term.Apply) => (nestedApplies(p), treeDepth(p.fun))
+      case _ => null
     }
 
   def getLambdaPenaltiesOnLeftBraceOnLeft(ft: FormatToken)(implicit
       ftoks: FormatTokens,
-  ): Option[(Int, Int)] = getSingleArgOnLeftBraceOnLeft(ft)
-    .flatMap((getSingleArgLambdaPenalties _).tupled)
+  ): (Int, Int) = getSingleArgOnLeftBraceOnLeft(getSingleArgLambdaPenalties)(ft)
 
   final def canBreakAfterFuncArrow(
       func: Member.Function,
@@ -401,12 +413,9 @@ object TreeOps {
   @tailrec
   final def lastLambda(
       first: Member.Function,
-      res: Option[Member.Function] = None,
-  )(implicit
-      ftoks: FormatTokens,
-      style: ScalafmtConfig,
-  ): Option[Member.Function] = {
-    val nextres = if (canBreakAfterFuncArrow(first)) Some(first) else res
+      res: Member.Function = null,
+  )(implicit ftoks: FormatTokens, style: ScalafmtConfig): Member.Function = {
+    val nextres = if (canBreakAfterFuncArrow(first)) first else res
     first.body match {
       case child: Member.Function => lastLambda(child, nextres)
       case b @ Term.Block((child: Member.Function) :: Nil)
@@ -425,10 +434,10 @@ object TreeOps {
   }
 
   @inline
-  final def asInfixApp(tree: Tree): Option[Member.Infix] = InfixApp.unapply(tree)
+  final def asInfixApp(tree: Tree): Member.Infix = InfixApp.get(tree)
 
   @inline
-  final def isInfixApp(tree: Tree): Boolean = asInfixApp(tree).isDefined
+  final def isInfixApp(tree: Tree): Boolean = tree.is[Member.Infix]
 
   @tailrec
   def isInfixArg(tree: Tree): Boolean = tree.parent match {
@@ -443,13 +452,13 @@ object TreeOps {
   @tailrec
   def findNextInfixInParent(tree: Tree, scope: Tree)(implicit
       ftoks: FormatTokens,
-  ): Option[Member.Infix] = tree.parent match {
+  ): Member.Infix = tree.parent match {
     case Some(t: Member.ArgClause) => findNextInfixInParent(t, scope)
     case Some(t: Term.Block) if !ftoks.isEnclosedInBraces(t) =>
       findNextInfixInParent(t, scope)
     case Some(t: Member.Infix) if tree ne scope =>
-      if (t.lhs eq tree) Some(t) else findNextInfixInParent(t, scope)
-    case _ => None
+      if (t.lhs eq tree) t else findNextInfixInParent(t, scope)
+    case _ => null
   }
 
   def infixSequenceLength(app: Member.Infix): Int = {
@@ -476,11 +485,10 @@ object TreeOps {
     case _ => false
   }
 
-  def getAssignAtSingleArgCallSite(args: Seq[Tree]): Option[Term.Assign] =
-    args match {
-      case Seq(fun: Term.Assign) => Some(fun)
-      case _ => None
-    }
+  def getAssignAtSingleArgCallSite(args: Seq[Tree]): Term.Assign = args match {
+    case Seq(fun: Term.Assign) => fun
+    case _ => null
+  }
 
   @inline
   def isSeqSingle(seq: Seq[_]): Boolean = seq.lengthCompare(1) == 0
@@ -494,26 +502,25 @@ object TreeOps {
   @inline
   def isMultiStatBlock(tree: Term.Block): Boolean = isSeqMulti(tree.stats)
 
-  def getSingleElement[A](elements: List[A]): Option[A] = elements match {
-    case elem :: Nil => Some(elem)
-    case _ => None
+  def getSingleElement[A >: Null](elements: List[A]): A = elements match {
+    case elem :: Nil => elem
+    case _ => null
   }
 
   @inline
-  def getSingleElement(tree: Tree.Block): Option[Tree] =
-    getSingleElement(tree.stats)
+  def getSingleElement(tree: Tree.Block): Tree = getSingleElement(tree.stats)
 
   @inline
   def hasSingleElement(tree: Tree.Block, value: Tree): Boolean =
-    getSingleElement(tree).contains(value)
+    getSingleElement(tree) eq value
 
   @inline
   def hasSingleElement(tree: Member.SyntaxValuesClause, value: Tree): Boolean =
-    getSingleElement(tree.values).contains(value)
+    getSingleElement(tree.values) eq value
 
-  def getBlockSingleStat(b: Term.Block): Option[Stat] = b.stats match {
-    case stat :: Nil => Some(stat)
-    case _ => None
+  def getBlockSingleStat(b: Term.Block): Stat = b.stats match {
+    case stat :: Nil => stat
+    case _ => null
   }
 
   def isTreeMultiStatBlock(tree: Tree): Boolean = tree match {
@@ -522,38 +529,38 @@ object TreeOps {
   }
 
   @tailrec
-  def getTreeSingleExpr(tree: Tree): Option[Term] = tree match {
+  def getTreeSingleExpr(tree: Tree): Term = tree match {
     case t: Term.Block => t.stats match {
         case stat :: Nil => getTreeSingleExpr(stat)
-        case _ => None
+        case _ => null
       }
-    case t: Term => Some(t)
-    case _ => None
+    case t: Term => t
+    case _ => null
   }
 
-  def isTreeSingleExpr(tree: Tree): Boolean = getTreeSingleExpr(tree).isDefined
+  def isTreeSingleExpr(tree: Tree): Boolean = getTreeSingleExpr(tree) ne null
 
   /* An end marker is really more like a closing brace for formatting purposes
    * (but not when rewriting) so we should ignore it when considering whether a
    * block contains only a single statement. NB: in FormatWriter, when choosing
    * to insert or remove end markers, we avoid such borderline cases.
    */
-  def getSingleStatExceptEndMarker[A <: Tree](ss: List[A]): Option[A] = ss match {
+  def getSingleStatExceptEndMarker[A >: Null <: Tree](ss: List[A]): A = ss match {
     case s :: rs if (rs match {
           case Nil | (_: Term.EndMarker) :: Nil => true
           case _ => false
-        }) => Some(s)
-    case _ => None
+        }) => s
+    case _ => null
   }
 
-  def getSingleStatExceptEndMarker(t: Tree): Option[Tree] = t match {
+  def getSingleStatExceptEndMarker(t: Tree): Tree = t match {
     case Term.Block(s) => getSingleStatExceptEndMarker(s)
-    case _ => Some(t)
+    case _ => t
   }
 
-  def getTreeSingleStat(t: Tree): Option[Tree] = t match {
+  def getTreeSingleStat(t: Tree): Tree = t match {
     case b: Term.Block => getBlockSingleStat(b)
-    case _ => Some(t)
+    case _ => t
   }
 
   def getTreeLineSpan(b: Tree): Int = getTreeLineSpan(b.pos)
@@ -569,10 +576,9 @@ object TreeOps {
 
   @tailrec
   def getBlockStat(t: Tree)(implicit ftoks: FormatTokens): Tree = t match {
-    case b: Term.Block => getSingleStatExceptEndMarker(b.stats) match {
-        case Some(s) if !ftoks.isEnclosedInBraces(b) => getBlockStat(s)
-        case _ => t
-      }
+    case b: Term.Block =>
+      val s = getSingleStatExceptEndMarker(b.stats)
+      if ((s eq null) || ftoks.isEnclosedInBraces(b)) t else getBlockStat(s)
     case _ => t
   }
 
@@ -605,30 +611,30 @@ object TreeOps {
     param.mods.forall(noExplicitImplicit(pStart, true))
   }
 
-  def getImplicitParamList(kwOwner: Tree): Option[Member.SyntaxValuesClause] =
+  def getImplicitParamList(kwOwner: Tree): Member.SyntaxValuesClause =
     kwOwner.parent match {
-      case Some(v @ Term.ArgClause(_, Some(`kwOwner`))) => Some(v)
+      case Some(v @ Term.ArgClause(_, Some(`kwOwner`))) => v
       case Some(v @ Term.ParamClause(_ :: rest, Some(`kwOwner`)))
           if !kwOwner.is[Mod.Implicit] || rest.isEmpty ||
-            rest.exists(noExplicitImplicit) => Some(v)
-      case _ => None
+            rest.exists(noExplicitImplicit) => v
+      case _ => null
     }
 
   def hasImplicitParamList(kwOwner: Tree): Boolean =
-    getImplicitParamList(kwOwner).isDefined
+    getImplicitParamList(kwOwner) ne null
 
-  def getEndOfFirstCall(tree: Tree)(implicit ftoks: FormatTokens) = {
+  def getEndOfFirstCall(tree: Tree)(implicit ftoks: FormatTokens): FT = {
     @tailrec
-    def traverse(tree: Tree, res: Option[Tree]): Option[Tree] = tree match {
-      case t: Term.SelectLike if res.isDefined => traverse(t.qual, Some(t.qual))
-      case t: Term.ApplyType => traverse(t.fun, Some(t))
-      case t: Member.Apply => traverse(t.fun, Some(t.fun))
-      case t: Init => traverse(t.tpe, Some(t.tpe))
+    def traverse(tree: Tree, res: Tree): Tree = tree match {
+      case t: Term.SelectLike if res ne null => traverse(t.qual, t.qual)
+      case t: Term.ApplyType => traverse(t.fun, t)
+      case t: Member.Apply => traverse(t.fun, t.fun)
+      case t: Init => traverse(t.tpe, t.tpe)
       case Term.Block(arg :: Nil) if !ftoks.isEnclosedInBraces(tree) =>
         traverse(arg, res)
       case _ => res
     }
-    traverse(tree, None).map(ftoks.getLast)
+    traverse(tree, null).nnMap(ftoks.getLast)
   }
 
   @inline
@@ -649,19 +655,27 @@ object TreeOps {
   }
 
   @tailrec
-  def findInterpolate(tree: Tree): Option[Term.Interpolate] = tree match {
-    case ti: Term.Interpolate => Some(ti)
+  def findInterpolate(tree: Tree): Term.Interpolate = tree match {
+    case ti: Term.Interpolate => ti
     case _ => tree.parent match {
         case Some(p) => findInterpolate(p)
-        case _ => None
+        case _ => null
       }
   }
 
-  def findArgAfter(end: Int, trees: Seq[Tree]): Option[Tree] = trees
-    .find(_.begOffset >= end)
+  def findArgAfter(end: Int, trees: Seq[Tree]): Tree = {
+    val iter = trees.iterator
+    while (iter.hasNext) {
+      val t = iter.next()
+      if (t.begOffset >= end) return t
+    }
+    null
+  }
 
-  def getStripMarginCharForInterpolate(tree: Tree): Option[Char] =
-    findInterpolate(tree).flatMap(getStripMarginChar)
+  def getStripMarginCharForInterpolate(tree: Tree): Option[Char] = {
+    val interp = findInterpolate(tree)
+    if (interp eq null) None else getStripMarginChar(interp)
+  }
 
   def getStripMarginChar(t: Tree): Option[Char] = t.parent match {
     case Some(ts: Term.SelectLike) if ts.name.value == "stripMargin" =>
@@ -676,7 +690,7 @@ object TreeOps {
   def isTripleQuote(syntax: String): Boolean = syntax.startsWith("\"\"\"")
 
   @tailrec
-  def findFirstTreeBetween(tree: Tree, beg: T, end: T): Option[Tree] = {
+  def findFirstTreeBetween(tree: Tree, beg: T, end: T): Tree = {
     def isWithinRange(x: Tokens): Boolean = x.nonEmpty &&
       x.head.start >= beg.start && x.last.end <= end.end
     def matches(tree: Tree): Boolean = {
@@ -684,10 +698,10 @@ object TreeOps {
       isWithinRange(x) ||
       x.nonEmpty && x.head.start <= beg.start && x.last.end >= end.end
     }
-    if (isWithinRange(tree.tokens)) Some(tree)
+    if (isWithinRange(tree.tokens)) tree
     else tree.children.find(matches) match {
       case Some(c) => findFirstTreeBetween(c, beg, end)
-      case _ => None
+      case _ => null
     }
   }
 
@@ -722,9 +736,9 @@ object TreeOps {
   def isCaseBodyABlock(ft: FT, caseStat: CaseTree): Boolean = ft.right
     .is[T.LeftBrace] && (caseStat.body eq ft.meta.rightOwner)
 
-  def getTemplateGroups(template: Template): Option[Seq[List[Tree]]] = {
+  def getTemplateGroups(template: Template): Seq[List[Tree]] = {
     val groups = Seq(template.inits, template.derives).filter(_.nonEmpty)
-    if (groups.isEmpty) None else Some(groups)
+    if (groups.isEmpty) null else groups
   }
 
   // Scala syntax allows commas before right braces in weird places,
@@ -763,30 +777,32 @@ object TreeOps {
     }
   }
 
-  def findEnclosedBetweenParens(lt: T, rt: T, tree: Tree): Option[Tree] = {
+  def findEnclosedBetweenParens(lt: T, rt: T, tree: Tree): Tree = {
     val beforeParens = lt.start
     val afterParens = rt.end
     val found = beforeParens <= tree.begOffset && tree.endOffset <= afterParens
-    if (found) Some(tree)
+    if (found) tree
     else {
       // `result` (null until decided) + a decided-flag avoids a non-local return
       // out of the `foreachChild` closure (which would allocate/throw a
       // NonLocalReturnControl); we just skip work once decided.
       var candidate: Tree = null
-      var result: Option[Tree] = null
+      var result: Tree = null
       tree.foreachChild { child =>
         if (result eq null)
           if (candidate ne null) result =
-            if (child.begOffset >= afterParens) Some(candidate) else None
+            if (child.begOffset >= afterParens) candidate else Tree.NoTree
           else {
             val headEnd = child.endOffset
             if (headEnd > beforeParens)
               if (headEnd > afterParens || child.begOffset >= headEnd)
-                result = None
+                result = Tree.NoTree
               else candidate = child
           }
       }
-      if (result ne null) result else Option(candidate)
+      if (result eq Tree.NoTree) null
+      else if (result ne null) result
+      else candidate
     }
   }
 
@@ -1075,26 +1091,22 @@ object TreeOps {
   }
 
   @tailrec
-  def getBlockWithNonSingleTermStat(t: Term.Block): Option[Term.Block] =
-    t.stats match {
-      case (x: Term.Block) :: Nil => getBlockWithNonSingleTermStat(x)
-      case (_: Term) :: Nil => None
-      case _ :: _ => Some(t)
-      case _ => None
-    }
+  def getBlockWithNonSingleTermStat(t: Term.Block): Term.Block = t.stats match {
+    case (x: Term.Block) :: Nil => getBlockWithNonSingleTermStat(x)
+    case (_: Term) :: Nil => null
+    case _ :: _ => t
+    case _ => null
+  }
 
   // look for arrow before body, if any, else after params
-  def getFuncArrow(term: Member.Function)(implicit
-      ftoks: FormatTokens,
-  ): Option[FT] = ftoks.tokenBeforeOpt(term.body).orElse(
-    ftoks.tokenAfterOpt(term.paramClause).map(getArrowAfter[T.FunctionArrow]),
-  )
+  def getFuncArrow(term: Member.Function)(implicit ftoks: FormatTokens): FT =
+    ftoks.tokenBefore(term.body) ?? ftoks.tokenAfter(term.paramClause)
+      .nnMap(getArrowAfter[T.FunctionArrow])
 
   // look for arrow before body, if any, else after cond/pat
   def getCaseArrow(term: Case)(implicit ftoks: FormatTokens): FT = ftoks
-    .tokenBeforeOpt(term.body).getOrElse(getArrowAfter[T.RightArrow](
-      ftoks.tokenAfter(term.cond.getOrElse(term.pat)),
-    ))
+    .tokenBefore(term.body) ??
+    getArrowAfter[T.RightArrow](ftoks.tokenAfter(term.cond.getOrElse(term.pat)))
 
   // look for arrow before body, if any, else after cond/pat
   def getCaseArrow(term: TypeCase)(implicit ftoks: FormatTokens): FT = ftoks

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -14,7 +14,7 @@ import java.nio.file.Path
   */
 class FidelityTest extends SharedFunSuiteBase with FormatAssertions {
 
-  private val numFiles = 279
+  private val numFiles = 280
 
   private val denyList = Set(
     "ConfigReader.scala",


### PR DESCRIPTION
Sweep Option/Either off the hot accessors and split/policy generation, returning null (or a Tree.NoTree / MaybeBool sentinel) and deconstructing directly -- no intermediate re-wrapping.

- token/tree accessors: findToken/findTokenEx, position accessors (getHead/getLast/tokenBefore/...), matching*/getMatchingDelims (-> ju.HashMap), *IfEnclosed/SingleArgInBraces, getClosingIfWithinParens, findTreeWithParent(Ex) (+ parentOrNoTree), findTreeEx/findTreeOrParent(Simple), defDefBody(Parent), getImplicitParamList, getEndOfFirstCall, getBlockSingleStat/getTreeSingleStat, findArgAfter, findFirst/findFirstOnRight, getSingleArgOnLeftBraceOnLeft (CPS), asInfixApp/InfixApp.
- split/policy generation: Router.getSplits (collect), andPolicy null-tolerant, getLineStartOwner, getSplitsBeforeOpenParen, defnSiteOptimalToken/templateCurly/getFuncArrow, getElseToken/getBreakBeforeElsePolicy/getElseChain, SplitsAfterLeftBrace (MaybeBool + nullable singleLineSplit), policyOnRightDelim/getPolicy tuples, forBinPack.
- OptimizationEntities.argumentStarts: Map[Int,Tree] ->
  Array[Tree] (idx-keyed, like statementStarts); argument returns nullable. Measured -3.8% Large / -5.4% Medium alloc (A/B vs ju.HashMap, which tied).