### PR TITLE
benchmarks: parameterize styles, add Scala 3 case

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,7 @@ lazy val benchmarks = project.in(file("scalafmt-benchmarks")).settings(
   publish / skip := true,
   moduleName := "scalafmt-benchmarks",
   libraryDependencies += scalametaTestkit.value,
+  libraryDependencies += munit.value % Test,
   run / javaOptions ++= Seq(
     "-Djava.net.preferIPv4Stack=true",
     "-XX:ReservedCodeCacheSize=128m",

--- a/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/BenchStyles.scala
+++ b/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/BenchStyles.scala
@@ -1,0 +1,42 @@
+package org.scalafmt.benchmarks
+
+import org.scalafmt.config._
+
+/** Config combinations used by the benchmarks, mirroring the community-test
+  * `TestStyles` source variants. `TestStyles` itself is `private[community]`
+  * and test-scoped, so it can't be reused here; this replicates the parts
+  * relevant to benchmarking (the four `newlines.source` modes, where `classic`
+  * is the unspecified/default source), on a base with the same stability tweaks
+  * (`escapeInPathologicalCases` off, no `maxStateVisits` cap, `docstrings`
+  * kept).
+  */
+object BenchStyles {
+
+  private val base = {
+    val d = ScalafmtConfig.default
+    d.copy(
+      docstrings = d.docstrings.copy(wrap = Docstrings.Wrap.keep),
+      newlines = d.newlines.copy(infix =
+        d.newlines.infix.copy(termSite =
+          Newlines.Infix.Site.default.copy(maxCountPerFileForKeep = Some(300)),
+        ),
+      ),
+      runner = d.runner.copy(
+        maxStateVisits = None,
+        optimizer = d.runner.optimizer.copy(escapeInPathologicalCases = false),
+      ),
+    )
+  }
+
+  private def withSource(s: Newlines.SourceHints): ScalafmtConfig = base
+    .copy(newlines = base.newlines.copy(source = s))
+
+  /** `classic` == unspecified/default `newlines.source`. */
+  val byName: Map[String, ScalafmtConfig] = Map(
+    "classic" -> base,
+    "keep" -> withSource(Newlines.keep),
+    "fold" -> withSource(Newlines.fold),
+    "unfold" -> withSource(Newlines.unfold),
+  )
+
+}

--- a/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
+++ b/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/FormatBenchmark.scala
@@ -7,9 +7,12 @@ import org.scalafmt.rewrite.{Imports, RedundantBraces}
 trait FormatBenchmark {
   // `SortImports` is a deprecated shim that throws NotImplementedError; the
   // modern equivalent is the unified `Imports` rule with `imports.sort`.
-  def formatRewrite(code: String): String = Scalafmt.formatCode(
+  def formatRewrite(
+      code: String,
+      base: ScalafmtConfig = ScalafmtConfig.default,
+  ): String = Scalafmt.formatCode(
     code,
-    baseStyle = ScalafmtConfig.default.copy(rewrite =
+    baseStyle = base.copy(rewrite =
       RewriteSettings(
         rules = Seq(Imports, RedundantBraces),
         imports = Imports.Settings(sort = Imports.Sort.ascii),

--- a/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/MicroBenchmark.scala
+++ b/scalafmt-benchmarks/src/main/scala/org/scalafmt/benchmarks/MicroBenchmark.scala
@@ -4,6 +4,8 @@ import org.scalafmt.Scalafmt
 import org.scalafmt.config.{Indents, ScalafmtConfig}
 import org.scalafmt.sysops.{FileOps, PlatformFileOps}
 
+import scala.meta.dialects
+
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
@@ -16,6 +18,10 @@ import org.openjdk.jmh.annotations._
   * > benchmarks/jmh:run -i 10 -wi 10 -f1 -t1 org.scalafmt.*
   * }}}
   *
+  * The `style` param selects a `newlines.source` mode from [[BenchStyles]]
+  * (`classic` == unspecified/default). Each corpus fixes its own dialect via
+  * `adjust` (Scala 2 corpus keeps the default; the Scala 3 corpus sets scala3).
+  *
   * @param path
   *   filename(s) to format
   */
@@ -27,8 +33,26 @@ abstract class MicroBenchmark(path: String*) extends FormatBenchmark {
   val classLoader = getClass.getClassLoader
   var code: String = _
 
+  @Param(Array("classic", "keep", "fold", "unfold"))
+  var style: String = _
+
+  var cfg: ScalafmtConfig = _
+  var relLhsCfg: ScalafmtConfig = _
+
+  /** Corpus-specific config tweak; overridden to set a non-default dialect. */
+  protected def adjust(cfg: ScalafmtConfig): ScalafmtConfig = cfg
+
   @Setup
-  def setup(): Unit = code = PlatformFileOps.readFile(getPath)
+  def setup(): Unit = {
+    code = PlatformFileOps.readFile(getPath)
+    cfg = adjust(BenchStyles.byName(style))
+    // exercises State.getUnexpired's non-empty `relativeToLhsLastLine` path
+    relLhsCfg = cfg.copy(indent =
+      cfg.indent.copy(relativeToLhsLastLine =
+        Seq(Indents.RelativeToLhs.`match`, Indents.RelativeToLhs.`infix`),
+      ),
+    )
+  }
 
   def getPath: Path = {
     val filename = FileOps.getFile(Seq("src", "resources") ++ path)
@@ -44,25 +68,19 @@ abstract class MicroBenchmark(path: String*) extends FormatBenchmark {
   }
 
   @Benchmark
-  def scalafmt(): String = Scalafmt.format(code).get
-
-  // exercises State.getUnexpired's non-empty `relativeToLhsLastLine` path
-  private val relLhsConfig: ScalafmtConfig = ScalafmtConfig.default
-    .copy(indent =
-      ScalafmtConfig.default.indent.copy(relativeToLhsLastLine =
-        Seq(Indents.RelativeToLhs.`match`, Indents.RelativeToLhs.`infix`),
-      ),
-    )
+  def scalafmt(): String = Scalafmt.format(code, cfg).get
 
   @Benchmark
-  def scalafmt_relLhs(): String = Scalafmt.format(code, relLhsConfig).get
+  def scalafmt_relLhs(): String = Scalafmt.format(code, relLhsCfg).get
 
   @Benchmark
-  def scalafmt_rewrite(): String = formatRewrite(code)
+  def scalafmt_rewrite(): String = formatRewrite(code, cfg)
 
   def testMe(): Unit = {
+    style = "classic"
     setup()
     scalafmt()
+    scalafmt_relLhs()
     scalafmt_rewrite()
   }
 
@@ -75,16 +93,14 @@ object Micro {
   abstract class SparkFile(filename: String)
       extends MicroBenchmark("spark", filename)
 
-//  class OptimizerCore extends ScalaJsFile("OptimizerCore.scala")
-
-//  class GenJsCode extends ScalaJsFile("GenJSCode.scala")
   class Small extends ScalaJsFile("EventSerializers.scala")
   class Medium extends ScalaJsFile("PrintStreamTest.scala")
   class Large extends SparkFile("HiveMetastoreCatalog.scala")
   class ExtraLarge extends ScalaJsFile("GenJSCode.scala")
 
-//  class ScalaJSClassEmitter
-//      extends ScalaJsFile("ScalaJSClassEmitter.scala")
-//
-//  class JavaLangString extends ScalaJsFile("JavaLangString.scala")
+  class Scala3 extends MicroBenchmark("scala3", "Scala3Syntax.scala") {
+    override protected def adjust(cfg: ScalafmtConfig): ScalafmtConfig = cfg
+      .withDialect(dialects.Scala3, "scala3")
+  }
+
 }

--- a/scalafmt-benchmarks/src/resources/scala3/Scala3Syntax.scala
+++ b/scalafmt-benchmarks/src/resources/scala3/Scala3Syntax.scala
@@ -1,0 +1,118 @@
+package org.scalafmt.bench.scala3
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+// A synthetic but representative Scala 3 file, written in significant-indentation
+// (optional-braces) style so it exercises the Scala-3-specific formatting paths:
+// enums, given/using, extensions, opaque types, `end` markers, new control
+// syntax, trait parameters, context functions, union/intersection types.
+
+opaque type Meters = Double
+object Meters:
+  def apply(d: Double): Meters = d
+  extension (m: Meters)
+    def toDouble: Double = m
+    def +(other: Meters): Meters = m + other
+    def <(other: Meters): Boolean = m < other
+end Meters
+
+enum Shape derives CanEqual:
+  case Circle(radius: Meters)
+  case Rectangle(width: Meters, height: Meters)
+  case Composite(parts: List[Shape])
+
+  def area: Double = this match
+    case Circle(r) =>
+      val rd = r.toDouble
+      math.Pi * rd * rd
+    case Rectangle(w, h) => w.toDouble * h.toDouble
+    case Composite(parts) =>
+      parts.foldLeft(0.0): (acc, shape) =>
+        acc + shape.area
+end Shape
+
+trait Show[A]:
+  extension (a: A) def show: String
+
+object Show:
+  given Show[Int] with
+    extension (a: Int) def show: String = s"Int($a)"
+
+  given Show[Meters] with
+    extension (a: Meters) def show: String = s"${a.toDouble}m"
+
+  given [A](using sa: Show[A]): Show[List[A]] with
+    extension (a: List[A])
+      def show: String =
+        a.map(_.show).mkString("[", ", ", "]")
+
+  def render[A](a: A)(using s: Show[A]): String = a.show
+end Show
+
+type Id[A] = A
+type StringOrInt = String | Int
+type Combined = Show[Int] & Show[Meters]
+
+class Registry[A](initial: Seq[A]):
+  private val items = mutable.ArrayBuffer.from(initial)
+
+  def add(a: A): this.type =
+    items += a
+    this
+
+  def find(p: A => Boolean): Option[A] =
+    @tailrec
+    def loop(i: Int): Option[A] =
+      if i >= items.length then None
+      else if p(items(i)) then Some(items(i))
+      else loop(i + 1)
+    loop(0)
+
+  def foreachIndexed(f: (A, Int) => Unit): Unit =
+    for
+      i <- items.indices
+      a = items(i)
+    do f(a, i)
+
+  def total(using num: Numeric[A]): A =
+    items.foldLeft(num.zero)(num.plus)
+end Registry
+
+given intOrdering: Ordering[Meters] with
+  def compare(x: Meters, y: Meters): Int =
+    if x < y then -1 else if y < x then 1 else 0
+
+def describe(shape: Shape): String =
+  shape match
+    case Shape.Circle(r) if r.toDouble > 10 =>
+      "a large circle"
+    case Shape.Circle(_) => "a circle"
+    case Shape.Rectangle(w, h) =>
+      if w.toDouble == h.toDouble then "a square"
+      else "a rectangle"
+    case Shape.Composite(parts) =>
+      val n = parts.length
+      s"a composite of $n shapes"
+
+object Runner:
+  def process(shapes: List[Shape]): Unit =
+    val registry = Registry(shapes)
+    registry.foreachIndexed: (shape, idx) =>
+      val label = describe(shape)
+      println(s"$idx: $label with area ${shape.area}")
+
+    val big = registry.find(_.area > 100.0)
+    big match
+      case Some(shape) => println(s"biggest-ish: ${describe(shape)}")
+      case None        => println("nothing large")
+
+  @main def main(): Unit =
+    val shapes = List(
+      Shape.Circle(Meters(5)),
+      Shape.Rectangle(Meters(3), Meters(3)),
+      Shape.Composite(List(Shape.Circle(Meters(1)), Shape.Circle(Meters(2)))),
+    )
+    process(shapes)
+    println(Show.render(List(1, 2, 3)))
+end Runner

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -14,7 +14,7 @@ import java.nio.file.Path
   */
 class FidelityTest extends SharedFunSuiteBase with FormatAssertions {
 
-  private val numFiles = 280
+  private val numFiles = 281
 
   private val denyList = Set(
     "ConfigReader.scala",


### PR DESCRIPTION
Add `munit % Test` to the benchmarks project so it builds on 2.12: the 2.12-only `BenchmarkOK` test needs munit, and `Jmh` extends `Test`, so the missing dep blocked `Jmh/run` on 2.12 (why benchmarking had been 2.13-only).

Parameterize `newlines.source` via a `style` JMH param (classic/keep/fold/unfold; classic = unspecified/default), from a new `BenchStyles` that mirrors the community `TestStyles` source variants and its stability tweaks (escapeInPathologicalCases off, no maxStateVisits cap, docstrings kept); `TestStyles` is private[community] and test-scoped, so it can't be reused directly.

Add `Micro.Scala3`, formatting a significant-indentation scala3 corpus with `runner.dialect = scala3` via `withDialect` -- the prior corpus (scala-js/Spark) is all Scala 2, so no Scala-3 path was covered. `formatRewrite` now takes a base config so the rewrite benchmark respects the selected style and dialect.