### PR TITLE
FormatOps: align a lambda's parameters under the first

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatOps.scala
@@ -625,7 +625,8 @@ class FormatOps(
     val close = matchingLeft(ft)
     val beforeClose = prev(close)
     val indentParam = style.indent.getDefnSite(lpOwner)
-    val indentSep = Indent((indentParam - 2).max(0), close, ExpiresOn.After)
+    val indentSepLen = (indentParam - 2).max(0)
+    val indentSep = Indent(indentSepLen, close, ExpiresOn.After)
     val isBracket = open.is[T.LeftBracket]
 
     def getClausesFromClauseGroup(tree: Member.ParamClauseGroup) = {
@@ -749,7 +750,25 @@ class FormatOps(
         style.newlines.forceAfterImplicitParamListModifier
       val nlNoAlt = implicitNL ||
         !rightIsImplicit && style.verticalMultiline.newlineAfterOpenParen
-      val nlMod = Newline.withAltIf(!nlNoAlt)(slbSplit.modExt)
+      /* a lambda has one clause, so its alternative can't be aligning a `)(`
+       * group; keeping the first param on the open paren line, the rest align
+       * under it rather than at the indent computed for a break */
+      val lambdaClause = lpOwner match {
+        case t: Term.ParamClause => t.parent.is[Term.FunctionTerm]
+        case _ => false
+      }
+      val altIndents =
+        if (!lambdaClause) Nil
+        else Seq(
+          Indent(Length.StateColumn, close, ExpiresOn.After),
+          // cancelled within the clause, so only the close drops to the paren
+          Indent(-1 - indentSepLen, close, ExpiresOn.After),
+          Indent(1 + indentSepLen, close, ExpiresOn.Before),
+        )
+      val nlMod = Newline.withAltIf(!nlNoAlt)(
+        slbSplit.modExt.withIndents(altIndents),
+        noAltIndent = lambdaClause,
+      )
       val spaceImplicit = !implicitNL && implicitParams.lengthCompare(1) > 0 &&
         style.newlines.notBeforeImplicitParamListModifier
       Seq(

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -14246,3 +14246,95 @@ object A {
     valid: (Tckt, Sess) => Res =
       (_, _) => ff)
 }
+<<< verticalMultiline, typed lambda, indent.defnSite = 2
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = false
+indent.defnSite = 2
+===
+object A {
+  val asrhs = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asasc: Any = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asarg = Some((ticket: Tckt, session: Sess) => ff(ticket))
+  val astwo = foo(xx, (ticket: Tckt, session: Sess) => ff(ticket))
+  val asparen = ((ticket: Tckt, session: Sess) => ff(ticket))
+  case class Cls(v: Res = (ticket: Tckt, session: Sess) => ff(ticket))
+}
+>>>
+object A {
+  val asrhs = (
+    ticket: Tckt,
+    session: Sess
+  ) => ff(ticket)
+  val asasc: Any = (
+    ticket: Tckt,
+    session: Sess
+  ) => ff(ticket)
+  val asarg = Some(
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  val astwo = foo(
+    xx,
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  val asparen = (
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  case class Cls(
+    v: Res = (
+      ticket: Tckt,
+      session: Sess
+    ) => ff(ticket))
+}
+<<< verticalMultiline, typed lambda, indent.defnSite = 6
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = false
+indent.defnSite = 6
+===
+object A {
+  val asrhs = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asasc: Any = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asarg = Some((ticket: Tckt, session: Sess) => ff(ticket))
+  val astwo = foo(xx, (ticket: Tckt, session: Sess) => ff(ticket))
+  val asparen = ((ticket: Tckt, session: Sess) => ff(ticket))
+  case class Cls(v: Res = (ticket: Tckt, session: Sess) => ff(ticket))
+}
+>>>
+object A {
+  val asrhs = (
+        ticket: Tckt,
+        session: Sess
+      ) => ff(ticket)
+  val asasc: Any = (
+        ticket: Tckt,
+        session: Sess
+      ) => ff(ticket)
+  val asarg = Some(
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  )
+  val astwo = foo(
+    xx,
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  )
+  val asparen = (
+        (ticket: Tckt,
+              session: Sess
+            ) => ff(ticket)
+      )
+  case class Cls(
+        v: Res = (
+              ticket: Tckt,
+              session: Sess
+            ) => ff(ticket))
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_classic.stat
@@ -14272,18 +14272,18 @@ object A {
   ) => ff(ticket)
   val asarg = Some(
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   val astwo = foo(
     xx,
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   val asparen = (
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   case class Cls(
@@ -14318,19 +14318,19 @@ object A {
       ) => ff(ticket)
   val asarg = Some(
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   )
   val astwo = foo(
     xx,
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   )
   val asparen = (
         (ticket: Tckt,
-              session: Sess
-            ) => ff(ticket)
+         session: Sess
+        ) => ff(ticket)
       )
   case class Cls(
         v: Res = (

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -13414,18 +13414,18 @@ object A {
   ) => ff(ticket)
   val asarg = Some(
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   val astwo = foo(
     xx,
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   val asparen = (
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   case class Cls(
@@ -13460,19 +13460,19 @@ object A {
       ) => ff(ticket)
   val asarg = Some(
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   )
   val astwo = foo(
     xx,
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   )
   val asparen = (
         (ticket: Tckt,
-              session: Sess
-            ) => ff(ticket)
+         session: Sess
+        ) => ff(ticket)
       )
   case class Cls(
         v: Res = (

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_fold.stat
@@ -13388,3 +13388,95 @@ object A {
     valid: (Tckt, Sess) => Res =
       (_, _) => ff)
 }
+<<< verticalMultiline, typed lambda, indent.defnSite = 2
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = false
+indent.defnSite = 2
+===
+object A {
+  val asrhs = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asasc: Any = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asarg = Some((ticket: Tckt, session: Sess) => ff(ticket))
+  val astwo = foo(xx, (ticket: Tckt, session: Sess) => ff(ticket))
+  val asparen = ((ticket: Tckt, session: Sess) => ff(ticket))
+  case class Cls(v: Res = (ticket: Tckt, session: Sess) => ff(ticket))
+}
+>>>
+object A {
+  val asrhs = (
+    ticket: Tckt,
+    session: Sess
+  ) => ff(ticket)
+  val asasc: Any = (
+    ticket: Tckt,
+    session: Sess
+  ) => ff(ticket)
+  val asarg = Some(
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  val astwo = foo(
+    xx,
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  val asparen = (
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  case class Cls(
+    v: Res = (
+      ticket: Tckt,
+      session: Sess
+    ) => ff(ticket))
+}
+<<< verticalMultiline, typed lambda, indent.defnSite = 6
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = false
+indent.defnSite = 6
+===
+object A {
+  val asrhs = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asasc: Any = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asarg = Some((ticket: Tckt, session: Sess) => ff(ticket))
+  val astwo = foo(xx, (ticket: Tckt, session: Sess) => ff(ticket))
+  val asparen = ((ticket: Tckt, session: Sess) => ff(ticket))
+  case class Cls(v: Res = (ticket: Tckt, session: Sess) => ff(ticket))
+}
+>>>
+object A {
+  val asrhs = (
+        ticket: Tckt,
+        session: Sess
+      ) => ff(ticket)
+  val asasc: Any = (
+        ticket: Tckt,
+        session: Sess
+      ) => ff(ticket)
+  val asarg = Some(
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  )
+  val astwo = foo(
+    xx,
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  )
+  val asparen = (
+        (ticket: Tckt,
+              session: Sess
+            ) => ff(ticket)
+      )
+  case class Cls(
+        v: Res = (
+              ticket: Tckt,
+              session: Sess
+            ) => ff(ticket))
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -14104,18 +14104,18 @@ object A {
   ) => ff(ticket)
   val asarg = Some(
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   val astwo = foo(
     xx,
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   val asparen = (
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   case class Cls(
@@ -14150,19 +14150,19 @@ object A {
       ) => ff(ticket)
   val asarg = Some(
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   )
   val astwo = foo(
     xx,
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   )
   val asparen = (
         (ticket: Tckt,
-              session: Sess
-            ) => ff(ticket)
+         session: Sess
+        ) => ff(ticket)
       )
   case class Cls(
         v: Res = (

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_keep.stat
@@ -14078,3 +14078,95 @@ object A {
     valid: (Tckt, Sess) => Res =
       (_, _) => ff)
 }
+<<< verticalMultiline, typed lambda, indent.defnSite = 2
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = false
+indent.defnSite = 2
+===
+object A {
+  val asrhs = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asasc: Any = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asarg = Some((ticket: Tckt, session: Sess) => ff(ticket))
+  val astwo = foo(xx, (ticket: Tckt, session: Sess) => ff(ticket))
+  val asparen = ((ticket: Tckt, session: Sess) => ff(ticket))
+  case class Cls(v: Res = (ticket: Tckt, session: Sess) => ff(ticket))
+}
+>>>
+object A {
+  val asrhs = (
+    ticket: Tckt,
+    session: Sess
+  ) => ff(ticket)
+  val asasc: Any = (
+    ticket: Tckt,
+    session: Sess
+  ) => ff(ticket)
+  val asarg = Some(
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  val astwo = foo(
+    xx,
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  val asparen = (
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  case class Cls(
+    v: Res = (
+      ticket: Tckt,
+      session: Sess
+    ) => ff(ticket))
+}
+<<< verticalMultiline, typed lambda, indent.defnSite = 6
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = false
+indent.defnSite = 6
+===
+object A {
+  val asrhs = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asasc: Any = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asarg = Some((ticket: Tckt, session: Sess) => ff(ticket))
+  val astwo = foo(xx, (ticket: Tckt, session: Sess) => ff(ticket))
+  val asparen = ((ticket: Tckt, session: Sess) => ff(ticket))
+  case class Cls(v: Res = (ticket: Tckt, session: Sess) => ff(ticket))
+}
+>>>
+object A {
+  val asrhs = (
+        ticket: Tckt,
+        session: Sess
+      ) => ff(ticket)
+  val asasc: Any = (
+        ticket: Tckt,
+        session: Sess
+      ) => ff(ticket)
+  val asarg = Some(
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  )
+  val astwo = foo(
+    xx,
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  )
+  val asparen = (
+        (ticket: Tckt,
+              session: Sess
+            ) => ff(ticket)
+      )
+  case class Cls(
+        v: Res = (
+              ticket: Tckt,
+              session: Sess
+            ) => ff(ticket))
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -14633,3 +14633,95 @@ object A {
     valid: (Tckt, Sess) => Res =
       (_, _) => ff)
 }
+<<< verticalMultiline, typed lambda, indent.defnSite = 2
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = false
+indent.defnSite = 2
+===
+object A {
+  val asrhs = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asasc: Any = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asarg = Some((ticket: Tckt, session: Sess) => ff(ticket))
+  val astwo = foo(xx, (ticket: Tckt, session: Sess) => ff(ticket))
+  val asparen = ((ticket: Tckt, session: Sess) => ff(ticket))
+  case class Cls(v: Res = (ticket: Tckt, session: Sess) => ff(ticket))
+}
+>>>
+object A {
+  val asrhs =
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  val asasc: Any =
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  val asarg = Some(
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  val astwo = foo(
+    xx,
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  val asparen = (
+    (ticket: Tckt,
+      session: Sess
+    ) => ff(ticket)
+  )
+  case class Cls(
+    v: Res =
+      (ticket: Tckt,
+        session: Sess
+      ) => ff(ticket))
+}
+<<< verticalMultiline, typed lambda, indent.defnSite = 6
+verticalMultiline.atDefnSite = true
+verticalMultiline.arityThreshold = 2
+verticalMultiline.newlineAfterOpenParen = false
+indent.defnSite = 6
+===
+object A {
+  val asrhs = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asasc: Any = (ticket: Tckt, session: Sess) => ff(ticket)
+  val asarg = Some((ticket: Tckt, session: Sess) => ff(ticket))
+  val astwo = foo(xx, (ticket: Tckt, session: Sess) => ff(ticket))
+  val asparen = ((ticket: Tckt, session: Sess) => ff(ticket))
+  case class Cls(v: Res = (ticket: Tckt, session: Sess) => ff(ticket))
+}
+>>>
+object A {
+  val asrhs =
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  val asasc: Any =
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  val asarg = Some(
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  )
+  val astwo = foo(
+    xx,
+    (ticket: Tckt,
+          session: Sess
+        ) => ff(ticket)
+  )
+  val asparen = (
+        (ticket: Tckt,
+              session: Sess
+            ) => ff(ticket)
+      )
+  case class Cls(
+        v: Res =
+          (ticket: Tckt,
+                session: Sess
+              ) => ff(ticket))
+}

--- a/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/newlines/source_unfold.stat
@@ -14585,16 +14585,16 @@ object A {
   ) = fff(aaa, bbb)
   val tfit =
     (a: Aa,
-      b: Bb
+     b: Bb
     ) => ff(a)
   val tmid =
     (a: Aa,
-      b: Bb
+     b: Bb
     ) => fff(aaa, bbb)
   val twide =
     (ticketing: Tckt,
-      sessioning: Sess,
-      contexting: Ctx
+     sessioning: Sess,
+     contexting: Ctx
     ) => ff(a)
   val ufit = (a, b) => ff(a)
   val umid =
@@ -14608,20 +14608,20 @@ object A {
     ) => ff(a)
   val mfit =
     (a: Aa,
-      b
+     b
     ) => ff(a)
   val mmid =
     (a: Aa,
-      b
+     b
     ) => fff(aaa, bbbb)
   val mwide =
     (ticketing,
-      sessioning: Sess,
-      contexting
+     sessioning: Sess,
+     contexting
     ) => ff(a)
   val amid: (Aa, Bb) => Rr =
     (a: Aa,
-      b
+     b
     ) => fff(aaa, bbb)
   val inarg = Some((a, b) =>
     fff(aaa, bbb)
@@ -14651,32 +14651,32 @@ object A {
 object A {
   val asrhs =
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   val asasc: Any =
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   val asarg = Some(
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   val astwo = foo(
     xx,
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   val asparen = (
     (ticket: Tckt,
-      session: Sess
+     session: Sess
     ) => ff(ticket)
   )
   case class Cls(
     v: Res =
       (ticket: Tckt,
-        session: Sess
+       session: Sess
       ) => ff(ticket))
 }
 <<< verticalMultiline, typed lambda, indent.defnSite = 6
@@ -14697,31 +14697,31 @@ object A {
 object A {
   val asrhs =
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   val asasc: Any =
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   val asarg = Some(
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   )
   val astwo = foo(
     xx,
     (ticket: Tckt,
-          session: Sess
-        ) => ff(ticket)
+     session: Sess
+    ) => ff(ticket)
   )
   val asparen = (
         (ticket: Tckt,
-              session: Sess
-            ) => ff(ticket)
+         session: Sess
+        ) => ff(ticket)
       )
   case class Cls(
         v: Res =
           (ticket: Tckt,
-                session: Sess
-              ) => ff(ticket))
+           session: Sess
+          ) => ff(ticket))
 }

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2615188, "total explored")
+      assertEquals(explored, 2620534, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2620534, "total explored")
+      assertEquals(explored, 2620542, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
When the first parameter stays on the open paren line, the rest kept an indent measured from the enclosing line and missed it by a few columns. Now they align under it, and the close sits at the paren.

