### PR TITLE
TermDisplay: rewind the full block height when redrawing

### DIFF
--- a/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/TermDisplay.scala
+++ b/scalafmt-cli/shared/src/main/scala/org/scalafmt/cli/TermDisplay.scala
@@ -194,7 +194,7 @@ private[cli] class TermDisplay(
       out.down(1)
       out.clearLine(2)
       out.down(1)
-      out.up(2)
+      out.up(4)
       out.left(10000)
     }
 


### PR DESCRIPTION
The overlay progress display prints two lines per refresh -- each truncatedPrintln appends a newline -- and then moves down twice more before rewinding. That is four rows of downward movement against up(2), so the block drifted two rows down the screen on every refresh instead of redrawing in place.

The drift is invisible when the cursor already sits on the last row, where the newlines scroll the screen and down(1) is clamped. That is why an already-full terminal looks correct while a freshly cleared one bleeds a new block per refresh.

Introduced in 50a17f34, which collapsed the per-line `for (_ <- downloads0.indices) out.up(2)` loop inherited from the coursier-derived code into a single up(2) while still printing two lines.