### PR TITLE
Presets: keep scala3 remove/insert braces apart

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4582,11 +4582,13 @@ The following presets are available for the `rewrite.scala3` section:
 
 - `common`: intends to approximate the
   [common style recommendation](https://contributors.scala-lang.org/t/towards-a-common-scala-style-recommendation/7383)
-  - as of v3.11.2, it includes:
+  - as of v3.11.6, it includes:
     - `rewrite.scala3.convertToNewSyntax = true`
     - `rewrite.scala3.newSyntax.deprecated = false`
     - `rewrite.scala3.endMarker.remove.blankGaps.min = 1`
+    - `rewrite.scala3.optionalBraces.enabled = true`
     - `rewrite.scala3.optionalBraces.insert.blankGaps.min = 1`
+    - `rewrite.scala3.optionalBraces.remove.blankGaps.max = 0`
 
 ### `rewrite.scala3.convertToNewSyntax`
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -211,11 +211,15 @@ object RewriteScala3Settings {
       else if (other.max < 0) max >= other.min
       else max >= other.min && min <= other.max
     def exclude(other: Between): Between =
-      if (other.enabled) copy(
+      if (!enabled || !other.enabled) this
+      else if (other.min == 0 && other.max < 0) Between.disabled // excludes all
+      else copy(
         min = if (other.max < 0) min else min.max(other.max + 1),
-        max = if (other.min < 0) max else max.min(other.min - 1),
+        max =
+          if (other.min < 0) max
+          else if (max < 0) other.min - 1 // was unbounded
+          else max.min(other.min - 1),
       )
-      else this
   }
   object Between {
     val disabled = new Between()

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -26,8 +26,9 @@ object RewriteScala3Settings {
   private val styleGuideCommon = new RewriteScala3Settings(
     convertToNewSyntax = true,
     newSyntax = ConvertToNewSyntax(deprecated = false),
-    optionalBraces = RemoveOptionalBraces(insert =
-      Some(BracesFilters(blankGaps = Between(min = 1))),
+    optionalBraces = RemoveOptionalBraces(
+      insert = Some(BracesFilters(blankGaps = Between(min = 1))),
+      remove = Some(BracesFilters(blankGaps = Between(max = 0))),
     ),
     endMarker = EndMarker(remove = EndMarker.Filters(blankGaps = Between(min = 1))),
   )

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -52,26 +52,26 @@ object RewriteScala3Settings {
   case class RemoveOptionalBraces(
       enabled: Boolean = true,
       preferInsert: Boolean = true,
-      insert: Option[BracesFilters] = None,
-      remove: Option[BracesFilters] = None,
+      private[config] val insert: Option[BracesFilters] = None,
+      private[config] val remove: Option[BracesFilters] = None,
       fewerBraces: FewerBraces = FewerBraces.default,
       oldSyntaxToo: Boolean = false,
   ) {
-    def isRemoveEnabled: Boolean = remove.forall(_.enabled)
-    def isInsertEnabled: Boolean = insert.exists(_.enabled)
+    private val ins = insert.filter(_.enabled)
+    private val rem = remove.filter(_.enabled)
 
-    private[config] def normalized: RemoveOptionalBraces = {
-      val ibOpt = insert.filter(_.enabled)
-      val rbOpt = remove.filter(_.enabled)
-      ibOpt.fold(copy(insert = None, remove = rbOpt))(ib =>
-        rbOpt.fold( // if insert is Some, remove must be too
-          copy(insert = ibOpt, remove = Some(BracesFilters.disabled)),
-        )(rb =>
-          if (preferInsert) copy(insert = ibOpt, remove = Some(rb.exclude(ib)))
-          else copy(insert = Some(ib.exclude(rb)), remove = rbOpt),
-        ),
-      )
+    // what to brace; loses the region `remove` claims unless preferred
+    val insertFilters: Option[BracesFilters] =
+      if (preferInsert) ins else ins.map(i => rem.fold(i)(i.exclude))
+
+    // what to unbrace; unset means always, disabled means never
+    val removeFilters: Option[BracesFilters] = ins.fold(rem) { i =>
+      val f = (r: BracesFilters) => if (preferInsert) r.exclude(i) else r
+      Some(rem.fold(BracesFilters.disabled)(f))
     }
+
+    def isRemoveEnabled: Boolean = removeFilters.forall(_.enabled)
+    def isInsertEnabled: Boolean = insertFilters.exists(_.enabled)
   }
 
   object RemoveOptionalBraces {
@@ -86,8 +86,8 @@ object RewriteScala3Settings {
       .deriveEncoder[RemoveOptionalBraces]
 
     implicit final val decoder: ConfDecoderEx[RemoveOptionalBraces] = generic
-      .deriveDecoderEx[RemoveOptionalBraces](no).map(_.normalized).noTypos
-      .detectSectionRenames.contramapPartial {
+      .deriveDecoderEx[RemoveOptionalBraces](no).noTypos.detectSectionRenames
+      .contramapPartial {
         case Conf.Bool(true) | Conf.Str("yes") => Conf
             .Obj("enabled" -> Conf(true))
         case Conf.Bool(false) | Conf.Str("no") => Conf

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -224,12 +224,12 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
         if (isSingleStatBlock) {
           val range = getSpan
           range >= style.maxColumn && x.satisfied(range)
-        } else x.max == 0 || x.satisfied(getSpan)
+        } else x.satisfied(getSpan)
       val checkBlankGaps = (x: RewriteScala3Settings.Between) =>
         if (isSingleStatBlock) {
           val range = getBlankGaps
           range >= 1 && x.satisfied(range)
-        } else x.max == 0 || x.satisfied(getBlankGaps)
+        } else x.satisfied(getBlankGaps)
       val checks = Iterator((ib.span, checkSpan), (ib.blankGaps, checkBlankGaps))
         .flatMap { case (bw, f) => if (bw.enabled) Some(f(bw)) else None }
       if (cfg.preferInsert) checks.contains(true)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -160,7 +160,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
     val nextFt = ftoks.nextNonCommentAfter(ft)
     val notOkToRewrite = hasFormatOff || { // can't force significant indentation
       val cfg = settings
-      !cfg.remove.forall { x =>
+      !cfg.removeFilters.forall { x =>
         import RewriteScala3Settings.Between
         val checks = Iterator[(Between, Between => Boolean)](
           (x.span, _.satisfied(session.getSpan(left))),
@@ -213,7 +213,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
   )(implicit session: Session, style: ScalafmtConfig): Boolean = {
     // left must be a LeftBrace
     val cfg = settings
-    !cfg.insert.exists { ib =>
+    !cfg.insertFilters.exists { ib =>
       val isSingleStatBlock = isTreeSingleExpr(left.how match {
         case x: ReplacementType.AppendAfter => x.ft.rightOwner
         case _ => left.ft.rightOwner

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10270,46 +10270,32 @@ def f: Int =
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 def body with blank line, insert and remove from zero
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 0
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 def body with blank line, insert bounded above
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.max = 0

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10230,27 +10230,19 @@ object Outer {
 }
 <<< #5366 def body with blank line, preset
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 braced def body with blank line, preset
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 def f: Int = {
   1
@@ -10258,17 +10250,11 @@ def f: Int = {
   2
 }
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,4 +1,5 @@
--def f: Int =
--   1
-+def f: Int = {
-+  1
- ∙
--   2
-+  2
-+}
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 braced def body without blank line, preset
 rewrite.scala3.preset = "common"
 ===

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10228,3 +10228,121 @@ object Outer {
   object Inner:
      val b = 2
 }
+<<< #5366 def body with blank line, preset
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 braced def body with blank line, preset
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+def f: Int = {
+  1
+
+  2
+}
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,4 +1,5 @@
+-def f: Int =
+-   1
++def f: Int = {
++  1
+ ∙
+-   2
++  2
++}
+<<< #5366 braced def body without blank line, preset
+rewrite.scala3.preset = "common"
+===
+def f: Int = {
+  1
+  2
+}
+>>>
+def f: Int =
+   1
+   2
+<<< #5366 def body with blank line, overlapping insert/remove
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 def body with blank line, insert and remove from zero
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 0
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 def body with blank line, insert bounded above
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.max = 0
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 1
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10300,21 +10300,13 @@ def f: Int = {
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.max = 0
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 1
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int =
+   1
+
+   2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -9835,3 +9835,121 @@ object Outer {
   object Inner:
      val b = 2
 }
+<<< #5366 def body with blank line, preset
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 braced def body with blank line, preset
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+def f: Int = {
+  1
+
+  2
+}
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,4 +1,5 @@
+-def f: Int =
+-   1
++def f: Int = {
++  1
+ ∙
+-   2
++  2
++}
+<<< #5366 braced def body without blank line, preset
+rewrite.scala3.preset = "common"
+===
+def f: Int = {
+  1
+  2
+}
+>>>
+def f: Int =
+   1
+   2
+<<< #5366 def body with blank line, overlapping insert/remove
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 def body with blank line, insert and remove from zero
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 0
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 def body with blank line, insert bounded above
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.max = 0
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 1
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -9877,46 +9877,32 @@ def f: Int =
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 def body with blank line, insert and remove from zero
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 0
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 def body with blank line, insert bounded above
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.max = 0

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -9907,21 +9907,13 @@ def f: Int = {
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.max = 0
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 1
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int =
+   1
+
+   2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -9837,27 +9837,19 @@ object Outer {
 }
 <<< #5366 def body with blank line, preset
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 braced def body with blank line, preset
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 def f: Int = {
   1
@@ -9865,17 +9857,11 @@ def f: Int = {
   2
 }
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,4 +1,5 @@
--def f: Int =
--   1
-+def f: Int = {
-+  1
- ∙
--   2
-+  2
-+}
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 braced def body without blank line, preset
 rewrite.scala3.preset = "common"
 ===

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10275,46 +10275,32 @@ def f: Int =
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 def body with blank line, insert and remove from zero
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 0
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 def body with blank line, insert bounded above
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.max = 0

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10235,27 +10235,19 @@ object Outer {
 }
 <<< #5366 def body with blank line, preset
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 braced def body with blank line, preset
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 def f: Int = {
   1
@@ -10263,17 +10255,11 @@ def f: Int = {
   2
 }
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,4 +1,5 @@
--def f: Int =
--   1
-+def f: Int = {
-+  1
- ∙
--   2
-+  2
-+}
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 braced def body without blank line, preset
 rewrite.scala3.preset = "common"
 ===

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10233,3 +10233,121 @@ object Outer {
   object Inner:
      val b = 2
 }
+<<< #5366 def body with blank line, preset
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 braced def body with blank line, preset
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+def f: Int = {
+  1
+
+  2
+}
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,4 +1,5 @@
+-def f: Int =
+-   1
++def f: Int = {
++  1
+ ∙
+-   2
++  2
++}
+<<< #5366 braced def body without blank line, preset
+rewrite.scala3.preset = "common"
+===
+def f: Int = {
+  1
+  2
+}
+>>>
+def f: Int =
+   1
+   2
+<<< #5366 def body with blank line, overlapping insert/remove
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 def body with blank line, insert and remove from zero
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 0
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 def body with blank line, insert bounded above
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.max = 0
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 1
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10305,21 +10305,13 @@ def f: Int = {
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.max = 0
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 1
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int =
+   1
+
+   2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10609,3 +10609,121 @@ object Outer {
   object Inner:
      val b = 2
 }
+<<< #5366 def body with blank line, preset
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 braced def body with blank line, preset
+rewrite.scala3.preset = "common"
+lineEndings = unix
+===
+def f: Int = {
+  1
+
+  2
+}
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,4 +1,5 @@
+-def f: Int =
+-   1
++def f: Int = {
++  1
+ ∙
+-   2
++  2
++}
+<<< #5366 braced def body without blank line, preset
+rewrite.scala3.preset = "common"
+===
+def f: Int = {
+  1
+  2
+}
+>>>
+def f: Int =
+   1
+   2
+<<< #5366 def body with blank line, overlapping insert/remove
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 def body with blank line, insert and remove from zero
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 0
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2
+<<< #5366 def body with blank line, insert bounded above
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.max = 0
+rewrite.scala3.optionalBraces.remove.blankGaps.min = 1
+lineEndings = unix
+===
+def f: Int =
+  1
+
+  2
+>>>
+Idempotency violated
+=> Diff (- expected, + obtained)
+@@ -1,5 +1,4 @@
+-def f: Int = {
+-  1
++def f: Int =
++   1
+ ∙
+-  2
+-}
++   2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10681,21 +10681,13 @@ def f: Int = {
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.max = 0
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 1
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int =
+   1
+
+   2

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10651,46 +10651,32 @@ def f: Int =
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 def body with blank line, insert and remove from zero
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 0
 rewrite.scala3.optionalBraces.remove.blankGaps.min = 0
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 def body with blank line, insert bounded above
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.max = 0

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10611,27 +10611,19 @@ object Outer {
 }
 <<< #5366 def body with blank line, preset
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 def f: Int =
   1
 
   2
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,5 +1,4 @@
--def f: Int = {
--  1
-+def f: Int =
-+   1
- ∙
--  2
--}
-+   2
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 braced def body with blank line, preset
 rewrite.scala3.preset = "common"
-lineEndings = unix
 ===
 def f: Int = {
   1
@@ -10639,17 +10631,11 @@ def f: Int = {
   2
 }
 >>>
-Idempotency violated
-=> Diff (- expected, + obtained)
-@@ -1,4 +1,5 @@
--def f: Int =
--   1
-+def f: Int = {
-+  1
- ∙
--   2
-+  2
-+}
+def f: Int = {
+  1
+
+  2
+}
 <<< #5366 braced def body without blank line, preset
 rewrite.scala3.preset = "common"
 ===

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2608588, "total explored")
+      assertEquals(explored, 2608764, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2608764, "total explored")
+      assertEquals(explored, 2608820, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2608412, "total explored")
+      assertEquals(explored, 2608588, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2607924, "total explored")
+      assertEquals(explored, 2608412, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
@@ -92,6 +92,7 @@ class RewriteScala3SettingsTest extends SharedFunSuiteBase {
   }
 
   Seq( // presets
+    "common",
     "true",
     "false",
   ).foreach(preset =>
@@ -99,16 +100,6 @@ class RewriteScala3SettingsTest extends SharedFunSuiteBase {
       val rob = hocon(s"rewrite.scala3.preset = $preset").rewrite.scala3
         .optionalBraces
       assertEquals(rob.normalized, rob, s"preset not normalized: $rob")
-    },
-  )
-
-  Seq( // presets not normalized
-    "common",
-  ).foreach(preset =>
-    test(s"RewriteScala3Settings: preset ranges [$preset] not normalized") {
-      val rob = hocon(s"rewrite.scala3.preset = $preset").rewrite.scala3
-        .optionalBraces
-      assertNotEquals(rob.normalized, rob, s"preset was normalized: $rob")
     },
   )
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
@@ -3,7 +3,10 @@ package config
 
 class RewriteScala3SettingsTest extends SharedFunSuiteBase {
 
-  import RewriteScala3Settings.Between
+  import RewriteScala3Settings._
+
+  private def hocon(str: String): ScalafmtConfig = ScalafmtConfig
+    .fromHoconString(str).get
 
   Seq(
     Between(),
@@ -43,5 +46,70 @@ class RewriteScala3SettingsTest extends SharedFunSuiteBase {
       ),
     )
   }
+
+  Seq(
+    (Between(min = 1, max = 5), Between(), Between(min = 1, max = 5)),
+    (Between(), Between(min = 1), Between()),
+    (Between(min = 1, max = 5), Between(max = 2), Between(min = 3, max = 5)),
+    (Between(min = 1, max = 5), Between(min = 4), Between(min = 1, max = 3)),
+    (
+      Between(min = 1, max = 5),
+      Between(min = 2, max = 4),
+      Between(min = 5, max = 1),
+    ),
+    (Between(max = 5), Between(max = 2), Between(min = 3, max = 5)),
+    (Between(min = 1), Between(min = 3), Between(min = 1)),
+    (Between(min = 0), Between(min = 1), Between(min = 0)),
+    (Between(min = 0), Between(min = 0), Between(min = 0)),
+  ).foreach { case (lt, rt, excluded) =>
+    test(s"RewriteScala3Settings.Between: exclude [$lt, $rt]")(
+      assertEquals(lt.exclude(rt), excluded),
+    )
+  }
+
+  test("RewriteScala3Settings: insert with an unset remove") {
+    val base = hocon("runner.dialect = scala3")
+    def styleFor(ob: RemoveOptionalBraces) = {
+      val rewrite = base.rewrite
+      base.copy(rewrite =
+        rewrite.copy(scala3 = rewrite.scala3.copy(optionalBraces = ob)),
+      )
+    }
+    val src = "def f: Int =\n  1\n\n  2\n"
+    def formatTwice(ob: RemoveOptionalBraces) = {
+      val style = styleFor(ob)
+      val once = Scalafmt.formatCode(src, style).get
+      (once, Scalafmt.formatCode(once, style).get)
+    }
+    val ob = RemoveOptionalBraces(insert =
+      Some(BracesFilters(blankGaps = Between(min = 1))),
+    )
+    // as built, `remove` means "always", so it takes back what insert added
+    val (once, twice) = formatTwice(ob)
+    assertNotEquals(twice, once)
+    val (onceNormal, twiceNormal) = formatTwice(ob.normalized)
+    assertEquals(twiceNormal, onceNormal)
+  }
+
+  Seq( // presets
+    "true",
+    "false",
+  ).foreach(preset =>
+    test(s"RewriteScala3Settings: preset ranges [$preset]") {
+      val rob = hocon(s"rewrite.scala3.preset = $preset").rewrite.scala3
+        .optionalBraces
+      assertEquals(rob.normalized, rob, s"preset not normalized: $rob")
+    },
+  )
+
+  Seq( // presets not normalized
+    "common",
+  ).foreach(preset =>
+    test(s"RewriteScala3Settings: preset ranges [$preset] not normalized") {
+      val rob = hocon(s"rewrite.scala3.preset = $preset").rewrite.scala3
+        .optionalBraces
+      assertNotEquals(rob.normalized, rob, s"preset was normalized: $rob")
+    },
+  )
 
 }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
@@ -84,11 +84,45 @@ class RewriteScala3SettingsTest extends SharedFunSuiteBase {
     val ob = RemoveOptionalBraces(insert =
       Some(BracesFilters(blankGaps = Between(min = 1))),
     )
-    // as built, `remove` means "always", so it takes back what insert added
+    // an unset `remove` reads as never once `insert` is set, not as always
     val (once, twice) = formatTwice(ob)
-    assertNotEquals(twice, once)
-    val (onceNormal, twiceNormal) = formatTwice(ob.normalized)
-    assertEquals(twiceNormal, onceNormal)
+    assertEquals(twice, once)
+  }
+
+  private val gapsFrom1 = BracesFilters(blankGaps = Between(min = 1))
+  private val spanTo5 = BracesFilters(span = Between(max = 5))
+  Seq(
+    // preferInsert, insert, remove, insertFilters, removeFilters
+    (true, None, None, None, None),
+    (true, None, Some(spanTo5), None, Some(spanTo5)),
+    (true, Some(gapsFrom1), None, Some(gapsFrom1), Some(BracesFilters.disabled)),
+    (
+      true,
+      Some(gapsFrom1),
+      Some(spanTo5),
+      Some(gapsFrom1),
+      Some(spanTo5.exclude(gapsFrom1)),
+    ),
+    (false, None, None, None, None),
+    (false, None, Some(spanTo5), None, Some(spanTo5)),
+    (false, Some(gapsFrom1), None, Some(gapsFrom1), Some(BracesFilters.disabled)),
+    (
+      false,
+      Some(gapsFrom1),
+      Some(spanTo5),
+      Some(gapsFrom1.exclude(spanTo5)),
+      Some(spanTo5),
+    ),
+  ).foreach { case (preferInsert, insert, remove, insFilters, remFilters) =>
+    test(s"RewriteScala3Settings: filters [preferInsert=$preferInsert, $insert, $remove]") {
+      val obtained = RemoveOptionalBraces(
+        preferInsert = preferInsert,
+        insert = insert,
+        remove = remove,
+      )
+      assertEquals(obtained.insertFilters, insFilters)
+      assertEquals(obtained.removeFilters, remFilters)
+    }
   }
 
   Seq( // presets
@@ -99,7 +133,12 @@ class RewriteScala3SettingsTest extends SharedFunSuiteBase {
     test(s"RewriteScala3Settings: preset ranges [$preset]") {
       val rob = hocon(s"rewrite.scala3.preset = $preset").rewrite.scala3
         .optionalBraces
-      assertEquals(rob.normalized, rob, s"preset not normalized: $rob")
+      val overlaps = rob.insertFilters.exists(i =>
+        rob.removeFilters.exists(r =>
+          i.span.overlaps(r.span) || i.blankGaps.overlaps(r.blankGaps),
+        ),
+      )
+      assert(!overlaps, s"preset ranges overlap: $rob")
     },
   )
 

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/RewriteScala3SettingsTest.scala
@@ -58,9 +58,9 @@ class RewriteScala3SettingsTest extends SharedFunSuiteBase {
       Between(min = 5, max = 1),
     ),
     (Between(max = 5), Between(max = 2), Between(min = 3, max = 5)),
-    (Between(min = 1), Between(min = 3), Between(min = 1)),
-    (Between(min = 0), Between(min = 1), Between(min = 0)),
-    (Between(min = 0), Between(min = 0), Between(min = 0)),
+    (Between(min = 1), Between(min = 3), Between(min = 1, max = 2)),
+    (Between(min = 0), Between(min = 1), Between(min = 0, max = 0)),
+    (Between(min = 0), Between(min = 0), Between()),
   ).foreach { case (lt, rt, excluded) =>
     test(s"RewriteScala3Settings.Between: exclude [$lt, $rt]")(
       assertEquals(lt.exclude(rt), excluded),


### PR DESCRIPTION
Fixes #5366.

The `"common"` preset left `remove` unset, which means "always" and overlaps
`insert`, so a brace-optional body with a blank line flipped between the two
forms on every pass. The preset now takes the range `insert` doesn't.

Two further overlaps are fixed here: exclusion left an unbounded max
unclipped, and an `insert` range bounded above passed any value. The filters
are then derived from the sections as written, rather than repaired after
decoding, so no construction path can skip it.

Supersedes the one-line guard proposed earlier on this branch; its case is
among the tests, pinned from either form in all four `OptionalBraces*.stat`
variants.
