### PR TITLE
Extensions: narrow the import with bspEnabled

### DIFF
--- a/docs/contributing-scalafmt.md
+++ b/docs/contributing-scalafmt.md
@@ -11,15 +11,27 @@ title: Contributing
   test for Scala.js, tests benchmark code and also compiles the documentation.
 - You should be able to import the project into IntelliJ as normal:
   `File -> New -> Project from existing source` and pick the `build.sbt` file.
-- IntelliJ imports the project for one Scala version, 2.13 by default. If you
-  need to modify the defaults, set the properties below under
-  `Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters`
-  and reload the sbt project:
-  - `-Dide.scala=X`: imports Scala version `X` instead (could be `2.12`, `2.13`,
-    or `3`). `-Dide.scala=`, with no value, imports the default.
-  - `-Dide.platform=Y`: if `Y` is empty, imports all platforms; otherwise, `Y`
-    is a comma-separated list of platforms to import, and `jvm` is implied,
-    whether or not it is explicitly listed, while `js` and `native` are optional.
+- sbt builds each project of this build once per Scala version and platform.
+  Several of those rows use the same source directories. Two system properties
+  control which rows an IDE imports: the build sets `bspEnabled := false` on
+  the other rows, and sbt then leaves them out of the BSP workspace.
+  - `-Dide.scala=X` — sbt keeps only the rows for Scala version `X`.
+    - matches full or binary version
+    - if unspecified or empty: keep all scala versions
+      - IntelliJ only: will be forced to `2.13`; see below why IntelliJ can't
+        load multiple versions.
+  - `-Dide.platform=Y` — sbt keeps only the rows for the platforms in `Y`, a
+    comma-separated list.
+    - matches `jvm`, `js`, or `native`
+    - if unspecified or empty: keep every platform
+- IntelliJ cannot import the whole matrix. It puts the sources that several
+  rows use into one module, and then compiles the Scala 2 and the Scala 3
+  sources of a project together. It starts sbt with `-Didea.managed=true`. If
+  you do not set `-Dide.scala`, that property selects 2.13. To choose another
+  version, add `-Dide.scala=X` under `Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters`, then reload the sbt project.
+- An sbt server uses the system properties from its own command line. It
+  ignores a property that you pass to a later command. Run `sbt shutdown`
+  before you test a change to these properties from the shell.
 
 ## Testing
 

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -48,26 +48,25 @@ object Extensions {
     )
   }
 
-  /* IntelliJ folds the source roots that matrix cells share into one module, so the whole matrix
-   * compiles scala-2.13 and scala-3 together. Only IntelliJ's importer reads `ide-skip-project`, so
-   * these properties change what the IDE sees and never what sbt builds. */
-  private val ideSkipProject = SettingKey[Boolean]("ide-skip-project")
-
+  /* `bspEnabled := false` leaves a row out of the BSP workspace, so an IDE does not import it.
+   * IntelliJ can't load multiple versions, though, so force 2.13 if `ide.scala` is absent. */
   private val ideScala = {
     val prop = sys.props.getOrElse("ide.scala", "").trim
-    if (prop.isEmpty) scala213 else prop
+    if (prop.nonEmpty) Some(prop)
+    else if (sys.props.contains("idea.managed")) Some(scala213) // this looks like IntelliJ
+    else None
   }
 
-  // the platforms to import besides the JVM, which the IDE always gets
+  // an empty set is no filter, so every platform
   private val idePlatforms = {
     val prop = sys.props.getOrElse("ide.platform", "").trim
-    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet + "jvm"
+    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet
   }
 
   // contributes nothing when it keeps a row, so it never overrides another setting
   private def ideSkip(platform: String, version: Option[String]): Seq[Setting[?]] = {
-    val skipVersion = version.exists(v => ideScala != v && ideScala != CrossVersion.binaryScalaVersion(v))
-    if (skipVersion || idePlatforms.nonEmpty && !idePlatforms(platform)) Seq(ideSkipProject := true) else Nil
+    val skipVersion = version.exists(v => ideScala.exists(s => s != v && s != CrossVersion.binaryScalaVersion(v)))
+    if (skipVersion || idePlatforms.nonEmpty && !idePlatforms(platform)) Seq(bspEnabled := false) else Nil
   }
 
   def isScalaVer(ver: String) = Def.setting(scalaBinaryVersion.value == ver)

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -64,10 +64,11 @@ object Extensions {
     if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet + "jvm"
   }
 
-  private def ideSkip(platform: String, scala: Boolean): Seq[Setting[?]] = Seq(ideSkipProject := {
-    val versions = Set(scalaBinaryVersion.value, scalaVersion.value)
-    scala && !versions(ideScala) || idePlatforms.nonEmpty && !idePlatforms(platform)
-  })
+  // contributes nothing when it keeps a row, so it never overrides another setting
+  private def ideSkip(platform: String, version: Option[String]): Seq[Setting[?]] = {
+    val skipVersion = version.exists(v => ideScala != v && ideScala != CrossVersion.binaryScalaVersion(v))
+    if (skipVersion || idePlatforms.nonEmpty && !idePlatforms(platform)) Seq(ideSkipProject := true) else Nil
+  }
 
   def isScalaVer(ver: String) = Def.setting(scalaBinaryVersion.value == ver)
   def isScala212 = isScalaVer("2.12")
