### PR TITLE
Leave build changes out of the release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,8 @@
 changelog:
+  exclude:
+    labels:
+      - build
+      - github_actions
   categories:
     - title: Features
       labels:
@@ -10,11 +14,9 @@ changelog:
         - bug
         - bug in dependency
         - regression
-    - title: Build and dependency updates
+    - title: Dependency updates
       labels:
-        - build
         - dependencies
-        - github_actions
         - library-update
         - sbt-plugin-update
     - title: Miscellaneous


### PR DESCRIPTION
Build and dependency updates shared one heading, and the build half is internal: CI matrices, unused files under project/. The last release had them cut out by hand. Now the label keeps them out, and what is left under Dependency updates moves a version a downstream build resolves.