### PR TITLE
Narrow BFS block recursion to wide multi-block clauses

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/BestFirstSearch.scala
@@ -44,12 +44,31 @@ private class BestFirstSearch private (range: Set[Range])(implicit
       style: ScalafmtConfig,
   ): Int = TokenOps.getEndOfBlock(ft, parens = true) match {
     case (close, _) if (ft.leftOwner match {
-          case Term.Block(_ :: tail) if tail.nonEmpty =>
-            indent + tokens.width(ft, close) > style.maxColumn
-          // Block must span at least 3 lines to be worth recursing.
+          // A block is worth recursing on once it is wide enough to be its own
+          // subproblem: 3*maxColumn normally, but only maxColumn for a
+          // multi-stat block whose enclosing arg clause is itself very wide
+          // (> 3*maxColumn) -- the shape that combinatorially explodes BFS
+          // (`Seq({ s1; s2 }, { s1; s2 }, ...)` × N). Requiring own width >
+          // maxColumn keeps `shortestPathMemo` sound: it only does a lookup
+          // when isOpt, so the path must already have been computed.
+          case b @ Term.Block(_ :: tail) if tail.nonEmpty =>
+            val w = indent + tokens.width(ft, close)
+            w > style.maxColumn * 3 ||
+            w > style.maxColumn && isInWideMultiBlockArgClause(b)
           case _ => indent + tokens.width(ft, close) > style.maxColumn * 3
         }) => close.idx
     case _ => -1
+  }
+
+  private def isInWideMultiBlockArgClause(
+      b: Term.Block,
+  )(implicit style: ScalafmtConfig): Boolean = b.parent.exists {
+    case ac: Term.ArgClause => ac.values.lengthCompare(1) > 0 &&
+      tokens.width(ac) > style.maxColumn * 3 && ac.values.count {
+        case bb: Term.Block => bb.stats.lengthCompare(1) > 0
+        case _ => false
+      } > 1
+    case _ => false
   }
 
   // LongMap: primitive Long key, no boxing on get/update in the search recursion

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatTokens.scala
@@ -350,6 +350,10 @@ class FormatTokens(leftTok2tok: FormatTokens.TokenToIndexMap)(val arr: Array[FT]
     offsetDiff(getHead(tree), getLast(tree))(f)
   def width(left: Int, right: Int): Int = offsetDiff(left, right)(_.width)
   def width(left: FT, right: FT): Int = width(left.idx, right.idx)
+  def width(tree: Tree): Int = {
+    val head = getRawHead(tree)
+    if (head eq null) 0 else width(head, apply(findLastVisibleToken(tree)))
+  }
   def span(left: Int, right: Int): Int = offsetDiff(left, right)(_.nonWs)
   def span(left: FT, right: FT): Int = span(left.idx, right.idx)
   def span(tree: Tree): Int = {

--- a/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
+++ b/scalafmt-tests-community/intellij/shared/src/test/scala/org/scalafmt/community/intellij/CommunityIntellijScalaSuite.scala
@@ -13,7 +13,7 @@ abstract class CommunityIntellijScalaSuite(name: String)
 class CommunityIntellijScala_2024_2_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59726110)
+  override protected def totalStatesVisited: Option[Int] = Some(59746357)
 
   override protected def builds = Seq {
     getBuild(
@@ -54,7 +54,7 @@ class CommunityIntellijScala_2024_2_Suite
 class CommunityIntellijScala_2024_3_Suite
     extends CommunityIntellijScalaSuite("intellij-scala-2024.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(59941370)
+  override protected def totalStatesVisited: Option[Int] = Some(59961609)
 
   override protected def builds = Seq {
     getBuild(

--- a/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
+++ b/scalafmt-tests-community/scala2/shared/src/test/scala/org/scalafmt/community/scala2/CommunityScala2Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala2Suite(name: String)
 
 class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42937188)
+  override protected def totalStatesVisited: Option[Int] = Some(42952792)
 
   override protected def builds =
     Seq(getBuild("v2.12.20", dialects.Scala212, 1277))
@@ -18,7 +18,7 @@ class CommunityScala2_12Suite extends CommunityScala2Suite("scala-2.12") {
 
 class CommunityScala2_13Suite extends CommunityScala2Suite("scala-2.13") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(52746534)
+  override protected def totalStatesVisited: Option[Int] = Some(52764593)
 
   override protected def builds =
     Seq(getBuild("v2.13.14", dialects.Scala213, 1287))

--- a/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
+++ b/scalafmt-tests-community/scala3/shared/src/test/scala/org/scalafmt/community/scala3/CommunityScala3Suite.scala
@@ -9,7 +9,7 @@ abstract class CommunityScala3Suite(name: String)
 
 class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(39488206)
+  override protected def totalStatesVisited: Option[Int] = Some(39493449)
 
   override protected def builds = Seq(getBuild("3.2.2", dialects.Scala32, 791))
 
@@ -17,7 +17,7 @@ class CommunityScala3_2Suite extends CommunityScala3Suite("scala-3.2") {
 
 class CommunityScala3_3Suite extends CommunityScala3Suite("scala-3.3") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(42629423)
+  override protected def totalStatesVisited: Option[Int] = Some(42634506)
 
   override protected def builds = Seq(getBuild("3.3.3", dialects.Scala33, 861))
 

--- a/scalafmt-tests-community/spark/shared/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
+++ b/scalafmt-tests-community/spark/shared/src/test/scala/org/scalafmt/community/spark/CommunitySparkSuite.scala
@@ -9,7 +9,7 @@ abstract class CommunitySparkSuite(name: String)
 
 class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(86395820)
+  override protected def totalStatesVisited: Option[Int] = Some(86410655)
 
   override protected def builds = Seq(getBuild("v3.4.1", dialects.Scala213, 2585))
 
@@ -17,7 +17,7 @@ class CommunitySpark3_4Suite extends CommunitySparkSuite("spark-3.4") {
 
 class CommunitySpark3_5Suite extends CommunitySparkSuite("spark-3.5") {
 
-  override protected def totalStatesVisited: Option[Int] = Some(91387851)
+  override protected def totalStatesVisited: Option[Int] = Some(91401966)
 
   override protected def builds = Seq(getBuild("v3.5.3", dialects.Scala213, 2756))
 

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -14060,3 +14060,97 @@ object Example {
                                                            (implicit ctx: RequestContext): Future[Int] = ???
   }
 }
+<<< block-recurse: Some(autoPos { .. }), single block arg of apply
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def f = peekToken match {
+    case _: LeftBrace => Some(autoPos {
+      next()
+      if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+      else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+    })
+  }
+}
+>>>
+object X {
+  def f = peekToken match {
+    case _: LeftBrace =>
+      Some(
+        autoPos {
+          next()
+          if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+          else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+        },
+      )
+  }
+}
+<<< block-recurse: Success(autoPos { .. }) with nested match
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def f = parseNew match {
+    case _: KwNew =>
+      canApply = false
+      Success(autoPos {
+        next()
+        val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+        tpl.inits match {
+          case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+            Term.New(init)
+          case _ => Term.NewAnonymous(tpl)
+        }
+      })
+  }
+}
+>>>
+object X {
+  def f = parseNew match {
+    case _: KwNew =>
+      canApply = false
+      Success(
+        autoPos {
+          next()
+          val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+          tpl.inits match {
+            case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+              Term.New(init)
+            case _ => Term.NewAnonymous(tpl)
+          }
+        },
+      )
+  }
+}
+<<< block-recurse: allCases += autoPos { .. }, block rhs of infix
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def cases() = listBy[TypeCase](allCases =>
+    while (at[KwCase]) {
+      allCases += autoPos {
+        next()
+        val pat = infixTypeOrTuple(inMatchType = true)
+        accept[RightArrow]
+        TypeCase(pat, typeIndentedOpt())
+      }
+      newLinesOpt()
+    }
+  )
+}
+>>>
+object X {
+  def cases() = listBy[TypeCase](allCases =>
+    while (at[KwCase]) {
+      allCases += autoPos {
+        next()
+        val pat = infixTypeOrTuple(inMatchType = true)
+        accept[RightArrow]
+        TypeCase(pat, typeIndentedOpt())
+      }
+      newLinesOpt()
+    },
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -14077,13 +14077,11 @@ object X {
 object X {
   def f = peekToken match {
     case _: LeftBrace =>
-      Some(
-        autoPos {
-          next()
-          if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
-          else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
-        },
-      )
+      Some(autoPos {
+        next()
+        if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+        else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+      })
   }
 }
 <<< block-recurse: Success(autoPos { .. }) with nested match
@@ -14110,17 +14108,15 @@ object X {
   def f = parseNew match {
     case _: KwNew =>
       canApply = false
-      Success(
-        autoPos {
-          next()
-          val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
-          tpl.inits match {
-            case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
-              Term.New(init)
-            case _ => Term.NewAnonymous(tpl)
-          }
-        },
-      )
+      Success(autoPos {
+        next()
+        val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+        tpl.inits match {
+          case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+            Term.New(init)
+          case _ => Term.NewAnonymous(tpl)
+        }
+      })
   }
 }
 <<< block-recurse: allCases += autoPos { .. }, block rhs of infix

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -14150,3 +14150,18 @@ object X {
     },
   )
 }
+<<< block-recurse: narrow multi-stat block siblings stay un-recursed
+object X {
+  val xs = Seq({ val a = f(1); g(a) }, { val a = f(2); g(a) }, { val a = f(3); g(a) }, { val a = f(4); g(a) }, { val a = f(5); g(a) }, { val a = f(6); g(a) })
+}
+>>>
+object X {
+  val xs = Seq(
+    { val a = f(1); g(a) },
+    { val a = f(2); g(a) },
+    { val a = f(3); g(a) },
+    { val a = f(4); g(a) },
+    { val a = f(5); g(a) },
+    { val a = f(6); g(a) }
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -13292,3 +13292,18 @@ object X {
     },
   )
 }
+<<< block-recurse: narrow multi-stat block siblings stay un-recursed
+object X {
+  val xs = Seq({ val a = f(1); g(a) }, { val a = f(2); g(a) }, { val a = f(3); g(a) }, { val a = f(4); g(a) }, { val a = f(5); g(a) }, { val a = f(6); g(a) })
+}
+>>>
+object X {
+  val xs = Seq(
+    { val a = f(1); g(a) },
+    { val a = f(2); g(a) },
+    { val a = f(3); g(a) },
+    { val a = f(4); g(a) },
+    { val a = f(5); g(a) },
+    { val a = f(6); g(a) }
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -13219,13 +13219,11 @@ object X {
 >>>
 object X {
   def f = peekToken match {
-    case _: LeftBrace => Some(
-        autoPos {
-          next()
-          if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
-          else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
-        },
-      )
+    case _: LeftBrace => Some(autoPos {
+        next()
+        if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+        else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+      })
   }
 }
 <<< block-recurse: Success(autoPos { .. }) with nested match
@@ -13252,17 +13250,15 @@ object X {
   def f = parseNew match {
     case _: KwNew =>
       canApply = false
-      Success(
-        autoPos {
-          next()
-          val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
-          tpl.inits match {
-            case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
-              Term.New(init)
-            case _ => Term.NewAnonymous(tpl)
-          }
-        },
-      )
+      Success(autoPos {
+        next()
+        val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+        tpl.inits match {
+          case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+            Term.New(init)
+          case _ => Term.NewAnonymous(tpl)
+        }
+      })
   }
 }
 <<< block-recurse: allCases += autoPos { .. }, block rhs of infix
@@ -13286,13 +13282,12 @@ object X {
 object X {
   def cases() = listBy[TypeCase](allCases =>
     while (at[KwCase]) {
-      allCases +=
-        autoPos {
-          next()
-          val pat = infixTypeOrTuple(inMatchType = true)
-          accept[RightArrow]
-          TypeCase(pat, typeIndentedOpt())
-        }
+      allCases += autoPos {
+        next()
+        val pat = infixTypeOrTuple(inMatchType = true)
+        accept[RightArrow]
+        TypeCase(pat, typeIndentedOpt())
+      }
       newLinesOpt()
     },
   )

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -13203,3 +13203,97 @@ object Example {
                                                            (implicit ctx: RequestContext): Future[Int] = ???
   }
 }
+<<< block-recurse: Some(autoPos { .. }), single block arg of apply
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def f = peekToken match {
+    case _: LeftBrace => Some(autoPos {
+      next()
+      if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+      else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+    })
+  }
+}
+>>>
+object X {
+  def f = peekToken match {
+    case _: LeftBrace => Some(
+        autoPos {
+          next()
+          if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+          else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+        },
+      )
+  }
+}
+<<< block-recurse: Success(autoPos { .. }) with nested match
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def f = parseNew match {
+    case _: KwNew =>
+      canApply = false
+      Success(autoPos {
+        next()
+        val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+        tpl.inits match {
+          case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+            Term.New(init)
+          case _ => Term.NewAnonymous(tpl)
+        }
+      })
+  }
+}
+>>>
+object X {
+  def f = parseNew match {
+    case _: KwNew =>
+      canApply = false
+      Success(
+        autoPos {
+          next()
+          val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+          tpl.inits match {
+            case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+              Term.New(init)
+            case _ => Term.NewAnonymous(tpl)
+          }
+        },
+      )
+  }
+}
+<<< block-recurse: allCases += autoPos { .. }, block rhs of infix
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def cases() = listBy[TypeCase](allCases =>
+    while (at[KwCase]) {
+      allCases += autoPos {
+        next()
+        val pat = infixTypeOrTuple(inMatchType = true)
+        accept[RightArrow]
+        TypeCase(pat, typeIndentedOpt())
+      }
+      newLinesOpt()
+    }
+  )
+}
+>>>
+object X {
+  def cases() = listBy[TypeCase](allCases =>
+    while (at[KwCase]) {
+      allCases +=
+        autoPos {
+          next()
+          val pat = infixTypeOrTuple(inMatchType = true)
+          accept[RightArrow]
+          TypeCase(pat, typeIndentedOpt())
+        }
+      newLinesOpt()
+    },
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -13893,3 +13893,92 @@ object Example {
                                                            (implicit ctx: RequestContext): Future[Int] = ???
   }
 }
+<<< block-recurse: Some(autoPos { .. }), single block arg of apply
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def f = peekToken match {
+    case _: LeftBrace => Some(autoPos {
+      next()
+      if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+      else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+    })
+  }
+}
+>>>
+object X {
+  def f = peekToken match {
+    case _: LeftBrace => Some(autoPos {
+        next()
+        if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+        else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+      })
+  }
+}
+<<< block-recurse: Success(autoPos { .. }) with nested match
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def f = parseNew match {
+    case _: KwNew =>
+      canApply = false
+      Success(autoPos {
+        next()
+        val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+        tpl.inits match {
+          case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+            Term.New(init)
+          case _ => Term.NewAnonymous(tpl)
+        }
+      })
+  }
+}
+>>>
+object X {
+  def f = parseNew match {
+    case _: KwNew =>
+      canApply = false
+      Success(autoPos {
+        next()
+        val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+        tpl.inits match {
+          case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+            Term.New(init)
+          case _ => Term.NewAnonymous(tpl)
+        }
+      })
+  }
+}
+<<< block-recurse: allCases += autoPos { .. }, block rhs of infix
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def cases() = listBy[TypeCase](allCases =>
+    while (at[KwCase]) {
+      allCases += autoPos {
+        next()
+        val pat = infixTypeOrTuple(inMatchType = true)
+        accept[RightArrow]
+        TypeCase(pat, typeIndentedOpt())
+      }
+      newLinesOpt()
+    }
+  )
+}
+>>>
+object X {
+  def cases() = listBy[TypeCase](allCases =>
+    while (at[KwCase]) {
+      allCases += autoPos {
+        next()
+        val pat = infixTypeOrTuple(inMatchType = true)
+        accept[RightArrow]
+        TypeCase(pat, typeIndentedOpt())
+      }
+      newLinesOpt()
+    },
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -13982,3 +13982,18 @@ object X {
     },
   )
 }
+<<< block-recurse: narrow multi-stat block siblings stay un-recursed
+object X {
+  val xs = Seq({ val a = f(1); g(a) }, { val a = f(2); g(a) }, { val a = f(3); g(a) }, { val a = f(4); g(a) }, { val a = f(5); g(a) }, { val a = f(6); g(a) })
+}
+>>>
+object X {
+  val xs = Seq(
+    { val a = f(1); g(a) },
+    { val a = f(2); g(a) },
+    { val a = f(3); g(a) },
+    { val a = f(4); g(a) },
+    { val a = f(5); g(a) },
+    { val a = f(6); g(a) }
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -14522,3 +14522,31 @@ object X {
     },
   )
 }
+<<< block-recurse: narrow multi-stat block siblings stay un-recursed
+object X {
+  val xs = Seq({ val a = f(1); g(a) }, { val a = f(2); g(a) }, { val a = f(3); g(a) }, { val a = f(4); g(a) }, { val a = f(5); g(a) }, { val a = f(6); g(a) })
+}
+>>>
+object X {
+  val xs = Seq(
+    {
+      val a = f(1);
+      g(a)
+    }, {
+      val a = f(2);
+      g(a)
+    }, {
+      val a = f(3);
+      g(a)
+    }, {
+      val a = f(4);
+      g(a)
+    }, {
+      val a = f(5);
+      g(a)
+    }, {
+      val a = f(6);
+      g(a)
+    }
+  )
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -14421,3 +14421,104 @@ object Example {
                                                            (implicit ctx: RequestContext): Future[Int] = ???
   }
 }
+<<< block-recurse: Some(autoPos { .. }), single block arg of apply
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def f = peekToken match {
+    case _: LeftBrace => Some(autoPos {
+      next()
+      if (PatternContext.isInside()) Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+      else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+    })
+  }
+}
+>>>
+object X {
+  def f =
+    peekToken match {
+      case _: LeftBrace =>
+        Some(
+          autoPos {
+            next()
+            if (PatternContext.isInside())
+              Term.SplicedMacroPat(autoPos(inBracesOnOpen(pattern())))
+            else
+              Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
+          },
+        )
+    }
+}
+<<< block-recurse: Success(autoPos { .. }) with nested match
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def f = parseNew match {
+    case _: KwNew =>
+      canApply = false
+      Success(autoPos {
+        next()
+        val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+        tpl.inits match {
+          case init :: Nil if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+            Term.New(init)
+          case _ => Term.NewAnonymous(tpl)
+        }
+      })
+  }
+}
+>>>
+object X {
+  def f =
+    parseNew match {
+      case _: KwNew =>
+        canApply = false
+        Success(
+          autoPos {
+            next()
+            val tpl = TemplateOwnerContext.within(OwnedByTrait)(template())
+            tpl.inits match {
+              case init :: Nil
+                  if !prev[RightBrace] && tpl.earlyClause.isEmpty && tpl.body.isEmpty =>
+                Term.New(init)
+              case _ =>
+                Term.NewAnonymous(tpl)
+            }
+          },
+        )
+    }
+}
+<<< block-recurse: allCases += autoPos { .. }, block rhs of infix
+maxColumn = 100
+rewrite.trailingCommas.style = always
+===
+object X {
+  def cases() = listBy[TypeCase](allCases =>
+    while (at[KwCase]) {
+      allCases += autoPos {
+        next()
+        val pat = infixTypeOrTuple(inMatchType = true)
+        accept[RightArrow]
+        TypeCase(pat, typeIndentedOpt())
+      }
+      newLinesOpt()
+    }
+  )
+}
+>>>
+object X {
+  def cases() = listBy[TypeCase](allCases =>
+    while (at[KwCase]) {
+      allCases +=
+        autoPos {
+          next()
+          val pat = infixTypeOrTuple(inMatchType = true)
+          accept[RightArrow]
+          TypeCase(pat, typeIndentedOpt())
+        }
+      newLinesOpt()
+    },
+  )
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2594960, "total explored")
+      assertEquals(explored, 2600444, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2605172, "total explored")
+      assertEquals(explored, 2606928, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2600444, "total explored")
+      assertEquals(explored, 2605172, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
#5283 let BFS recurse on any multi-statement block wider than maxColumn, and #5284 widened it with indent. That over-recurses: a block that is the sole argument of an apply/infix (e.g. `Some(autoPos { s1; s2 })`, `Def.task { s1; s2 }`) is solved as an isolated subproblem, and the committed sub-solution needlessly breaks the wrapper. This silently reformatted untouched code on a version bump (now-closed scalameta/scalameta#4687, 3.11.1 -> 3.11.2).

Using the proposal from #5282, keep the maxColumn relaxation only where it pays off -- a multi-stat block whose enclosing arg clause is itself wide (`> 3*maxColumn`), has more than one argument, and holds more than one multi-stat block. That is the shape that combinatorially explodes BFS (`Seq({ s1; s2 }, ...) x N`); lone block args fall back to the 3*maxColumn bar and keep their 3.11.1 formatting. Own width must still exceed maxColumn so `shortestPathMemo` stays sound: with isOpt it only does a lookup, so the path must already have been computed on the non-opt pass.
