### PR TITLE
Docs: emit config defaults as a self-contained properties block

### DIFF
--- a/scalafmt-docs/src/main/scala/docs/DefaultsModifier.scala
+++ b/scalafmt-docs/src/main/scala/docs/DefaultsModifier.scala
@@ -12,28 +12,29 @@ class DefaultsModifier extends StringModifier {
   private val default = ConfEncoder[ScalafmtConfig]
     .writeObj(ScalafmtConfig.default)
 
-  override def process(info: String, code: Input, reporter: Reporter): String =
-    if (info == "all") {
-      val result = Conf.printHocon(ScalafmtConfig.default)
-      "```\n" + result + "\n```"
-    } else {
-      def getDefaultValue(param: String): String = {
-        val path = param.split("\\.").toList
-        val down = path.foldLeft(default.dynamic)(_ selectDynamic _)
-        down.asConf.fold { e =>
-          reporter.error(Position.Range(code, 0, 0), e.toString())
-          "<fail>"
-        }(_.toString())
-      }
+  override def process(
+      info: String,
+      code: Input,
+      reporter: Reporter,
+  ): String = {
+    val result =
+      if (info == "all") Conf.printHocon(ScalafmtConfig.default)
+      else processCode(code, reporter)
+    "```properties\n" + result + "\n```"
+  }
 
-      val params = code.text.split("\\s+")
-      if (params.length == 1) {
-        val param = params(0)
-        s"Default: `$param = ${getDefaultValue(param)}`\n"
-      } else {
-        val defaults = params.map(param => s"$param = ${getDefaultValue(param)}")
-        ScalafmtModifier
-          .mdConfigCodeBlock(defaults.mkString("# Defaults\n", "\n", ""))
-      }
+  private def processCode(code: Input, reporter: Reporter): String = {
+    def getDefaultValue(param: String): String = {
+      val path = param.split("\\.").toList
+      val down = path.foldLeft(default.dynamic)(_ selectDynamic _)
+      down.asConf.fold { e =>
+        reporter.error(Position.Range(code, 0, 0), e.toString())
+        "<fail>"
+      }(_.toString())
     }
+
+    code.text.split("\\s+").map(p => s"$p = ${getDefaultValue(p)}")
+      .mkString("# Defaults\n", "\n", "")
+  }
+
 }


### PR DESCRIPTION
DefaultsModifier builds its own ```properties fenced block instead of borrowing a helper from ScalafmtModifier. `properties` highlights the key = value lines (and treats the "# Defaults" header as a comment), and Conf.printHocon's flat dotted output for `defaults:all` fits it too. This also frees ScalafmtModifier of the String-returning block helper.