### PR TITLE
CI: cancel superseded runs via concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - '*'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Add a concurrency group keyed on workflow + ref with cancel-in-progress, so pushing again to a branch/PR cancels its now-obsolete in-flight run instead of letting stale runs finish.