### PR TITLE
Extensions: let the IDE import one Scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -313,9 +313,8 @@ lazy val docs = projectMatrix(
   "scalafmt-docs",
   VirtualAxis.jvm,
   VirtualAxis.scalaABIVersion(scala212),
-).settings(unpublished, mdoc := (Compile / run).evaluated)
-  .jvmPlatform(Seq(scala212)).dependsOn(cli, dynamic)
-  .enablePlugins(DocusaurusPlugin)
+).settings(unpublished, mdoc := (Compile / run).evaluated).crossJvmAt(scala212)
+  .dependsOn(cli, dynamic).enablePlugins(DocusaurusPlugin)
 
 val V = "\\d+\\.\\d+\\.\\d+"
 val ReleaseCandidate = s"($V-RC\\d+).*".r

--- a/docs/contributing-scalafmt.md
+++ b/docs/contributing-scalafmt.md
@@ -11,6 +11,15 @@ title: Contributing
   test for Scala.js, tests benchmark code and also compiles the documentation.
 - You should be able to import the project into IntelliJ as normal:
   `File -> New -> Project from existing source` and pick the `build.sbt` file.
+- IntelliJ imports the project for one Scala version, 2.13 by default. If you
+  need to modify the defaults, set the properties below under
+  `Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters`
+  and reload the sbt project:
+  - `-Dide.scala=X`: imports Scala version `X` instead (could be `2.12`, `2.13`,
+    or `3`). `-Dide.scala=`, with no value, imports the default.
+  - `-Dide.platform=Y`: if `Y` is empty, imports all platforms; otherwise, `Y`
+    is a comma-separated list of platforms to import, and `jvm` is implied,
+    whether or not it is explicitly listed, while `js` and `native` are optional.
 
 ## Testing
 

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -48,6 +48,27 @@ object Extensions {
     )
   }
 
+  /* IntelliJ folds the source roots that matrix cells share into one module, so the whole matrix
+   * compiles scala-2.13 and scala-3 together. Only IntelliJ's importer reads `ide-skip-project`, so
+   * these properties change what the IDE sees and never what sbt builds. */
+  private val ideSkipProject = SettingKey[Boolean]("ide-skip-project")
+
+  private val ideScala = {
+    val prop = sys.props.getOrElse("ide.scala", "").trim
+    if (prop.isEmpty) scala213 else prop
+  }
+
+  // the platforms to import besides the JVM, which the IDE always gets
+  private val idePlatforms = {
+    val prop = sys.props.getOrElse("ide.platform", "").trim
+    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet + "jvm"
+  }
+
+  private def ideSkip(platform: String, scala: Boolean): Seq[Setting[?]] = Seq(ideSkipProject := {
+    val versions = Set(scalaBinaryVersion.value, scalaVersion.value)
+    scala && !versions(ideScala) || idePlatforms.nonEmpty && !idePlatforms(platform)
+  })
+
   def isScalaVer(ver: String) = Def.setting(scalaBinaryVersion.value == ver)
   def isScala212 = isScalaVer("2.12")
   def isScala213 = isScalaVer("2.13")
@@ -106,25 +127,26 @@ object Extensions {
       named.settings(roots(named.base, "shared"))
     }
 
-    def crossJvm(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .jvmPlatform(scalaVersions, jvmRoots ++ ss.flatMap(_.settings))
+    def crossJvm(ss: Def.SettingsDefinition*): ProjectMatrix = self.jvmPlatform(scalaVersions, jvmRoots(ss))
 
-    def crossJs(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .jsPlatform(scalaVersions, roots(self.base, "js", "js-jvm", "js-native") ++ ss.flatMap(_.settings))
+    def crossJs(ss: Def.SettingsDefinition*): ProjectMatrix = self.jsPlatform(scalaVersions, jsRoots(ss))
 
-    def crossNative(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .nativePlatform(scalaVersions, roots(self.base, "native", "jvm-native", "js-native") ++ ss.flatMap(_.settings))
+    def crossNative(ss: Def.SettingsDefinition*): ProjectMatrix = self.nativePlatform(scalaVersions, nativeRoots(ss))
 
     // A JVM row carrying no Scala version, for Java-only sources. Not
     // `jvmPlatform(autoScalaLibrary = false)`: that one passes VirtualAxis.jvm to a customRow which
     // appends it again, and the doubled axis renames the generated directories to `scalajvm-jvm`.
     // The cell id is unaffected, so it would just compile nothing.
+    // The row carries no Scala version, so `ide.scala` neither selects nor rejects it.
     def crossJvmJava(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .customRow(autoScalaLibrary = false, axisValues = Nil, settings = jvmRoots ++ ss.flatMap(_.settings))
+      .customRow(autoScalaLibrary = false, axisValues = Nil, settings = jvmRoots(ss, scala = false))
+
+    // a JVM row for a project that does not cross-build
+    def crossJvmAt(version: String): ProjectMatrix = self.jvmPlatform(Seq(version), jvmRoots())
 
     // a row that needs the cell itself, not just its settings
     def crossJvmRow(version: String, configure: Project => Project): ProjectMatrix = self
-      .jvmPlatform(Seq(version), Nil, configure(_).settings(jvmRoots))
+      .jvmPlatform(Seq(version), Nil, configure(_).settings(jvmRoots()))
 
     // a row that needs the cell itself, not just its settings
     def crossJvmRow(versions: String*)(configure: String => Project => Project): ProjectMatrix = versions
@@ -138,7 +160,14 @@ object Extensions {
 
     def communityTest: ProjectMatrix = self.settings(communityTestsSettings).crossJvmNative(scalaNativeConfig)
 
-    private def jvmRoots = roots(self.base, "jvm", "jvm-native", "js-jvm")
+    private def platformRoots(platform: String, ss: Seq[Def.SettingsDefinition], scala: Boolean = true)(
+        platforms: String*,
+    ) = roots(self.base, platform +: platforms *) ++ ideSkip(platform, scala) ++ ss.flatMap(_.settings)
+
+    private def jvmRoots(ss: Seq[Def.SettingsDefinition] = Nil, scala: Boolean = true) =
+      platformRoots("jvm", ss, scala)("jvm-native", "js-jvm")
+    private def jsRoots(ss: Seq[Def.SettingsDefinition]) = platformRoots("js", ss)("js-jvm", "js-native")
+    private def nativeRoots(ss: Seq[Def.SettingsDefinition]) = platformRoots("native", ss)("jvm-native", "js-native")
   }
 
 }


### PR DESCRIPTION
Under crossProject sbt offered one Scala version at a time, so IntelliJ imported one row per platform. A matrix offers every cell at once, and the import stopped compiling. Now the IDE imports 2.13 on every platform: `-Dide.scala` picks the version, `-Dide.platform` picks the platforms besides the JVM, and `-Dide.scala=` restores the whole matrix.

`ide-skip-project` is IntelliJ's own key, so no plugin is needed. Every row is declared through a `cross*` helper for it to reach, which is why the docs row moves to one.