### PR TITLE
ScalafmtRunner: report the failure it exited on

### DIFF
--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ExitCode.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ExitCode.scala
@@ -8,7 +8,13 @@ sealed abstract case class ExitCode(code: Int, name: String) {
   def is(c: ExitCode): Boolean = (code & c.code) != 0
   override def toString: String = s"$name=$code"
 
+  /** What to report about the file this code came from, or null. */
+  def msg: String = null
+
   def future: Future[ExitCode] = Future.successful(this)
+  def withMsg(x: String): ExitCode = new ExitCode(code, name) {
+    override def msg: String = x
+  }
 }
 
 object ExitCode {
@@ -50,6 +56,7 @@ object ExitCode {
       result
     }
 
+  // a msg describes one file, but not two; callers report it before merging
   def merge(exit1: ExitCode, exit2: ExitCode): ExitCode =
     apply(exit1.code | exit2.code)
 }

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/InputMethod.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/InputMethod.scala
@@ -19,6 +19,9 @@ sealed abstract class InputMethod {
   protected def list(options: CliOptions): Unit
   protected def overwrite(text: String, options: CliOptions): Future[Unit]
 
+  /** Returns the exit code and what to say about this file, or null if there's
+    * nothing to say; the caller decides when to print it.
+    */
   final def write(
       formatted: String,
       original: String,
@@ -39,8 +42,7 @@ sealed abstract class InputMethod {
         val msg =
           if (diff.nonEmpty) diff
           else s"--- +$pathStr\n    => modified line endings only"
-        options.common.err.println(msg)
-        ExitCode.TestError.future
+        ExitCode.TestError.withMsg(msg).future
       case _ => options.exitCodeOnChange.future
     }
   }

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -141,12 +141,12 @@ trait ScalafmtRunner {
         }(writeContext).transform { r =>
           val ok = r == Success(ExitCode.Ok)
           termDisplay.foreach(_.doneWrite(ok = ok))
-          r.foreach(printErr)
-          if (!ok && options.check) {
-            val code = asExit(r)
-            // a tolerated error won't fail the run, so it mustn't stop it
-            if (!options.tolerate(code).isOk) completed.trySuccess(code)
-          }
+          if (!ok)
+            if (options.check) {
+              val code = asExit(r)
+              // a tolerated error won't fail the run, so it mustn't stop it
+              if (!options.tolerate(code).isOk) completed.trySuccess(code)
+            } else r.foreach(printErr)
           Success(r)
         }
         tasks += future
@@ -157,7 +157,10 @@ trait ScalafmtRunner {
       ExitCode.merge(res, asExit(r))
     }.onComplete(completed.tryComplete)
 
-    completed.future.td { case (td, _) => td.end() }
+    completed.future.td { case (td, _) => td.end() }.map { code =>
+      if (options.check) printErr(code)
+      code
+    }
   }
 
 }

--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/ScalafmtRunner.scala
@@ -124,6 +124,8 @@ trait ScalafmtRunner {
     }
 
     val completed = Promise[ExitCode]()
+    val printErr =
+      (r: ExitCode) => if (r.msg ne null) options.common.err.println(r.msg)
 
     val tasks = List.newBuilder[Future[Try[ExitCode]]]
     inputMethods.foreach { inputMethod =>
@@ -139,6 +141,7 @@ trait ScalafmtRunner {
         }(writeContext).transform { r =>
           val ok = r == Success(ExitCode.Ok)
           termDisplay.foreach(_.doneWrite(ok = ok))
+          r.foreach(printErr)
           if (!ok && options.check) {
             val code = asExit(r)
             // a tolerated error won't fail the run, so it mustn't stop it

--- a/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
+++ b/scalafmt-cli/shared/src/test/scala/org/scalafmt/cli/CliTest.scala
@@ -693,7 +693,8 @@ trait CliTestBehavior {
 
     test(s"unparseable file among misformatted ones, --check: $label")(
       unparseableAmongMisformatted("")("--check").map { case (exit, out) =>
-        // fail-fast stops at the first real failure, so only one diff
+        // fail-fast reports one failure, whichever file got there first
+        assertEquals(CliTest.countDiffs(out), 1)
         assertContains(out, "error: --test failed")
         assertEquals(exit, ExitCode.TestError)
       },
@@ -803,6 +804,26 @@ trait CliTestBehavior {
 class CliTest extends AbstractCliTest with CliTestBehavior {
   if (PlatformCompat.isJVM) testCli("1.6.0-RC4") // test for runDynamic, incompatible with Scala Native
   testCli(stableVersion) // test for runScalafmt
+
+  // how many failures race in before fail-fast latches depends on the write
+  // execution context, so pin both wirings
+  Seq(Seq.empty[String], Seq("--async-format")).foreach { extraArgs =>
+    val label = extraArgs.mkString(" ")
+    test(s"--check reports a single file out of many $label") {
+      val files = (1 to 20).map(i => s"/f$i.scala\nobject   F$i { }\n").mkString
+      val dir = string2dir(
+        s"""|/.scalafmt.conf
+            |version = "$stableVersion"
+            |$files
+            |""".stripMargin,
+      )
+      val out = new ByteArrayOutputStream()
+      val init = getMockOptions(dir, dir, new PrintStream(out))
+      val config = Cli.getConfig(init, ("--check" +: extraArgs): _*).get
+      run(config, ExitCode.TestError)
+        .map(_ => assertEquals(CliTest.countDiffs(out.toString), 1))
+    }
+  }
 
   test(s"path-error") {
     val input =
@@ -1466,6 +1487,9 @@ class CliTest extends AbstractCliTest with CliTestBehavior {
 }
 
 object CliTest {
+
+  def countDiffs(out: String): Int = out.linesIterator
+    .count(_.startsWith("+++ b"))
 
   val stripCR: String => String = {
     val eol = System.lineSeparator()


### PR DESCRIPTION
--check promises status 1 on the first failure, but every file that raced in before the latch printed its diff too, so a run reported an arbitrary subset -- 8 to 18 of 20 misformatted files across five runs.

Carry the message on the promise that latches the exit code, so the reported file is by construction the one whose code we exit with.