### PR TITLE
Allow users to disable aligning tokens from multi-line statements

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1585,6 +1585,11 @@ tokens to align, with the following values:
 
 - (since v3.11.6) `adjacent`: align tokens only on adjacent lines (was: `false`)
 - (since v3.11.6) `all`: align consecutive statements even if tokens to align are not on adjacent lines (was: `true`)
+- (since v3.11.6) `none`: a multiline statement contributes no token to align
+  by, and a line left with none interrupts the alignment block; this was
+  roughly the behaviour before v3.9.7
+- (since v3.11.6) `skip`: the same, except the block runs on to the next blank
+  line, so the lines on either side still align with each other
 
 > Since v2.5.0.
 
@@ -1618,6 +1623,50 @@ for {
   }
   dd <- ddddd
 } yield ()
+```
+
+```scala mdoc:scalafmt
+align.preset = more
+align.multiline = none
+---
+for {
+  a <- aaa
+  bbb <- bb
+  cccccc <- c {
+    3
+  }
+  dd <- ddddd
+} yield ()
+```
+
+```scala mdoc:scalafmt
+align.preset = more
+align.multiline = skip
+---
+for {
+  a <- aaa
+  bbb <- bb
+  cccccc <- c {
+    3
+  }
+  dd <- ddddd
+} yield ()
+```
+
+Keep in mind that `skip` shares the block rule of `all`, so a column can be set
+by a statement far above:
+
+```scala mdoc:scalafmt
+align.preset = more
+align.multiline = skip
+---
+trait A {
+  def meta: Map[Int, Int] = Map()
+  def data: Data =
+    Data()
+      .plus(x)
+  def other = 1
+}
 ```
 
 ### `align.allowOverflow`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1583,8 +1583,8 @@ was disabled since the parameter's introduction in v2.5.0.
 This flag controls whether to include multiline statements in the search for
 tokens to align, with the following values:
 
-- `false`: align tokens only on adjacent lines
-- `true`: align consecutive statements even if tokens to align are not on adjacent lines
+- (since v3.11.6) `adjacent`: align tokens only on adjacent lines (was: `false`)
+- (since v3.11.6) `all`: align consecutive statements even if tokens to align are not on adjacent lines (was: `true`)
 
 > Since v2.5.0.
 
@@ -1594,7 +1594,7 @@ align.multiline
 
 ```scala mdoc:scalafmt
 align.preset = more
