### PR TITLE
sbt2 prep: define explicit root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,10 @@
-import scala.scalanative.build._
 import scala.util.Properties
 
-import org.scalajs.linker.interface.ESVersion
-
 import Dependencies._
+import Extensions._
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 def isCI = System.getenv("CI") != null
-
-def scala212 = "2.12.21"
-def scala213 = "2.13.18"
-def scala3 = "3.3.8"
-val scala2Versions = Seq(scala213, scala212)
-val scalaVersions = scala2Versions :+ scala3
-
-def isScalaVer(ver: String) = Def.setting(scalaBinaryVersion.value == ver)
-def isScala212 = isScalaVer("2.12")
-def isScala213 = isScalaVer("2.13")
-def isScala3 = isScalaVer("3")
 
 inThisBuild {
   List(
@@ -182,32 +169,6 @@ lazy val macros = crossProject(JVMPlatform, NativePlatform, JSPlatform)
 
 import sbtassembly.AssemblyPlugin.defaultUniversalScript
 
-val scalacJvmOptions = Def.setting {
-  val cross = if (!isScala213.value) Nil else Seq("-Ymacro-annotations")
-
-  val warningAsError =
-    if (isScala212.value) Seq("-Xfatal-warnings", "-deprecation:false")
-    else Seq("-Wconf:any:error,cat=deprecation:silent")
-
-  val unused =
-    if (isScala3.value) "-Wunused:all"
-    else if (isScala213.value)
-      "-Wunused:imports,privates,locals,patvars,implicits,explicits,params"
-    else "-Ywarn-unused:imports,privates,locals,patvars,implicits"
-
-  val javaver =
-    if (isScala3.value) Seq("-java-output-version:8")
-    else Seq("-target:8", "-release:8")
-
-  cross ++ warningAsError ++ javaver :+ unused
-}
-
-val scalacSettings = Def.settings(
-  javacOptions ++= Seq("-source", "8", "-target", "8"),
-  Compile / compile / scalacOptions ++= scalacJvmOptions.value,
-  Test / compile / scalacOptions ++= scalacJvmOptions.value,
-)
-
 lazy val cli = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   .withoutSuffixFor(JVMPlatform).in(file("scalafmt-cli")).settings(
     moduleName := "scalafmt-cli",
@@ -266,7 +227,7 @@ lazy val cli = crossProject(JVMPlatform, NativePlatform, JSPlatform)
 
 lazy val tests = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   .withoutSuffixFor(JVMPlatform).in(file("scalafmt-tests")).settings(
-    publish / skip := true,
+    unpublished,
     sharedTestSettings,
     libraryDependencies += scalametaTestkit.value % Test,
     libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.13.1" % Test,
@@ -280,8 +241,6 @@ lazy val tests = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   ).enablePlugins(BuildInfoPlugin).dependsOn(core).aggregate(core)
   .jvmSettings(javaOptions += "-Dfile.encoding=UTF8", parallelCollections)
   .jsSettings(scalaJsSettings).jsEnablePlugins(ScalaJSPlugin)
-
-lazy val sharedTestSettings = Seq(libraryDependencies += munit.value % Test)
 
 lazy val communityTestsCommon = crossProject(JVMPlatform, NativePlatform)
   .withoutSuffixFor(JVMPlatform)
@@ -311,14 +270,14 @@ lazy val communityTestsOther = crossProject(JVMPlatform, NativePlatform)
 def confCommunityTestShared(where: String)(
     project: sbtcrossproject.CrossProject,
 ) = project.in(file(where)).settings(communityTestsSettings)
-  .settings(sharedTestSettings).nativeSettings(scalaNativeConfig)
+  .nativeSettings(scalaNativeConfig)
 
 def confCommunityTest(where: String)(project: sbtcrossproject.CrossProject) =
   project.configureCross(confCommunityTestShared(where))
     .dependsOn(communityTestsCommon % "test->test")
 
 lazy val benchmarks = project.in(file("scalafmt-benchmarks")).settings(
-  publish / skip := true,
+  unpublished,
   moduleName := "scalafmt-benchmarks",
   libraryDependencies += scalametaTestkit.value,
   libraryDependencies += munit.value % Test,
@@ -334,7 +293,7 @@ lazy val benchmarks = project.in(file("scalafmt-benchmarks")).settings(
 
 lazy val docs = project.in(file("scalafmt-docs")).settings(
   crossScalaVersions := List(scala212),
-  publish / skip := true,
+  unpublished,
   mdoc := (Compile / run).evaluated,
 ).dependsOn(cli.jvm, dynamic).enablePlugins(DocusaurusPlugin)
 
@@ -367,23 +326,3 @@ def buildInfoSettings(pkg: String, obj: String): Seq[Def.Setting[_]] = Seq(
   buildInfoPackage := pkg,
   buildInfoObject := obj,
 )
-
-lazy val communityTestsSettings: Seq[Def.Setting[_]] = Def.settings(
-  publish / skip := true,
-  scalacSettings,
-  javaOptions += "-Dfile.encoding=UTF8",
-)
-
-lazy val scalaJsSettings = Seq(
-  // to support Node.JS functionality
-  scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
-  // to support MULTILINE in regex
-  scalaJSLinkerConfig ~= (_.withESFeatures(_.withESVersion(ESVersion.ES2018))),
-)
-
-lazy val scalaNativeConfig = nativeConfig ~= { _.withMode(Mode.releaseFull) }
-
-def parallelCollections = libraryDependencies ++= {
-  if (!isScala213.value) Nil
-  else Seq("org.scala-lang.modules" %%% "scala-parallel-collections" % "1.2.0")
-}

--- a/build.sbt
+++ b/build.sbt
@@ -35,21 +35,48 @@ inThisBuild {
   )
 }
 
-name := "scalafmtRoot"
-publish / skip := true
-
 lazy val runAssembly = inputKey[Unit]("Run assembly")
 
 lazy val copyScalaNative = taskKey[Unit]("Copy Scala Native output to root")
 
-copyScalaNative := {
-  val binaryVersion = (cli.native / scalaBinaryVersion).value
-  val suffix = if (Properties.isWin) ".exe" else ""
-  val nativeOutput = (cli.native / Compile / target).value /
-    s"scala-$binaryVersion" / s"scalafmt-cli$suffix"
-  val output = baseDirectory.value / s"scalafmt$suffix"
-  IO.copyFile(nativeOutput, output)
-}
+def rootSettings = Def.settings(
+  name := "scalafmtRoot",
+  unpublished,
+  copyScalaNative := {
+    val binaryVersion = (cliNative / scalaBinaryVersion).value
+    val suffix = if (Properties.isWin) ".exe" else ""
+    val nativeOutput = (cliNative / Compile / target).value /
+      s"scala-$binaryVersion" / s"scalafmt-cli$suffix"
+    val output = baseDirectory.value / s"scalafmt$suffix"
+    IO.copyFile(nativeOutput, output)
+  },
+)
+
+def allMatrices = Seq(
+  interfaces,
+  sysops,
+  config,
+  macros,
+  core,
+  dynamicCore,
+  dynamic,
+  cli,
+  tests,
+  communityTestsCommon,
+  communityTestsScala2,
+  communityTestsScala3,
+  communityTestsSpark,
+  communityTestsIntellij,
+  communityTestsOther,
+  benchmarks,
+  docs,
+).flatMap(_.componentProjects.map(p => LocalProject(p.id)))
+
+// An explicit root, rather than the one sbt generates: in sbt 2 a bare
+// top-level setting applies to every project, so `publish / skip` must have a
+// project to live in or it would silently disable publishing build-wide.
+lazy val root = project.in(file(".")).withId("scalafmt-root")
+  .aggregate(allMatrices: _*).settings(rootSettings)
 
 addCommandAlias("native-image", "cli/nativeImage")
 addCommandAlias(
@@ -224,6 +251,7 @@ lazy val cli = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   .jsSettings(scalaJsSettings, scalaJSUseMainModuleInitializer := true)
   .jvmEnablePlugins(NativeImagePlugin)
   .jvmConfigure(_.dependsOn(dynamic).aggregate(dynamic))
+def cliNative = cli.native
 
 lazy val tests = crossProject(JVMPlatform, NativePlatform, JSPlatform)
   .withoutSuffixFor(JVMPlatform).in(file("scalafmt-tests")).settings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,12 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport.*
 // scalafmt: { maxColumn = 120 }
 
 object Dependencies {
+  val scala212 = "2.12.21"
+  val scala213 = "2.13.18"
+  val scala3 = "3.3.8"
+  val scala2Versions = Seq(scala213, scala212)
+  val scalaVersions = scala2Versions :+ scala3
+
   val metaconfigV = "0.18.7"
   val scalametaV = "4.17.3"
   val coursier = "2.1.24"

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -1,0 +1,64 @@
+// scalafmt: { maxColumn = 120 }
+
+import sbt.*
+import sbt.Keys.*
+
+import scala.scalanative.build.Mode
+import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.*
+
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport.*
+import org.scalajs.linker.interface.{ESVersion, ModuleKind}
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.*
+
+object Extensions {
+
+  import Dependencies.*
+
+  def isScalaVer(ver: String) = Def.setting(scalaBinaryVersion.value == ver)
+  def isScala212 = isScalaVer("2.12")
+  def isScala213 = isScalaVer("2.13")
+  def isScala3 = isScalaVer("3")
+
+  val unpublished = publish / skip := true
+
+  lazy val sharedTestSettings = Seq(libraryDependencies += munit.value % Test)
+
+  val scalacJvmOptions = Def.setting {
+    val cross = if (!isScala213.value) Nil else Seq("-Ymacro-annotations")
+
+    val warningAsError =
+      if (isScala212.value) Seq("-Xfatal-warnings", "-deprecation:false")
+      else Seq("-Wconf:any:error,cat=deprecation:silent")
+
+    val unused =
+      if (isScala3.value) "-Wunused:all"
+      else if (isScala213.value) "-Wunused:imports,privates,locals,patvars,implicits,explicits,params"
+      else "-Ywarn-unused:imports,privates,locals,patvars,implicits"
+
+    val javaver = if (isScala3.value) Seq("-java-output-version:8") else Seq("-target:8", "-release:8")
+
+    cross ++ warningAsError ++ javaver :+ unused
+  }
+
+  val scalacSettings = Def.settings(
+    javacOptions ++= Seq("-source", "8", "-target", "8"),
+    Compile / compile / scalacOptions ++= scalacJvmOptions.value,
+    Test / compile / scalacOptions ++= scalacJvmOptions.value,
+  )
+
+  lazy val scalaJsSettings = Seq(
+    // to support Node.JS functionality
+    scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
+    // to support MULTILINE in regex
+    scalaJSLinkerConfig ~= (_.withESFeatures(_.withESVersion(ESVersion.ES2018))),
+  )
+
+  lazy val scalaNativeConfig = nativeConfig ~= { _.withMode(Mode.releaseFull) }
+
+  def parallelCollections = libraryDependencies ++=
+    { if (!isScala213.value) Nil else Seq("org.scala-lang.modules" %%% "scala-parallel-collections" % "1.2.0") }
+
+  lazy val communityTestsSettings: Seq[Def.Setting[_]] = Def
+    .settings(unpublished, scalacSettings, sharedTestSettings, javaOptions += "-Dfile.encoding=UTF8")
+
+}

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FidelityTest.scala
@@ -14,7 +14,7 @@ import java.nio.file.Path
   */
 class FidelityTest extends SharedFunSuiteBase with FormatAssertions {
 
-  private val numFiles = 284
+  private val numFiles = 285
 
   private val denyList = Set(
     "ConfigReader.scala",


### PR DESCRIPTION
sbt 2 applies a bare top-level setting to every project, so the settings sbt would have given its generated root need a project of their own.