### PR TITLE
sbt2 prep: use projectMatrix, not crossProject

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,17 +60,17 @@ jobs:
         run: git config --global user.email "scalafmt@scalameta.org" && git config --global user.name "scalafmt"
       - &testjvm212
         if: ${{ !cancelled() && steps.env.outcome == 'success' }}
-        run: sbt ++2.12 test-jvm
+        run: sbt test-jvm-2_12
       - &testjvm213
         id: jvm213
         if: ${{ !cancelled() && steps.env.outcome == 'success' }}
-        run: sbt ++2.13 test-jvm
+        run: sbt test-jvm-2_13
       - &testjvm33
         if: ${{ !cancelled() && steps.env.outcome == 'success' }}
-        run: sbt ++3.3 test-jvm
+        run: sbt test-jvm-3
       - &assembly213
         if: ${{ !cancelled() && steps.jvm213.outcome == 'success' }}
-        run: sbt ++2.13 "cli/assembly; cli/runAssembly --non-interactive"
+        run: sbt "cli/assembly; cli/runAssembly --non-interactive"
 
   post-native:             # the slow, flaky native link+run + JS + all-platform publishLocal
     # Native output is JDK-independent; exercised on the OSes we publish for.
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macOS-15, windows-2025 ]
-        scala: [ '2.12', '2.13', '3.3' ]
+        scala: [ '2_12', '2_13', '3' ]
     runs-on: ${{ matrix.os }}
     env:
       SCALANATIVE_GC_TRAP_BASED_YIELDPOINTS: "0"   # avoid intermittent SIGSEGV (scala-native#4917)
@@ -93,12 +93,13 @@ jobs:
       # bash (not the Windows default pwsh) so `||` behaves on every runner.
       - if: ${{ !cancelled() && steps.env.outcome == 'success' }}
         shell: bash
-        run: sbt ++${{ matrix.scala }} test-native || sbt ++${{ matrix.scala }} test-native
+        run: sbt test-native-${{ matrix.scala }} || sbt test-native-${{ matrix.scala }}
       - &testjs
         if: ${{ !cancelled() && steps.env.outcome == 'success' && runner.os == 'Linux' }}
-        run: sbt ++${{ matrix.scala || '2.13' }} test-js
-      - if: ${{ !cancelled() && steps.env.outcome == 'success' && runner.os == 'Linux' }}
-        run: sbt ++${{ matrix.scala }} publishLocal
+        run: sbt test-js-${{ matrix.scala || '2_13' }}
+      # publishLocal now covers every cell, so one matrix entry suffices
+      - if: ${{ !cancelled() && steps.env.outcome == 'success' && runner.os == 'Linux' && matrix.scala == '2_13' }}
+        run: sbt publishLocal
 
   # ===== PR gate: 5 balanced ubuntu/JDK17 workers (run on PR *and* push) =====
   w1-spark-fmt:            # community Spark (~10.3) + formatting (~0.5)
@@ -149,7 +150,7 @@ jobs:
       # native COMPILE only (Scala->NIR): catches a forgotten platform impl in
       # ~1 min. The slow, flaky native link+run lives in post-native (push only).
       - if: ${{ !cancelled() && steps.env.outcome == 'success' }}
-        run: sbt ++2.13 testsNative/Test/compile
+        run: sbt testsNative/Test/compile
       - if: ${{ !cancelled() && steps.env.outcome == 'success' }}
         run: sbt communityTestsScala3/test
 
@@ -164,7 +165,7 @@ jobs:
       # docs is Scala 2.12 (mdoc + yarn build); reuses the 2.12 core compiled
       # just above. linkHygiene=true also fails the run on dead doc links.
       - if: ${{ !cancelled() && steps.env.outcome == 'success' }}
-        run: sbt -Dmdoc.linkHygiene=true ++2.12 docs/docusaurusCreateSite
+        run: sbt -Dmdoc.linkHygiene=true docs/docusaurusCreateSite
       - if: ${{ !cancelled() && steps.env.outcome == 'success' }}
         run: sbt communityTestsScala2/test
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import scala.util.Properties
 
 import Dependencies._
 import Extensions._
-import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 def isCI = System.getenv("CI") != null
 
@@ -27,7 +26,6 @@ inThisBuild {
       url("https://geirsson.com"),
     )),
     scalaVersion := scala213,
