### PR TITLE
CI: fix intermittent native SIGSEGV in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
         if: ${{ (success() || failure()) && steps.gitconfig.outcome == 'success' }}
       - run: sbt ++${{ matrix.scala }} test-native
         if: ${{ (success() || failure()) && steps.gitconfig.outcome == 'success' }}
+        # Workaround for scala-native/scala-native#4917 (intermittent SIGSEGV
+        # in the multithreaded native binary), as in release-native.yml.
+        env:
+          SCALANATIVE_GC_TRAP_BASED_YIELDPOINTS: "0"
       - run: sbt ++${{ matrix.scala }} publishLocal
         if: ${{ (success() || failure()) && steps.gitconfig.outcome == 'success' }}
       # Build and sanity-check the fat jar


### PR DESCRIPTION
The native tests hit scala-native#4917 (intermittent SIGSEGV in the multithreaded native binary) which release-native.yml already works around but CI did not. Set SCALANATIVE_GC_TRAP_BASED_YIELDPOINTS=0 on the test-native step, matching the release build.