### PR TITLE
TreeOps/FormatTokens: read tree tokens via Origin, drop Tokens slices

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -375,8 +375,18 @@ class FormatOps(
         case Some(p: Case) => p.cond.contains(fullInfix)
         case Some(p: Member.ArgClause) => isEnclosedWithinParens(p)
         case _ => false
-      }) || app.op.tokens.rfindWideNot(_.is[T.HTrivia], -1, Int.MinValue)
-        .exists(_.is[T.AtEOL]) // had a break in the original code
+      }) || {
+        // last non-HTrivia token before app.op's first token (searching the
+        // full input); had a break in the original code. Via origin to avoid a
+        // `Tokens` slice: equivalent to app.op.tokens.rfindWideNot(p,-1,MinValue).
+        val o = parsedOrigin(app.op)
+        val res =
+          if (o eq null) app.op.tokens
+            .rfindWideNotOrNull(_.is[T.HTrivia], -1, Int.MinValue)
+          else o.allInputTokens()
+            .rfindNotOrNull(_.is[T.HTrivia], o.begTokenIdx - 1, -1)
+        res.is[T.AtEOL] // null-safe: classifier is isInstanceOf
+      }
 
     def modNL = Newline2x(fullInfixEnclosedInParens && ft.hasBlankLine)
     def nl(cost: Int)(implicit fl: FileLine) = Split(modNL, cost)
@@ -979,8 +989,7 @@ class FormatOps(
         isKeep: Boolean,
         spaceIndents: Seq[Indent] = Seq.empty,
     )(implicit style: ScalafmtConfig, ft: FT): Seq[Split] = {
-      val btokens = body.tokens
-      val blast = getLastNonTrivial(btokens, body)
+      val blast = getLastNonTrivial(body)
       val expire = nextNonCommentSameLine(blast)
       def penalize(penalty: Int) = Policy ? (penalty > 0) &&
         new PolicyOps.PenalizeAllNewlines(penalty) <= blast

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -92,36 +92,22 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   @inline
   def matchingRightOrNull(ft: FT): FT = matchingOrNull(ft.idx + 1)
 
-  def getHeadAndLastIfEnclosed(tokens: Tokens, tree: Tree): (FT, FT) =
-    getHead(tokens, tree).nnMap(h =>
-      h -> matchingLeftOrNull(h).nnMap { other =>
-        val last = getLastNonTrivial(tokens, tree)
-        if (last eq other) last else null
-      },
-    )
-  def getHeadAndLastIfEnclosed(tree: Tree): (FT, FT) =
-    getHeadAndLastIfEnclosed(tree.tokens, tree)
+  def getHeadAndLastIfEnclosed(tree: Tree): (FT, FT) = getHead(tree).nnMap(h =>
+    h -> matchingLeftOrNull(h).nnMap { other =>
+      val last = getLastNonTrivial(tree)
+      if (last eq other) last else null
+    },
+  )
 
-  def getDelimsIfEnclosed(tokens: Tokens, tree: Tree): (FT, FT) =
-    getHeadAndLastIfEnclosed(tokens, tree).nnIf(_.nnHas(_._2 ne null))
-
-  def getDelimsIfEnclosed(tree: Tree): (FT, FT) =
-    getDelimsIfEnclosed(tree.tokens, tree)
-
-  def getHeadIfEnclosed(tokens: Tokens, tree: Tree): FT =
-    getDelimsIfEnclosed(tokens, tree).nnMap(_._1)
+  def getDelimsIfEnclosed(tree: Tree): (FT, FT) = getHeadAndLastIfEnclosed(tree)
+    .nnIf(_.nnHas(_._2 ne null))
 
   def getHeadIfEnclosed(tree: Tree): FT = getDelimsIfEnclosed(tree).nnMap(_._1)
 
-  def getLastIfEnclosed(tokens: Tokens, tree: Tree): FT =
-    getDelimsIfEnclosed(tokens, tree).nnMap(_._2)
-
   def getLastIfEnclosed(tree: Tree): FT = getDelimsIfEnclosed(tree).nnMap(_._2)
 
-  def isEnclosedInMatching(tokens: Tokens, tree: Tree): Boolean =
-    getDelimsIfEnclosed(tokens, tree) ne null
-  def isEnclosedInMatching(tree: Tree): Boolean =
-    isEnclosedInMatching(tree.tokens, tree)
+  def isEnclosedInMatching(tree: Tree): Boolean = getDelimsIfEnclosed(tree) ne
+    null
 
   @inline
   def getBracesIfEnclosed(tree: Tree): (FT, FT) = getDelimsIfEnclosed(tree)
@@ -249,19 +235,17 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
     else getOnOrAfterOwned(nextFt, tree)
   }
 
-  @inline
-  private def getHeadImpl(tokens: Tokens): FT = after(tokens.head)
-  def getHead(tokens: Tokens, tree: Tree): FT =
-    if (tokens.isEmpty) null else getOnOrBeforeOwned(after(tokens.head), tree)
-  @inline
-  def getHead(tree: Tree): FT = getHead(tree.tokens, tree)
+  // head/last token come from the tree's Origin (TreeOps/TokenOps), avoiding a
+  // `tree.tokens` slice; so there's no `(tokens: Tokens, tree)` overload to let
+  // callers reuse a slice -- there's nothing to reuse.
 
-  @inline
-  private def getLastImpl(tokens: Tokens): FT =
-    apply(findLastVisibleToken(tokens))
+  def getRawHead(tree: Tree): FT = TreeOps.headTokenOrNull(tree).nnMap(after)
 
