### PR TITLE
CLI: Don't let a tolerated error mask a real one

### DIFF
--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/Cli.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/Cli.scala
@@ -161,12 +161,6 @@ object Cli extends CliUtils {
         options.common.out.println("error: --test failed")
         options.onTestFailure.foreach(options.common.out.println)
       } else options.common.out.println(s"error: $exit")
-    if (
-      options.writeMode == WriteMode.Test && !options.fatalWarnings &&
-      exit.is(ExitCode.ParseError)
-    )
-      // Ignore parse errors etc.
-      ExitCode.Ok
-    else exit
+    options.tolerate(exit)
   }
 }

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/CliOptions.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/CliOptions.scala
@@ -210,4 +210,12 @@ case class CliOptions(
   private[cli] def exitCodeOnChange =
     if (error) ExitCode.TestError else ExitCode.Ok
 
+  /** Clears the bits this run is configured to tolerate; see #1835, a parse
+    * error is reported but doesn't fail `--test`. Keeps the other bits, so a
+    * tolerated error can't mask a real failure in another file.
+    */
+  private[cli] def tolerate(exit: ExitCode): ExitCode =
+    if (writeMode != WriteMode.Test || fatalWarnings) exit
+    else ExitCode(exit.code & ~ExitCode.ParseError.code)
+
 }

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -139,7 +139,11 @@ trait ScalafmtRunner {
         }(writeContext).transform { r =>
           val ok = r == Success(ExitCode.Ok)
           termDisplay.foreach(_.doneWrite(ok = ok))
-          if (!ok && options.check) completed.trySuccess(asExit(r))
+          if (!ok && options.check) {
+            val code = asExit(r)
+            // a tolerated error won't fail the run, so it mustn't stop it
+            if (!options.tolerate(code).isOk) completed.trySuccess(code)
+          }
           Success(r)
         }
         tasks += future

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -687,8 +687,15 @@ trait CliTestBehavior {
         assertContains(out, "+object Bar {}")
         assertContains(out, "+object Baz {}")
         assertContains(out, "error: --test failed")
-        // the parse error zeroes out the whole code, TestError included
-        assertEquals(exit, ExitCode.Ok)
+        assertEquals(exit, ExitCode.TestError)
+      },
+    )
+
+    test(s"unparseable file among misformatted ones, --check: $label")(
+      unparseableAmongMisformatted("")("--check").map { case (exit, out) =>
+        // fail-fast stops at the first real failure, so only one diff
+        assertContains(out, "error: --test failed")
+        assertEquals(exit, ExitCode.TestError)
       },
     )
 

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -660,6 +660,48 @@ trait CliTestBehavior {
       )
     }
 
+    def unparseableAmongMisformatted(
+        extraConf: String,
+    )(args: String*): Future[(ExitCode, String)] = {
+      val input =
+        s"""|/.scalafmt.conf
+            |version = "$version"
+            |$extraConf
+            |/bar.scala
+            |object   Bar { }
+            |/baz.scala
+            |object   Baz { }
+            |/broken.scala
+            |object Broken { val b =
+            |""".stripMargin
+      val dir = string2dir(input)
+      val out = new ByteArrayOutputStream()
+      val config = Cli
+        .getConfig(getMockOptions(dir, dir, new PrintStream(out)), args: _*).get
+      Cli.run(config).map((_, CliTest.stripCR(out.toString)))
+    }
+
+    test(s"unparseable file among misformatted ones: $label")(
+      unparseableAmongMisformatted("")("--test").map { case (exit, out) =>
+        assertContains(out, s"broken.scala:2: error:$dialectError")
+        assertContains(out, "+object Bar {}")
+        assertContains(out, "+object Baz {}")
+        assertContains(out, "error: --test failed")
+        // the parse error zeroes out the whole code, TestError included
+        assertEquals(exit, ExitCode.Ok)
+      },
+    )
+
+    test(s"unparseable file among misformatted ones, fatalWarnings: $label")(
+      unparseableAmongMisformatted("runner.fatalWarnings = true")("--test")
+        .map { case (exit, out) =>
+          assertContains(out, s"broken.scala:2: error:$dialectError")
+          assertContains(out, "+object Bar {}")
+          assertContains(out, "error: --test failed")
+          assertEquals(exit, ExitCode(3)) // TestError+ParseError
+        },
+    )
+
     test(s"exception is thrown on invalid .scalafmt.conf: $label") {
       val input =
         s"""/.scalafmt.conf


### PR DESCRIPTION
A parse error is reported but doesn't fail --test (#1835). That was implemented by resetting the whole exit code to Ok, which also threw away a TestError earned by a different, perfectly parseable file: the run printed the diffs and "error: --test failed", then exited 0.

Clear only the tolerated bit, and consult the same rule at --check's fail-fast latch, which stopped the batch on the first non-zero code even when that code was about to be forgiven -- abandoning the files behind it, so their diffs were never printed either.

Fixes #5359.