### PR TITLE
cli: daemon-thread the TermDisplay poller

### DIFF
--- a/scalafmt-cli/jvm-native/src/main/scala/org/scalafmt/cli/PlatformPollingScheduler.scala
+++ b/scalafmt-cli/jvm-native/src/main/scala/org/scalafmt/cli/PlatformPollingScheduler.scala
@@ -3,8 +3,17 @@ package org.scalafmt.cli
 import java.util.concurrent._
 
 class PlatformPollingScheduler extends PollingScheduler {
+  // daemon: the progress-display poller must never keep the JVM alive (the
+  // final render happens synchronously in TermDisplay.end)
   private val scheduler: ScheduledExecutorService = Executors
-    .newScheduledThreadPool(1)
+    .newScheduledThreadPool(
+      1,
+      (r: Runnable) => {
+        val t = new Thread(r, "scalafmt-term-display")
+        t.setDaemon(true)
+        t
+      },
+    )
 
   override def start(
       intervalMs: Int,


### PR DESCRIPTION
PlatformPollingScheduler created its ScheduledExecutorService with non-daemon threads and never shut it down (cancel() only cancels the scheduled task), so the poller thread outlived the work. In the CLI this is masked because main calls System.exit, but it leaks a thread in any long-lived embedder and makes a forked JVM (e.g. a benchmark) hang until a 30s shutdown timeout. Make the poller a daemon thread; TermDisplay.end already does the final render synchronously.