### PR TITLE
cli: prune excluded subtrees in recursive search

### DIFF
--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtCoreRunner.scala
@@ -32,7 +32,11 @@ object ScalafmtCoreRunner extends ScalafmtRunner {
   private def runWithFilterMatcher(options: CliOptions, displayMsg: String)(
       filterMatcher: ProjectFiles.FileMatcher,
   )(implicit scalafmtConf: ScalafmtConfig): Future[ExitCode] = {
-    val inputMethods = getInputMethods(options, filterMatcher.matchesPath)
+    val inputMethods = getInputMethods(
+      options,
+      filterMatcher.matchesPath,
+      filterMatcher.excludesDir,
+    )
     if (inputMethods.isEmpty) ExitCode.Ok.future
     else {
       val adjustedScalafmtConf = {

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -35,12 +35,13 @@ trait ScalafmtRunner {
   protected def getInputMethods(
       options: CliOptions,
       filter: Path => Boolean,
+      skipDir: Path => Boolean = _ => false,
   ): Seq[InputMethod] =
     if (options.stdIn)
       Seq(InputMethod.StdinCode(options.assumeFilename, options.common.in))
     else {
       val projectFiles: Seq[AbsoluteFile] =
-        getFilesFromCliOptions(options, filter)
+        getFilesFromCliOptions(options, filter, skipDir)
       if (projectFiles.isEmpty && options.mode.isEmpty)
         throw Error.NoMatchingFiles
       options.common.debug
@@ -52,12 +53,13 @@ trait ScalafmtRunner {
   private[this] def getFilesFromCliOptions(
       options: CliOptions,
       canFormat: Path => Boolean,
+      skipDir: Path => Boolean,
   ): Seq[AbsoluteFile] = {
     val gitOps = options.gitOps
     val finder = options.fileFetchMode match {
       case GitFiles => new BatchPathFinder.GitFiles(gitOps)(canFormat)
       case RecursiveSearch =>
-        new BatchPathFinder.DirFiles(options.cwd)(canFormat)
+        new BatchPathFinder.DirFiles(options.cwd)(canFormat, skipDir)
       case DiffFiles(branch) =>
         new BatchPathFinder.GitBranchFiles(gitOps, branch)(canFormat)
       case ChangedFiles => new BatchPathFinder.GitDirtyFiles(gitOps)(canFormat)

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -957,6 +957,43 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
     noArgTest(input, expected, Seq(Array.empty[String], Array("--mode", "diff")))
   }
 
+  test(s"scalafmt excludePaths glob prunes the excluded subtree") {
+    // a `.../X/**` glob lets recursive discovery skip the whole `X` subtree;
+    // the resulting file set must match the per-file exclude (target untouched)
+    val input = string2dir {
+      s"""|/foo.scala
+          |object    FormatMe {
+          |  val x = 1
+          |}
+          |
+          |/target/foo.scala
+          |object A   { }
+          |
+          |/.scalafmt.conf
+          |version = $stableVersion
+          |maxColumn = 2
+          |project { excludePaths = ["glob:**/target/**"] }
+          |""".stripMargin
+    }
+
+    val expected =
+      s"""|/.scalafmt.conf
+          |version = $stableVersion
+          |maxColumn = 2
+          |project { excludePaths = ["glob:**/target/**"] }
+          |
+          |/foo.scala
+          |object FormatMe {
+          |  val x =
+          |    1
+          |}
+          |
+          |/target/foo.scala
+          |object A   { }
+          |""".stripMargin
+    noArgTest(input, expected, Seq(Array.empty[String], Array("--mode", "diff")))
+  }
+
   test(s"scalafmt: includeFilters overrides default includePaths") {
     val input = string2dir {
       s"""|/bar.scala

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ProjectFiles.scala
@@ -53,6 +53,13 @@ object ProjectFiles {
       new FileMatcher(
         nio(includePaths) ++ regex(pf.includeFilters),
         nio(pf.excludePaths) ++ regex(pf.excludeFilters ++ regexExclude),
+        // a `glob:.../X/**` exclude means every descendant of an `X` dir is
+        // excluded, so the whole subtree can be pruned during a recursive walk;
+        // key on the `glob:.../X` dir. (regex/non-`/**` excludes can't be safely
+        // reduced to a dir, so they stay per-file.)
+        nio(pf.excludePaths.collect {
+          case s if s.startsWith("glob:") && s.endsWith("/**") => s.dropRight(3)
+        }),
       )
     }
 
@@ -63,12 +70,20 @@ object ProjectFiles {
 
   }
 
-  class FileMatcher(include: Seq[PathMatcher], exclude: Seq[PathMatcher]) {
+  class FileMatcher(
+      include: Seq[PathMatcher],
+      exclude: Seq[PathMatcher],
+      excludeDirs: Seq[PathMatcher] = Nil,
+  ) {
     def matchesPath(path: file.Path): Boolean = include
       .exists(_.matches(path)) && !exclude.exists(_.matches(path))
     def matches(filename: String): Boolean =
       matchesPath(FileOps.getPath(filename))
     def matchesFile(file: AbsoluteFile): Boolean = matchesPath(file.path)
+
+    /** a directory whose every descendant is excluded (safe to prune) */
+    def excludesDir(path: file.Path): Boolean = excludeDirs
+      .exists(_.matches(path))
   }
 
   case class FileInfo(lang: String, isTest: Boolean)

--- a/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/BatchPathFinder.scala
+++ b/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/BatchPathFinder.scala
@@ -31,13 +31,22 @@ trait BatchPathFinder {
 
 object BatchPathFinder {
 
-  final class DirFiles(val cwd: AbsoluteFile)(val matches: Path => Boolean)
-      extends BatchPathFinder {
-    private def filter(path: Path, attrs: FileStat): Boolean =
-      attrs.isRegularFile && matches(path)
+  final class DirFiles(val cwd: AbsoluteFile)(
+      val matches: Path => Boolean,
+      skipDir: Path => Boolean = _ => false,
+  ) extends BatchPathFinder {
+    // prune fully-excluded subtrees during the walk instead of visiting and
+    // filtering every file under them
+    private val visitor = new FileOps.WalkVisitor {
+      override def onTree(dir: Path, attrs: FileStat): FileOps.WalkVisit =
+        if (skipDir(dir)) FileOps.WalkVisit.Skip else FileOps.WalkVisit.Good
+      override def onFile(file: Path, attrs: FileStat): FileOps.WalkVisit =
+        if (attrs.isRegularFile && matches(file)) FileOps.WalkVisit.Good
+        else FileOps.WalkVisit.Skip
+    }
     override def findFiles(dir: AbsoluteFile*): Seq[AbsoluteFile] = {
       val dirs = if (dir.isEmpty) Seq(cwd.path) else dir.map(_.path)
-      dirs.flatMap(FileOps.listFiles(filter)).map(new AbsoluteFile(_))
+      dirs.flatMap(FileOps.walkFiles(visitor)).map(new AbsoluteFile(_))
     }
   }
 


### PR DESCRIPTION
RecursiveSearch (project.git = false) walked the entire tree via Files.find and filtered per file, so a repo with a large excluded directory (e.g. target) paid to visit every file in it -- on scala-js, 24k entries walked to return 1.4k (~320 ms).

DirFiles now walks via walkFiles and skips a subtree when its directory is fully excluded. FileMatcher.excludesDir derives dir matchers from `glob:.../X/**` excludes (-> `glob:.../X`): every descendant of such a dir matches the file exclude, so pruning yields the same file set. Threaded as an optional skipDir; the core runner passes excludesDir, while the dynamic runner and default no-exclude configs prune nothing (unchanged). regex and non-`/**` excludes stay per-file.

scala-js recursive discovery: 320 -> 34 ms.