### PR TITLE
Fix non-idempotency of rewrite.scala3.preset = "common" for nested objects with blank lines

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -185,7 +185,8 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
         case _ => false
       }) ||
       (left.ft.right match {
-        case _: T.Colon => !shouldRewriteColonOnRight(left)
+        case _: T.Colon =>
+          !shouldRewriteColonOnRight(left) || !skipRightToBraces(left)
         case _ => false
       })
     ft.right match {

--- a/scalafmt-tests/shared/src/test/resources/scala3/Issues.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/Issues.stat
@@ -117,3 +117,18 @@ lazy val versions = new {
 lazy val versions = new {
   val cats = "2.10.0"
 }
+<<< preset=common, nested object with blank line is non-idempotent
+rewrite.scala3.preset = "common"
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+object Outer {
+  val a = 1
+
+  object Inner:
+    val b = 2
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10213,3 +10213,18 @@ then
    report.errorAndAbort(
      s"Failed to derive a ZLayer: type `${tpeSymbol.fullName}` is not a concrete class."
    )
+<<< preset=common, nested object with blank line is non-idempotent
+rewrite.scala3.preset = "common"
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+object Outer {
+  val a = 1
+
+  object Inner:
+     val b = 2
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -9820,3 +9820,18 @@ if tpe.classSymbol.isEmpty || tpeSymbol.flags.is(Flags.Abstract) ||
 then
    report.errorAndAbort(s"Failed to derive a ZLayer: type `${tpeSymbol
        .fullName}` is not a concrete class.")
+<<< preset=common, nested object with blank line is non-idempotent
+rewrite.scala3.preset = "common"
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+object Outer {
+  val a = 1
+
+  object Inner:
+     val b = 2
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10218,3 +10218,18 @@ then
    report.errorAndAbort(
      s"Failed to derive a ZLayer: type `${tpeSymbol.fullName}` is not a concrete class."
    )
+<<< preset=common, nested object with blank line is non-idempotent
+rewrite.scala3.preset = "common"
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+object Outer {
+  val a = 1
+
+  object Inner:
+     val b = 2
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10594,3 +10594,18 @@ then
      s"Failed to derive a ZLayer: type `${tpeSymbol
          .fullName}` is not a concrete class."
    )
+<<< preset=common, nested object with blank line is non-idempotent
+rewrite.scala3.preset = "common"
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+object Outer {
+  val a = 1
+
+  object Inner:
+     val b = 2
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2607500, "total explored")
+      assertEquals(explored, 2607860, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
## Summary

Fixes #5346.

With `rewrite.scala3.preset = "common"`, the formatter oscillated between two states for nested objects separated by a blank line:

- **State A** (colon/colon) → formatter inserts braces on the outer object (blank-gap condition met) → **State B** (brace/colon)
- **State B** (brace/colon) → formatter removes braces from the outer object → **State A** again

Neither state passed `--test`.

### Root cause

`onToken` creates a `{`→`:` Replace for `Template.Body` blocks (brace removal). Because `replaceToken(":")` stores a copy of the FT with `right = T.Colon`, the `onRight` dispatch sends it to `onRightFromBraces`. The colon case in `notOkToRewrite` there only called `shouldRewriteColonOnRight`, which returns `true` for `Template.Body` — unconditionally allowing removal without checking whether the `optionalBraces.insert` blank-gap condition required keeping the braces.

### Fix

Added `|| !skipRightToBraces(left)` to the colon case in `notOkToRewrite` inside `onRightFromBraces`:

```scala
// before
case _: T.Colon => !shouldRewriteColonOnRight(left)

// after
case _: T.Colon =>
  !shouldRewriteColonOnRight(left) || !skipRightToBraces(left)
```

When the insert condition (e.g. blank gaps ≥ 1) is satisfied, `skipRightToBraces` returns `false`, making `notOkToRewrite = true` and preserving the braces. When the condition is not satisfied, `skipRightToBraces` returns `true` and removal proceeds as before.

## Test plan

- [x] Added regression test in `scala3/Issues.stat`: colon/colon input → brace/colon output (only outer object gets braces; inner has no blank-line gap)
- [x] The test framework's built-in idempotency check confirms brace/colon → brace/colon (stable state)
- [x] Full test suite passes (`16228` tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)