@@ -127,11 +128,15 @@ object Extensions {
       named.settings(roots(named.base, "shared"))
     }
 
-    def crossJvm(ss: Def.SettingsDefinition*): ProjectMatrix = self.jvmPlatform(scalaVersions, jvmRoots(ss))
+    // one row at a time, so each one knows the version it is built for
+    def crossJvm(ss: Def.SettingsDefinition*): ProjectMatrix = scalaVersions
+      .foldLeft(self)((acc, v) => acc.jvmPlatform(Seq(v), jvmRoots(Some(v), ss)))
 
-    def crossJs(ss: Def.SettingsDefinition*): ProjectMatrix = self.jsPlatform(scalaVersions, jsRoots(ss))
+    def crossJs(ss: Def.SettingsDefinition*): ProjectMatrix = scalaVersions
+      .foldLeft(self)((acc, v) => acc.jsPlatform(Seq(v), jsRoots(v, ss)))
 
-    def crossNative(ss: Def.SettingsDefinition*): ProjectMatrix = self.nativePlatform(scalaVersions, nativeRoots(ss))
+    def crossNative(ss: Def.SettingsDefinition*): ProjectMatrix = scalaVersions
+      .foldLeft(self)((acc, v) => acc.nativePlatform(Seq(v), nativeRoots(v, ss)))
 
     // A JVM row carrying no Scala version, for Java-only sources. Not
     // `jvmPlatform(autoScalaLibrary = false)`: that one passes VirtualAxis.jvm to a customRow which
@@ -139,14 +144,14 @@ object Extensions {
     // The cell id is unaffected, so it would just compile nothing.
     // The row carries no Scala version, so `ide.scala` neither selects nor rejects it.
     def crossJvmJava(ss: Def.SettingsDefinition*): ProjectMatrix = self
-      .customRow(autoScalaLibrary = false, axisValues = Nil, settings = jvmRoots(ss, scala = false))
+      .customRow(autoScalaLibrary = false, axisValues = Nil, settings = jvmRoots(None, ss))
 
     // a JVM row for a project that does not cross-build
-    def crossJvmAt(version: String): ProjectMatrix = self.jvmPlatform(Seq(version), jvmRoots())
+    def crossJvmAt(version: String): ProjectMatrix = self.jvmPlatform(Seq(version), jvmRoots(Some(version)))
 
     // a row that needs the cell itself, not just its settings
     def crossJvmRow(version: String, configure: Project => Project): ProjectMatrix = self
-      .jvmPlatform(Seq(version), Nil, configure(_).settings(jvmRoots()))
+      .jvmPlatform(Seq(version), Nil, configure(_).settings(jvmRoots(Some(version))))
 
     // a row that needs the cell itself, not just its settings
     def crossJvmRow(versions: String*)(configure: String => Project => Project): ProjectMatrix = versions
@@ -160,14 +165,16 @@ object Extensions {
 
     def communityTest: ProjectMatrix = self.settings(communityTestsSettings).crossJvmNative(scalaNativeConfig)
 
-    private def platformRoots(platform: String, ss: Seq[Def.SettingsDefinition], scala: Boolean = true)(
+    private def platformRoots(platform: String, version: Option[String], ss: Seq[Def.SettingsDefinition])(
         platforms: String*,
-    ) = roots(self.base, platform +: platforms *) ++ ideSkip(platform, scala) ++ ss.flatMap(_.settings)
+    ) = roots(self.base, platform +: platforms *) ++ ideSkip(platform, version) ++ ss.flatMap(_.settings)
 
-    private def jvmRoots(ss: Seq[Def.SettingsDefinition] = Nil, scala: Boolean = true) =
-      platformRoots("jvm", ss, scala)("jvm-native", "js-jvm")
-    private def jsRoots(ss: Seq[Def.SettingsDefinition]) = platformRoots("js", ss)("js-jvm", "js-native")
-    private def nativeRoots(ss: Seq[Def.SettingsDefinition]) = platformRoots("native", ss)("jvm-native", "js-native")
+    private def jvmRoots(version: Option[String], ss: Seq[Def.SettingsDefinition] = Nil) =
+      platformRoots("jvm", version, ss)("jvm-native", "js-jvm")
+    private def jsRoots(version: String, ss: Seq[Def.SettingsDefinition]) =
+      platformRoots("js", Some(version), ss)("js-jvm", "js-native")
+    private def nativeRoots(version: String, ss: Seq[Def.SettingsDefinition]) =
+      platformRoots("native", Some(version), ss)("jvm-native", "js-native")
   }
 
 }


### PR DESCRIPTION
`ide-skip-project` is IntelliJ's own key, and the filter picked 2.13 whether or not anyone asked for it, so Metals and a command-line `sbt` saw a narrowed build they never asked to narrow.

sbt owns `bspEnabled`, so the build sets that instead. It picks a Scala version only when `-Dide.scala` is set, or when IntelliJ starts sbt with `-Didea.managed=true`. Everything else keeps every row.

`-Dide.platform` no longer adds `jvm` to the list it is given, so `-Dide.platform=js` imports the Scala.js rows alone.

*- Claude (on behalf of Albert)*
