### PR TITLE
add excludeOwners to skip insert/remove braces for specific owners

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4822,6 +4822,11 @@ The section contains the following settings (available since v3.8.1):
     - an [interval](#rewritescala3-interval-checks) parameter,
       applied to the number of blank-line gaps within the region
     - `remove.maxBlankGaps` was used earlier for `remove.blankGaps.max`
+  - (since v3.11.6) `insert.includeOwners`, `insert.excludeOwners`
+    - list of owners to match on (see [`align.tokens`](#aligntokens)), if non-empty
+    - an owner refers to a tree which owns the region, such as `Term.If`,
+      `Term.Match`, `Defn.Def`, or `Case`
+    - this logic doesn't apply to regions which don't qualify as optional-braces
   - if `preferInsert = false`, these intervals will be modified, if necessary,
     to exclude those in `remove` section
 - (since v3.10.8) `remove`: will remove braces if at least
@@ -4837,6 +4842,8 @@ The section contains the following settings (available since v3.8.1):
     - an [interval](#rewritescala3-interval-checks) parameter,
       applied to the number of blank-line gaps between the braces
     - before v3.11.2, `remove.maxBlankGaps` was used instead of `remove.blankGaps.max`
+  - (since v3.11.6) `remove.includeOwners`, `remove.excludeOwners`
+    - see `insert.includeOwners` and `insert.excludeOwners` above
   - if `preferInsert = true`, these values will be decreased, if necessary,
     to be less than those in `insert` section
 - (since v3.8.1) `fewerBraces`

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -105,6 +105,8 @@ object RewriteScala3Settings {
   case class BracesFilters(
       span: Between = Between.disabled,
       blankGaps: Between = Between.disabled,
+      includeOwners: TreePatterns = TreePatterns.empty,
+      excludeOwners: TreePatterns = TreePatterns.empty,
   ) {
     def enabled: Boolean = span.enabled || blankGaps.enabled
 

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/RewriteScala3Settings.scala
@@ -110,6 +110,14 @@ object RewriteScala3Settings {
   ) {
     def enabled: Boolean = span.enabled || blankGaps.enabled
 
+    def matchesOwner(owner: => meta.Tree): Boolean =
+      includeOwners.isEmpty && excludeOwners.isEmpty || {
+        val tree = owner
+        (tree eq null) ||
+        (includeOwners.isEmpty || includeOwners.matches(tree)) &&
+        !excludeOwners.matches(tree)
+      }
+
     def exclude(that: BracesFilters): BracesFilters = {
       val span = this.span.exclude(that.span)
       val blankGaps = this.blankGaps.exclude(that.blankGaps)

--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/rewrite/RemoveScala3OptionalBraces.scala
@@ -121,6 +121,7 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
       if (skip) null
       else if (block.parent.is[Case]) if (isColon) removeToken else null
       else if (isColonArgFunction(ob.owner)) null
+      else if (!settings.insertFilters.forall(_.matchesOwner(ownerOf(ob)))) null
       else {
         val rb = ftoks.getLast(block)
         if (rb eq null) null
@@ -137,6 +138,9 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
         }
       }
     }
+
+  private def ownerOf(ob: OptionalBraces): Tree = ob.owner ??
+    ob.block.parentOrNull
 
   private def isColonArgFunction(owner: Tree): Boolean = owner match {
     case t: Term.FunctionLike => ftoks.tokenBefore(t).left.is[T.Colon]
@@ -172,8 +176,10 @@ private class RemoveScala3OptionalBraces(implicit val ftoks: FormatTokens)
           (x.span, _.satisfied(session.getSpan(left))),
           (x.blankGaps, _.satisfied(session.getBlankGaps(left))),
         ).flatMap { case (bw, f) => if (bw.enabled) Some(f(bw)) else None }
-        if (!cfg.preferInsert) checks.contains(true)
-        else checks.hasNext && !checks.contains(false)
+        x.matchesOwner(getOptionalBraces(left.ft).nnMap(y => ownerOf(y._1))) && {
+          if (!cfg.preferInsert) checks.contains(true)
+          else checks.hasNext && !checks.contains(false)
+        }
       }
     } ||
       (nextFt.meta.rightOwner match {

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10397,12 +10397,11 @@ foo match
 
     baz
 >>>
-foo match {
-  case x =>
-    bar
+foo match
+   case x =>
+     bar
 
-    baz
-}
+     baz
 <<< insert with includeOwners naming an if
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
@@ -10414,12 +10413,11 @@ foo match
 
     baz
 >>>
-foo match {
-  case x =>
-    bar
+foo match
+   case x =>
+     bar
 
-    baz
-}
+     baz
 <<< insert with includeOwners naming the match
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
@@ -10450,10 +10448,11 @@ foo match
   }
 >>>
 foo match
-   case x =>
+   case x => {
      bar
 
      baz
+   }
 <<< braced lambda arg with includeOwners naming an apply
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces.stat
@@ -10386,3 +10386,87 @@ foo match {
 
     baz
 }
+<<< insert with excludeOwners naming the match
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.excludeOwners = [{regex = "Term.Match"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< insert with includeOwners naming an if
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.includeOwners = [{regex = "Term.If"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< insert with includeOwners naming the match
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.includeOwners = [{regex = "Term.Match"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< remove with excludeOwners naming the case
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000
+rewrite.scala3.optionalBraces.remove.excludeOwners = [{regex = "Case"}]
+===
+foo match
+  case x => {
+    bar
+
+    baz
+  }
+>>>
+foo match
+   case x =>
+     bar
+
+     baz
+<<< braced lambda arg with includeOwners naming an apply
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000
+rewrite.scala3.optionalBraces.fewerBraces.span.max = 1000
+rewrite.scala3.optionalBraces.remove.includeOwners = [{regex = "Term.Apply"}]
+===
+list.map { x =>
+  val a = x
+
+  a
+}
+>>>
+list.map: x =>
+   val a = x
+
+   a

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -9993,3 +9993,87 @@ foo match {
 
     baz
 }
+<<< insert with excludeOwners naming the match
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.excludeOwners = [{regex = "Term.Match"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< insert with includeOwners naming an if
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.includeOwners = [{regex = "Term.If"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< insert with includeOwners naming the match
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.includeOwners = [{regex = "Term.Match"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< remove with excludeOwners naming the case
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000
+rewrite.scala3.optionalBraces.remove.excludeOwners = [{regex = "Case"}]
+===
+foo match
+  case x => {
+    bar
+
+    baz
+  }
+>>>
+foo match
+   case x =>
+     bar
+
+     baz
+<<< braced lambda arg with includeOwners naming an apply
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000
+rewrite.scala3.optionalBraces.fewerBraces.span.max = 1000
+rewrite.scala3.optionalBraces.remove.includeOwners = [{regex = "Term.Apply"}]
+===
+list.map { x =>
+  val a = x
+
+  a
+}
+>>>
+list.map: x =>
+   val a = x
+
+   a

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_fold.stat
@@ -10004,12 +10004,11 @@ foo match
 
     baz
 >>>
-foo match {
-  case x =>
-    bar
+foo match
+   case x =>
+     bar
 
-    baz
-}
+     baz
 <<< insert with includeOwners naming an if
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
@@ -10021,12 +10020,11 @@ foo match
 
     baz
 >>>
-foo match {
-  case x =>
-    bar
+foo match
+   case x =>
+     bar
 
-    baz
-}
+     baz
 <<< insert with includeOwners naming the match
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
@@ -10057,10 +10055,11 @@ foo match
   }
 >>>
 foo match
-   case x =>
+   case x => {
      bar
 
      baz
+   }
 <<< braced lambda arg with includeOwners naming an apply
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10402,12 +10402,11 @@ foo match
 
     baz
 >>>
-foo match {
-  case x =>
-    bar
+foo match
+   case x =>
+     bar
 
-    baz
-}
+     baz
 <<< insert with includeOwners naming an if
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
@@ -10419,12 +10418,11 @@ foo match
 
     baz
 >>>
-foo match {
-  case x =>
-    bar
+foo match
+   case x =>
+     bar
 
-    baz
-}
+     baz
 <<< insert with includeOwners naming the match
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
@@ -10455,10 +10453,11 @@ foo match
   }
 >>>
 foo match
-   case x =>
+   case x => {
      bar
 
      baz
+   }
 <<< braced lambda arg with includeOwners naming an apply
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_keep.stat
@@ -10391,3 +10391,87 @@ foo match {
 
     baz
 }
+<<< insert with excludeOwners naming the match
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.excludeOwners = [{regex = "Term.Match"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< insert with includeOwners naming an if
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.includeOwners = [{regex = "Term.If"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< insert with includeOwners naming the match
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.includeOwners = [{regex = "Term.Match"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< remove with excludeOwners naming the case
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000
+rewrite.scala3.optionalBraces.remove.excludeOwners = [{regex = "Case"}]
+===
+foo match
+  case x => {
+    bar
+
+    baz
+  }
+>>>
+foo match
+   case x =>
+     bar
+
+     baz
+<<< braced lambda arg with includeOwners naming an apply
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000
+rewrite.scala3.optionalBraces.fewerBraces.span.max = 1000
+rewrite.scala3.optionalBraces.remove.includeOwners = [{regex = "Term.Apply"}]
+===
+list.map { x =>
+  val a = x
+
+  a
+}
+>>>
+list.map: x =>
+   val a = x
+
+   a

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10778,12 +10778,11 @@ foo match
 
     baz
 >>>
-foo match {
-  case x =>
-    bar
+foo match
+   case x =>
+     bar
 
-    baz
-}
+     baz
 <<< insert with includeOwners naming an if
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
@@ -10795,12 +10794,11 @@ foo match
 
     baz
 >>>
-foo match {
-  case x =>
-    bar
+foo match
+   case x =>
+     bar
 
-    baz
-}
+     baz
 <<< insert with includeOwners naming the match
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
@@ -10831,10 +10829,11 @@ foo match
   }
 >>>
 foo match
-   case x =>
+   case x => {
      bar
 
      baz
+   }
 <<< braced lambda arg with includeOwners naming an apply
 rewrite.scala3.optionalBraces.enabled = true
 rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000

--- a/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
+++ b/scalafmt-tests/shared/src/test/resources/scala3/OptionalBraces_unfold.stat
@@ -10767,3 +10767,87 @@ foo match {
 
     baz
 }
+<<< insert with excludeOwners naming the match
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.excludeOwners = [{regex = "Term.Match"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< insert with includeOwners naming an if
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.includeOwners = [{regex = "Term.If"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< insert with includeOwners naming the match
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.insert.blankGaps.min = 1
+rewrite.scala3.optionalBraces.insert.includeOwners = [{regex = "Term.Match"}]
+===
+foo match
+  case x =>
+    bar
+
+    baz
+>>>
+foo match {
+  case x =>
+    bar
+
+    baz
+}
+<<< remove with excludeOwners naming the case
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000
+rewrite.scala3.optionalBraces.remove.excludeOwners = [{regex = "Case"}]
+===
+foo match
+  case x => {
+    bar
+
+    baz
+  }
+>>>
+foo match
+   case x =>
+     bar
+
+     baz
+<<< braced lambda arg with includeOwners naming an apply
+rewrite.scala3.optionalBraces.enabled = true
+rewrite.scala3.optionalBraces.remove.blankGaps.max = 1000
+rewrite.scala3.optionalBraces.fewerBraces.span.max = 1000
+rewrite.scala3.optionalBraces.remove.includeOwners = [{regex = "Term.Apply"}]
+===
+list.map { x =>
+  val a = x
+
+  a
+}
+>>>
+list.map: x =>
+   val a = x
+
+   a

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2631420, "total explored")
+      assertEquals(explored, 2631404, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/FormatTests.scala
@@ -159,7 +159,7 @@ class FormatTests
     val explored = Debug.explored.get()
     logger.debug(s"Total explored: $explored")
     if (!onlyUnit && !onlyManual)
-      assertEquals(explored, 2630556, "total explored")
+      assertEquals(explored, 2631420, "total explored")
     if (!sys.env.contains("CI")) PlatformFileOps.writeFileAsync(
       FileOps.getPath("target", "index.html"),
       Report.heatmap(debugResults.result()),

--- a/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ScalafmtConfigTest.scala
+++ b/scalafmt-tests/shared/src/test/scala/org/scalafmt/config/ScalafmtConfigTest.scala
@@ -145,6 +145,7 @@ class ScalafmtConfigTest extends SharedFunSuiteBase {
   Seq(
     """align.tokens = [{code = "=", owners = [{}]}]""",
     "rewrite.insertBraces.overrideFor = [{owner = [{}]}]",
+    "rewrite.scala3.optionalBraces.insert.excludeOwners = [{}]",
   ).foreach(conf =>
     test(s"tree pattern must not be empty: $conf")(
       ScalafmtConfig.fromHoconString(conf) match {


### PR DESCRIPTION
This PR allows to, for example, add braces to long `if`s but not for the `match`es