### PR TITLE
Align: implement align.atLineStart

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1669,6 +1669,72 @@ trait A {
 }
 ```
 
+### `align.atLineStart`
+
+This parameter controls if and when to consider for alignment tokens at the start of a line.
+
+> Since v3.11.6.
+
+It takes the following values:
+
+- `none`: the token is ignored
+- `skip`: the entire line is ignored
+- `all`: the token is aligned
+
+With significant indentation, moving the first token of a line can change what
+that line belongs to. Such a token is aligned only if its line is indented
+further than the line its statement begins on. A token which begins its own
+statement is left alone whatever this parameter is set to.
+
+This parameter decides only how such a token is treated. Whether the expression
+it belongs to may be aligned at all is decided by
+[`align.multiline`](#alignmultiline), so under `align.multiline = none` or
+`align.multiline = skip` the first token of a wrapped infix expression is not
+aligned, whatever `align.atLineStart` is set to.
+
+```scala mdoc:defaults
+align.atLineStart
+```
+
+```scala mdoc:scalafmt
+align.preset = more
+newlines.source = keep
+align.atLineStart = none
+---
+Seq(
+  a % b % c,
+  aa % bb
+    % ddddddd % ee,
+  aaaaaa % bbbbb % cccc
+)
+```
+
+```scala mdoc:scalafmt
+align.preset = more
+newlines.source = keep
+align.atLineStart = skip
+---
+Seq(
+  a % b % c,
+  aa % bb
+    % ddddddd % ee,
+  aaaaaa % bbbbb % cccc
+)
+```
+
+```scala mdoc:scalafmt
+align.preset = more
+newlines.source = keep
+align.atLineStart = all
+---
+Seq(
+  a % b % c,
+  aa % bb
+    % ddddddd % ee,
+  aaaaaa % bbbbb % cccc
+)
+```
+
 ### `align.allowOverflow`
 
 If this flag is set, as long as unaligned lines did not overflow, we will not check

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Align.scala
@@ -73,6 +73,19 @@ import metaconfig._
   *   - `skip`: the same, except the block ends only at a blank line, so the
   *     lines on either side still align with each other
   *
+  * @param atLineStart
+  *   Controls a token to align by which begins its line. Such a token follows a
+  *   newline, and the line ends before it is examined, so it never becomes an
+  *   align candidate.
+  *   - `none`: it is not aligned; its line keeps its other tokens, and a line
+  *     left with none interrupts the alignment block
+  *   - `skip`: its line is left out of the alignment block, which survives,
+  *     unless a blank line follows
+  *   - `all`: it is aligned, and the empty cell before it is padded
+  *
+  * With significant indentation, a token is aligned only if its line is
+  * indented further than the line its statement begins on.
+  *
   * @param stripMargin
   *   If set, indent lines with a strip-margin character in a multiline string
   *   constant relative to the opening quotes (or the strip-margin character if
@@ -83,6 +96,7 @@ case class Align(
     allowOverflow: Boolean = false,
     delayUntilSpace: Boolean = true,
     multiline: Align.Multiline = Align.Multiline.adjacent,
+    atLineStart: Align.AtLineStart = Align.AtLineStart.none,
     stripMargin: Boolean = true,
     closeParenSite: Boolean = false,
     private val openBracketCallSite: Option[Boolean] = None,
@@ -190,6 +204,16 @@ object Align {
         case Conf.Bool(flag) =>
           if (flag) Conf.nameOf(all) else Conf.nameOf(adjacent)
       }
+  }
+
+  sealed abstract class AtLineStart
+  object AtLineStart {
+    case object none extends AtLineStart
+    case object skip extends AtLineStart
+    case object all extends AtLineStart
+
+    implicit val codec: ConfCodecEx[AtLineStart] = ConfCodecEx
+      .oneOf[AtLineStart](none, skip, all)
   }
 
   implicit val alignTokensDecoder: ConfDecoderEx[Seq[AlignToken]] = AlignToken

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -474,14 +474,18 @@ class FormatWriter(formatOps: FormatOps) {
       ): Int = {
         val mod = state.mod
         def align = tokenAligns.get(i).fold(0)(_ + alignOffset) + delayedAlign
+        def shiftAlign(required: Int): Int = {
+          val extra = align
+          sb.append(getIndentation(required + extra))
+          extra
+        }
         mod match {
           case nl: NewlineT =>
             val extraBlanks =
               if (i == locations.length - 1) 0
               else extraBlankTokens.getOrElse(i, if (nl.isDouble) 1 else 0)
             sb.append(getNewlines(extraBlanks))
-            if (!nl.noIndent) sb.append(getIndentation(state.indentation))
-            0
+            if (nl.noIndent) 0 else shiftAlign(state.indentation)
 
           case p: Provided =>
             sb.append(p.betweenText)
@@ -489,10 +493,7 @@ class FormatWriter(formatOps: FormatOps) {
 
           case NoSplit if style.align.delayUntilSpace => -align // delay
 
-          case _ =>
-            val alignShift = align
-            sb.append(getIndentation(mod.length + alignShift))
-            alignShift
+          case _ => shiftAlign(mod.length)
         }
       }
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/internal/FormatWriter.scala
@@ -1215,10 +1215,12 @@ class FormatWriter(formatOps: FormatOps) {
 
           def processLineEnd(
               wasSlc: Boolean,
+              alignKind: AlignKind = AlignKind.No,
           )(implicit floc: FormatLocation): Unit = {
             val isBlankLine = floc.state.mod.isBlankLine ||
               extraBlankTokens.contains(floc.formatToken.idx)
-            if (state.alignContainer ne null) {
+
+            def addLine(): Unit = if (state.alignContainer ne null) {
               val candidates = columnCandidates.result()
               val block = state.getOrCreateBlock()
               val blockWasEmpty = block.isEmpty
@@ -1243,14 +1245,20 @@ class FormatWriter(formatOps: FormatOps) {
 
               state.setPrevBlock(block)
             }
-            if (isBlankLine || state.alignContainer.eq(null)) {
+
+            def flush(): Unit = if (isBlankLine || state.alignContainer.eq(null)) {
               val toFlush = state.getBlockToFlush(
                 getAlignContainer(isSlc = wasSlc)._1,
                 isBlankLine,
               )
               if (toFlush ne null) flushAlignBlock(toFlush)
             }
-            state.resetLine()
+
+            if (isBlankLine || !state.takeSkipLine()) {
+              addLine()
+              flush()
+            }
+            state.resetLine(alignKind)
           }
 
           def isEligible(isSlc: Boolean)(implicit
@@ -1286,8 +1294,10 @@ class FormatWriter(formatOps: FormatOps) {
           def processLine(wasSlc: Boolean): Unit = {
             implicit val floc: FormatLocation = state.getAndNext()
             val ft = floc.formatToken
-            if (wasSlc || floc.hasBreakAfter || ft.leftHasNewline || state.done())
-              processLineEnd(wasSlc)
+            if (state.done()) processLineEnd(wasSlc = wasSlc)
+            else if (wasSlc || floc.hasBreakAfter)
+              processLineEnd(wasSlc = wasSlc, shouldAlign(ft, slc = false))
+            else if (ft.leftHasNewline) processLineEnd(wasSlc = false)
             else {
               val isSlc = ft.right.is[T.Comment] && state.get().hasBreakAfter &&
                 !ft.rightHasNewline
@@ -1298,6 +1308,15 @@ class FormatWriter(formatOps: FormatOps) {
             }
           }
 
+          if (state.pending ne null) {
+            implicit val floc: FormatLocation = state.pending
+            state.pending = null
+            /* this candidate faces the same test as any other; its column is
+             * the new line's indentation, which is `RT`, since no text precedes
+             * it on the line for `LT` to measure */
+            if (isEligible(isSlc = false))
+              processEligible(isSlc = false, AlignKind.RT)
+          }
           processLine(wasSlc = false)
         }
         state.flush(flushAlignBlock)
@@ -1775,6 +1794,8 @@ object FormatWriter {
     private var prevBlock: AlignBlock =
       if (isMultiline) null else createBlock(null)
     var alignContainer: Tree = _
+    private var skipLine: Boolean = false
+    var pending: FormatLocation = _
 
     private def createBlock(x: Tree) = blocks
       .computeIfAbsent(x, _ => new AlignBlock)
@@ -1802,9 +1823,27 @@ object FormatWriter {
       floc
     }
 
-    def resetLine(): Unit = {
+    def resetLine(
+        alignKind: AlignKind,
+    )(implicit floc: FormatLocation, ftoks: FormatTokens): Unit = {
       columnShift = 0
       alignContainer = null
+      val ignoreLineStart = alignKind == AlignKind.No ||
+        floc.style.dialect.allowSignificantIndentation &&
+        ftoks.getRawHead(getAlignStatement(floc.formatToken.rightOwner)).orHas(
+          x => locations(x.idx).state.indentation >= floc.state.indentation,
+        )
+      if (!ignoreLineStart) floc.style.align.atLineStart match {
+        case Align.AtLineStart.skip => skipLine = true
+        case Align.AtLineStart.all => pending = floc
+        case _ =>
+      }
+    }
+
+    def takeSkipLine(): Boolean = {
+      val res = skipLine
+      skipLine = false
+      res
     }
 
     def getColumn(state: State): Int = state.column + columnShift

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -700,10 +700,10 @@ object x {
 >>>
 object x {
   Seq(
-    a                   % b     % c,
-    aa                  % bb
+    a      % b     % c,
+    aa     % bb
       % ddddddddddddddd % ee,
-    aaaaaa              % bbbbb % cccc
+    aaaaaa % bbbbb % cccc
   )
 }
 <<< wrapped infix, break before the operator, atLineStart=all
@@ -721,10 +721,10 @@ object x {
 >>>
 object x {
   Seq(
-    a                   % b     % c,
-    aa                  % bb
+    a      % b               % c,
+    aa     % bb
       % ddddddddddddddd % ee,
-    aaaaaa              % bbbbb % cccc
+    aaaaaa % bbbbb           % cccc
   )
 }
 <<< wrapped infix, break before the operator after a comment, atLineStart=none
@@ -763,10 +763,10 @@ object x {
 >>>
 object x {
   Seq(
-    a                   % b     % c,
-    aa                  % bb // note
+    a      % b     % c,
+    aa     % bb // note
       % ddddddddddddddd % ee,
-    aaaaaa              % bbbbb % cccc
+    aaaaaa % bbbbb % cccc
   )
 }
 <<< wrapped infix, break before the operator after a comment, atLineStart=all
@@ -784,10 +784,10 @@ object x {
 >>>
 object x {
   Seq(
-    a                   % b     % c,
-    aa                  % bb // note
+    a      % b               % c,
+    aa     % bb // note
       % ddddddddddddddd % ee,
-    aaaaaa              % bbbbb % cccc
+    aaaaaa % bbbbb           % cccc
   )
 }
 <<< wrapped infix, continuation line with only the operator, atLineStart=none
@@ -829,11 +829,11 @@ object x {
 >>>
 object x {
   Seq(
-    a  % b % c,
-    aa % bb
+    a      % b     % c,
+    aa     % bb
       % cc
       % dddd % ee,
-    aaaaaa   % bbbbb % cccc
+    aaaaaa % bbbbb % cccc
   )
 }
 <<< wrapped infix, continuation line with only the operator, atLineStart=all
@@ -852,11 +852,11 @@ object x {
 >>>
 object x {
   Seq(
-    a  % b % c,
-    aa % bb
+    a      % b     % c,
+    aa     % bb
       % cc
-      % dddd % ee,
-    aaaaaa   % bbbbb % cccc
+      % dddd  % ee,
+    aaaaaa % bbbbb % cccc
   )
 }
 <<< line after a comment starts with a non-align token, atLineStart=none
@@ -1260,9 +1260,9 @@ object a:
   aaaaaa % bbbbb % cccc
 >>>
 object a:
-  aa                  % bb
+  aa     % bb
     % ddddddddddddddd % ee
-  aaaaaa              % bbbbb % cccc
+  aaaaaa % bbbbb % cccc
 <<< right-aligned assignments, scala3, atLineStart=skip
 runner.dialect = scala3
 align.tokens."+" = [{
@@ -1356,9 +1356,9 @@ object a:
   aaaaaa % bbbbb % cccc
 >>>
 object a:
-  aa                  % bb
+  aa     % bb
     % ddddddddddddddd % ee
-  aaaaaa              % bbbbb % cccc
+  aaaaaa % bbbbb           % cccc
 <<< right-aligned assignments, scala3, atLineStart=all
 runner.dialect = scala3
 align.tokens."+" = [{

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -723,7 +723,7 @@ object x {
   Seq(
     a      % b               % c,
     aa     % bb
-      % ddddddddddddddd % ee,
+           % ddddddddddddddd % ee,
     aaaaaa % bbbbb           % cccc
   )
 }
@@ -786,7 +786,7 @@ object x {
   Seq(
     a      % b               % c,
     aa     % bb // note
-      % ddddddddddddddd % ee,
+           % ddddddddddddddd % ee,
     aaaaaa % bbbbb           % cccc
   )
 }
@@ -854,8 +854,8 @@ object x {
   Seq(
     a      % b     % c,
     aa     % bb
-      % cc
-      % dddd  % ee,
+           % cc
+           % dddd  % ee,
     aaaaaa % bbbbb % cccc
   )
 }
@@ -1339,9 +1339,9 @@ object x {
 object x {
   def f(): Unit = {
     println(0)
-    a = 2
-    bb = 2
-    ccc = 2
+       a = 2
+      bb = 2
+     ccc = 2
     dddd = 2
   }
 }
@@ -1357,7 +1357,7 @@ object a:
 >>>
 object a:
   aa     % bb
-    % ddddddddddddddd % ee
+         % ddddddddddddddd % ee
   aaaaaa % bbbbb           % cccc
 <<< right-aligned assignments, scala3, atLineStart=all
 runner.dialect = scala3

--- a/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
+++ b/scalafmt-tests/shared/src/test/resources/align/DefaultWithAlign.stat
@@ -664,6 +664,743 @@ object x {
     aaaaaa % bbbbb % cccc
   )
 }
+<<< wrapped infix, break before the operator, atLineStart=none
+newlines.source = keep
+align.atLineStart = none
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a                   % b     % c,
+    aa                  % bb
+      % ddddddddddddddd % ee,
+    aaaaaa              % bbbbb % cccc
+  )
+}
+<<< wrapped infix, break before the operator, atLineStart=skip
+newlines.source = keep
+align.atLineStart = skip
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a                   % b     % c,
+    aa                  % bb
+      % ddddddddddddddd % ee,
+    aaaaaa              % bbbbb % cccc
+  )
+}
+<<< wrapped infix, break before the operator, atLineStart=all
+newlines.source = keep
+align.atLineStart = all
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a                   % b     % c,
+    aa                  % bb
+      % ddddddddddddddd % ee,
+    aaaaaa              % bbbbb % cccc
+  )
+}
+<<< wrapped infix, break before the operator after a comment, atLineStart=none
+newlines.source = keep
+align.atLineStart = none
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb // note
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a                   % b     % c,
+    aa                  % bb // note
+      % ddddddddddddddd % ee,
+    aaaaaa              % bbbbb % cccc
+  )
+}
+<<< wrapped infix, break before the operator after a comment, atLineStart=skip
+newlines.source = keep
+align.atLineStart = skip
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb // note
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a                   % b     % c,
+    aa                  % bb // note
+      % ddddddddddddddd % ee,
+    aaaaaa              % bbbbb % cccc
+  )
+}
+<<< wrapped infix, break before the operator after a comment, atLineStart=all
+newlines.source = keep
+align.atLineStart = all
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb // note
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a                   % b     % c,
+    aa                  % bb // note
+      % ddddddddddddddd % ee,
+    aaaaaa              % bbbbb % cccc
+  )
+}
+<<< wrapped infix, continuation line with only the operator, atLineStart=none
+newlines.source = keep
+align.atLineStart = none
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % cc
+      % dddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a  % b % c,
+    aa % bb
+      % cc
+      % dddd % ee,
+    aaaaaa   % bbbbb % cccc
+  )
+}
+<<< wrapped infix, continuation line with only the operator, atLineStart=skip
+newlines.source = keep
+align.atLineStart = skip
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % cc
+      % dddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a  % b % c,
+    aa % bb
+      % cc
+      % dddd % ee,
+    aaaaaa   % bbbbb % cccc
+  )
+}
+<<< wrapped infix, continuation line with only the operator, atLineStart=all
+newlines.source = keep
+align.atLineStart = all
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % cc
+      % dddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a  % b % c,
+    aa % bb
+      % cc
+      % dddd % ee,
+    aaaaaa   % bbbbb % cccc
+  )
+}
+<<< line after a comment starts with a non-align token, atLineStart=none
+newlines.source = keep
+align.atLineStart = none
+===
+object x {
+  val aa = 1 // note
+  ccc.foo(bar)
+  val d = 2
+}
+>>>
+object x {
+  val aa = 1 // note
+  ccc.foo(bar)
+  val d = 2
+}
+<<< line after a comment starts with a non-align token, atLineStart=skip
+newlines.source = keep
+align.atLineStart = skip
+===
+object x {
+  val aa = 1 // note
+  ccc.foo(bar)
+  val d = 2
+}
+>>>
+object x {
+  val aa = 1 // note
+  ccc.foo(bar)
+  val d = 2
+}
+<<< line after a comment starts with a non-align token, atLineStart=all
+newlines.source = keep
+align.atLineStart = all
+===
+object x {
+  val aa = 1 // note
+  ccc.foo(bar)
+  val d = 2
+}
+>>>
+object x {
+  val aa = 1 // note
+  ccc.foo(bar)
+  val d = 2
+}
+<<< closing brace starting a line, atLineStart=none
+newlines.source = keep
+align.atLineStart = none
+===
+object x {
+  class A { def f = 1 }
+  class BBBBBBBB {
+    def g = 2
+  }
+  class C { def h = 3 }
+}
+>>>
+object x {
+  class A        { def f = 1 }
+  class BBBBBBBB {
+    def g = 2
+  }
+  class C { def h = 3 }
+}
+<<< closing brace starting a line, atLineStart=skip
+newlines.source = keep
+align.atLineStart = skip
+===
+object x {
+  class A { def f = 1 }
+  class BBBBBBBB {
+    def g = 2
+  }
+  class C { def h = 3 }
+}
+>>>
+object x {
+  class A        { def f = 1 }
+  class BBBBBBBB {
+    def g = 2
+  }
+  class C { def h = 3 }
+}
+<<< closing brace starting a line, atLineStart=all
+newlines.source = keep
+align.atLineStart = all
+===
+object x {
+  class A { def f = 1 }
+  class BBBBBBBB {
+    def g = 2
+  }
+  class C { def h = 3 }
+}
+>>>
+object x {
+  class A        { def f = 1 }
+  class BBBBBBBB {
+    def g = 2
+  }
+  class C { def h = 3 }
+}
+<<< template braces across a blank line, atLineStart=none
+runner.parser = source
+align.multiline = all
+align.atLineStart = none
+===
+object A {
+  val foo = "foo"
+}
+
+class Foo(
+) {
+  def bar: String = "foo"
+}
+
+case class SomeLongNameClass(
+    foo: String
+)
+object SomeLongNameObject {
+  val foo = "foo"
+}
+>>>
+object A {
+  val foo = "foo"
+}
+
+class Foo(
+) {
+  def bar: String = "foo"
+}
+
+case class SomeLongNameClass(
+    foo: String
+)
+object SomeLongNameObject {
+  val foo = "foo"
+}
+<<< template braces across a blank line, atLineStart=skip
+runner.parser = source
+align.multiline = all
+align.atLineStart = skip
+===
+object A {
+  val foo = "foo"
+}
+
+class Foo(
+) {
+  def bar: String = "foo"
+}
+
+case class SomeLongNameClass(
+    foo: String
+)
+object SomeLongNameObject {
+  val foo = "foo"
+}
+>>>
+object A {
+  val foo = "foo"
+}
+
+class Foo(
+) {
+  def bar: String = "foo"
+}
+
+case class SomeLongNameClass(
+    foo: String
+)
+object SomeLongNameObject {
+  val foo = "foo"
+}
+<<< template braces across a blank line, atLineStart=all
+runner.parser = source
+align.multiline = all
+align.atLineStart = all
+===
+object A {
+  val foo = "foo"
+}
+
+class Foo(
+) {
+  def bar: String = "foo"
+}
+
+case class SomeLongNameClass(
+    foo: String
+)
+object SomeLongNameObject {
+  val foo = "foo"
+}
+>>>
+object A {
+  val foo = "foo"
+}
+
+class Foo(
+) {
+  def bar: String = "foo"
+}
+
+case class SomeLongNameClass(
+    foo: String
+)
+object SomeLongNameObject {
+  val foo = "foo"
+}
+<<< wrapped infix, break before the operator, multiline=skip, atLineStart=none
+newlines.source = keep
+align.multiline = skip
+align.atLineStart = none
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a      % b     % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+<<< wrapped infix, break before the operator, multiline=skip, atLineStart=all
+newlines.source = keep
+align.multiline = skip
+align.atLineStart = all
+===
+object x {
+  Seq(
+    a % b % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+>>>
+object x {
+  Seq(
+    a      % b     % c,
+    aa % bb
+      % ddddddddddddddd % ee,
+    aaaaaa % bbbbb % cccc
+  )
+}
+<<< statement starts a line, scala3, atLineStart=none
+runner.dialect = scala3
+align.tokens."+" = [ "foo" ]
+align.atLineStart = none
+===
+object a:
+  bar.foo(1)
+  foo(2)
+  baz.foo(3)
+>>>
+object a:
+  bar.foo(1)
+  foo(2)
+  baz.foo(3)
+<<< right-aligned assignments, atLineStart=none
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Term\\.Name", parents = [ "Term\\.Assign" ] }]
+}]
+align.atLineStart = none
+===
+object x {
+  def f(): Unit = {
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+  }
+}
+>>>
+object x {
+  def f(): Unit = {
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+  }
+}
+<<< wrapped infix, scala3, atLineStart=none
+runner.dialect = scala3
+newlines.source = keep
+align.atLineStart = none
+===
+object a:
+  aa % bb
+    % ddddddddddddddd % ee
+  aaaaaa % bbbbb % cccc
+>>>
+object a:
+  aa                  % bb
+    % ddddddddddddddd % ee
+  aaaaaa              % bbbbb % cccc
+<<< right-aligned assignments, scala3, atLineStart=none
+runner.dialect = scala3
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Term\\.Name", parents = [ "Term\\.Assign" ] }]
+}]
+align.atLineStart = none
+===
+object x:
+  def f(): Unit =
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+>>>
+object x:
+  def f(): Unit =
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+<<< for enumerators, scala3, atLineStart=none
+runner.dialect = scala3
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Pat\\.Var|Term\\.Name", parents = [ "Enumerator" ] }]
+}]
+align.atLineStart = none
+===
+object a:
+  val foo = for
+    bar <- baz
+    quxxxx <- quux
+  yield bar
+>>>
+object a:
+  val foo = for
+    bar    <- baz
+    quxxxx <- quux
+  yield bar
+<<< statement starts a line, scala3, atLineStart=skip
+runner.dialect = scala3
+align.tokens."+" = [ "foo" ]
+align.atLineStart = skip
+===
+object a:
+  bar.foo(1)
+  foo(2)
+  baz.foo(3)
+>>>
+object a:
+  bar.foo(1)
+  foo(2)
+  baz.foo(3)
+<<< right-aligned assignments, atLineStart=skip
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Term\\.Name", parents = [ "Term\\.Assign" ] }]
+}]
+align.atLineStart = skip
+===
+object x {
+  def f(): Unit = {
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+  }
+}
+>>>
+object x {
+  def f(): Unit = {
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+  }
+}
+<<< wrapped infix, scala3, atLineStart=skip
+runner.dialect = scala3
+newlines.source = keep
+align.atLineStart = skip
+===
+object a:
+  aa % bb
+    % ddddddddddddddd % ee
+  aaaaaa % bbbbb % cccc
+>>>
+object a:
+  aa                  % bb
+    % ddddddddddddddd % ee
+  aaaaaa              % bbbbb % cccc
+<<< right-aligned assignments, scala3, atLineStart=skip
+runner.dialect = scala3
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Term\\.Name", parents = [ "Term\\.Assign" ] }]
+}]
+align.atLineStart = skip
+===
+object x:
+  def f(): Unit =
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+>>>
+object x:
+  def f(): Unit =
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+<<< for enumerators, scala3, atLineStart=skip
+runner.dialect = scala3
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Pat\\.Var|Term\\.Name", parents = [ "Enumerator" ] }]
+}]
+align.atLineStart = skip
+===
+object a:
+  val foo = for
+    bar <- baz
+    quxxxx <- quux
+  yield bar
+>>>
+object a:
+  val foo = for
+    bar    <- baz
+    quxxxx <- quux
+  yield bar
+<<< statement starts a line, scala3, atLineStart=all
+runner.dialect = scala3
+align.tokens."+" = [ "foo" ]
+align.atLineStart = all
+===
+object a:
+  bar.foo(1)
+  foo(2)
+  baz.foo(3)
+>>>
+object a:
+  bar.foo(1)
+  foo(2)
+  baz.foo(3)
+<<< right-aligned assignments, atLineStart=all
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Term\\.Name", parents = [ "Term\\.Assign" ] }]
+}]
+align.atLineStart = all
+===
+object x {
+  def f(): Unit = {
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+  }
+}
+>>>
+object x {
+  def f(): Unit = {
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+  }
+}
+<<< wrapped infix, scala3, atLineStart=all
+runner.dialect = scala3
+newlines.source = keep
+align.atLineStart = all
+===
+object a:
+  aa % bb
+    % ddddddddddddddd % ee
+  aaaaaa % bbbbb % cccc
+>>>
+object a:
+  aa                  % bb
+    % ddddddddddddddd % ee
+  aaaaaa              % bbbbb % cccc
+<<< right-aligned assignments, scala3, atLineStart=all
+runner.dialect = scala3
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Term\\.Name", parents = [ "Term\\.Assign" ] }]
+}]
+align.atLineStart = all
+===
+object x:
+  def f(): Unit =
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+>>>
+object x:
+  def f(): Unit =
+    println(0)
+    a = 2
+    bb = 2
+    ccc = 2
+    dddd = 2
+<<< for enumerators, scala3, atLineStart=all
+runner.dialect = scala3
+align.tokens."+" = [{
+  code = ""
+  owners = [{ regex = "Pat\\.Var|Term\\.Name", parents = [ "Enumerator" ] }]
+}]
+align.atLineStart = all
+===
+object a:
+  val foo = for
+    bar <- baz
+    quxxxx <- quux
+  yield bar
+>>>
+object a:
+  val foo = for
+    bar    <- baz
+    quxxxx <- quux
+  yield bar
 <<< infix owner
    Ok(Json.obj(
        "api" -> Json.obj(

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2625260, "total explored")
+      assertEquals(explored, 2629452, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),


### PR DESCRIPTION
Our alignment logic doesn't consider tokens at the beginning of a line. Let's add a parameter with which we will control this behaviour.