### PR TITLE
Splits: allow empty trees to have inverted offsets

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/Splits.scala
@@ -1442,7 +1442,8 @@ object SplitsAfterTemplateKeyword extends Splits {
         import lo._
         val policy = Policy ?
           (cfg.binPack.keepParentConstructors ||
-            templ.begOffset == templ.endOffset) || {
+            // empty template; its offsets are inverted if it spans whitespace
+            templ.begOffset >= templ.endOffset) || {
             val expire = templateDerivesOrCurlyOrLastNonTrivial(templ)
             val forceNewlineBeforeExtends = Policy.beforeLeft(expire, "NLPCTOR") {
               case Decision(FT(_, soft.ExtendsOrDerives(), m), s)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/util/TreeOps.scala
@@ -636,7 +636,7 @@ object TreeOps {
     */
   def noExplicitImplicit(m: Mod.Implicit, ownerStart: Int): Boolean = {
     val beg = m.begOffset
-    beg < ownerStart || beg == m.endOffset
+    beg < ownerStart || beg >= m.endOffset // empty: offsets can invert
   }
 
   def noExplicitImplicit(ownerStart: Int, orElse: Boolean)(m: Mod): Boolean =

--- a/scalafmt-tests/shared/src/test/resources/unit/Template.source
+++ b/scalafmt-tests/shared/src/test/resources/unit/Template.source
@@ -32,23 +32,21 @@ class A(b: B)
   def x = 2
 }
 <<< #5362 trailing space, empty template, then stat
-onTestFailure = "NullPointerException"
-===
 class A 
 class B
 >>>
-test failed: java.lang.NullPointerException: Cannot invoke "org.scalafmt.internal.FormatToken.idx()" because "exp$1" is null
+class A
+class B
 <<< #5362 trailing space, empty template, at eof
 class A 
 >>>
 class A
 <<< #5362 trailing space, empty template, comment before
-onTestFailure = "NullPointerException"
-===
 class A /*c*/ 
 class B
 >>>
-test failed: java.lang.NullPointerException: Cannot invoke "org.scalafmt.internal.FormatToken.idx()" because "exp$1" is null
+class A /*c*/
+class B
 <<< #5362 trailing space, template with parent
 class A extends B 
 class C

--- a/scalafmt-tests/shared/src/test/resources/unit/Template.source
+++ b/scalafmt-tests/shared/src/test/resources/unit/Template.source
@@ -31,3 +31,33 @@ class A(b: B)
     with G {
   def x = 2
 }
+<<< #5362 trailing space, empty template, then stat
+onTestFailure = "NullPointerException"
+===
+class A 
+class B
+>>>
+test failed: java.lang.NullPointerException: Cannot invoke "org.scalafmt.internal.FormatToken.idx()" because "exp$1" is null
+<<< #5362 trailing space, empty template, at eof
+class A 
+>>>
+class A
+<<< #5362 trailing space, empty template, comment before
+onTestFailure = "NullPointerException"
+===
+class A /*c*/ 
+class B
+>>>
+test failed: java.lang.NullPointerException: Cannot invoke "org.scalafmt.internal.FormatToken.idx()" because "exp$1" is null
+<<< #5362 trailing space, template with parent
+class A extends B 
+class C
+>>>
+class A extends B
+class C
+<<< #5362 trailing space, template with body
+class A { def f = 1 } 
+class B
+>>>
+class A { def f = 1 }
+class B

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2607880, "total explored")
+      assertEquals(explored, 2607924, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2607788, "total explored")
+      assertEquals(explored, 2607880, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
An empty tree spanning whitespace gets an inverted position. Fixes #5362.