### PR TITLE
FormatWriter: keep a docstring's blank first line

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5164,7 +5164,7 @@ Takes the following values:
 
 > Since v2.7.5.
 >
-> - Ignored for `docstrings.style = keep` or `docstrings.wrap = no`.
+> - Ignored for `docstrings.style = keep`.
 > - [since v3.8.4] For `docstrings.style = Asterisk`, only `fold` changes default behaviour.
 
 ```scala mdoc:scalafmt

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -879,23 +879,23 @@ class FormatWriter(formatOps: FormatOps) {
         private var lastBreak: Int = -1
 
         def format(): Unit = {
-          val noWrap = (wrap eq Docstrings.Wrap.keep) || {
-            ScaladocParser.parse(tok.meta.left.text) match {
-              case Some(doc) =>
-                val sbLen = sb.length
-                try { formatWithWrap(doc); false }
-                catch { case _: Throwable => sb.setLength(sbLen); true }
-              case None => true
+          val noWrap = (wrap eq Docstrings.Wrap.keep) ||
+            ScaladocParser.parse(text).forall { doc =>
+              val sbLen = sb.length
+              try { formatWithWrap(doc); false }
+              catch { case _: Throwable => sb.setLength(sbLen); true }
             }
-          }
           if (noWrap) formatNoWrap()
         }
 
         private def formatWithWrap(doc: Scaladoc): Unit = {
           sb.append("/**")
           val afterOpen = sb.length
+          val eol = text.indexOf('\n')
+          val hadBlankFirstLine = eol > 0 &&
+            State.getLineLength(text, 3, eol) == 0 // 3 skips "/**"
           val (sbLen, beforeText) =
-            if (style.docstrings.skipFirstLineIf(false)) {
+            if (style.docstrings.skipFirstLineIf(hadBlankFirstLine)) {
               appendBreak()
               (0, sb.length) // 0 force margin but not extra asterisk
             } else {

--- a/scalafmt-tests/shared/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/shared/src/test/resources/test/JavaDoc.stat
@@ -3659,7 +3659,8 @@ val a = 1
 >>>
 /** text on the first line
   */
-/** blank first line
+/**
+  * blank first line
   */
 val a = 1
 <<< blankFirstLine=keep, not wrapping

--- a/scalafmt-tests/shared/src/test/resources/test/JavaDoc.stat
+++ b/scalafmt-tests/shared/src/test/resources/test/JavaDoc.stat
@@ -3644,3 +3644,39 @@ object a
  * qux
  */
 object a
+<<< blankFirstLine=keep, wrapping
+docstrings.blankFirstLine = keep
+docstrings.style = SpaceAsterisk
+docstrings.wrap = unfold
+maxColumn = 30
+===
+/** text on the first line
+  */
+/**
+  * blank first line
+  */
+val a = 1
+>>>
+/** text on the first line
+  */
+/** blank first line
+  */
+val a = 1
+<<< blankFirstLine=keep, not wrapping
+docstrings.blankFirstLine = keep
+docstrings.style = SpaceAsterisk
+maxColumn = 30
+===
+/** text on the first line
+  */
+/**
+  * blank first line
+  */
+val a = 1
+>>>
+/** text on the first line
+  */
+/**
+  * blank first line
+  */
+val a = 1

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2608876, "total explored")
+      assertEquals(explored, 2608940, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
The wrapping path asked `skipFirstLineIf(false)`, so it could not tell `docstrings.blankFirstLine = keep` from `fold`. Only the path that leaves a docstring unwrapped honoured `keep`, which is why the documented caveat had it backwards: `docstrings.wrap = no` was the one setting under which the parameter always worked.