### PR TITLE
RemoveScala3OptionalBraces: avoid brace/colon yoyo

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -185,7 +185,8 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
         case _ => false
       }) ||
       (left.ft.right match {
-        case _: T.Colon => !shouldRewriteColonOnRight(left)
+        case _: T.Colon => !shouldRewriteColonOnRight(left) ||
+          !skipRightToBraces(left)
         case _ => false
       })
     ft.right match {

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10213,3 +10213,26 @@ then
    report.errorAndAbort(
      s"Failed to derive a ZLayer: type `${tpeSymbol.fullName}` is not a concrete class."
    )
+<<< #5346 non-idempotent nested optional-braces with blank line
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,6 +1,5 @@
+-object Outer {
+-  val a = 1
++object Outer:
++   val a = 1
+ ∙
+-  object Inner:
+-     val b = 2
+-}
++   object Inner:
++      val b = 2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10215,7 +10215,6 @@ then
    )
 <<< #5346 non-idempotent nested optional-braces with blank line
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 object Outer:
   val a = 1
@@ -10223,16 +10222,9 @@ object Outer:
   object Inner:
     val b = 2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,6 +1,5 @@
--object Outer {
--  val a = 1
-+object Outer:
-+   val a = 1
- ∙
--  object Inner:
--     val b = 2
--}
-+   object Inner:
-+      val b = 2
+object Outer {
+  val a = 1
+
+  object Inner:
+     val b = 2
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -9820,3 +9820,26 @@ if tpe.classSymbol.isEmpty || tpeSymbol.flags.is(Flags.Abstract) ||
 then
    report.errorAndAbort(s"Failed to derive a ZLayer: type `${tpeSymbol
        .fullName}` is not a concrete class.")
+<<< #5346 non-idempotent nested optional-braces with blank line
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,6 +1,5 @@
+-object Outer {
+-  val a = 1
++object Outer:
++   val a = 1
+ ∙
+-  object Inner:
+-     val b = 2
+-}
++   object Inner:
++      val b = 2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -9822,7 +9822,6 @@ then
        .fullName}` is not a concrete class.")
 <<< #5346 non-idempotent nested optional-braces with blank line
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 object Outer:
   val a = 1
@@ -9830,16 +9829,9 @@ object Outer:
   object Inner:
     val b = 2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,6 +1,5 @@
--object Outer {
--  val a = 1
-+object Outer:
-+   val a = 1
- ∙
--  object Inner:
--     val b = 2
--}
-+   object Inner:
-+      val b = 2
+object Outer {
+  val a = 1
+
+  object Inner:
+     val b = 2
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10218,3 +10218,26 @@ then
    report.errorAndAbort(
      s"Failed to derive a ZLayer: type `${tpeSymbol.fullName}` is not a concrete class."
    )
+<<< #5346 non-idempotent nested optional-braces with blank line
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,6 +1,5 @@
+-object Outer {
+-  val a = 1
++object Outer:
++   val a = 1
+ ∙
+-  object Inner:
+-     val b = 2
+-}
++   object Inner:
++      val b = 2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10220,7 +10220,6 @@ then
    )
 <<< #5346 non-idempotent nested optional-braces with blank line
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 object Outer:
   val a = 1
@@ -10228,16 +10227,9 @@ object Outer:
   object Inner:
     val b = 2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,6 +1,5 @@
--object Outer {
--  val a = 1
-+object Outer:
-+   val a = 1
- ∙
--  object Inner:
--     val b = 2
--}
-+   object Inner:
-+      val b = 2
+object Outer {
+  val a = 1
+
+  object Inner:
+     val b = 2
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10596,7 +10596,6 @@ then
    )
 <<< #5346 non-idempotent nested optional-braces with blank line
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 object Outer:
   val a = 1
@@ -10604,16 +10603,9 @@ object Outer:
   object Inner:
     val b = 2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,6 +1,5 @@
--object Outer {
--  val a = 1
-+object Outer:
-+   val a = 1
- ∙
--  object Inner:
--     val b = 2
--}
-+   object Inner:
-+      val b = 2
+object Outer {
+  val a = 1
+
+  object Inner:
+     val b = 2
+}

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10594,3 +10594,26 @@ then
      s"Failed to derive a ZLayer: type `${tpeSymbol
          .fullName}` is not a concrete class."
    )
+<<< #5346 non-idempotent nested optional-braces with blank line
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+object Outer:
+  val a = 1
+
+  object Inner:
+    val b = 2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,6 +1,5 @@
+-object Outer {
+-  val a = 1
++object Outer:
++   val a = 1
+ ∙
+-  object Inner:
+-     val b = 2
+-}
++   object Inner:
++      val b = 2

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2607640, "total explored")
+      assertEquals(explored, 2607788, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -149,7 +149,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2607500, "total explored")
+      assertEquals(explored, 2607640, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Let's not replace braces with colon in onRightFromBraces when the next iteration would invoke onRightToBraces and succeed. Fixes #5346. Supersedes #5347.