### PR TITLE
cli: add --mode diff-base to format only files changed since fork

### DIFF
--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/FileFetchMode.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/FileFetchMode.scala
@@ -11,6 +11,8 @@ sealed trait FileFetchMode {
 object FileFetchMode {
 
   private val diffRefPrefix = "diff-ref="
+  private val diffBase = "diff-base"
+  private val diffBasePrefix = diffBase + "="
   private val availableModes = Seq(
     "diff" -> DiffFiles("master"),
     "changed" -> ChangedFiles,
@@ -20,8 +22,10 @@ object FileFetchMode {
   private val availableModesMap: Map[String, FileFetchMode] =
     availableModes.toMap
 
-  def help: String = (("diff-ref=xxx", DiffFiles("xxx")) +: availableModes)
-    .map { case (k, v) => s"$k: ${v.desc}" }.mkString("   ", "\n   ", "")
+  def help: String =
+    (Seq("diff-ref=xxx" -> DiffFiles("xxx"), diffBase -> DiffBase(None)) ++
+      availableModes).map { case (k, v) => s"$k: ${v.desc}" }
+      .mkString("   ", "\n   ", "")
 
   /** The read instance is practically is not exhaustive due to the
     * RecursiveSearch and GitFiles are the fallback used in the absence of other
@@ -30,6 +34,9 @@ object FileFetchMode {
   implicit val read: Read[FileFetchMode] = Read.reads(x =>
     if (x.startsWith(diffRefPrefix))
       DiffFiles(x.substring(diffRefPrefix.length).trim)
+    else if (x == diffBase) DiffBase(None)
+    else if (x.startsWith(diffBasePrefix))
+      DiffBase(Some(x.substring(diffBasePrefix.length).trim))
     else availableModesMap
       .getOrElse(x, throw new IllegalArgumentException(s"unknown mode: $x")),
   )
@@ -55,6 +62,20 @@ case object GitFiles extends FileFetchMode {
 final case class DiffFiles(branch: String) extends FileFetchMode {
   def desc: String =
     s"format files listed in `git diff` against gitref `$branch`"
+}
+
+/** Files changed since HEAD forked from a base branch: `git diff` against
+  * `git merge-base HEAD <ref>`, where `ref` defaults to the branch's configured
+  * upstream (`@{upstream}`). If the scalafmt config changed since that fork
+  * point, all tracked files are formatted instead (a config change can reformat
+  * anything); likewise if no upstream is configured (nothing to diff against).
+  *
+  * When this is set, files passed via the cli are ignored.
+  */
+final case class DiffBase(ref: Option[String]) extends FileFetchMode {
+  def desc: String = ref.fold(
+    "format files changed since this branch forked from its upstream (@{upstream})",
+  )(r => s"format files changed since this branch forked from `$r`")
 }
 
 /** A call to `git status --porcelain`

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -62,6 +62,12 @@ trait ScalafmtRunner {
         new BatchPathFinder.DirFiles(options.cwd)(canFormat, skipDir)
       case DiffFiles(branch) =>
         new BatchPathFinder.GitBranchFiles(gitOps, branch)(canFormat)
+      case DiffBase(refOpt) => diffBaseRef(options, gitOps, refOpt) match {
+          case Some(base) =>
+            new BatchPathFinder.GitBranchFiles(gitOps, base)(canFormat)
+          case None => // unresolvable base or config changed: format all tracked
+            new BatchPathFinder.GitFiles(gitOps)(canFormat)
+        }
       case ChangedFiles => new BatchPathFinder.GitDirtyFiles(gitOps)(canFormat)
     }
     val files = finder.findMatchingFiles(
@@ -71,6 +77,24 @@ trait ScalafmtRunner {
     val excludeRegexp = options.excludeFilterRegexp.pattern
     files.filter(f => !excludeRegexp.matcher(f.toString()).find())
   }
+
+  /** The fork-point to diff against for [[DiffBase]], or None to signal "format
+    * all tracked files" — when the base can't be resolved, or the scalafmt
+    * config changed since the fork (a config change can reformat anything).
+    */
+  private[this] def diffBaseRef(
+      options: CliOptions,
+      gitOps: GitOps,
+      refOpt: Option[String],
+  ): Option[String] = refOpt.orElse(gitOps.upstreamBranch)
+    .flatMap(gitOps.mergeBase).filter { base =>
+      val configFile = options.canonicalConfigFile.flatMap(_.toOption)
+      val configChanged = configFile
+        .exists(p => gitOps.changedSince(base, AbsoluteFile(p)))
+      if (configChanged) options.common.debug
+        .println("scalafmt config changed since fork; formatting all files")
+      !configChanged
+    }
 
   protected def runInputs(
       options: CliOptions,

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -994,6 +994,63 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
     noArgTest(input, expected, Seq(Array.empty[String], Array("--mode", "diff")))
   }
 
+  // git double: HEAD forked from "origin/main" at "BASE"; `changed` are the
+  // files git reports changed since BASE; `configChanged` toggles the guard.
+  private def diffBaseOptions(
+      root: AbsoluteFile,
+      changed: Seq[String],
+      configChanged: Boolean,
+  ): CliOptions = baseCliOptions.copy(
+    gitOpsConstructor = _ =>
+      new FakeGitOps(root) {
+        override def upstreamBranch: Option[String] = Some("origin/main")
+        override def mergeBase(ref: String): Option[String] = Some("BASE")
+        override def diff(b: String, dir: AbsoluteFile*): Seq[AbsoluteFile] =
+          changed.map(root / _)
+        override def changedSince(ref: String, f: AbsoluteFile): Boolean =
+          configChanged
+        // git ls-files with no dir args lists all tracked files (the fallback
+        // when the config changed); the base fake returns empty for empty args
+        override def lsTree(dir: AbsoluteFile*): Seq[AbsoluteFile] =
+          root.listFiles
+      },
+    common = baseCliOptions.common.copy(cwd = Some(root)),
+  )
+
+  private val diffBaseInput =
+    s"""|/a.scala
+        |object A{val x=1}
+        |/b.scala
+        |object B{val y=2}
+        |/.scalafmt.conf
+        |version = $stableVersion
+        |""".stripMargin
+
+  test("--mode diff-base formats only files changed since the fork") {
+    val input = string2dir(diffBaseInput)
+    val options = diffBaseOptions(input, Seq("a.scala"), configChanged = false)
+    Cli.run(Cli.getConfig(options, "--mode", "diff-base").get).map { _ =>
+      val res = dir2string(input)
+      assertContains(res, "object A { val x = 1 }") // changed -> formatted
+      assertContains(res, "object B{val y=2}") // not changed -> untouched
+    }
+  }
+
+  test("--mode diff-base formats all files when the config changed") {
+    val input = string2dir(diffBaseInput)
+    val options = diffBaseOptions(input, Seq("a.scala"), configChanged = true)
+    Cli.run(Cli.getConfig(options, "--mode", "diff-base").get).map { _ =>
+      val res = dir2string(input)
+      assertContains(res, "object A { val x = 1 }")
+      assertContains(res, "object B { val y = 2 }") // guard -> all formatted
+    }
+  }
+
+  test("--mode diff-base=<ref> parses")(assertEquals(
+    getConfig("--mode", "diff-base=origin/dev").mode,
+    Option(DiffBase(Some("origin/dev"))),
+  ))
+
   test(s"scalafmt: includeFilters overrides default includePaths") {
     val input = string2dir {
       s"""|/bar.scala

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/FakeGitOps.scala
@@ -10,4 +10,7 @@ class FakeGitOps(root: AbsoluteFile) extends GitOps {
   override def diff(branch: String, dir: AbsoluteFile*): Seq[AbsoluteFile] =
     lsTree(dir: _*)
   override def getAutoCRLF: Option[String] = None
+  override def upstreamBranch: Option[String] = None
+  override def mergeBase(ref: String): Option[String] = Some(ref)
+  override def changedSince(ref: String, file: AbsoluteFile): Boolean = false
 }

--- a/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/GitOps.scala
+++ b/scalafmt-sysops/shared/src/main/scala/org/scalafmt/sysops/GitOps.scala
@@ -43,6 +43,17 @@ trait GitOps {
   def lsTree(dir: AbsoluteFile*): Seq[AbsoluteFile]
   def rootDir: Option[AbsoluteFile]
   def getAutoCRLF: Option[String]
+
+  /** the current branch's configured upstream (e.g. `origin/main`), if set;
+    * git's only reliable record of a base — no remote/branch-name guessing
+    */
+  def upstreamBranch: Option[String]
+
+  /** the fork point: the commit HEAD and `ref` diverged from */
+  def mergeBase(ref: String): Option[String]
+
+  /** whether `file` differs between `ref` and the work tree */
+  def changedSince(ref: String, file: AbsoluteFile): Boolean
 }
 
 private class GitOpsImpl(val workingDirectory: AbsoluteFile) extends GitOps {
@@ -90,6 +101,19 @@ private class GitOpsImpl(val workingDirectory: AbsoluteFile) extends GitOps {
 
   override def getAutoCRLF: Option[String] =
     tryExec("config", "--get", "core.autocrlf").toOption.flatMap(_.headOption)
+
+  private def firstLine(t: Try[Seq[String]]): Option[String] = t.toOption
+    .flatMap(_.headOption).map(_.trim).filter(_.nonEmpty)
+
+  override def upstreamBranch: Option[String] =
+    // git's own tracking record; fails (-> None) if no upstream is configured
+    firstLine(tryExec("rev-parse", "--abbrev-ref", "@{upstream}"))
+
+  override def mergeBase(ref: String): Option[String] =
+    firstLine(tryExec("merge-base", "HEAD", ref))
+
+  override def changedSince(ref: String, file: AbsoluteFile): Boolean =
+    firstLine(tryExec("diff", "--name-only", ref, "--", file)).isDefined
 
   private final val renameStatusCode = "R"
   private final val renameStatusArrowDelimiter = "-> "


### PR DESCRIPTION
Formats just the files changed since HEAD forked from a base branch: git diff against `merge-base(HEAD, <ref>)`. With no ref, <ref> is the branch's configured upstream (`@{upstream}`) -- git's only reliable record of a base, with no remote/branch-name guessing. If no upstream is set (e.g. a detached CI checkout), all tracked files are formatted. This targets the common edit/re-run loop, where re-formatting every tracked file is wasted work.

Config guard: if .scalafmt.conf changed since the fork point, all tracked files are formatted instead -- a config change can reformat anything, so limiting to the diff would be unsound.

Adds GitOps.upstreamBranch/mergeBase/changedSince and the DiffBase mode (`--mode diff-base` or `diff-base=<ref>`); opt-in, existing modes unchanged.