### PR TITLE
ScalafmtSession: add listFiles interface method

### DIFF
--- a/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicSession.scala
+++ b/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamicSession.scala
@@ -2,7 +2,7 @@ package org.scalafmt.dynamic
 
 import org.scalafmt.dynamic.exceptions._
 import org.scalafmt.interfaces._
-import org.scalafmt.sysops.{AbsoluteFile, GitOps}
+import org.scalafmt.sysops.{AbsoluteFile, BatchPathFinder, GitOps}
 
 import java.nio.file.Path
 
@@ -25,6 +25,20 @@ final case class ScalafmtDynamicSession(
     .isIncludedInProject(file)
 
   override def isGitOnly: Boolean = cfg.projectIsGit
+
+  override def listFiles(root: Path, paths: Path*): java.util.List[Path] = {
+    val rootAbs = AbsoluteFile(root)
+    val matches: Path => Boolean = cfg.isIncludedInProject
+    val finder: BatchPathFinder =
+      if (cfg.projectIsGit)
+        new BatchPathFinder.GitFiles(GitOps.FactoryImpl(rootAbs))(matches)
+      else new BatchPathFinder.DirFiles(rootAbs)(matches)
+    // no explicit paths: search under root itself
+    val searchPaths = paths.map(AbsoluteFile.apply)
+    val out = new java.util.ArrayList[Path]
+    finder.findMatchingFiles(true, searchPaths: _*).foreach(f => out.add(f.path))
+    out
+  }
 
   private def tryFormat(file: Path, code: String): FormatResult =
     if (properties.respectExcludeFilters && !matchesProjectFilters(file)) {

--- a/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -278,6 +278,25 @@ class DynamicSuite extends FunSuite {
     assertNoDiff(err, "Invalid config: Invalid path matcher pattern: foo.scala")
   }
 
+  check("listFiles") { f =>
+    f.setVersion(
+      latest,
+      "scala213",
+      """project.excludePaths = ["glob:**/Ignore.scala"]""",
+    )
+    val base = Files.createTempDirectory("scalafmt-listFiles")
+    Files.createDirectories(base.resolve("a").resolve("b"))
+    def write(rel: String): Unit = Files
+      .write(base.resolve(rel), "object A".getBytes(StandardCharsets.UTF_8))
+    write("Top.scala")
+    write("a/b/Deep.scala")
+    write("a/Ignore.scala") // matched by project.excludePaths
+    write("notes.txt") // not a scala source
+    def load() = f.dynamic.createSession(f.config).listFiles(base)
+    // no discovery implementation yet: the default throws
+    intercept[UnsupportedOperationException](load())
+  }
+
   check("config-cache") { f =>
     f.setVersion(latest, "scala211")
     f.assertFormat()

--- a/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -293,8 +293,13 @@ class DynamicSuite extends FunSuite {
     write("a/Ignore.scala") // matched by project.excludePaths
     write("notes.txt") // not a scala source
     def load() = f.dynamic.createSession(f.config).listFiles(base)
-    // no discovery implementation yet: the default throws
-    intercept[UnsupportedOperationException](load())
+    // discovers sources in any subdirectory, honoring project filters
+    val files = load()
+    val found = (0 until files.size()).iterator
+      .map(files.get(_).toString.replace('\\', '/')).toList
+    assertEquals(found.size, 2, found)
+    assert(found.exists(_.endsWith("/Top.scala")), found)
+    assert(found.exists(_.endsWith("/a/b/Deep.scala")), found)
   }
 
   check("config-cache") { f =>

--- a/scalafmt-interfaces/js/src/main/scala/org/scalafmt/interfaces/ScalafmtSession.scala
+++ b/scalafmt-interfaces/js/src/main/scala/org/scalafmt/interfaces/ScalafmtSession.scala
@@ -44,4 +44,25 @@ trait ScalafmtSession {
     */
   def isGitOnly: Boolean
 
+  /** Discover the files this configuration would format, the way the
+    * command-line interface does: git-tracked files when the configuration
+    * enables git, otherwise a recursive filesystem walk. The returned files
+    * already match the 'project.{excludeFilters,includeFilters}' settings.
+    *
+    * @param root
+    *   the directory that anchors discovery: the git working directory when the
+    *   configuration enables git, and the walk root otherwise.
+    * @param paths
+    *   specific files or directories to search under; if none are given, `root`
+    *   itself is searched.
+    * @return
+    *   the matching files, as absolute paths.
+    * @throws UnsupportedOperationException
+    *   if this implementation does not support discovery.
+    */
+  def listFiles(root: Path, paths: Path*): java.util.List[Path] =
+    throw new UnsupportedOperationException(
+      "listFiles is not implemented by this ScalafmtSession",
+    )
+
 }

--- a/scalafmt-interfaces/jvm/src/main/java/org/scalafmt/interfaces/ScalafmtSession.java
+++ b/scalafmt-interfaces/jvm/src/main/java/org/scalafmt/interfaces/ScalafmtSession.java
@@ -41,4 +41,21 @@ public interface ScalafmtSession {
      */
     boolean isGitOnly();
 
+    /**
+     * Discover the files this configuration would format, the way the command-line
+     * interface does: git-tracked files when the configuration enables git, otherwise a
+     * recursive filesystem walk. The returned files already match the
+     * 'project.{excludeFilters,includeFilters}' settings.
+     *
+     * @param root the directory that anchors discovery: the git working directory when
+     *             the configuration enables git, and the walk root otherwise.
+     * @param paths specific files or directories to search under; if none are given,
+     *              {@code root} itself is searched.
+     * @return the matching files, as absolute paths.
+     * @throws UnsupportedOperationException if this implementation does not support discovery.
+     */
+    default java.util.List<java.nio.file.Path> listFiles(java.nio.file.Path root, java.nio.file.Path... paths) {
+        throw new UnsupportedOperationException("listFiles is not implemented by this ScalafmtSession");
+    }
+
 }


### PR DESCRIPTION
listFiles discover files the way the CLI does -- git-tracked when project.git is set, else a filesystem walk from root -- reusing sysops' BatchPathFinder (the same discovery the CLI uses) with the config's project filters. Flip the test from asserting the default throws to asserting the discovered file set.