### PR TITLE
ScalafmtReflect: only close a classloader it owns

### DIFF
--- a/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
+++ b/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtDynamic.scala
@@ -16,8 +16,7 @@ final case class ScalafmtDynamic(
     with RepositoryCredential.ScalafmtExtension
     with ScalafmtSessionFactory {
 
-  val moduleLoader: ScalafmtModuleLoader = ScalafmtModuleLoader
-    .CachedProxy(_moduleLoader)
+  val moduleLoader = ScalafmtModuleLoader.CachedProxy(_moduleLoader)
 
   def this(
       moduleLoader: ScalafmtModuleLoader,

--- a/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtModuleLoader.scala
+++ b/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtModuleLoader.scala
@@ -4,15 +4,15 @@ import org.scalafmt.CompatCollections.JavaConverters._
 import org.scalafmt.dynamic.ScalafmtDynamicError._
 import org.scalafmt.dynamic.utils.ReentrantCache
 import org.scalafmt.interfaces.RepositoryPackageDownloaderFactory
+import org.scalafmt.sysops.PlatformRunOps
 
-import java.io.{Closeable, File}
+import java.io.Closeable
 import java.net.URLClassLoader
 import java.nio.file.Path
 
-import scala.concurrent.ExecutionContext
 import scala.util.Try
 
-trait ScalafmtModuleLoader extends Closeable {
+trait ScalafmtModuleLoader {
 
   def load(
       configPath: Path,
@@ -20,6 +20,7 @@ trait ScalafmtModuleLoader extends Closeable {
       properties: ScalafmtProperties,
   ): FormatEval[ScalafmtReflect]
 
+  def close(obj: ScalafmtReflect): Unit = obj.closeClassLoader(this)
 }
 
 object ScalafmtModuleLoader {
@@ -39,11 +40,19 @@ object ScalafmtModuleLoader {
         dependencies.asJava,
       )).fold(
         x => Left(new CannotDownload(configPath, version, x)),
-        loadClassPath(configPath, version),
+        jars => {
+          val urls = jars.asScala.map(_.toURI.toURL).toSeq
+          Try {
+            val classloader = new URLClassLoader(urls.toArray, null)
+            ScalafmtReflect(classloader, version, ownedBy = this)
+          }.toEither.left.map {
+            case e: ReflectiveOperationException =>
+              new CorruptedClassPath(configPath, version, urls, e)
+            case e => new UnknownConfigError(configPath, e)
+          }
+        },
       )
     }
-
-    override def close(): Unit = {}
   }
 
   object CachedProxy {
@@ -68,25 +77,12 @@ object ScalafmtModuleLoader {
       cache.getOrAddToCache(version)(load)
     }
 
+    override def close(obj: ScalafmtReflect): Unit = {}
     override def close(): Unit = {
-      cache.clear()
-        .foreach(_.foreach(_.right.foreach(_.close()))(ExecutionContext.global))
-      loader.close()
+      implicit val ec = PlatformRunOps.parasiticExecutionContext
+      cache.clear().foreach(_.foreach(_.foreach(loader.close)))
     }
-  }
 
-  private def loadClassPath(configPath: Path, version: ScalafmtVersion)(
-      jars: java.lang.Iterable[File],
-  ): FormatEval[ScalafmtReflect] = {
-    val urls = jars.asScala.map(_.toURI.toURL).toSeq
-    Try {
-      val classloader = new URLClassLoader(urls.toArray, null)
-      ScalafmtReflect(classloader, version)
-    }.toEither.left.map {
-      case e: ReflectiveOperationException =>
-        new CorruptedClassPath(configPath, version, urls, e)
-      case e => new UnknownConfigError(configPath, e)
-    }
   }
 
 }

--- a/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
+++ b/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtReflect.scala
@@ -10,9 +10,12 @@ import scala.util.{Failure, Try}
 
 import com.typesafe.config.ConfigFactory
 
-case class ScalafmtReflect(classLoader: ClassLoader, version: ScalafmtVersion)
-    extends Closeable {
-  import classLoader.loadClass
+case class ScalafmtReflect(
+    private val classLoader: ClassLoader,
+    version: ScalafmtVersion,
+    ownedBy: ScalafmtModuleLoader = null,
+) {
+  def loadClass(name: String): Class[_] = classLoader.loadClass(name)
 
   // FIXME: the class does not exist for version old versions, e.g. v0.2.8
   private val formattedCls = loadClass("org.scalafmt.Formatted")
@@ -166,8 +169,8 @@ case class ScalafmtReflect(classLoader: ClassLoader, version: ScalafmtVersion)
     module.get(null)
   }
 
-  override def close(): Unit = classLoader match {
-    case x: Closeable => x.close()
+  def closeClassLoader(loader: ScalafmtModuleLoader): Unit = classLoader match {
+    case x: Closeable if ownedBy eq loader => x.close()
     case _ =>
   }
 }

--- a/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtReflectConfig.scala
+++ b/scalafmt-dynamic-core/src/main/scala/org/scalafmt/dynamic/ScalafmtReflectConfig.scala
@@ -13,11 +13,10 @@ class ScalafmtReflectConfig private[dynamic] (val fmtReflect: ScalafmtReflect)(
     private[dynamic] val target: Object,
 ) {
   import ScalafmtReflectConfig._
-  import fmtReflect.classLoader
   private val targetCls = target.getClass
 
-  private val dialectCls = classLoader.loadClass("scala.meta.Dialect")
-  private val dialectsCls = classLoader.loadClass("scala.meta.dialects.package")
+  private val dialectCls = fmtReflect.loadClass("scala.meta.Dialect")
+  private val dialectsCls = fmtReflect.loadClass("scala.meta.dialects.package")
 
   private val projectField = target.invoke("project")
   private val projectMatcherField = projectField.invoke("matcher")

--- a/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
+++ b/scalafmt-dynamic/src/test/scala/org/scalafmt/dynamic/DynamicSuite.scala
@@ -412,12 +412,7 @@ class DynamicSuite extends FunSuite {
     f.setVersion(version.toString, "Scala211")
     f.assertFormat()
 
-    val cache = f.dynamic.moduleLoader match {
-      case x: ScalafmtModuleLoader.CachedProxy => x.cache
-      case x =>
-        fail("ReflectResolver is not cached: " + x.getClass.getSimpleName)
-    }
-    cache.getFromCache(version) match {
+    f.dynamic.moduleLoader.cache.getFromCache(version) match {
       case Some(Right(x)) => assert(x.intellijScalaFmtConfig.nonEmpty)
       case _ => fail(s"failed cache.getFromCache($version)")
     }
@@ -650,7 +645,8 @@ private object DynamicSuite {
     ): FormatEval[ScalafmtReflect] =
       if (ver.toString == nightly) Right(ScalafmtReflect(clsLoader, ver))
       else downloader.load(cfg, ver, props)
-    override def close(): Unit = downloader.close()
+    // we delegate, so the downloader owns what it made and has to release it
+    override def close(obj: ScalafmtReflect): Unit = downloader.close(obj)
   }
 
   def getBackQuote(version: ScalafmtVersion): String =


### PR DESCRIPTION
`close()` closed whatever loader it was handed. For a downloaded version that loader is ours, but a caller may pass its own — `Scalafmt.create` takes one — and closing a host's classloader breaks the host.

sbt 1 hid this: its test classloaders ignored `close()` unless `closeClassLoaders` was set. sbt 2 closes them, so DynamicSuite, which hands over sbt's own test loader for the current version, closed it midway through the run and every class loaded after that came from a stale copy.