### PR TITLE
CI: move ubuntu runners to 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
           - '21'
         os:
           - windows-2025
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         scala:
           - '2.12.21'
           - '2.13.18'

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -25,7 +25,7 @@ jobs:
         deploy: [
           { os: macOS-15-intel, name: scalafmt-x86_64-apple-darwin.zip },
           { os: macOS-15, name: scalafmt-aarch64-apple-darwin.zip },
-          { os: ubuntu-22.04, name: scalafmt-x86_64-pc-linux.zip },
+          { os: ubuntu-24.04, name: scalafmt-x86_64-pc-linux.zip },
           { os: ubuntu-24.04-arm, name: scalafmt-aarch64-pc-linux.zip },
           { os: windows-2025, name: scalafmt-x86_64-pc-win32.zip }
         ]


### PR DESCRIPTION
Bump the CI test matrix (ubuntu-22.04 -> ubuntu-24.04, plus its arm variant) and the release-native x86_64 Linux build to match, so CI builds and tests native on the same image that produces the published binary (glibc/toolchain parity).