### PR TITLE
Tests: raise munit per-test timeout to 2 minutes

### DIFF
--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/SharedFunSuiteBase.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/SharedFunSuiteBase.scala
@@ -1,10 +1,16 @@
 package org.scalafmt
 
+import scala.concurrent.duration._
+
 import munit.diff.DiffOptions
 
 trait SharedFunSuiteBase extends munit.FunSuite {
 
   implicit val diffOptions: DiffOptions = DiffOptions.withShowLines(true)
     .withContextSize(10)
+
+  // munit's default is 30s per test; a few heavy format cases exceed that on
+  // Native/JS, which lack a JIT and run several times slower than the JVM.
+  override def munitTimeout: Duration = 2.minutes
 
 }


### PR DESCRIPTION
A few heavy format cases exceed munit's default 30s per-test timeout on Native/JS, which lack a JIT and run several times slower than the JVM (e.g. a Scala 3 fewer-braces case: ~15-20s in the JVM, ~44s on Windows native). Override munitTimeout on the shared base suite.