-align.multiline = true
+align.multiline = all
 ---
 for {
   a <- aaa
@@ -1608,7 +1608,7 @@ for {
 
 ```scala mdoc:scalafmt
 align.preset = more
-align.multiline = false
+align.multiline = adjacent
 ---
 for {
   a <- aaa

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -168,13 +168,22 @@ object Align {
 
   /** @param spansBlock
     *   the block ends only at a blank line, not when the container changes
+    * @param skipsMultiline
+    *   a token whose expression spans several lines is not aligned
     */
-  sealed abstract class Multiline(val spansBlock: Boolean)
+  sealed abstract class Multiline(
+      val spansBlock: Boolean,
+      val skipsMultiline: Boolean,
+  ) {
+    /* a default argument would live in `object Multiline`, which the case
+     * objects would then initialize; `codec` reads them back as nulls */
+    def this(spansBlock: Boolean) = this(spansBlock, skipsMultiline = false)
+  }
   object Multiline {
     case object adjacent extends Multiline(spansBlock = false)
     case object all extends Multiline(spansBlock = true)
-    case object none extends Multiline(spansBlock = false)
-    case object skip extends Multiline(spansBlock = true)
+    case object none extends Multiline(spansBlock = false, skipsMultiline = true)
+    case object skip extends Multiline(spansBlock = true, skipsMultiline = true)
 
     implicit val codec: ConfCodecEx[Multiline] = ConfCodecEx
       .oneOfCustom[Multiline](adjacent, all, none, skip) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -62,6 +62,13 @@ import metaconfig._
   *   }}}
   *   Note. Requires mixedOwners to be true.
   *
+  * @param multiline
+  *   Controls whether to include multiline statements in the search for tokens
+  *   to align.
+  *   - `adjacent`: a multiline statement's tokens align with tokens on adjacent
+  *     lines
+  *   - `all`: they align across the block, which ends only at a blank line
+  *
   * @param stripMargin
   *   If set, indent lines with a strip-margin character in a multiline string
   *   constant relative to the opening quotes (or the strip-margin character if
@@ -71,7 +78,7 @@ import metaconfig._
 case class Align(
     allowOverflow: Boolean = false,
     delayUntilSpace: Boolean = true,
-    multiline: Boolean = false,
+    multiline: Align.Multiline = Align.Multiline.adjacent,
     stripMargin: Boolean = true,
     closeParenSite: Boolean = false,
     private val openBracketCallSite: Option[Boolean] = None,
@@ -142,7 +149,7 @@ object Align {
   // please open PR adding more stuff to it if you like.
   val most: Align = more.copy(
     allowOverflow = true,
-    multiline = true,
+    multiline = Multiline.all,
     arrowEnumeratorGenerator = true,
     tokenCategory = Map("Equals" -> "Assign", "LeftArrow" -> "Assign"),
   )
@@ -153,6 +160,20 @@ object Align {
     case Conf.Str("some" | "default") => Align.some
     case Conf.Str("more") | Conf.Bool(true) => Align.more
     case Conf.Str("most") => Align.most
+  }
+
+  /** @param spansBlock
+    *   the block ends only at a blank line, not when the container changes
+    */
+  sealed abstract class Multiline(val spansBlock: Boolean)
+  object Multiline {
+    case object adjacent extends Multiline(spansBlock = false)
+    case object all extends Multiline(spansBlock = true)
+
+    implicit val codec: ConfCodecEx[Multiline] = ConfCodecEx
+      .oneOfCustom[Multiline](adjacent, all) { case Conf.Bool(flag) =>
+        if (flag) Conf.nameOf(all) else Conf.nameOf(adjacent)
+      }
   }
 
   implicit val alignTokensDecoder: ConfDecoderEx[Seq[AlignToken]] = AlignToken

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -68,6 +68,10 @@ import metaconfig._
   *   - `adjacent`: a multiline statement's tokens align with tokens on adjacent
   *     lines
   *   - `all`: they align across the block, which ends only at a blank line
+  *   - `none`: a multiline statement contributes no token, and a line left with
+  *     none interrupts the alignment block
+  *   - `skip`: the same, except the block ends only at a blank line, so the
+  *     lines on either side still align with each other
   *
   * @param stripMargin
   *   If set, indent lines with a strip-margin character in a multiline string
@@ -169,10 +173,13 @@ object Align {
   object Multiline {
     case object adjacent extends Multiline(spansBlock = false)
     case object all extends Multiline(spansBlock = true)
+    case object none extends Multiline(spansBlock = false)
+    case object skip extends Multiline(spansBlock = true)
 
     implicit val codec: ConfCodecEx[Multiline] = ConfCodecEx
-      .oneOfCustom[Multiline](adjacent, all) { case Conf.Bool(flag) =>
-        if (flag) Conf.nameOf(all) else Conf.nameOf(adjacent)
+      .oneOfCustom[Multiline](adjacent, all, none, skip) {
+        case Conf.Bool(flag) =>
+          if (flag) Conf.nameOf(all) else Conf.nameOf(adjacent)
       }
   }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1206,7 +1206,8 @@ class FormatWriter(formatOps: FormatOps) {
       lazy val noAlignTokens = styleMap.forall(_.align.tokens.isEmpty)
       if (locations.length != tokens.length || noAlignTokens) Map.empty[Int, Int]
       else {
-        val state = new AlignState(locations, styleMap.init.align.multiline)
+        val state =
+          new AlignState(locations, styleMap.init.align.multiline.spansBlock)
         implicit val finalResult = Map.newBuilder[Int, Int]
 
         while (!state.done()) {
@@ -1407,7 +1408,7 @@ class FormatWriter(formatOps: FormatOps) {
     )(implicit builder: mutable.Builder[(Int, Int), Map[Int, Int]]): Unit = {
       val endIndex = locations.length - 1
       block.foreach { x =>
-        if (x.style.align.multiline) {
+        if (x.style.align.multiline.spansBlock) {
           val headStop = x.stops.head
           val ftIndex = headStop.ft.meta.idx
           if (ftIndex < endIndex)
@@ -1927,7 +1928,7 @@ object FormatWriter {
         def matchStops() = (refStop.isSlc, curStop.isSlc) match {
           case (false, false) =>
             val isMatchPossible = sameOwner &&
-              (floc.style.align.multiline ||
+              (floc.style.align.multiline.eq(Align.Multiline.all) ||
                 refStop.ft.rightOwner.endOffset <=
                 curStop.ft.rightOwner.begOffset)
             if (isMatchPossible) {

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1253,6 +1253,11 @@ class FormatWriter(formatOps: FormatOps) {
             state.resetLine()
           }
 
+          def isEligible(isSlc: Boolean)(implicit
+              floc: FormatLocation,
+          ): Boolean = isSlc || !floc.style.align.multiline.skipsMultiline ||
+            onSingleLine(getAlignStatement(floc.formatToken.rightOwner))
+
           def processEligible(isSlc: Boolean, alignKind: AlignKind)(implicit
               floc: FormatLocation,
           ): Unit = {
@@ -1287,7 +1292,8 @@ class FormatWriter(formatOps: FormatOps) {
               val isSlc = ft.right.is[T.Comment] && state.get().hasBreakAfter &&
                 !ft.rightHasNewline
               val alignKind = shouldAlign(ft, isSlc)
-              if (alignKind != AlignKind.No) processEligible(isSlc, alignKind)
+              if (alignKind != AlignKind.No && isEligible(isSlc))
+                processEligible(isSlc, alignKind)
               processLine(wasSlc = isSlc)
             }
           }
@@ -2032,6 +2038,21 @@ object FormatWriter {
     // if we didn't care about align token lengths, we'd always "useLeft"
     val left = alignKind == AlignKind.LT || floc.formatToken.right.is[T.Comment]
     if (left) floc.state.prev else floc.state
+  }
+
+  /** The statement a token to align by belongs to. An infix operator belongs to
+    * the whole chain, not to the application it heads: in `aa % bb % cc`, both
+    * `%` belong to `aa % bb % cc`.
+    */
+  private def getAlignStatement(t: Tree): Tree = {
+    @tailrec
+    def loop(t: Tree, res: Tree): Tree = t.parentOrNoTree match {
+      case p: Term.ApplyInfix if !p.isAssignment => loop(p, p)
+      case p: Term.ArgClause => loop(p, res)
+      case p: Term.Block => loop(p, res)
+      case _ => res
+    }
+    loop(t, t)
   }
 
   /** Owner of the token to align by; not meaningful for a comment align stop.

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -376,6 +376,21 @@ val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbb
   val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
     function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
 }
+<<< only align single-line statements, break before multiline, multiline=none
+align.multiline = none
+===
+{
+val a = function(1, b)
+val aaaaa = function(1, b)
+val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+}
+>>>
+{
+  val a                                = function(1, b)
+  val aaaaa                            = function(1, b)
+  val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
+    function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+}
 <<< only align single-line statements, break within multiline
 {
 val a = function(1, b)
@@ -392,6 +407,261 @@ val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
     1,
     b,
     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  )
+}
+<<< only align single-line statements, break within multiline, multiline=none
+align.multiline = none
+===
+{
+val a = function(1, b)
+val aaaaa = function(1, b)
+val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
+  1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+)
+}
+>>>
+{
+  val a                                = function(1, b)
+  val aaaaa                            = function(1, b)
+  val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
+    1,
+    b,
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  )
+}
+<<< multiline statement in the middle of a block, multiline=none
+align.multiline = none
+===
+object a {
+  val a    = 1
+  val bbbb = {
+    2
+  }
+  val cc = 3
+}
+>>>
+object a {
+  val a    = 1
+  val bbbb = {
+    2
+  }
+  val cc = 3
+}
+<<< multiline defn signature
+object a {
+  def foo(
+    a: Int,
+    b: Int
+  ): Int = 1
+  def bar: Int = 2
+}
+>>>
+object a {
+  def foo(
+      a: Int,
+      b: Int
+  ): Int       = 1
+  def bar: Int = 2
+}
+<<< multiline defn signature, multiline=none
+align.multiline = none
+===
+object a {
+  def foo(
+    a: Int,
+    b: Int
+  ): Int = 1
+  def bar: Int = 2
+}
+>>>
+object a {
+  def foo(
+      a: Int,
+      b: Int
+  ): Int       = 1
+  def bar: Int = 2
+}
+<<< multiline defn body, multiline=none
+align.multiline = none
+===
+trait Display {
+  def data(): Map[String, String]
+  def metadata(): Map[String, String] = Map()
+  def displayData(): DisplayData      =
+    DisplayData()
+      .withDetailedData(data())
+  def other = 1
+}
+>>>
+trait Display {
+  def data(): Map[String, String]
+  def metadata(): Map[String, String] = Map()
+  def displayData(): DisplayData      =
+    DisplayData()
+      .withDetailedData(data())
+  def other = 1
+}
+<<< multiline case body
+object a {
+  x match {
+    case aa => 1
+    case bbbbbb =>
+      22222
+    case c => 3
+  }
+}
+>>>
+object a {
+  x match {
+    case aa     => 1
+    case bbbbbb =>
+      22222
+    case c => 3
+  }
+}
+<<< multiline case body, multiline=none
+align.multiline = none
+===
+object a {
+  x match {
+    case aa     => 1
+    case bbbbbb =>
+      22222
+    case c => 3
+  }
+}
+>>>
+object a {
+  x match {
+    case aa     => 1
+    case bbbbbb =>
+      22222
+    case c => 3
+  }
+}
+<<< wrapped infix in a table, multiline=none
+align.multiline = none
+===
+object a {
+  Seq(
+    "org.scalameta" %% "munit"              % "1.0.0" % Test,
+    "org.typelevel" %% "cats-core-and-more" %
+      "2.10.0"       % "internal",
+    "co.fs2"        %% "fs2-core"           % "3.9.0"
+  )
+}
+>>>
+object a {
+  Seq(
+    "org.scalameta" %% "munit"              % "1.0.0" % Test,
+    "org.typelevel" %% "cats-core-and-more" %
+      "2.10.0"       % "internal",
+    "co.fs2"        %% "fs2-core"           % "3.9.0"
+  )
+}
+<<< wrapped infix in a table, multiline=skip
+align.multiline = skip
+===
+object a {
+  Seq(
+    "org.scalameta" %% "munit" % "1.0.0" % Test,
+    "org.typelevel" %% "cats-core-and-more" %
+      "2.10.0" % "internal",
+    "co.fs2" %% "fs2-core" % "3.9.0"
+  )
+}
+>>>
+object a {
+  Seq(
+    "org.scalameta" %% "munit"              % "1.0.0" % Test,
+    "org.typelevel" %% "cats-core-and-more" %
+      "2.10.0"       % "internal",
+    "co.fs2"        %% "fs2-core"           % "3.9.0"
+  )
+}
+<<< #1811 1 with break within rhs, multiline=skip
+align.multiline = skip
+===
+object a {
+  for {
+    a <- Option(1)
+    bbb <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd <- Option(4)
+  } yield ()
+}
+>>>
+object a {
+  for {
+    a      <- Option(1)
+    bbb    <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd     <- Option(4)
+  } yield ()
+}
+<<< multiline defn body, multiline=skip
+align.multiline = skip
+===
+trait Display {
+  def data(): Map[String, String]
+  def metadata(): Map[String, String] = Map()
+  def displayData(): DisplayData =
+    DisplayData()
+      .withDetailedData(data())
+  def other = 1
+}
+>>>
+trait Display {
+  def data(): Map[String, String]
+  def metadata(): Map[String, String] = Map()
+  def displayData(): DisplayData      =
+    DisplayData()
+      .withDetailedData(data())
+  def other                           = 1
+}
+<<< wrapped infix, break before the operator
+newlines.source = keep
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a                   % b     % c,
+    aa                  % bb
+      % ddddddddddddddd % ee,
+    aaaaaa              % bbbbb % cccc
+  )
+}
+<<< wrapped infix, break before the operator, multiline=skip
+newlines.source = keep
+align.multiline = skip
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a                   % b     % c,
+    aa                  % bb
+      % ddddddddddddddd % ee,
+    aaaaaa              % bbbbb % cccc
   )
 }
 <<< infix owner
@@ -778,6 +1048,52 @@ object a {
     dd <- Option(4)
   } yield ()
 }
+<<< #1811 1 with break within rhs, multiline=none
+align.multiline = none
+===
+object a {
+  for {
+    a      <- Option(1)
+    bbb    <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd <- Option(4)
+  } yield ()
+}
+>>>
+object a {
+  for {
+    a      <- Option(1)
+    bbb    <- Option(2)
+    cccccc <- Option {
+      3
+    }
+    dd <- Option(4)
+  } yield ()
+}
+<<< #1811 1 with break before rhs, multiline=none
+align.multiline = none
+===
+object a {
+  for {
+    a   <- Option(1)
+    bbb <- Option(2)
+    cccccc <-
+     Option(3)
+    dd <- Option(4)
+  } yield ()
+}
+>>>
+object a {
+  for {
+    a      <- Option(1)
+    bbb    <- Option(2)
+    cccccc <-
+      Option(3)
+    dd <- Option(4)
+  } yield ()
+}
 <<< #1811 1 no blanks
 align.multiline = true
 ===
@@ -1093,6 +1409,30 @@ val x = blar match {
 }
 <<< #2449, allowOverflow
 align.allowOverflow = true
+===
+class ThisIsMyClass(a: Long, b: Long) {
+  val taskid = "abcd" + (new Random).nextLong
+  val init = 1234567890123L
+  val end = 1234567891123L
+  val myClass = new ThisIsMyClass(init, end)
+  val thisIsMyListOfClasses: ListBuffer[ThisIsMyClass] = ListBuffer()
+  val abcdefghijklmnopqrstuvwxyz = new ThisIsMyClass(init, end)
+  val abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst = new ThisIsMyClass(init, end)
+}
+>>>
+class ThisIsMyClass(a: Long, b: Long) {
+  val taskid                                           = "abcd" + (new Random).nextLong
+  val init                                             = 1234567890123L
+  val end                                              = 1234567891123L
+  val myClass                                          = new ThisIsMyClass(init, end)
+  val thisIsMyListOfClasses: ListBuffer[ThisIsMyClass] = ListBuffer()
+  val abcdefghijklmnopqrstuvwxyz                       = new ThisIsMyClass(init, end)
+  val abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst   =
+    new ThisIsMyClass(init, end)
+}
+<<< #2449, allowOverflow, multiline=none
+align.allowOverflow = true
+align.multiline = none
 ===
 class ThisIsMyClass(a: Long, b: Long) {
   val taskid = "abcd" + (new Random).nextLong

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -386,8 +386,8 @@ val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbb
 }
 >>>
 {
-  val a                                = function(1, b)
-  val aaaaa                            = function(1, b)
+  val a     = function(1, b)
+  val aaaaa = function(1, b)
   val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa =
     function(1, b, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
 }
@@ -421,8 +421,8 @@ val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
 }
 >>>
 {
-  val a                                = function(1, b)
-  val aaaaa                            = function(1, b)
+  val a     = function(1, b)
+  val aaaaa = function(1, b)
   val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
     1,
     b,
@@ -433,7 +433,7 @@ val aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = function(
 align.multiline = none
 ===
 object a {
-  val a    = 1
+  val a = 1
   val bbbb = {
     2
   }
@@ -441,7 +441,7 @@ object a {
 }
 >>>
 object a {
-  val a    = 1
+  val a = 1
   val bbbb = {
     2
   }
@@ -478,7 +478,7 @@ object a {
   def foo(
       a: Int,
       b: Int
-  ): Int       = 1
+  ): Int = 1
   def bar: Int = 2
 }
 <<< multiline defn body, multiline=none
@@ -487,7 +487,7 @@ align.multiline = none
 trait Display {
   def data(): Map[String, String]
   def metadata(): Map[String, String] = Map()
-  def displayData(): DisplayData      =
+  def displayData(): DisplayData =
     DisplayData()
       .withDetailedData(data())
   def other = 1
@@ -496,7 +496,7 @@ trait Display {
 trait Display {
   def data(): Map[String, String]
   def metadata(): Map[String, String] = Map()
-  def displayData(): DisplayData      =
+  def displayData(): DisplayData =
     DisplayData()
       .withDetailedData(data())
   def other = 1
@@ -524,7 +524,7 @@ align.multiline = none
 ===
 object a {
   x match {
-    case aa     => 1
+    case aa => 1
     case bbbbbb =>
       22222
     case c => 3
@@ -533,7 +533,7 @@ object a {
 >>>
 object a {
   x match {
-    case aa     => 1
+    case aa => 1
     case bbbbbb =>
       22222
     case c => 3
@@ -544,19 +544,19 @@ align.multiline = none
 ===
 object a {
   Seq(
-    "org.scalameta" %% "munit"              % "1.0.0" % Test,
+    "org.scalameta" %% "munit" % "1.0.0" % Test,
     "org.typelevel" %% "cats-core-and-more" %
-      "2.10.0"       % "internal",
-    "co.fs2"        %% "fs2-core"           % "3.9.0"
+      "2.10.0" % "internal",
+    "co.fs2" %% "fs2-core" % "3.9.0"
   )
 }
 >>>
 object a {
   Seq(
-    "org.scalameta" %% "munit"              % "1.0.0" % Test,
+    "org.scalameta" %% "munit" % "1.0.0" % Test,
     "org.typelevel" %% "cats-core-and-more" %
-      "2.10.0"       % "internal",
-    "co.fs2"        %% "fs2-core"           % "3.9.0"
+      "2.10.0" % "internal",
+    "co.fs2" %% "fs2-core" % "3.9.0"
   )
 }
 <<< wrapped infix in a table, multiline=skip
@@ -573,10 +573,10 @@ object a {
 >>>
 object a {
   Seq(
-    "org.scalameta" %% "munit"              % "1.0.0" % Test,
+    "org.scalameta" %% "munit"    % "1.0.0" % Test,
     "org.typelevel" %% "cats-core-and-more" %
-      "2.10.0"       % "internal",
-    "co.fs2"        %% "fs2-core"           % "3.9.0"
+      "2.10.0" % "internal",
+    "co.fs2"        %% "fs2-core" % "3.9.0"
   )
 }
 <<< #1811 1 with break within rhs, multiline=skip
@@ -595,12 +595,12 @@ object a {
 >>>
 object a {
   for {
-    a      <- Option(1)
-    bbb    <- Option(2)
+    a   <- Option(1)
+    bbb <- Option(2)
     cccccc <- Option {
       3
     }
-    dd     <- Option(4)
+    dd  <- Option(4)
   } yield ()
 }
 <<< multiline defn body, multiline=skip
@@ -618,7 +618,7 @@ trait Display {
 trait Display {
   def data(): Map[String, String]
   def metadata(): Map[String, String] = Map()
-  def displayData(): DisplayData      =
+  def displayData(): DisplayData =
     DisplayData()
       .withDetailedData(data())
   def other                           = 1
@@ -658,10 +658,10 @@ object x {
 >>>
 object x {
   Seq(
-    a                   % b     % c,
-    aa                  % bb
+    a      % b     % c,
+    aa % bb
       % ddddddddddddddd % ee,
-    aaaaaa              % bbbbb % cccc
+    aaaaaa % bbbbb % cccc
   )
 }
 <<< infix owner
@@ -1053,8 +1053,8 @@ align.multiline = none
 ===
 object a {
   for {
-    a      <- Option(1)
-    bbb    <- Option(2)
+    a   <- Option(1)
+    bbb <- Option(2)
     cccccc <- Option {
       3
     }
@@ -1064,8 +1064,8 @@ object a {
 >>>
 object a {
   for {
-    a      <- Option(1)
-    bbb    <- Option(2)
+    a   <- Option(1)
+    bbb <- Option(2)
     cccccc <- Option {
       3
     }
@@ -1087,8 +1087,8 @@ object a {
 >>>
 object a {
   for {
-    a      <- Option(1)
-    bbb    <- Option(2)
+    a   <- Option(1)
+    bbb <- Option(2)
     cccccc <-
       Option(3)
     dd <- Option(4)
@@ -1451,7 +1451,7 @@ class ThisIsMyClass(a: Long, b: Long) {
   val myClass                                          = new ThisIsMyClass(init, end)
   val thisIsMyListOfClasses: ListBuffer[ThisIsMyClass] = ListBuffer()
   val abcdefghijklmnopqrstuvwxyz                       = new ThisIsMyClass(init, end)
-  val abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst   =
+  val abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst =
     new ThisIsMyClass(init, end)
 }
 <<< #2449, !allowOverflow

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2620542, "total explored")
+      assertEquals(explored, 2623120, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
This fixes an issue that's been biting me in some of my projects since scalafmt `3.9.7`, resulting in quite large diffs, and code harder to read (https://github.com/coursier/coursier/pull/3423, https://github.com/almond-sh/almond/pull/1533).

This PR proposes to fix it by introducing a new parameter, `align.multilineStatements`, defaulting to false (preserving scalafmt's current behavior), but that users can set to true (drastically reducing the diff of the scalafmt updates in two linked repos above).

In more detail, since `3.9.7`, scalafmt has been formatting the following code
```scala
def metadata(): Map[String, String] = Map()
def displayData(): DisplayData =
  DisplayData()
    .withDetailedData(data())
```
to this
```scala
def metadata(): Map[String, String] = Map()
def displayData(): DisplayData      =
  DisplayData()
    .withDetailedData(data())
```
(note the shifted `=` on the `def displayData` line)

Setting `align.multilineStatements` disables that (and recovers scalafmt pre-`3.9.7` behavior).

These changes are LLM-generated, but I reviewed them carefully. I'm new to this codebase though. I left the LLM comments in the individual commits if you'd like more details from the LLM.