-    crossScalaVersions := scalaVersions,
     resolvers += Resolver.sonatypeCentralSnapshots,
     testFrameworks += TestFrameworks.MUnit,
     // causes native image issues
@@ -42,6 +40,7 @@ lazy val copyScalaNative = taskKey[Unit]("Copy Scala Native output to root")
 def rootSettings = Def.settings(
   name := "scalafmtRoot",
   unpublished,
+  crossScalaVersions := Nil, // the cells answer for their own versions
   copyScalaNative := {
     val binaryVersion = (cliNative / scalaBinaryVersion).value
     val suffix = if (Properties.isWin) ".exe" else ""
@@ -70,7 +69,7 @@ def allMatrices = Seq(
   communityTestsOther,
   benchmarks,
   docs,
-).flatMap(_.componentProjects.map(p => LocalProject(p.id)))
+).flatMap(_.projectRefs)
 
 // An explicit root, rather than the one sbt generates: in sbt 2 a bare
 // top-level setting applies to every project, so `publish / skip` must have a
@@ -78,16 +77,14 @@ def allMatrices = Seq(
 lazy val root = project.in(file(".")).withId("scalafmt-root")
   .aggregate(allMatrices: _*).settings(rootSettings)
 
-addCommandAlias("native-image", "cli/nativeImage")
+addCommandAlias("native-image", s"${cli.jvm(scala213).id}/nativeImage")
 addCommandAlias(
   "scala-native",
-  "cliNative/compile;cliNative/nativeLink;copyScalaNative",
+  tasks(tasksOf(cliNative, "compile", "nativeLink") :+ "copyScalaNative"),
 )
-addCommandAlias("test-jvm", "tests/test;cli/test")
-addCommandAlias("test-js", "testsJS/test;cliJS/test")
-addCommandAlias("test-native", "testsNative/test;cliNative/test")
+testAliases(scalaVersions, tests, cli)
 
-lazy val dynamicCore = project.in(file("scalafmt-dynamic-core")).settings(
+lazy val dynamicCore = projectMatrix("scalafmt-dynamic-core").settings(
   moduleName := "scalafmt-dynamic-core",
   description := "Implementation of scalafmt-interfaces",
   buildInfoSettings("org.scalafmt.dynamic", "BuildInfo"),
@@ -103,10 +100,10 @@ lazy val dynamicCore = project.in(file("scalafmt-dynamic-core")).settings(
       val oldStrategy = (assembly / assemblyMergeStrategy).value
       oldStrategy(x)
   },
-).dependsOn(interfaces.jvm, sysops.jvm).dependsOn(core.jvm % "test")
+).crossJvm().dependsOn(interfaces, sysops).dependsOn(core % "test")
   .enablePlugins(BuildInfoPlugin)
 
-lazy val dynamic = project.in(file("scalafmt-dynamic")).settings(
+lazy val dynamic = projectMatrix("scalafmt-dynamic").settings(
   moduleName := "scalafmt-dynamic",
   description := "Implementation of scalafmt-dynamic using coursier",
   libraryDependencies += {
@@ -117,7 +114,7 @@ lazy val dynamic = project.in(file("scalafmt-dynamic")).settings(
   },
   sharedTestSettings,
   scalacSettings,
-).dependsOn(dynamicCore).dependsOn(core.jvm % "test")
+).crossJvm().dependsOn(dynamicCore).dependsOn(core % "test")
 
 def interfacesSettings = Def.settings(
   moduleName := "scalafmt-interfaces",
@@ -139,11 +136,9 @@ def interfacesJvmSettings = Def.settings(
   Compile / doc / javacOptions := Seq("-Xdoclint:none", "-quiet"),
   Compile / doc / scalacOptions ++=
     Seq("-no-link-warnings", "-Wconf:cat=doc:silent"),
-  crossVersion := CrossVersion.disabled,
-  autoScalaLibrary := false,
 )
 
-lazy val interfaces = crossProject(allPlatforms *)("scalafmt-interfaces")
+lazy val interfaces = projectMatrix("scalafmt-interfaces")
   .settings(interfacesSettings).crossJvmJava(interfacesJvmSettings)
   .crossJsNative
 
@@ -160,8 +155,8 @@ def sysopsJsSettings = Def.settings(
   scalaJsSettings,
 )
 
-lazy val sysops = crossProject(allPlatforms *)("scalafmt-sysops")
-  .settings(sysopsSettings).crossJvm().crossNative().crossJs(sysopsJsSettings)
+lazy val sysops = projectMatrix("scalafmt-sysops").settings(sysopsSettings)
+  .crossJvm().crossNative().crossJs(sysopsJsSettings)
 
 def configSettings = Def.settings(
   moduleName := "scalafmt-config",
@@ -174,9 +169,9 @@ def configJvmSettings = libraryDependencies += metaconfigTypesafe.value
 def configNativeSettings = libraryDependencies += metaconfigSconfig.value
 def configJsSettings = Def.settings(configNativeSettings, scalaJsSettings)
 
-lazy val config = crossProject(allPlatforms *)("scalafmt-config")
-  .settings(configSettings).crossJvm(configJvmSettings)
-  .crossNative(configNativeSettings).crossJs(configJsSettings)
+lazy val config = projectMatrix("scalafmt-config").settings(configSettings)
+  .crossJvm(configJvmSettings).crossNative(configNativeSettings)
+  .crossJs(configJsSettings)
 
 def coreSettings = Def.settings(
   moduleName := "scalafmt-core",
@@ -195,11 +190,10 @@ def coreSettings = Def.settings(
 def coreNativeSettings = libraryDependencies +=
   "com.lihaoyi" %%% "fastparse" % "3.1.1"
 
-lazy val core = crossProject(allPlatforms *)("scalafmt-core")
-  .settings(coreSettings).crossJvm().crossJs().crossNative(coreNativeSettings)
-  .aggregate(sysops, config, macros).dependsOn(sysops, config, macros)
-  .enablePlugins(BuildInfoPlugin)
-lazy val coreJVM = core.jvm
+lazy val core = projectMatrix("scalafmt-core").settings(coreSettings).crossJvm()
+  .crossJs().crossNative(coreNativeSettings).aggregate(sysops, config, macros)
+  .dependsOn(sysops, config, macros).enablePlugins(BuildInfoPlugin)
+lazy val coreJVM = core.jvm(scala213)
 
 def macrosSettings = Def.settings(
   moduleName := "scalafmt-macros",
@@ -211,8 +205,8 @@ def macrosSettings = Def.settings(
   },
 )
 
-lazy val macros = crossProject(allPlatforms *)("scalafmt-macros")
-  .settings(macrosSettings).crossAll
+lazy val macros = projectMatrix("scalafmt-macros").settings(macrosSettings)
+  .crossAll
 
 import sbtassembly.AssemblyPlugin.defaultUniversalScript
 
@@ -272,13 +266,17 @@ def cliSettings = Def.settings(
   sharedTestSettings,
 )
 
-lazy val cli = crossProject(allPlatforms *)("scalafmt-cli").settings(cliSettings)
-  .crossJvm(cliJvmSettings).crossNative(scalaNativeConfig)
+lazy val cli = projectMatrix("scalafmt-cli").settings(cliSettings)
+  .crossJvmRow(scalaVersions: _*)(cliJvmRow).crossNative(scalaNativeConfig)
   .dependsOn(core, interfaces)
   // TODO: enable NPM publishing
-  .crossJs(cliJsSettings).jvmEnablePlugins(NativeImagePlugin)
-  .jvmConfigure(_.dependsOn(dynamic).aggregate(dynamic))
-def cliNative = cli.native
+  .crossJs(cliJsSettings)
+def cliNative = cli.native(scala213)
+
+// `dynamic` is JVM-only, so a matrix-wide dependency would leave the JS and
+// native rows with no row to resolve against.
+def cliJvmRow(v: String): Project => Project = _.enablePlugins(NativeImagePlugin)
+  .dependsOn(dynamic.jvm(v)).aggregate(dynamic.jvm(v)).settings(cliJvmSettings)
 
 def testsSettings = Def.settings(
   unpublished,
@@ -287,46 +285,41 @@ def testsSettings = Def.settings(
   libraryDependencies += "com.lihaoyi" %%% "scalatags" % "0.13.1" % Test,
   scalacSettings,
   buildInfoPackage := "org.scalafmt.tests",
-  buildInfoKeys := Seq[BuildInfoKey]("resourceDirectory" -> {
-    val sharedTests = (baseDirectory.value.getParentFile / "shared").toPath
-    (Test / resourceDirectories).value.find(_.toPath.startsWith(sharedTests))
-      .get
-  }),
+  // a cell's baseDirectory is a generated .sbt/matrix directory, so name the
+  // shared tree from the build root
+  buildInfoKeys := Seq[BuildInfoKey](
+    "resourceDirectory" -> (ThisBuild / baseDirectory).value /
+      "scalafmt-tests" / "shared" / "src" / "test" / "resources",
+  ),
 )
 
 def testsJvmSettings = Def
   .settings(javaOptions += "-Dfile.encoding=UTF8", parallelCollections)
 
-lazy val tests = crossProject(allPlatforms *)("scalafmt-tests")
-  .settings(testsSettings).enablePlugins(BuildInfoPlugin).dependsOn(core)
-  .aggregate(core).crossJvm(testsJvmSettings).crossJs(scalaJsSettings)
-  .crossNative()
+lazy val tests = projectMatrix("scalafmt-tests").settings(testsSettings)
+  .enablePlugins(BuildInfoPlugin).dependsOn(core).aggregate(core)
+  .crossJvm(testsJvmSettings).crossJs(scalaJsSettings).crossNative()
 
-lazy val communityTestsCommon =
-  crossProject(jvmAndNative *)("scalafmt-tests-community/common").communityTest
-    .dependsOn(core)
+lazy val communityTestsCommon = projectMatrix("scalafmt-tests-community/common")
+  .communityTest.dependsOn(core)
 
-lazy val communityTestsScala2 =
-  crossProject(jvmAndNative *)("scalafmt-tests-community/scala2").communityTest
-    .dependsOn(communityTestsCommon % "test->test")
+lazy val communityTestsScala2 = projectMatrix("scalafmt-tests-community/scala2")
+  .communityTest.dependsOn(communityTestsCommon % "test->test")
 
-lazy val communityTestsScala3 =
-  crossProject(jvmAndNative *)("scalafmt-tests-community/scala3").communityTest
-    .dependsOn(communityTestsCommon % "test->test")
+lazy val communityTestsScala3 = projectMatrix("scalafmt-tests-community/scala3")
+  .communityTest.dependsOn(communityTestsCommon % "test->test")
 
-lazy val communityTestsSpark =
-  crossProject(jvmAndNative *)("scalafmt-tests-community/spark").communityTest
-    .dependsOn(communityTestsCommon % "test->test")
+lazy val communityTestsSpark = projectMatrix("scalafmt-tests-community/spark")
+  .communityTest.dependsOn(communityTestsCommon % "test->test")
 
 lazy val communityTestsIntellij =
-  crossProject(jvmAndNative *)("scalafmt-tests-community/intellij")
-    .communityTest.dependsOn(communityTestsCommon % "test->test")
-
-lazy val communityTestsOther =
-  crossProject(jvmAndNative *)("scalafmt-tests-community/other").communityTest
+  projectMatrix("scalafmt-tests-community/intellij").communityTest
     .dependsOn(communityTestsCommon % "test->test")
 
-lazy val benchmarks = project.in(file("scalafmt-benchmarks")).settings(
+lazy val communityTestsOther = projectMatrix("scalafmt-tests-community/other")
+  .communityTest.dependsOn(communityTestsCommon % "test->test")
+
+lazy val benchmarks = projectMatrix("scalafmt-benchmarks").settings(
   unpublished,
   moduleName := "scalafmt-benchmarks",
   libraryDependencies += scalametaTestkit.value,
@@ -339,13 +332,15 @@ lazy val benchmarks = project.in(file("scalafmt-benchmarks")).settings(
     "-Xms512M",
     "-Xmx2G",
   ),
-).dependsOn(coreJVM, cli.jvm).enablePlugins(JmhPlugin)
+).crossJvm().dependsOn(core, cli).enablePlugins(JmhPlugin)
 
-lazy val docs = project.in(file("scalafmt-docs")).settings(
-  crossScalaVersions := List(scala212),
-  unpublished,
-  mdoc := (Compile / run).evaluated,
-).dependsOn(cli.jvm, dynamic).enablePlugins(DocusaurusPlugin)
+lazy val docs = projectMatrix(
+  "scalafmt-docs",
+  VirtualAxis.jvm,
+  VirtualAxis.scalaABIVersion(scala212),
+).settings(unpublished, mdoc := (Compile / run).evaluated)
+  .jvmPlatform(Seq(scala212)).dependsOn(cli, dynamic)
+  .enablePlugins(DocusaurusPlugin)
 
 val V = "\\d+\\.\\d+\\.\\d+"
 val ReleaseCandidate = s"($V-RC\\d+).*".r

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -2,26 +2,53 @@
 
 import sbt.*
 import sbt.Keys.*
+import sbt.internal.{ProjectFinder, ProjectMatrix}
 
 import scala.scalanative.build.Mode
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.*
 
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport.*
 import org.scalajs.linker.interface.{ESVersion, ModuleKind}
-import org.scalajs.sbtplugin.ScalaJSPlugin
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.*
-
-import sbtcrossproject.CrossPlugin.autoImport.*
-import sbtcrossproject.CrossProject
-import scalajscrossproject.ScalaJSCrossPlugin.autoImport.*
-import scalanativecrossproject.ScalaNativeCrossPlugin.autoImport.*
 
 object Extensions {
 
   import Dependencies.*
 
-  val allPlatforms = Seq(JVMPlatform, NativePlatform, JSPlatform)
-  val jvmAndNative = Seq(JVMPlatform, NativePlatform)
+  // Leaves the JVM/2.13 cell unsuffixed; left alone a matrix unsuffixes JVM/Scala 3.
+  def bareAxes: Seq[VirtualAxis] = Seq(VirtualAxis.jvm, VirtualAxis.scalaABIVersion(scala213))
+
+  // sbt runs a `;`-separated list; the leading separator is required
+  def tasks(ts: Seq[String]): String = ts.mkString("; ", "; ", "")
+
+  def tasksOf(p: Project, ts: String*): Seq[String] = ts.map(t => s"${p.id}/$t")
+
+  // `++<version>` selects no row, so every version gets its own alias. Cell ids are generated, so
+  // the names are taken from them rather than spelled out.
+  def testAliases(versions: Seq[String], matrices: ProjectMatrix*): Seq[Setting[_]] = versions.flatMap { v =>
+    def alias(name: String, f: ProjectMatrix => ProjectFinder) = addCommandAlias(
+      s"test-$name-${VirtualAxis.scalaABIVersion(v).idSuffix}",
+      tasks(matrices.map(m => s"${f(m)(v).id}/test")),
+    )
+    alias("jvm", _.jvm) ++ alias("js", _.js) ++ alias("native", _.native)
+  }
+
+  // A matrix has one base directory, so a cell has to name every tree it reads. Directories that
+  // do not exist are harmless.
+  private def roots(base: File, dirs: String*): Seq[Setting[_]] = {
+    def under(conf: String, leaf: String => Seq[String]) = Def.setting {
+      // a matrix base may be relative, and a relative source root resolves against the wrong one
+      val root = IO.resolve((ThisBuild / baseDirectory).value, base)
+      for (dir <- dirs.toList; name <- leaf(scalaBinaryVersion.value)) yield root / dir / "src" / conf / name
+    }
+    def sources(sbv: String) = Seq("scala", "java", s"scala-$sbv", s"scala-${sbv.head}").distinct
+    Def.settings(
+      Compile / unmanagedSourceDirectories ++= under("main", sources).value,
+      Test / unmanagedSourceDirectories ++= under("test", sources).value,
+      Compile / unmanagedResourceDirectories ++= under("main", _ => Seq("resources")).value,
+      Test / unmanagedResourceDirectories ++= under("test", _ => Seq("resources")).value,
+    )
+  }
 
   def isScalaVer(ver: String) = Def.setting(scalaBinaryVersion.value == ver)
   def isScala212 = isScalaVer("2.12")
@@ -70,32 +97,50 @@ object Extensions {
   lazy val communityTestsSettings: Seq[Def.Setting[_]] = Def
     .settings(unpublished, scalacSettings, sharedTestSettings, javaOptions += "-Dfile.encoding=UTF8")
 
-  implicit class CrossProjectBuilderExtensions(private val self: CrossProject.Builder) extends AnyVal {
-    def apply(name: String): CrossProject = self.withoutSuffixFor(JVMPlatform).in(file(name))
-  }
+  // `projectMatrix` is a macro that reads the name of the val it is assigned to, so it cannot be
+  // called here; it arrives as the receiver instead.
+  implicit class ProjectMatrixExtensions(private val self: ProjectMatrix) extends AnyVal {
 
-  // A crossProject declares its platforms up front, so the per-platform methods only carry
-  // settings and the whole-set ones have nothing to do. Both become real once each row is
-  // declared separately.
-  implicit class CrossProjectExtensions(private val self: CrossProject) extends AnyVal {
+    def apply(name: String, axes: VirtualAxis*): ProjectMatrix = {
+      val axesToUse = if (axes.isEmpty) bareAxes else axes
+      // off `in`'s result, not `self`: until then the base is still the val name
+      val named = self.in(file(name)).defaultAxes(axesToUse *)
+      named.settings(roots(named.base, "shared"))
+    }
 
-    def crossJvm(ss: Def.SettingsDefinition*): CrossProject = self.jvmSettings(ss *)
+    def crossJvm(ss: Def.SettingsDefinition*): ProjectMatrix = self
+      .jvmPlatform(scalaVersions, jvmRoots ++ ss.flatMap(_.settings))
 
-    // JSPlatform already enables the plugin; naming it is how the row asks for it under a matrix
-    def crossJs(ss: Def.SettingsDefinition*): CrossProject = self.jsEnablePlugins(ScalaJSPlugin).jsSettings(ss *)
+    def crossJs(ss: Def.SettingsDefinition*): ProjectMatrix = self
+      .jsPlatform(scalaVersions, roots(self.base, "js", "js-jvm", "js-native") ++ ss.flatMap(_.settings))
 
-    def crossNative(ss: Def.SettingsDefinition*): CrossProject = self.nativeSettings(ss *)
+    def crossNative(ss: Def.SettingsDefinition*): ProjectMatrix = self
+      .nativePlatform(scalaVersions, roots(self.base, "native", "jvm-native", "js-native") ++ ss.flatMap(_.settings))
 
-    // a JVM row carrying no Scala version, for Java-only sources
-    def crossJvmJava(ss: Def.SettingsDefinition*): CrossProject = self.jvmSettings(ss *)
+    // A JVM row carrying no Scala version, for Java-only sources. Not
+    // `jvmPlatform(autoScalaLibrary = false)`: that one passes VirtualAxis.jvm to a customRow which
+    // appends it again, and the doubled axis renames the generated directories to `scalajvm-jvm`.
+    // The cell id is unaffected, so it would just compile nothing.
+    def crossJvmJava(ss: Def.SettingsDefinition*): ProjectMatrix = self
+      .customRow(autoScalaLibrary = false, axisValues = Nil, settings = jvmRoots ++ ss.flatMap(_.settings))
 
-    def crossAll: CrossProject = self.crossJvm().crossJs().crossNative()
+    // a row that needs the cell itself, not just its settings
+    def crossJvmRow(version: String, configure: Project => Project): ProjectMatrix = self
+      .jvmPlatform(Seq(version), Nil, configure(_).settings(jvmRoots))
 
-    def crossJsNative: CrossProject = self.crossJs().crossNative()
+    // a row that needs the cell itself, not just its settings
+    def crossJvmRow(versions: String*)(configure: String => Project => Project): ProjectMatrix = versions
+      .foldLeft(self)((acc, version) => acc.crossJvmRow(version, configure(version)))
 
-    def crossJvmNative(nativeOnly: Def.SettingsDefinition*): CrossProject = self.crossJvm().crossNative(nativeOnly *)
+    def crossAll: ProjectMatrix = self.crossJvm().crossJs().crossNative()
 
-    def communityTest: CrossProject = self.settings(communityTestsSettings).crossJvmNative(scalaNativeConfig)
+    def crossJsNative: ProjectMatrix = self.crossJs().crossNative()
+
+    def crossJvmNative(nativeOnly: Def.SettingsDefinition*): ProjectMatrix = self.crossJvm().crossNative(nativeOnly *)
+
+    def communityTest: ProjectMatrix = self.settings(communityTestsSettings).crossJvmNative(scalaNativeConfig)
+
+    private def jvmRoots = roots(self.base, "jvm", "jvm-native", "js-jvm")
   }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,7 @@ val crossProjectV = "1.3.2"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.4.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")


### PR DESCRIPTION
sbt-crossproject has no sbt 2 release, and sbt 2 in-sources projectMatrix, so the cross-building mechanism has to change before the sbt version can.