-  def getOnOrAfterLast(tokens: Tokens, tree: Tree): FT = {
-    val last = findLastVisibleToken(tokens)
+  def getHead(tree: Tree): FT = getRawHead(tree)
+    .nnMap(getOnOrBeforeOwned(_, tree))
+
+  def getOnOrAfterLast(tree: Tree): FT = {
+    val last = findLastVisibleToken(tree)
     val beforeLast = before(last)
     val res = getOnOrAfterOwned(beforeLast, tree)
     val ok = (res eq beforeLast) && res.right.is[T.Comment] &&
@@ -269,18 +253,11 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
     if (ok) next(res) else res
   }
 
-  @inline
-  def getOnOrAfterLast(tree: Tree): FT = getOnOrAfterLast(tree.tokens, tree)
+  def getRawLast(tree: Tree): FT = findLastVisibleTokenOrNull(tree).nnMap(apply)
 
-  def getLast(tokens: Tokens, tree: Tree): FT =
-    findLastVisibleTokenOrNull(tokens)
-      .nnMap(last => getOnOrAfterOwned(apply(last), tree))
-  @inline
-  def getLast(tree: Tree): FT = getLast(tree.tokens, tree)
+  def getLast(tree: Tree): FT = getRawLast(tree).nnMap(getOnOrAfterOwned(_, tree))
 
-  def getLastNonTrivial(tokens: Tokens, tree: Tree): FT = getLast(tokens, tree)
-    .nnMap(prevNonComment)
-  def getLastNonTrivial(tree: Tree): FT = getLastNonTrivial(tree.tokens, tree)
+  def getLastNonTrivial(tree: Tree): FT = getLast(tree).nnMap(prevNonComment)
 
   def getLastNotTrailingComment(tree: Tree): Either[FT, FT] = getLast(tree)
     .nnMap(prevNotTrailingComment)
@@ -346,10 +323,8 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   def isAttachedCommentThenBreak(ft: FT): Boolean = ft.noBreak &&
     isRightCommentThenBreak(ft)
 
-  def isEmpty(tree: Tree): Boolean = {
-    val toks = tree.tokens
-    toks.headOption.forall(after(_).left.end > toks.last.end)
-  }
+  def isEmpty(tree: Tree): Boolean = getRawHead(tree)
+    .orHas(_.left.end > TreeOps.lastTokenOrNull(tree).end)
 
   // Maps token to number of non-whitespace bytes before the token's position.
   private final lazy val offsets: Array[FormatTokens.Offsets] = {
@@ -371,18 +346,16 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
   }
   def offsetDiff(left: FT, right: FT)(f: FormatTokens.Offsets => Int): Int =
     offsetDiff(left.idx, right.idx)(f)
-  def offsetDiff(tree: Tree)(f: FormatTokens.Offsets => Int): Int = {
-    val tokens = tree.tokens
-    offsetDiff(getHead(tokens, tree), getLast(tokens, tree))(f)
-  }
+  def offsetDiff(tree: Tree)(f: FormatTokens.Offsets => Int): Int =
+    offsetDiff(getHead(tree), getLast(tree))(f)
   def width(left: Int, right: Int): Int = offsetDiff(left, right)(_.width)
   def width(left: FT, right: FT): Int = width(left.idx, right.idx)
   def span(left: Int, right: Int): Int = offsetDiff(left, right)(_.nonWs)
   def span(left: FT, right: FT): Int = span(left.idx, right.idx)
-  def span(tokens: Tokens): Int =
-    if (tokens.isEmpty) 0 else span(getHeadImpl(tokens), getLastImpl(tokens))
-  @inline
-  def span(tree: Tree): Int = span(tree.tokens)
+  def span(tree: Tree): Int = {
+    val head = getRawHead(tree)
+    if (head eq null) 0 else span(head, apply(findLastVisibleToken(tree)))
+  }
 
   @tailrec
   final def getNonMultilineEnd(ft: FT, inInterp: Int = 0): FT = {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -286,9 +286,8 @@ class FormatWriter(formatOps: FormatOps) {
     locations.foreach { floc =>
       val owner = getOptionalBracesOwner(floc, 2)
       if (owner ne null) {
-        val ownerTokens = owner.tokens
         val (endFt, maybeEndMarkerFt) = {
-          val last = nextNonCommentSameLine(getOnOrAfterLast(ownerTokens, owner))
+          val last = nextNonCommentSameLine(getOnOrAfterLast(owner))
           last.right match {
             case _: T.Semicolon =>
               val newLast = nextNonCommentSameLineAfter(last)
@@ -314,7 +313,7 @@ class FormatWriter(formatOps: FormatOps) {
                 (cfg.insert.blankGaps, getBlankGapsDiff),
               )(loc, eLoc)
 
-            val bLoc = locations(getHead(ownerTokens, owner).idx)
+            val bLoc = locations(getHead(owner).idx)
             val begIndent = bLoc.state.prev.indentation
             def appendOwner(): Unit = updateOwner(_ + (begIndent -> owner))
             def removeOwner(): Unit = updateOwner(_ - begIndent)
@@ -1333,10 +1332,10 @@ class FormatWriter(formatOps: FormatOps) {
     }
 
     private def onSingleLine(t: Tree): Boolean = {
-      val ttokens = t.tokens
-      val beg = after(ttokens.head)
-      val end = before(ttokens.last)
-      getLineDiff(locations, beg, end) == 0
+      val head = getRawHead(t)
+      val last = getRawLast(t)
+      (head ne null) && (last ne null) &&
+      getLineDiff(locations, head, last) == 0
     }
 
     object AlignContainer {
@@ -1374,12 +1373,10 @@ class FormatWriter(formatOps: FormatOps) {
         // containers that can be traversed further if lhs single-line
         case Some(p @ AlignContainer.WithBody(mods, b)) =>
           val keepGoing = {
-            val ptokens = p.tokens
-            val beg = mods.lastOption
-              .fold(after(ptokens.head))(m => next(tokenAfter(m)))
+            val beg = mods.lastOption.fold(getRawHead(p))(m => next(tokenAfter(m)))
             val useBody = b.eq(child) || p.eq(child)
             val beforeBody = if (useBody) tokenJustBefore(b) else null
-            val end = beforeBody ?? before(ptokens.last)
+            val end = beforeBody ?? getRawLast(p)
             getLineDiff(locations, beg, end) == 0
           }
           if (keepGoing) getAlignContainerParent(p, depth) else (p, depth)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/InfixSplits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/InfixSplits.scala
@@ -203,7 +203,7 @@ class InfixSplits(
     case _: Term.If | _: Term.While | _: Source => true
     case Term.Block(_ :: rest) => rest.nonEmpty ||
       (p.parent match {
-        case Some(pp) => p.tokens.head match { // check brace was not rewritten
+        case Some(pp) => headTokenOrNull(p) match { // check brace was not rewritten
             case head: T.LeftBrace => (ftoks.before(head).left eq head) ||
               isOldTopLevelWithParent(p)(pp)
             case _ => true
@@ -224,7 +224,7 @@ class InfixSplits(
     case p: Term.While => p.expr eq tree
     case p: Term.Do => p.expr eq tree
     case p: Term.Block => hasSingleElement(p, tree) &&
-      (p.tokens.head match {
+      (headTokenOrNull(p) match {
         case head: T.LeftBrace => // check brace was not rewritten
           (ftoks.before(head).left eq head) || isAloneEnclosed(p)
         case _ => true
@@ -240,7 +240,7 @@ class InfixSplits(
     case _: Term.If | _: Term.While | _: Term.Do => true
     case _: Member.ArgClause => true
     case p: Term.Block => hasSingleElement(p, tree) &&
-      (p.tokens.head match {
+      (headTokenOrNull(p) match {
         case head: T.LeftBrace => // check brace was not rewritten
           (ftoks.before(head).left eq head) || isAloneArgOrBody(p)
         case _ => true

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptimizationEntities.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptimizationEntities.scala
@@ -132,10 +132,10 @@ object OptimizationEntities {
     ): Unit = {
       addAllStmts(mods.view.filter(_.is[Mod.Annot])) // Each @annotation gets a separate line
       mods.findOrNull(!_.is[Mod.Annot]).nnFold(
-        tree.tokens.find(isMatch) // No non-annotation modifier, fallback to keyword like `object`
-          .fold(throw Error.CantFindDefnToken(what, tree))(addStmtTok(tree)),
+        // No non-annotation modifier exists, fallback to keyword like `object`
+        TreeOps.findTokenOrNull(tree)(isMatch)
+          .nnMapOr(addStmtTok(tree))(throw Error.CantFindDefnToken(what, tree)),
       )(x => addStmtTree(x, tree)) // Non-annotation modifier, for example `sealed`/`abstract`
-
     }
 
     private def addDefn[T](mods: Seq[Mod], tree: Tree)(implicit
@@ -173,10 +173,11 @@ object OptimizationEntities {
         addAllStmts(t.body.stats)
       // special handling for rewritten blocks
       case t @ Term.Block(_ :: Nil)
-          if t.tokens.headOption.exists(x =>
-            // ignore single-stat block if opening brace was removed
-            x.is[T.LeftBrace] && ftoks(x).left.ne(x),
-          ) =>
+          // ignore single-stat block if opening brace was removed
+          if {
+            val h = TreeOps.headTokenOrNull(t)
+            (h ne null) && h.is[T.LeftBrace] && ftoks(h).left.ne(h)
+          } =>
       case t: Term.EnumeratorsBlock =>
         var wasGuard = false
         def iter(prev: FT, curr: Enumerator): FT = {
@@ -207,10 +208,10 @@ object OptimizationEntities {
       case t @ Term.ArgClause(s :: Nil, _)
           if !s.isAny[Term.Block, Term.PartialFunction] &&
             !skipBlockSingleStat(s, isInArgClause = true) =>
-        t.tokens.headOption.foreach(x =>
-          // check for single-stat arg if opening paren was replaced with brace
-          if (x.is[T.LeftParen] && ftoks(x).left.is[T.LeftBrace]) addOneStmt(s),
-        )
+        // check for single-stat arg if opening paren was replaced with brace
+        val h = TreeOps.headTokenOrNull(t)
+        if ((h ne null) && h.is[T.LeftParen] && ftoks(h).left.is[T.LeftBrace])
+          addOneStmt(s)
       case Tree.Block(s) => addAllStmts(s)
       case _ => // Nothing
     }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/OptionalBraces.scala
@@ -98,11 +98,10 @@ object OptionalBraces {
       ftoks: FormatTokens,
   ): Seq[Split] = {
     import ftoks._
-    val treeTokens = tree.tokens
-    val end = getOnOrAfterLast(treeTokens, tree)
+    val end = getOnOrAfterLast(tree)
     val nonTrivialEnd = prevNonComment(end)
     val slbExpire = nextNonCommentSameLine(nonTrivialEnd)
-    def head = getHead(treeTokens, tree)
+    def head = getHead(tree)
     val close = {
       val close = tree match {
         case _: Member.Tuple => null
@@ -830,13 +829,12 @@ object OptionalBraces {
     import ftoks._
     if (!style.dialect.allowSignificantIndentation) return null
 
-    val treeTokens = tree.tokens
-    val head = treeTokens.head
+    val head = headTokenOrNull(tree)
     val hft = after(head)
     if (hft.left.eq(head) && tree.is[Term.Block] && !split.isNL) return null
 
     val beg = getOnOrBeforeOwned(hft, tree)
-    val end = getLastNonTrivial(treeTokens, tree)
+    val end = getLastNonTrivial(tree)
     val kw = next {
       val close = getClosingIfWithinParens(end)(beg)
       if (close eq null) end else next(close)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -329,7 +329,7 @@ object SplitsAfterLeftBrace extends Splits {
             if (t.parent.parent.isOpt[Term.NewAnonymous]) getLambdaInfo(t.stats)
             else getLambdaNone
           case Some(owner) =>
-            val anno = owner.tokens.last
+            val anno = lastTokenOrNull(owner)
             val indent = cfg.indent.main
             val annoFT = tokens(anno)
             val arrow = annoFT.left.is[T.RightArrow]
@@ -1120,13 +1120,23 @@ object SplitsBeforeSemicolon extends Splits {
       cfg: ScalafmtConfig,
   ): Seq[Split] = {
     import fo._, tokens._, ft._
-    val forceBreak = hasBreak && {
-      val ltoks = leftOwner.tokens
-      val maxTokens = topSourceTree.tokens.length
-      !ltoks
-        .getWideOpt(ltoks.skipWideIf(_.is[T.Whitespace], ltoks.length, maxTokens))
-        .contains(right) // something was removed
-    }
+    val forceBreak = hasBreak &&
+      (right ne {
+        // first non-whitespace token after leftOwner's last token (searching the
+        // full input) is not `right` => something was removed. Via origin to avoid
+        // slicing leftOwner.tokens (and topSourceTree.tokens just for its length).
+        val o = parsedOrigin(leftOwner)
+        if (o eq null) {
+          val ltoks = leftOwner.tokens
+          val maxTokens = topSourceTree.tokens.length
+          val idx = ltoks.skipWideIf(_.is[T.Whitespace], ltoks.length, maxTokens)
+          ltoks.getWideOrNull(idx)
+        } else {
+          val all = o.allInputTokens()
+          val idx = all.skipWideIf(_.is[T.Whitespace], o.endTokenIdx, all.length)
+          all.getWideOrNull(idx)
+        }
+      })
     val policy = Policy ? forceBreak &&
       decideNewlinesOnlyAfterToken(nextNonCommentSameLineAfter(ft))
     Seq(Split(NoSplit, 0, policy))
@@ -2352,7 +2362,7 @@ object SplitsAfterReturnLowPriority extends Splits {
     val mod =
       if (hasBlankLine) Newline2x
       else leftOwner match {
-        case Term.Return(unit: Lit.Unit) if unit.tokens.isEmpty =>
+        case Term.Return(unit: Lit.Unit) if headTokenOrNull(unit) eq null =>
           if (right.is[T.RightParen]) Space(cfg.spaces.inParentheses)
           else Newline //  force blank line for Unit "return".
         case _ => Space
@@ -2890,9 +2900,10 @@ object SplitsAfterIdent extends Splits {
             if (right.is[T.Colon]) Seq(Split(NoSplit, 0))
             else insideInfixSplit(p)
           case Some(p: Lit.WithUnary)
-              if (p.op eq t) && (t.tokens.head eq left) => Seq(Split(NoSplit, 0))
+              if (p.op eq t) && (headTokenOrNull(t) eq left) =>
+            Seq(Split(NoSplit, 0))
           case Some(p: Term.ApplyUnary)
-              if (p.op eq t) && (t.tokens.head eq left) =>
+              if (p.op eq t) && (headTokenOrNull(t) eq left) =>
             val useSpace = right match {
               case _: T.LeftBrace => true
               case r: T.Ident => isSymbolicName(r.value)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/AvoidInfix.scala
@@ -2,7 +2,7 @@ package org.scalafmt
 package rewrite
 
 import org.scalafmt.config.RewriteSettings
-import org.scalafmt.util.InfixApp
+import org.scalafmt.util.{InfixApp, TreeOps}
 
 import scala.meta._
 import scala.meta.internal.trees.PlaceholderChecks.hasPlaceholder
@@ -43,7 +43,7 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
 
   private def noDotMatch(t: Term.Match): T =
     if (allowMatchAsOperator && t.mods.isEmpty && !cfg.excludeMatch) ctx
-      .tokenTraverser.prevNonTrivialToken(t.casesBlock.tokens.head)
+      .tokenTraverser.prevNonTrivialToken(TreeOps.headTokenOrNull(t.casesBlock))
     else null
 
   private def rewriteImpl(
@@ -100,7 +100,7 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
         case _: Lit.Unit => ctx.dialect.allowEmptyInfixArgs
         case ac: Term.ArgClause => ac.values match {
             case Nil => ctx.dialect.allowEmptyInfixArgs
-            case arg :: Nil => (arg.tokens.head ne argsHead) ||
+            case arg :: Nil => (TreeOps.headTokenOrNull(arg) ne argsHead) ||
               !arg.is[Lit.Unit] && rhsWrapped
             case _ => true
           }
@@ -168,10 +168,8 @@ class AvoidInfix(implicit ctx: RewriteCtx) extends RewriteSession {
   private def isWrapped(head: T, last: T): Boolean =
     isWrapped(head, last, ctx.tokenTraverser.prevNonTrivialToken(head))
 
-  private def ends(t: Tree): (T, T) = {
-    val tokens = t.tokens
-    (tokens.head, tokens.last)
-  }
+  private def ends(t: Tree): (T, T) =
+    (TreeOps.headTokenOrNull(t), TreeOps.lastTokenOrNull(t))
 
   private def isWrapped(t: Tree): Boolean = {
     val (head, last) = ends(t)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/Imports.scala
@@ -372,7 +372,7 @@ object Imports extends RewriteFactory {
 
       stats.foreach {
         case t: ImportExportStat =>
-          if (ctx.tokenTraverser.isExcluded(t.tokens.head)) flush()
+          if (ctx.tokenTraverser.isExcluded(TreeOps.headTokenOrNull(t))) flush()
           else seqBuffer += t
         case _ => flush()
       }
@@ -488,11 +488,12 @@ object Imports extends RewriteFactory {
       case _ => None
     }).exists(x =>
       // in scala3, `as` doesn't need braces
-      ctx.tokenTraverser.nextNonTrivialToken(x.tokens.last).is[T.RightArrow],
+      ctx.tokenTraverser.nextNonTrivialToken(TreeOps.lastTokenOrNull(x))
+        .is[T.RightArrow],
     )
 
     protected final def getCommentsAround(tree: Tree): (Seq[T], T) =
-      getCommentsBefore(tree.tokens) -> getCommentAfter(tree)
+      getCommentsBefore(tree) -> getCommentAfter(tree)
 
     protected final def getCommentsBefore(tok: T): Seq[T] = {
       var hadLf = false
@@ -510,8 +511,8 @@ object Imports extends RewriteFactory {
       slc.result()
     }
 
-    protected final def getCommentsBefore(tokens: Tokens): Seq[T] =
-      getCommentsBefore(tokens.head)
+    protected final def getCommentsBefore(tree: Tree): Seq[T] =
+      getCommentsBefore(TreeOps.headTokenOrNull(tree))
 
     protected final def getCommentAfter(tok: T): T = ctx.tokenTraverser
       .findAtOrAfter(ctx.getIndex(tok) + 1) {
@@ -521,7 +522,7 @@ object Imports extends RewriteFactory {
       }
 
     protected final def getCommentAfter(tree: Tree): T =
-      getCommentAfter(tree.tokens.last)
+      getCommentAfter(TreeOps.lastTokenOrNull(tree))
 
     private val eol = LineEndings
       .eol(ctx.style.lineEndings.contains(LineEndings.windows))
@@ -563,7 +564,7 @@ object Imports extends RewriteFactory {
               case t => iter(nextOff, t)
             }
           }
-        val head = stats.head.tokens.head
+        val head = TreeOps.headTokenOrNull(stats.head)
         iter(ctx.tokenTraverser.getIndex(head), head)
       }
       val folding = settings.removeRedundantSelectors ||
@@ -572,7 +573,7 @@ object Imports extends RewriteFactory {
       def addToGroup(kw: String, ref: String, importers: Seq[Importer]): Unit =
         addClausesToGroup(groups(settings.group(ref)), kw, ref, importers)
       stats.foreach { s =>
-        val kw = s.tokens.head.toString
+        val kw = TreeOps.headTokenOrNull(s).toString
         s.importers.foreach { i =>
           val ref = getRef(i)
           if (!folding) addToGroup(kw, ref, i :: Nil)
@@ -594,17 +595,16 @@ object Imports extends RewriteFactory {
       )(tree: Importee): Unit = tree.parent match {
         case Some(p: Importer) =>
           val newSeen = seenImports.updateWith(p)(x => Some(1 + x.getOrElse(0)))
-          val pTokens = p.tokens
           val isHead = newSeen.contains(1)
           val isLast = newSeen.contains(p.importees.length)
           if (isLast) getCommentAfter(p).nnFor(appendTailComment)
           p.parent match {
             case Some(pp: ImportExportStat) =>
               if (isHead && pp.importers.headOption.contains(p))
-                getCommentsBefore(pp.tokens).foreach(appendComment)
+                getCommentsBefore(pp).foreach(appendComment)
             case _ =>
           }
-          if (isHead) getCommentsBefore(pTokens).foreach(appendComment)
+          if (isHead) getCommentsBefore(p).foreach(appendComment)
         case _ =>
       }
 
@@ -659,8 +659,8 @@ object Imports extends RewriteFactory {
       else processAllGroups(stats)
 
     private def getTokenRange(x: Seq[ImportExportStat]): (T, T) = {
-      val headTok = x.head.tokens.head
-      val lastTok = x.last.tokens.last
+      val headTok = TreeOps.headTokenOrNull(x.head)
+      val lastTok = TreeOps.lastTokenOrNull(x.last)
       (
         getCommentsBefore(headTok).headOption.getOrElse(headTok),
         getCommentAfter(lastTok) ?? lastTok,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ProcedureSyntax.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/ProcedureSyntax.scala
@@ -15,11 +15,13 @@ class ProcedureSyntax private (implicit ctx: RewriteCtx)
 
   override def rewrite(tree: Tree): Unit = tree match {
     case t: Defn.Def if TreeOps.isProcedureSyntax(t) =>
-      val tok = t.paramClauseGroups.lastOption.getOrElse(t.name).tokens.last
+      val tok = TreeOps
+        .lastTokenOrNull(t.paramClauseGroups.lastOption.getOrElse(t.name))
       if (!ctx.tokenTraverser.nextNonTrivialToken(tok).is[T.Equals]) ctx
         .addPatchSet(TokenPatch.AddRight(tok, ": Unit = ", keepTok = true))
     case t: Decl.Def if TreeOps.isProcedureSyntaxDeclTpe(t.decltpe) =>
-      val tok = t.paramClauseGroups.lastOption.getOrElse(t.name).tokens.last
+      val tok = TreeOps
+        .lastTokenOrNull(t.paramClauseGroups.lastOption.getOrElse(t.name))
       ctx.addPatchSet(TokenPatch.AddRight(tok, ": Unit", keepTok = true))
     case _ =>
   }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RedundantBraces.scala
@@ -36,7 +36,7 @@ object RedundantBraces extends Rewrite with FormatTokensRewrite.RuleFactory {
      * parens only for a single param */
     f.paramClause match {
       case pc @ Term.ParamClause(param :: Nil, _) => param.decltpe.nonEmpty &&
-        !pc.tokens.head.is[T.LeftParen]
+        !headTokenOrNull(pc).is[T.LeftParen]
       case _ => false
     }
 
@@ -363,7 +363,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       else null
 
     owner match {
-      case t: Term.FunctionLike if t.tokens.last.is[T.RightBrace] =>
+      case t: Term.FunctionLike if lastTokenOrNull(t).is[T.RightBrace] =>
         if (!okToRemoveFunctionInApplyOrInit(t)) null else removeToken
       case t: Term.PartialFunction =>
         val pft = ftoks.prevNonComment(ft)
@@ -568,7 +568,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       ft: FT,
       session: Session,
       style: ScalafmtConfig,
-  ): Boolean = b.stats.nonEmpty && b.tokens.headOption.contains(ft.right) &&
+  ): Boolean = b.stats.nonEmpty && (headTokenOrNull(b) eq ft.right) &&
     okToRemoveBlock(b) && !braceSeparatesTwoXmlTokens &&
     (b.parent match {
       case Some(p: Term.ArgClause) => p.parent.exists(checkValidInfixParent)
@@ -692,7 +692,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
       // can't allow: new A with B .foo
       // can allow if: no ".foo", no "with B", or has braces
       !b.parent.is[Term.Select] || t.templ.inits.lengthCompare(1) <= 0 ||
-      t.templ.body.stats.nonEmpty || t.tokens.last.is[T.RightBrace]
+      t.templ.body.stats.nonEmpty || lastTokenOrNull(t).is[T.RightBrace]
     case _ => isTreeSingleExpr(s)
   }
 
@@ -705,7 +705,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
         !fb.is[Term.Block] ||
         // don't rewrite block if the inner block will be rewritten, too
         // sometimes a function body block doesn't have braces
-        fb.tokens.headOption.is[T.LeftBrace] &&
+        headTokenOrNull(fb).is[T.LeftBrace] &&
         !okToRemoveAroundFunctionBody(fb, true)
       }
     case _: Term.Assign => false // f({ a = b }) is not the same as f(a = b)
@@ -730,10 +730,11 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
           // same is true with "try (a, b)" and "try ()"
           // return true if rewrite is not OK
           // inside exists, return true if rewrite is OK
-          !stat.tokens.headOption.exists {
+          !(headTokenOrNull(stat) match {
+            case null => false
             case x: T.LeftParen => matching(x) match {
                 case null => true
-                case y if y.left ne stat.tokens.last =>
+                case y if y.left ne lastTokenOrNull(stat) =>
                   session.rule[RedundantParens].nnHas(
                     _.onToken(ftoks(x, -1), session, style).nnHas(_.isRemove),
                   )
@@ -742,7 +743,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
                 case _ => true
               }
             case x: T.LeftBrace => matching(x) match {
-                case y if (y ne null) && (y.left ne stat.tokens.last) =>
+                case y if (y ne null) && (y.left ne lastTokenOrNull(stat)) =>
                   findFirstTreeBetween(stat, x, y.left) match {
                     case z: Term.Block => okToRemoveBlock(z)
                     case _ => false
@@ -750,7 +751,7 @@ class RedundantBraces(implicit val ftoks: FormatTokens)
                 case _ => true
               }
             case _ => true
-          }
+          })
 
         case _: Case => !RewriteCtx.isPostfixExpr(stat)
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -64,7 +64,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
           else replaceToken(":")(new T.Colon(x.input, x.dialect, x.start))
         case t: Term.ArgClause => onLeftForArgClause(t)
         case t: Term.PartialFunction => t.parent match {
-            case Some(p: Term.ArgClause) if (p.tokens.head match {
+            case Some(p: Term.ArgClause) if (headTokenOrNull(p) match {
                   case px: T.LeftBrace => px eq x
                   case px: T.LeftParen =>
                     shouldRewriteArgClauseWithLeftParen[RedundantBraces](px)
@@ -174,8 +174,10 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
         case t: Term.Name => t.parent.exists {
             case p: Term.SelectPostfix => p.name eq t // select without `.`
             case p: Term.ApplyInfix if p.op eq t =>
-              !style.dialect.allowInfixOperatorAfterNL ||
-              !t.tokens.head.isSymbolicInfixOperator
+              !style.dialect.allowInfixOperatorAfterNL || {
+                val head = headTokenOrNull(t)
+                (head ne null) && !head.isSymbolicInfixOperator
+              }
             case _ => false
           }
         case _: Term.Select => nextFt.noBreak &&
@@ -311,7 +313,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       else if (pft.left.is[T.Equals]) removeToken
       else null
     case p: Tree.WithBody => if (p.body eq tree) removeToken else null
-    case p: Term.ArgClause => p.tokens.head match {
+    case p: Term.ArgClause => headTokenOrNull(p) match {
         case _: T.LeftBrace => onLeftForArgClause(p)
         case px: T.LeftParen
             if shouldRewriteArgClauseWithLeftParen[RedundantParens](px) =>

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/SortModifiers.scala
@@ -58,8 +58,9 @@ class SortModifiers(implicit ctx: RewriteCtx) extends RewriteSession {
     ctx.addPatchSet(sortedMods.zip(sanitized).flatMap { case (next, old) =>
       if (next eq old) Seq.empty
       else {
-        val removeOld = old.tokens.tail.map(TokenPatch.Remove.apply)
-        val addNext = TokenPatch.Replace(old.tokens.head, next.toString())
+        val tokens = old.tokens
+        val removeOld = tokens.tail.map(TokenPatch.Remove.apply)
+        val addNext = TokenPatch.Replace(tokens.head, next.toString())
         addNext +: removeOld
       }
     }: _*)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/StyleMap.scala
@@ -77,7 +77,7 @@ class StyleMap(tokens: FormatTokens, initStyle: ScalafmtConfig) {
       val strName = tree match {
         case t: Lit.Int
             if 0 <= t.value && t.value < Byte.MaxValue &&
-              lit.tokens.head.toString.startsWith("0x") => "Byte"
+              TreeOps.headTokenOrNull(lit).toString.startsWith("0x") => "Byte"
         case _: Lit.Null => "Null"
         case _ => lit.value.getClass.getName
       }

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenOps.scala
@@ -7,6 +7,7 @@ import org.scalafmt.internal._
 import scala.meta._
 import scala.meta.classifiers.Classifier
 import scala.meta.tokens.{Token => T, _}
+import scala.meta.trees.Origin
 
 import scala.annotation.tailrec
 
@@ -53,12 +54,33 @@ object TokenOps {
   def findLastVisibleTokenIndex(tokens: Tokens): Int = tokens
     .rskipIf(_.isAny[T.Whitespace, T.EOF], tokens.length - 1)
 
-  def findLastVisibleTokenOrNull(tokens: Tokens): T = {
-    val idx = findLastVisibleTokenIndex(tokens)
-    if (idx < 0) null else tokens(idx)
+  // Tree overloads that avoid the `tree.tokens` slice: a parsed tree's origin
+  // indexes into the shared full-input array, so we scan that range directly
+  // with the same predicate as the `Tokens` variants above. Fall back to the
+  // slice for non-parsed origins.
+  def findLastVisibleTokenOrNull(tree: Tree): T = tree.origin match {
+    case o: Origin.ParsedPartial =>
+      val all = o.allInputTokens()
+      val lo = o.begTokenIdx
+      var i = o.endTokenIdx - 1
+      while (i >= lo && all(i).isAny[T.Whitespace, T.EOF]) i -= 1
+      if (i < lo) null else all(i)
+    case _ =>
+      val tokens = tree.tokens
+      val idx = findLastVisibleTokenIndex(tokens)
+      if (idx < 0) null else tokens(idx)
   }
-  def findLastVisibleToken(tokens: Tokens): T =
-    tokens(findLastVisibleTokenIndex(tokens).max(0))
+  def findLastVisibleToken(tree: Tree): T = tree.origin match {
+    case o: Origin.ParsedPartial =>
+      val all = o.allInputTokens()
+      val lo = o.begTokenIdx
+      var i = o.endTokenIdx - 1
+      while (i > lo && all(i).isAny[T.Whitespace, T.EOF]) i -= 1
+      all(i.max(lo)) // matches the slice variant's `.max(0)` when all trivia
+    case _ =>
+      val tokens = tree.tokens
+      tokens(findLastVisibleTokenIndex(tokens).max(0))
+  }
 
   @inline
   def withNoIndent(ft: FT): Boolean = ft.between.lastOption.is[T.AtEOL]
@@ -122,7 +144,7 @@ object TokenOps {
     }
   }
 
-  def getIndentTrigger(tree: Tree): T = tree.tokens.head
+  def getIndentTrigger(tree: Tree): T = TreeOps.headTokenOrNull(tree)
 
   def getEndOfBlock(ft: FT)(
       f: FT => MaybeBool,

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TokenTraverser.scala
@@ -37,8 +37,8 @@ class TokenTraverser(tokens: Tokens, input: Input)(implicit
     (map.result(), excluded.result())
   }
 
-  final def isExcluded(token: T): Boolean = excludedTokens
-    .contains(TokenOps.hash(token))
+  final def isExcluded(token: T): Boolean =
+    (token ne null) && excludedTokens.contains(TokenOps.hash(token))
 
   @inline
   def getIndex(token: T): Int = tok2idx(token)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -9,7 +9,8 @@ import org.scalafmt.util.LoggerOps._
 
 import scala.meta._
 import scala.meta.classifiers.Classifier
-import scala.meta.tokens.{Token => T, Tokens}
+import scala.meta.tokens.{Token => T}
+import scala.meta.trees.Origin
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -23,6 +24,43 @@ object TreeOps {
   // ordering by the child's first-token start offset without boxing.
   private val byChildBegStart: java.util.Comparator[(Tree, T, T)] =
     (a, b) => Integer.compare(a._2.start, b._2.start)
+
+  // A parsed tree's `origin` indexes into the shared full-input token array, so
+  // its head/last token (and searches over its token range, or `Wide` searches
+  // into the surrounding input) reduce to array reads with no `Tokens` slice.
+  // null = not a parsed tree (rewrite-synthesized); callers fall back to a slice.
+  def parsedOrigin(tree: Tree): Origin.ParsedPartial = tree.origin match {
+    case o: Origin.ParsedPartial => o
+    case _ => null
+  }
+
+  // Head/last token of a tree WITHOUT allocating a `Tokens` slice. null = none.
+  def headTokenOrNull(tree: Tree): T = {
+    val o = parsedOrigin(tree)
+    if (o eq null) tree.tokens.headOrNull
+    else if (o.begTokenIdx < o.endTokenIdx) o.allInputTokens()(o.begTokenIdx)
+    else null
+  }
+
+  def lastTokenOrNull(tree: Tree): T = {
+    val o = parsedOrigin(tree)
+    if (o eq null) tree.tokens.lastOrNull
+    else if (o.begTokenIdx < o.endTokenIdx) o.allInputTokens()(o.endTokenIdx - 1)
+    else null
+  }
+
+  // First token of a tree matching `p`, without a slice. null = none.
+  def findTokenOrNull(tree: Tree)(p: T => Boolean): T = {
+    val o = parsedOrigin(tree)
+    if (o eq null) tree.tokens.find(p).orNull
+    else {
+      val all = o.allInputTokens()
+      val end = o.endTokenIdx
+      var i = o.begTokenIdx
+      while (i < end && !p(all(i))) i += 1
+      if (i < end) all(i) else null
+    }
+  }
 
   @tailrec
   def topTypeWith(typeWith: Type.With): Type.With = typeWith.parent match {
@@ -474,7 +512,8 @@ object TreeOps {
   }
 
   // procedure syntax has decltpe: Some("")
-  def isProcedureSyntaxDeclTpe(tpe: Type): Boolean = tpe.tokens.isEmpty
+  def isProcedureSyntaxDeclTpe(tpe: Type): Boolean = headTokenOrNull(tpe) eq
+    null
 
   def isProcedureSyntax(defn: Defn.Def): Boolean = defn.decltpe
     .exists(isProcedureSyntaxDeclTpe)
@@ -691,14 +730,19 @@ object TreeOps {
 
   @tailrec
   def findFirstTreeBetween(tree: Tree, beg: T, end: T): Tree = {
-    def isWithinRange(x: Tokens): Boolean = x.nonEmpty &&
-      x.head.start >= beg.start && x.last.end <= end.end
-    def matches(tree: Tree): Boolean = {
-      val x = tree.tokens
-      isWithinRange(x) ||
-      x.nonEmpty && x.head.start <= beg.start && x.last.end >= end.end
+    def isWithinRange(t: Tree): Boolean = {
+      val h = headTokenOrNull(t)
+      (h ne null) && h.start >= beg.start && lastTokenOrNull(t).end <= end.end
     }
-    if (isWithinRange(tree.tokens)) tree
+    def matches(t: Tree): Boolean = {
+      val h = headTokenOrNull(t)
+      (h ne null) && {
+        val le = lastTokenOrNull(t).end
+        h.start >= beg.start && le <= end.end ||
+        h.start <= beg.start && le >= end.end
+      }
+    }
+    if (isWithinRange(tree)) tree
     else tree.children.find(matches) match {
       case Some(c) => findFirstTreeBetween(c, beg, end)
       case _ => null
@@ -850,15 +894,12 @@ object TreeOps {
         if (childCap == 0) null else new Array[(Tree, T, T)](childCap)
       var childCount = 0
       if (allChildren ne null) elem.foreachChild { x =>
-        val tokens = x.tokens
-        if (tokens.nonEmpty) {
-          val beg = tokens.head
-          if (beg.start >= treeBeg) { // sometimes with implicit
-            val end = tokens.last
-            if (end.end <= treeEnd) {
-              allChildren(childCount) = (x, beg, end)
-              childCount += 1
-            }
+        val beg = headTokenOrNull(x)
+        if ((beg ne null) && beg.start >= treeBeg) { // sometimes with implicit
+          val end = lastTokenOrNull(x)
+          if (end.end <= treeEnd) {
+            allChildren(childCount) = (x, beg, end)
+            childCount += 1
           }
         }
       }
@@ -1029,7 +1070,7 @@ object TreeOps {
 
   def isEmptyTree(tree: Tree): Boolean = tree match {
     case t: Term.Block => t.stats.isEmpty
-    case t => t.tokens.isEmpty
+    case t => headTokenOrNull(t) eq null
   }
 
   def isEmptyFunctionBody(tree: Tree): Boolean = tree match {
@@ -1121,7 +1162,7 @@ object TreeOps {
 
   def isBlockWithoutBraces(
       t: Term.Block,
-  )(implicit ftoks: FormatTokens): Boolean = t.tokens.head match {
+  )(implicit ftoks: FormatTokens): Boolean = headTokenOrNull(t) match {
     case lb: T.LeftBrace => lb ne ftoks.before(lb).left
     case _ => true
   }


### PR DESCRIPTION
`tree.tokens` allocates a `Tokens` slice wrapper per call; the vast majority of scalafmt's uses only need the first/last token, a membership/find over the tree's token range, or a `Wide` search into the surrounding input. A parsed tree's `origin` (`Origin.ParsedPartial`) already indexes into the shared full-input token array, so all of these reduce to array reads with no slice (`allInputTokens()` is cached). Non-parsed origins fall back to `tree.tokens`.

Added to TreeOps: parsedOrigin / headTokenOrNull / lastTokenOrNull /
findTokenOrNull; to TokenOps: findLastVisibleToken(OrNull)(tree).

FormatTokens: getHead/getHeadOrNull/getLast/getOnOrAfterLast/getLastOrNull/ getLastNonTrivial(OrNull)/get*IfEnclosed/isEnclosedInMatching/span/isEmpty/ offsetDiff now go through Origin; REMOVED the whole `(tokens: Tokens, tree)` overload family + getHeadImpl/getLastImpl/span(Tokens) (they existed only to let callers reuse one slice across calls, now pointless).

Swept remaining call sites: getStyleAndOwners.treeAt, getIndentTrigger, InfixSplits, Splits (incl. the `skipWideIf` search), StyleMap, TreeOps (findFirstTreeBetween/isProcedureSyntaxDeclTpe/isEmptyTree/isBlockWithoutBraces), OptimizationEntities, AvoidInfix, and FormatOps (the `rfindWideNot` search -- equivalent to allInputTokens().rfindNot(p, begTokenIdx-1, -1)).
